### PR TITLE
Show placeholder image for items without images

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -21,7 +21,7 @@ private
 
   def present(content_item)
     case content_item['format']
-      when 'case_study' then ContentItemPresenter.new(content_item)
+      when 'case_study' then ContentItemPresenter.new(content_item, view_context)
       when 'unpublishing' then UnpublishingPresenter.new(content_item)
       when 'coming_soon' then ComingSoonPresenter.new(content_item)
       else raise "No support for format \"#{content_item['format']}\""

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -55,7 +55,7 @@ class ContentItemPresenter
   end
 
   def image
-    content_item["details"]["image"]
+    content_item["details"]["image"].presence || placeholder_image_data
   end
 
   def archived?
@@ -94,5 +94,13 @@ private
     content_item["links"][type].map do |link|
       @view_context.link_to(link["title"], link["base_path"])
     end
+  end
+
+  def placeholder_image_data
+    {
+      'url' => @view_context.url_to_image('placeholder.jpg'),
+      'alt_text' => 'placeholder',
+      'caption' => nil
+    }
   end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,10 +1,9 @@
 class ContentItemPresenter
-  include ActionView::Helpers::UrlHelper
-
   attr_reader :content_item, :title, :description, :body, :format, :format_display_type, :locale
 
-  def initialize(content_item)
+  def initialize(content_item, view_context)
     @content_item = content_item
+    @view_context = view_context
 
     @title = content_item["title"]
     @description = content_item["description"]
@@ -71,7 +70,7 @@ class ContentItemPresenter
   def archive_notice
     notice = content_item["details"]["archive_notice"]
     {
-      time: content_tag(:time, display_time(notice["archived_at"]), datetime: notice["archived_at"]),
+      time: @view_context.content_tag(:time, display_time(notice["archived_at"]), datetime: notice["archived_at"]),
       explanation: notice["explanation"]
     }
   end
@@ -93,7 +92,7 @@ private
   def links(type)
     return [] unless content_item["links"][type]
     content_item["links"][type].map do |link|
-      link_to(link["title"], link["base_path"])
+      @view_context.link_to(link["title"], link["base_path"])
     end
   end
 end

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -87,6 +87,20 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     assert_equal ['en', 'ar', 'es'], locales.map {|t| t["locale"]}
   end
 
+  test "#image returns placeholder image data for content item without images" do
+    case_study_without_images = case_study
+    case_study_without_images['details'].delete('image')
+
+    presented_case_study_without_images = presented_case_study(case_study_without_images)
+    placeholder_image_data = {
+      'url' => view_context.url_to_image('placeholder.jpg'),
+      'alt_text' => 'placeholder',
+      'caption' => nil
+    }
+
+    assert_equal placeholder_image_data, presented_case_study_without_images.image
+  end
+
 private
 
   def presented_case_study(overrides={})

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class ContentItemPresenterTest < ActiveSupport::TestCase
-  include ActionView::Helpers::UrlHelper
-
   test 'presents the basic details of a content item' do
     assert_equal case_study['description'], presented_case_study.description
     assert_equal case_study['format'], presented_case_study.format
@@ -42,9 +40,9 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     ]
 
     expected_from_links = [
-      link_to('Lead org', '/orgs/lead'),
-      link_to('Supporting org', '/orgs/supporting'),
-      link_to('DFID Pakistan', '/government/world/organisations/dfid-pakistan'),
+      view_context.link_to('Lead org', '/orgs/lead'),
+      view_context.link_to('Supporting org', '/orgs/supporting'),
+      view_context.link_to('DFID Pakistan', '/government/world/organisations/dfid-pakistan'),
     ]
 
     assert_equal expected_from_links, presented_case_study(with_organisations).from
@@ -63,10 +61,10 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     ]
 
     expected_part_of_links = [
-      link_to('Work Programme real life stories', '/government/collections/work-programme-real-life-stories'),
-      link_to('Cheese', '/policy/cheese'),
-      link_to('Cheese around the world', '/world_prior/cheese'),
-      link_to('Pakistan', '/government/world/pakistan'),
+      view_context.link_to('Work Programme real life stories', '/government/collections/work-programme-real-life-stories'),
+      view_context.link_to('Cheese', '/policy/cheese'),
+      view_context.link_to('Cheese around the world', '/world_prior/cheese'),
+      view_context.link_to('Pakistan', '/government/world/pakistan'),
     ]
     assert_equal expected_part_of_links, presented_case_study(with_extras).part_of
   end
@@ -85,14 +83,14 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
 
   test "available_translations sorts languages by locale with English first" do
     translated = govuk_content_schema_example('case_study', 'translated')
-    locales = ContentItemPresenter.new(translated).available_translations
+    locales = ContentItemPresenter.new(translated, view_context).available_translations
     assert_equal ['en', 'ar', 'es'], locales.map {|t| t["locale"]}
   end
 
 private
 
   def presented_case_study(overrides={})
-    ContentItemPresenter.new(case_study.merge(overrides))
+    ContentItemPresenter.new(case_study.merge(overrides), view_context)
   end
 
   def presented_case_study_with_updates
@@ -106,5 +104,9 @@ private
 
   def case_study
     govuk_content_schema_example('case_study', 'case_study')
+  end
+
+  def view_context
+    @view_context ||= ActionController::Base.new.view_context
   end
 end


### PR DESCRIPTION
https://trello.com/c/VzKdQ6xm

Whitehall doesn't send image_data for a content item if:

- the edition has no image assigned, and
- the edition's organisation also doesn't have a default image

see: alphagov/whitehall@ab30110

this allows the frontend app to decide what to do in such a scenario.
we're choosing to display a placeholder image.

this required changing the content item presenter to have `view_context`.

we should prefer this method for using view helper methods over
mixing-in related modules in the presenter. [asset URL helper
methods](https://github.com/rails/rails/blob/v4.1.5/actionview/lib/action_view/helpers/asset_url_helper.rb#L194) depend on `view_context` to access configuration and
request information, for example request protocol.

as a result, `*_url` methods don't work in a presenter when
mixed-in, because they don't have access to `config` where it
looks for the asset host. without knowing asset_host it returns
a path instead of returning the full URL, and to make it worse,
does that silently.

hat-tip: @heathd 