### PR TITLE
Add some styles to the unpublishing page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,4 +7,5 @@
 
 // pages specific view imports
 @import "views/case-studies";
+@import "views/unpublishing";
 

--- a/app/assets/stylesheets/views/_unpublishing.scss
+++ b/app/assets/stylesheets/views/_unpublishing.scss
@@ -1,0 +1,9 @@
+.unpublishing {
+  margin-bottom: $gutter*2;
+
+  .summary,
+  .alternative {
+    @include core-19;
+    margin-bottom: $gutter-half;
+  }
+}

--- a/app/views/content_items/unpublishing.html.erb
+++ b/app/views/content_items/unpublishing.html.erb
@@ -1,15 +1,20 @@
 <%= content_for :page_class, "unpublishing" %>
 <%= content_for :title, "No longer available - GOV.UK" %>
 
-<h2>The page you are looking for is no longer available</h2>
-<p class="summary">
-  The information on this page has been removed because it was published in error.
-</p>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title', title: 'The page you are looking for is no longer available' %>
 
-<%= @content_item.explanation %>
+    <p class="summary">
+      The information on this page has been removed because it was published in error.
+    </p>
 
-<% if @content_item.alternative_url.present? %>
-  <p>
-    Visit: <%= link_to(@content_item.alternative_url, @content_item.alternative_url) %>
-  </p>
-<% end %>
+    <%= render 'govuk_component/govspeak', content: @content_item.explanation %>
+
+    <% if @content_item.alternative_url.present? %>
+      <p class="alternative">
+        Visit: <%= link_to(@content_item.alternative_url, @content_item.alternative_url) %>
+      </p>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
So that the page doesn't look odd use the standard header and govspeak
styling to make the page look more uniform.

Also wrapped the page in a two-third width column so the text on the
page doesn't get longer than a comfortable reading width.

![screen shot 2014-12-17 at 12 48 19](https://cloud.githubusercontent.com/assets/35035/5471214/0379bdfa-85eb-11e4-91d1-a958830ae945.png)
