### PR TITLE
Show document collections edition belongs to

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -19,7 +19,7 @@ class ContentItemPresenter
   end
 
   def part_of
-    links("related_policies") + links("worldwide_priorities") + links("world_locations")
+    links("document_collections") + links("related_policies") + links("worldwide_priorities") + links("world_locations")
   end
 
   def available_translations

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -50,8 +50,11 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     assert_equal expected_from_links, presented_case_study(with_organisations).from
   end
 
-  test '#part_of returns an array of related policies, worldwide priorities and world locations' do
+  test '#part_of returns an array of document_collections, related policies, worldwide priorities and world locations' do
     with_extras = case_study
+    with_extras['links']['document_collections'] = [
+      { "title" => "Work Programme real life stories", "base_path" => "/government/collections/work-programme-real-life-stories" }
+    ]
     with_extras['links']['related_policies'] = [
       { "title" => "Cheese", "base_path" => "/policy/cheese" }
     ]
@@ -60,6 +63,7 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     ]
 
     expected_part_of_links = [
+      link_to('Work Programme real life stories', '/government/collections/work-programme-real-life-stories'),
       link_to('Cheese', '/policy/cheese'),
       link_to('Cheese around the world', '/world_prior/cheese'),
       link_to('Pakistan', '/government/world/pakistan'),


### PR DESCRIPTION
https://trello.com/c/pfvFRgg5

Currently, document collection membership is not shown next to 'Part of:' in the metadata section in the header or footer as shown here: https://www.gov.uk/government/case-studies/clever-engineering-macrete-bridges-the-technology-gap