### PR TITLE
Bump gds api adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,4 +27,3 @@ group :test do
   gem 'webmock', '~> 1.18.0', :require => false
   gem 'govuk-content-schema-test-helpers', '1.1.0'
 end
-

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'rails_translation_manager', '~> 0.0.2'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '20.0.0'
+  gem 'gds-api-adapters', '20.1.1'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.5.2)
-    gds-api-adapters (20.0.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -169,7 +169,7 @@ DEPENDENCIES
   airbrake (= 4.0)
   better_errors
   binding_of_caller
-  gds-api-adapters (= 20.0.0)
+  gds-api-adapters (= 20.1.1)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk_frontend_toolkit (= 2.0.1)
   logstasher (= 0.6.1)


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information