### PR TITLE
Handle paths for translated content

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
-  get 'healthcheck', to: proc { [200, {}, ['']] }
-  get '*path' => 'content_items#show'
+  with_options :format => false do |r|
+    r.get 'healthcheck', to: proc { [200, {}, ['']] }
+    r.get '*path' => 'content_items#show', constraints: { path: %r[.*] }
+  end
 end

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -4,6 +4,13 @@ require 'test_helper'
 class ContentItemsControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::ContentStore
 
+  test "routing handles translated content paths" do
+    translated_path = 'government/case-studies/allez.fr'
+
+    assert_routing({ path: translated_path, method: :get },
+      { controller: 'content_items', action: 'show', path: translated_path })
+  end
+
   test "gets item from content store" do
     path = 'government/case-studies/get-britain-building-carlisle-park'
     content_store_has_item('/' + path, read_content_store_fixture('case_study'))


### PR DESCRIPTION
Rails by default assumes anything after a full stop in a request path represents the format of the request. We override the constraints in the routing to ensure the entire request path makes it through to the controller so that we can handle paths for translated content.
