### PR TITLE
Add startup script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+bundle install
+bundle exec rails s -p 3090


### PR DESCRIPTION
Runs government-frontend on the correct port. A convenience for local development.
