### PR TITLE
Don't specify Ruby 1.9.1 in Bundler bin stub

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
-#!/usr/bin/env ruby1.9.1
+#!/usr/bin/env ruby
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 load Gem.bin_path('bundler', 'bundle')


### PR DESCRIPTION
I was suprised that `bin/bundle` uses Ruby 1.9.1 whereas `.ruby-version`
specifies Ruby 2.1.4. I noticed this because I don't have a `ruby1.91`
executable in my path on my Mac.

Looking at alphagov/contacts-frontend and alphagov/manuals-frontend,
both of those applications specify `/usr/bin/env ruby` in their
`bin/bundle` stubs. This makes more sense to me, since `/usr/bin/env
ruby` will invoke the Ruby version set in `.ruby-version` via rbenv:

    matt➜~/govuk/government-frontend(bundle_ruby_version✗)» /usr/bin/env ruby --version
    ruby 2.1.4p265 (2014-10-27 revision 48166) [x86_64-darwin13.0]
    matt➜~/govuk/government-frontend(bundle_ruby_version✗)» cat .ruby-version
    2.1.4
    matt➜~/govuk/government-frontend(bundle_ruby_version✗)»