### PR TITLE
"Archived" content is now "Withdrawn"

### DIFF
--- a/app/assets/stylesheets/views/_case-studies.scss
+++ b/app/assets/stylesheets/views/_case-studies.scss
@@ -4,7 +4,7 @@
     text-align: start;
   }
 
-  .archive-notice {
+  .withdrawal-notice {
     clear: both;
     margin: 15px 0;
     padding: 15px 10px;

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -59,16 +59,16 @@ class ContentItemPresenter
     content_item["details"]["image"]
   end
 
-  def archived?
+  def withdrawn?
     content_item["details"].include? "archive_notice"
   end
 
   def page_title
-    archived? ? "[Archived] #{title}" : title
+    withdrawn? ? "[Withdrawn] #{title}" : title
   end
 
 
-  def archive_notice
+  def withdrawal_notice
     notice = content_item["details"]["archive_notice"]
     {
       time: content_tag(:time, display_time(notice["archived_at"]), datetime: notice["archived_at"]),

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -14,10 +14,10 @@
     translations: @content_item.available_translations
   %>
   </div>
-  <% if @content_item.archived? %>
-    <div class="archive-notice">
-      <h2>This <%= t("content_item.format.#{@content_item.format_display_type}", count: 1).downcase %> was archived on <%= @content_item.archive_notice[:time] %></h2>
-      <%= render 'govuk_component/govspeak', content: @content_item.archive_notice[:explanation] %>
+  <% if @content_item.withdrawn? %>
+    <div class="withdrawal-notice">
+      <h2>This <%= t("content_item.format.#{@content_item.format_display_type}", count: 1).downcase %> was withdrawn on <%= @content_item.withdrawal_notice[:time] %></h2>
+      <%= render 'govuk_component/govspeak', content: @content_item.withdrawal_notice[:explanation] %>
     </div>
   <% end %>
 


### PR DESCRIPTION
This updates the display of previously "archived" content to be labelled as
"withdrawn", to be consistent with the retention policy guidance:
https://www.gov.uk/guidance/content-design/gov-uk-content-retention-and-withdrawal-archiving-policy.

It also updates the presenter code accordingly. Separate work will have to
happen to update the schema and migrate the existing content to use the term
"withdrawal" instead or "archive" in the content items themselves.

BEFORE:

![screen shot 2015-05-27 at 16 22 59](https://cloud.githubusercontent.com/assets/3687/7839888/b7a34f10-048c-11e5-92c3-08428eca4b92.png)

AFTER:

![screen shot 2015-05-27 at 16 23 11](https://cloud.githubusercontent.com/assets/3687/7839898/bcb9d988-048c-11e5-885c-5e1da6bc0f7b.png)

 
The corresponding changes in whitehall are here: https://github.com/alphagov/whitehall/pull/2197

Part of: https://trello.com/c/nhvXmcY9/127-changing-archiving-to-withdrawing-in-whitehall-and-on-frontend