### PR TITLE
Test coverage for ContentItemPresenter

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -83,7 +83,7 @@ private
   end
 
   def any_updates?
-    Date.parse(content_item["public_updated_at"]) != Date.parse(content_item["details"]["first_public_at"])
+    DateTime.parse(content_item["public_updated_at"]) != DateTime.parse(content_item["details"]["first_public_at"])
   end
 
   def links(type)

--- a/test/models/content_item_presenter_test.rb
+++ b/test/models/content_item_presenter_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+
+class ContentItemPresenterTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::ContentStore
+  include ActionView::Helpers::UrlHelper
+
+  test 'presents the basic details of a content item' do
+    assert_equal case_study['description'], presented_case_study.description
+    assert_equal case_study['format'], presented_case_study.format
+    assert_equal case_study['locale'], presented_case_study.locale
+    assert_equal case_study['title'], presented_case_study.title
+    assert_equal case_study['details']['body'], presented_case_study.body
+    assert_equal case_study['details']['format_display_type'], presented_case_study.format_display_type
+  end
+
+  test '#published returns a formatted date of the day the content item became public' do
+    assert_equal '17 December 2012', presented_case_study.published
+  end
+
+  test '#updated returns nil if the content item has no updates' do
+    assert_nil presented_case_study.updated
+  end
+
+  test '#updated returns a formatted date of the last day the content item was updated' do
+    assert_equal '21 March 2013', presented_case_study_with_updates.updated
+  end
+
+  test '#short_history returns the published day of a non-updated content item' do
+    assert_equal 'Published 17 December 2012', presented_case_study.short_history
+  end
+
+  test '#short_history returns the last update day for a content item that has updates' do
+    assert_equal 'Updated 21 March 2013', presented_case_study_with_updates.short_history
+  end
+
+  test '#from returns links to lead organisations and supporting organisations' do
+    with_organisations = case_study
+    with_organisations['links']['lead_organisations'] = [
+      { "title" => 'Lead org', "base_path" => '/orgs/lead'}
+    ]
+    with_organisations['links']['supporting_organisations'] = [
+      { "title" => 'Supporting org', "base_path" => '/orgs/supporting' }
+    ]
+
+    expected_from_links = [
+      link_to('Lead org', '/orgs/lead'),
+      link_to('Supporting org', '/orgs/supporting')
+    ]
+
+    assert_equal expected_from_links, presented_case_study(with_organisations).from
+  end
+
+  test '#history returns an empty array if the content item has no updates' do
+    assert_equal [], presented_case_study.history
+  end
+
+  test '#history returns a formatted history if the content item has updates' do
+    expected_history = [
+      { display_time: '21 March 2013', note: 'Something changed', timestamp: '2013-03-21T00:00:00+00:00'},
+    ]
+
+    assert_equal expected_history, presented_case_study_with_updates.history
+  end
+
+private
+
+  def presented_case_study(overrides={})
+    ContentItemPresenter.new(case_study.merge(overrides))
+  end
+
+  def presented_case_study_with_updates
+    march_21_2013 = DateTime.new(2013, 3, 21).to_s
+    with_history = case_study
+    with_history['details']['change_history'] = [{ 'note' => 'Something changed', 'public_timestamp' => march_21_2013 }]
+    with_history['public_updated_at'] = march_21_2013
+
+    presented_case_study(with_history)
+  end
+
+  def case_study
+    govuk_content_schema_example('case_study')
+  end
+end


### PR DESCRIPTION
Adds missing test coverage for the `ContentItemPresenter`. Note that this also fixes a bug in the any_updates? method - it was checking based on a date, which meant that it would return false for a content item updated on the same day as it was created.
