### PR TITLE
Prevent exception if item has no first_public_at.

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -87,7 +87,11 @@ private
   end
 
   def any_updates?
-    DateTime.parse(content_item["public_updated_at"]) != DateTime.parse(content_item["details"]["first_public_at"])
+    if (first_public_at = content_item["details"]["first_public_at"]).present?
+      DateTime.parse(content_item["public_updated_at"]) != DateTime.parse(first_public_at)
+    else
+      false
+    end
   end
 
   def links(type)

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -83,6 +83,13 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     assert_equal expected_history, presented_case_study_with_updates.history
   end
 
+  test '#history returns an empty array if the content item is not published' do
+    never_published = case_study
+    never_published['details'].delete('first_public_at')
+    presented = ContentItemPresenter.new(never_published)
+    assert_equal [], presented.history
+  end
+
   test "available_translations sorts languages by locale with English first" do
     translated = govuk_content_schema_example('case_study', 'translated')
     locales = ContentItemPresenter.new(translated).available_translations


### PR DESCRIPTION
Draft ContentItems that have never been published will not have a
first_public_at date in their details; previously the presenter was
choking in this case.