### PR TITLE
Handle withdrawn or archived content items

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -60,7 +60,7 @@ class ContentItemPresenter
   end
 
   def withdrawn?
-    content_item["details"].include? "archive_notice"
+    content_item["details"].include?("archive_notice") || content_item["details"].include?("withdrawn_notice")
   end
 
   def page_title
@@ -69,11 +69,17 @@ class ContentItemPresenter
 
 
   def withdrawal_notice
-    notice = content_item["details"]["archive_notice"]
-    {
-      time: content_tag(:time, display_time(notice["archived_at"]), datetime: notice["archived_at"]),
-      explanation: notice["explanation"]
-    }
+    if notice = content_item["details"]["withdrawn_notice"]
+      {
+        time: content_tag(:time, display_time(notice["withdrawn_at"]), datetime: notice["withdrawn_at"]),
+        explanation: notice["explanation"]
+      }
+    elsif notice = content_item["details"]["archive_notice"]
+      {
+        time: content_tag(:time, display_time(notice["archived_at"]), datetime: notice["archived_at"]),
+        explanation: notice["explanation"]
+      }
+    end
   end
 
 private


### PR DESCRIPTION
Whitehall has been updated to refer to withdrawing documents rather than
archiving them. This enables content to be sent to the content store
with either withdrawn or archived state. Once all the content in the
content store has been updated this can be changed to only handle
withdrawn documents.

This is the matching change for this schema pull request: https://github.com/alphagov/govuk-content-schemas/pull/79