### PR TITLE
Don't show caption if it is false.

### DIFF
--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -37,10 +37,10 @@
 
 <div class="grid-row">
   <div class="column-third">
-    <% if @content_item.image %>
+    <% if (image = @content_item.image) %>
       <figure class="sidebar-image">
-        <img src="<%= @content_item.image["url"] %>" alt="<%= @content_item.image["alt_text"] %>">
-        <figcaption><%= @content_item.image["caption"] %></figcaption>
+        <img src="<%= image["url"] %>" alt="<%= image["alt_text"] %>">
+        <% if image["caption"].present? %><figcaption><%= image["caption"] %></figcaption><% end %>
       </figure>
     <% end %>
   </div>


### PR DESCRIPTION
A large number of case studies contain the boolean value "false" as the image caption, and this was displaying underneath the picture. This change just hides that value; a separate change to Whitehall will be needed to ensure no value is sent to content-store if there is an empty caption.