### PR TITLE
Use translation manager gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'sass-rails', '~> 4.0.3'
 gem 'slimmer', '5.0.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8'
+gem 'rails_translation_manager', '~> 0.0.1'
 
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,11 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.1.5)
       sprockets-rails (~> 2.0)
+    rails-i18n (0.7.3)
+      i18n (~> 0.5)
+    rails_translation_manager (0.0.1)
+      activesupport
+      rails-i18n
     railties (4.1.5)
       actionpack (= 4.1.5)
       activesupport (= 4.1.5)
@@ -160,6 +165,7 @@ DEPENDENCIES
   logstasher (= 0.6.1)
   plek (= 1.9)
   rails (= 4.1.5)
+  rails_translation_manager (~> 0.0.1)
   sass-rails (~> 4.0.3)
   slimmer (= 5.0.0)
   uglifier (>= 1.3.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,9 +23,11 @@ module GovernmentFrontend
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
 
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    # Explicitly set default locale
+    config.i18n.default_locale = :en
+
+    # Explicitly set available locales
+    config.i18n.available_locales = [:es, :ar, :en]
 
     # Disable rack::cache
     config.action_dispatch.rack_cache = nil


### PR DESCRIPTION
Use the [`rails_translation_manager`](https://github.com/alphagov/rails_translation_manager) gem to support workflow around translating page furniture (export translations to CSV, import from CSV).

https://trello.com/c/PLRk2VJL/27-add-support-for-loading-translations-to-government-frontend