### PR TITLE
Add Worldwide Organisations to "From" metadata

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -15,7 +15,7 @@ class ContentItemPresenter
   end
 
   def from
-    links("lead_organisations") + links("supporting_organisations")
+    links("lead_organisations") + links("supporting_organisations") + links("worldwide_organisations")
   end
 
   def part_of

--- a/test/models/content_item_presenter_test.rb
+++ b/test/models/content_item_presenter_test.rb
@@ -32,7 +32,7 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     assert_equal 'Updated 21 March 2013', presented_case_study_with_updates.short_history
   end
 
-  test '#from returns links to lead organisations and supporting organisations' do
+  test '#from returns links to lead organisations, supporting organisations and worldwide organisations' do
     with_organisations = case_study
     with_organisations['links']['lead_organisations'] = [
       { "title" => 'Lead org', "base_path" => '/orgs/lead'}
@@ -43,7 +43,8 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
 
     expected_from_links = [
       link_to('Lead org', '/orgs/lead'),
-      link_to('Supporting org', '/orgs/supporting')
+      link_to('Supporting org', '/orgs/supporting'),
+      link_to('DFID Pakistan', '/government/world/organisations/dfid-pakistan'),
     ]
 
     assert_equal expected_from_links, presented_case_study(with_organisations).from


### PR DESCRIPTION
Case Studies can have Worldwide Organisations, so we should display them.

The test failure is an unrelated pre-existing one already happening on master.