### PR TITLE
Fix schema build

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -39,7 +39,7 @@ git checkout $SCHEMA_GIT_COMMIT
 cd ../..
 
 time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rake test:contracts --trace
+RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rake test:contracts
 
 EXIT_STATUS=$?
 echo "EXIT STATUS: $EXIT_STATUS"


### PR DESCRIPTION
After rake was updated from 10.3.2 to 10.4.2, the schema build, which runs the
jenkins-schema.sh script started to fail:
```
  + time bundle exec rake test:contracts --trace
  ** Invoke test:contracts (first_time)
  ** Invoke test:prepare (first_time)
  ** Execute test:prepare
  ** Execute test:contracts

  invalid option: --trace
```
minitest is complaining that it doesn't know about --trace, but that argument
is meant for rake.

This seems to be related to changes in Rake regarding the editing of ARGV in
Rake: https://github.com/ruby/rake/blob/master/History.rdoc

Rather than downgrade Rake, this change removes the option that is triggering
the bug.
/cc @danielroseman @tommyp