### PR TITLE
Display the "part of" metadata

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -19,7 +19,7 @@ class ContentItemPresenter
   end
 
   def part_of
-    []
+    links("related_policies") + links("worldwide_priorities") + links("world_locations")
   end
 
   def history

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -21,7 +21,8 @@
         updated: @content_item.updated,
         history: @content_item.short_history,
         published: @content_item.published,
-        direction: page_text_direction
+        direction: page_text_direction,
+        part_of: @content_item.part_of
     %>
   </div>
 </div>
@@ -49,4 +50,6 @@
         updated: @content_item.updated,
         history: @content_item.history,
         published: @content_item.published,
-        direction: page_text_direction %>
+        direction: page_text_direction,
+        part_of: @content_item.part_of
+%>

--- a/test/models/content_item_presenter_test.rb
+++ b/test/models/content_item_presenter_test.rb
@@ -49,6 +49,23 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     assert_equal expected_from_links, presented_case_study(with_organisations).from
   end
 
+  test '#part_of returns an array of related policies, worldwide priorities and world locations' do
+    with_extras = case_study
+    with_extras['links']['related_policies'] = [
+      { "title" => "Cheese", "base_path" => "/policy/cheese" }
+    ]
+    with_extras['links']['worldwide_priorities'] = [
+      { "title" => "Cheese around the world", "base_path" => "/world_prior/cheese" }
+    ]
+
+    expected_part_of_links = [
+      link_to('Cheese', '/policy/cheese'),
+      link_to('Cheese around the world', '/world_prior/cheese'),
+      link_to('Pakistan', '/government/world/pakistan'),
+    ]
+    assert_equal expected_part_of_links, presented_case_study(with_extras).part_of
+  end
+
   test '#history returns an empty array if the content item has no updates' do
     assert_equal [], presented_case_study.history
   end


### PR DESCRIPTION
I based this upon the code which currently does it in Whitehall:
https://github.com/alphagov/whitehall/blob/b1f827a2daa1df50cf69785af6827a621857e815/app/helpers/document_helper.rb#L205-L247

~~Note that the code in Whitehall has many more fields in it, but these aren't
currently sent to content-store. I think this may be based upon an assumption
that Case Studies only have the fields currently being sent to content-store.~~

~~Are there any other "part of" fields which do in fact appear for Case Studies?~~ 

Note: the tests are currently failing on an unrelated pre-existing failure that @danielroseman is working on.