### PR TITLE
Support Coming Soon content items

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,5 +7,6 @@
 
 // pages specific view imports
 @import "views/case-studies";
+@import "views/coming-soon";
 @import "views/unpublishing";
 

--- a/app/assets/stylesheets/views/_coming-soon.scss
+++ b/app/assets/stylesheets/views/_coming-soon.scss
@@ -1,0 +1,6 @@
+.coming-soon {
+  .summary {
+    @include core-24;
+    margin-bottom: $gutter-half;
+  }
+}

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -23,6 +23,7 @@ private
     case content_item['format']
       when 'case_study' then ContentItemPresenter.new(content_item)
       when 'unpublishing' then UnpublishingPresenter.new(content_item)
+      when 'coming_soon' then ComingSoonPresenter.new(content_item)
       else raise "No support for format \"#{content_item['format']}\""
     end
   end

--- a/app/presenters/coming_soon_presenter.rb
+++ b/app/presenters/coming_soon_presenter.rb
@@ -1,0 +1,33 @@
+class ComingSoonPresenter
+  attr_reader :content_item, :title, :format, :locale, :publish_time
+
+  def initialize(content_item)
+    @content_item = content_item
+
+    @title = content_item["title"]
+    @format = content_item["format"]
+    @locale = content_item["locale"] || "en"
+    @publish_time = content_item["details"]["publish_time"]
+  end
+
+  def iso8601_publish_time
+    @publish_time # This will be iso8601 because it's a JSON datetime
+  end
+
+  def formatted_publish_date
+    display_date(@publish_time.to_date)
+  end
+
+  def formatted_publish_time
+    display_time(DateTime.parse(@publish_time))
+  end
+
+private
+  def display_date(date)
+    date.strftime("%e %B %Y")
+  end
+
+  def display_time(timestamp)
+    timestamp.strftime("%H:%M")
+  end
+end

--- a/app/views/content_items/coming_soon.html.erb
+++ b/app/views/content_items/coming_soon.html.erb
@@ -1,0 +1,15 @@
+<%= content_for :page_class, "coming-soon" %>
+<%= content_for :title, "Coming soon - GOV.UK" %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title', title: 'Coming soon' %>
+
+    <p class="summary">
+      This document will be published on<br />
+      <%= content_tag(:time, class: 'publish_time', datetime: @content_item.iso8601_publish_time) do %>
+        <%= @content_item.formatted_publish_date + " at " + @content_item.formatted_publish_time %>
+      <% end %>
+    </p>
+  </div>
+</div>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -18,6 +18,17 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_equal content_item['title'], assigns[:content_item].title
   end
 
+  test "sets the expiry as sent by content-store" do
+    content_item = govuk_content_schema_example('coming_soon')
+
+    expires_in = 20
+    content_store_has_item(content_item['base_path'], content_item, expires_in)
+
+    get :show, path: path_for(content_item)
+    assert_response :success
+    assert_equal "max-age=20, public", @response.headers['Cache-Control']
+  end
+
   test "renders translated content items in their locale" do
     content_item = govuk_content_schema_example('translated')
     translated_format_name = I18n.t("content_item.format.case_study", count: 10, locale: 'es')

--- a/test/presenters/coming_soon_presenter_test.rb
+++ b/test/presenters/coming_soon_presenter_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class ComingSoonPresenterTest < ActiveSupport::TestCase
+  test 'presents the basic details required to display a coming soon item' do
+    assert_equal coming_soon['title'], presented_coming_soon.title
+    assert_equal coming_soon['format'], presented_coming_soon.format
+    assert_equal coming_soon['locale'], presented_coming_soon.locale
+    assert_equal coming_soon['details']['publish_time'], presented_coming_soon.publish_time
+  end
+
+  test '#formatted_publish_time' do
+    assert_equal '09:30', presented_coming_soon.formatted_publish_time
+  end
+
+  test '#formatted_publish_date' do
+    assert_equal '17 December 2014', presented_coming_soon.formatted_publish_date
+  end
+
+private
+  def presented_coming_soon(overrides={})
+    ComingSoonPresenter.new(coming_soon.merge(overrides))
+  end
+
+  def coming_soon
+    govuk_content_schema_example('coming_soon')
+  end
+
+end

--- a/test/support/govuk_content_schema_examples.rb
+++ b/test/support/govuk_content_schema_examples.rb
@@ -65,6 +65,7 @@ module GovukContentSchemaExamples
     def supported_format?(data)
       supported_formats = %w{
         case_study
+        coming_soon
         redirect
         unpublishing
       }


### PR DESCRIPTION
Coming Soon content items are used for scheduled publishing. It is important in
scheduled publishing that all users see the new version as quickly as possible.
For content that is replacing existing content, this is easy: we simply wind in
the cache headers leading up to the publish time. For new content, this is
harder, because our stack doesn't respect the cache time for HTTP responses
with the 404 status. So instead, we return a 200 status and display a "Coming
Soon" page with the same cache header winding.

Whitehall:
![screen shot 2015-02-23 at 15 08 30](https://cloud.githubusercontent.com/assets/93739/6330151/e360a476-bb6d-11e4-9519-53e8587e6bc8.png)

government-frontend:
![screen shot 2015-02-23 at 15 08 40](https://cloud.githubusercontent.com/assets/93739/6330159/f2a3a596-bb6d-11e4-807a-6196cd9ab451.png)
