### PR TITLE
Use base_path not web_url in translation links.

### DIFF
--- a/app/views/shared/_available_languages.html.erb
+++ b/app/views/shared/_available_languages.html.erb
@@ -6,7 +6,7 @@
           <% if translation["locale"] == I18n.locale.to_s %>
             <span><%= native_language_name_for(translation["locale"]) %></span>
           <% else %>
-            <%= link_to native_language_name_for(translation["locale"]), translation["web_url"] %>
+            <%= link_to native_language_name_for(translation["locale"]), translation["base_path"] %>
           <% end %>
         </li>
       <% end %>


### PR DESCRIPTION
This gives a relative path which will work on all environments, and is consistent with what we use for all other links.