### PR TITLE
Update statistics format labels

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -278,7 +278,7 @@ ar:
         few:
         many:
         other: "مجموعات بيانات إحصائية"
-      statistics:
+      official_statistics:
         zero:
         one: "إحصائية"
         two:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -120,7 +120,7 @@ az:
       statistical_data_set:
         one: statistik məlumatlar bazası
         other: statistik məlumatlar bazaları
-      statistics:
+      official_statistics:
         one: statistika
         other: statistika
       statutory_guidance:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -198,7 +198,7 @@ be:
         few:
         many:
         other: "Статыстычныя дадзеныя"
-      statistics:
+      official_statistics:
         one: "Статыстыка"
         few:
         many:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -120,7 +120,7 @@ bg:
       statistical_data_set:
         one: "Набор от статистически данни"
         other: "Набори от статистически данни"
-      statistics:
+      official_statistics:
         one: "Статистики"
         other: "Статистики"
       statutory_guidance:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -120,7 +120,7 @@ bn:
       statistical_data_set:
         one:
         other:
-      statistics:
+      official_statistics:
         one:
         other:
       statutory_guidance:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -159,7 +159,7 @@ cs:
         one: Statistická data
         few:
         other: Statistická data
-      statistics:
+      official_statistics:
         one: Statistika
         few:
         other: Statistiky

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -276,7 +276,7 @@ cy:
         few:
         many:
         other: Setiau data ystadegol
-      statistics:
+      official_statistics:
         zero:
         one: Ystadegau
         two:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -120,7 +120,7 @@ de:
       statistical_data_set:
         one: Statistischer Datensatz
         other: Statistische Datensätze
-      statistics:
+      official_statistics:
         one: Statistik
         other: Statistiken
       statutory_guidance:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -120,7 +120,7 @@ dr:
       statistical_data_set:
         one: "ارقام احصائیوی"
         other: "ارقام احصائیوی"
-      statistics:
+      official_statistics:
         one: "احصائیه ها"
         other: "احصائیه ها"
       statutory_guidance:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -120,7 +120,7 @@ el:
       statistical_data_set:
         one: "Στατιστικά στοιχεία"
         other: "Στατιστικά στοιχεία"
-      statistics:
+      official_statistics:
         one: "Στατιστικά στοιχεία"
         other: "Στατιστικά στοιχεία"
       statutory_guidance:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,8 +122,8 @@ en:
         one: World priority
         other: World priorities
       national_statistics:
-        one: Statistics - national statistics
-        other: Statistics - national statistics
+        one: National statistics
+        other: National statistics
       news_article:
         one: News article
         other: News articles
@@ -172,9 +172,9 @@ en:
       statistical_data_set:
         one: Statistical data set
         other: Statistical data sets
-      statistics:
-        one: Statistics
-        other: Statistics
+      official_statistics:
+        one: Official statistics
+        other: Official statistics
       transcript:
         one: Transcript
         other: Transcripts

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -120,7 +120,7 @@ es-419:
       statistical_data_set:
         one: Conjunto de datos estadísticos
         other: Conjuntos de datos estadísticos
-      statistics:
+      official_statistics:
         one: Estadísticas
         other: Estadísticas
       statutory_guidance:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -120,7 +120,7 @@ es:
       statistical_data_set:
         one: Conjunto de datos estadísticos
         other: Conjuntos de datos estadísticos
-      statistics:
+      official_statistics:
         one: Estadísticas
         other: Estadísticas
       statutory_guidance:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -120,7 +120,7 @@ et:
       statistical_data_set:
         one: Statistiline andmekogu
         other: Statistilised andmekogud
-      statistics:
+      official_statistics:
         one: 'Statistika '
         other: Statistika
       statutory_guidance:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -120,7 +120,7 @@ fa:
       statistical_data_set:
         one: "بسته ی داده های آماری"
         other: "بسته های داده های آماری"
-      statistics:
+      official_statistics:
         one: "آمار"
         other: "آمار"
       statutory_guidance:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -120,7 +120,7 @@ fr:
       statistical_data_set:
         one: Ensemble de données statistiques
         other: Ensembles de données statistiques
-      statistics:
+      official_statistics:
         one: Statistiques
         other: Statistiques
       statutory_guidance:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -198,7 +198,7 @@ he:
         two:
         many:
         other: "מידע סטטיסטי"
-      statistics:
+      official_statistics:
         one: "נתונים"
         two:
         many:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -120,7 +120,7 @@ hi:
       statistical_data_set:
         one: "सांख्यिकीय आंकड़े का समूह"
         other: "सांख्यिकीय आंकड़े का समूह"
-      statistics:
+      official_statistics:
         one: "आंकड़े"
         other: "आंकड़े"
       statutory_guidance:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -120,7 +120,7 @@ hu:
       statistical_data_set:
         one: Statisztikai adatcsoport
         other: Statisztikai adatcsoportok
-      statistics:
+      official_statistics:
         one: Statisztika
         other: Statisztikák
       statutory_guidance:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -120,7 +120,7 @@ hy:
       statistical_data_set:
         one: "Վիճակագրական տվյալ"
         other: "Վիճակագրական տվյալներ"
-      statistics:
+      official_statistics:
         one: "Վիճակագրություն"
         other: "Վիճակագրություն"
       statutory_guidance:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -120,7 +120,7 @@ id:
       statistical_data_set:
         one: Set data statistik
         other: Set data statistik
-      statistics:
+      official_statistics:
         one: Statistik
         other: Statistik-statistik
       statutory_guidance:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -120,7 +120,7 @@ it:
       statistical_data_set:
         one: Dati statistici
         other: Dati stitistici
-      statistics:
+      official_statistics:
         one: Statistica
         other: Statistiche
       statutory_guidance:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -120,7 +120,7 @@ ja:
       statistical_data_set:
         one: "統計データセット"
         other: "統計データセット"
-      statistics:
+      official_statistics:
         one: "統計"
         other: "統計"
       statutory_guidance:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -120,7 +120,7 @@ ka:
       statistical_data_set:
         one:
         other:
-      statistics:
+      official_statistics:
         one:
         other:
       statutory_guidance:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -120,7 +120,7 @@ ko:
       statistical_data_set:
         one: "통계 데이터 세트"
         other: "통계 데이터 세트"
-      statistics:
+      official_statistics:
         one: "통계"
         other: "통계"
       statutory_guidance:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -159,7 +159,7 @@ lt:
         one: Statistiniai duomenys
         few:
         other: Statistiniai duomenys
-      statistics:
+      official_statistics:
         one: Statistika
         few:
         other: Statistika

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -120,7 +120,7 @@ lv:
       statistical_data_set:
         one: Statistiskas datu kopums
         other: Statistikas datu kopumi
-      statistics:
+      official_statistics:
         one: Statistika
         other: Statistika
       statutory_guidance:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -120,7 +120,7 @@ ms:
       statistical_data_set:
         one:
         other:
-      statistics:
+      official_statistics:
         one:
         other:
       statutory_guidance:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -198,7 +198,7 @@ pl:
         few:
         many:
         other: Zestawy danych statystycznych
-      statistics:
+      official_statistics:
         one: Statystyki
         few:
         many:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -120,7 +120,7 @@ ps:
       statistical_data_set:
         one: "د شمیرنې اطلاعات"
         other: "د شمیرنې اطلاعات"
-      statistics:
+      official_statistics:
         one: "شمیرنه"
         other: "شمیرنه"
       statutory_guidance:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -120,7 +120,7 @@ pt:
       statistical_data_set:
         one: Conjunto de dados estastísticos
         other: Conjuntos de dados estatísticos
-      statistics:
+      official_statistics:
         one: Estatística
         other: Estatísticas
       statutory_guidance:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -159,7 +159,7 @@ ro:
         one: Date statistice
         few:
         other: Date statistice
-      statistics:
+      official_statistics:
         one: Statistici
         few:
         other: Statistici

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -198,7 +198,7 @@ ru:
         few:
         many:
         other: "Статистические данные"
-      statistics:
+      official_statistics:
         one: "Статистика"
         few:
         many:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -120,7 +120,7 @@ si:
       statistical_data_set:
         one: "සංඛ්යාන දත්ත සමූහය  "
         other: "සංඛ්යාන දත්ත සමූහ"
-      statistics:
+      official_statistics:
         one: "සංඛ්යාන"
         other: "සංඛ්යාන"
       statutory_guidance:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -159,7 +159,7 @@ sk:
         one:
         few:
         other:
-      statistics:
+      official_statistics:
         one:
         few:
         other:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -120,7 +120,7 @@ so:
       statistical_data_set:
         one: Xirmo xog istaatistik ah
         other: Xirmooyin xog istaatistik ah
-      statistics:
+      official_statistics:
         one: Istaatistik
         other: Istaatistik
       statutory_guidance:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -120,7 +120,7 @@ sq:
       statistical_data_set:
         one: Grup te dhenash statistikore
         other: Grupe te dhenash stasistikore
-      statistics:
+      official_statistics:
         one: Statistika
         other: Statistika
       statutory_guidance:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -198,7 +198,7 @@ sr:
         few:
         many:
         other: set statističkih podataka
-      statistics:
+      official_statistics:
         one: statistika
         few:
         many:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -120,7 +120,7 @@ sw:
       statistical_data_set:
         one:
         other:
-      statistics:
+      official_statistics:
         one:
         other:
       statutory_guidance:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -120,7 +120,7 @@ ta:
       statistical_data_set:
         one: "புள்ளிவிபர தரவுத் தொகுதி"
         other: "புள்ளிவிபர தரவுத் தொகுதிகள்"
-      statistics:
+      official_statistics:
         one: "புள்ளிவிபரம்"
         other: "புள்ளிவிபரம்"
       statutory_guidance:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -120,7 +120,7 @@ th:
       statistical_data_set:
         one: "ชุดข้อมูลสถิติ"
         other: "ชุดข้อมูลสถิติ"
-      statistics:
+      official_statistics:
         one: "สถิติ"
         other: "สถิติ"
       statutory_guidance:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -120,7 +120,7 @@ tk:
       statistical_data_set:
         one:
         other:
-      statistics:
+      official_statistics:
         one:
         other:
       statutory_guidance:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -120,7 +120,7 @@ tr:
       statistical_data_set:
         one: "İstatiksel veri setleri"
         other: "İstatiksel veri setleri"
-      statistics:
+      official_statistics:
         one: "İstatistikler"
         other: "İstatistikler"
       statutory_guidance:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -198,7 +198,7 @@ uk:
         few:
         many:
         other: "Набори статистичних даних"
-      statistics:
+      official_statistics:
         one: "Статистика"
         few:
         many:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -120,7 +120,7 @@ ur:
       statistical_data_set:
         one: "شماریاتی ڈیٹا سیٹ"
         other: " شماریاتی ڈیٹا سیٹس"
-      statistics:
+      official_statistics:
         one: "اعدادوشمار"
         other: "اعدادو شمار"
       statutory_guidance:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -120,7 +120,7 @@ uz:
       statistical_data_set:
         one: Statistika ma'lumot to'plami
         other: Statistika ma'lumot to'plamlari
-      statistics:
+      official_statistics:
         one: Statistika
         other: Statistika
       statutory_guidance:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -120,7 +120,7 @@ vi:
       statistical_data_set:
         one: Bộ dữ liệu thống kê
         other: Bộ dữ liệu thống kê
-      statistics:
+      official_statistics:
         one: Thống kê
         other: Thống kê
       statutory_guidance:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -120,7 +120,7 @@ zh-hk:
       statistical_data_set:
         one: "統計數據資料"
         other: "其他統計數據資料"
-      statistics:
+      official_statistics:
         one: "統計資料"
         other: "其他統計資料"
       statutory_guidance:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -120,7 +120,7 @@ zh-tw:
       statistical_data_set:
         one: "統計數據資料"
         other: "其他統計數據料"
-      statistics:
+      official_statistics:
         one: "統計"
         other: "統計"
       statutory_guidance:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -122,7 +122,7 @@ zh:
       statistical_data_set:
         one: "统计数据集"
         other: "统计数据集"
-      statistics:
+      official_statistics:
         one: "统计数据"
         other: "统计数据"
       statutory_guidance:


### PR DESCRIPTION
The Statistics type is only used for publishing Official Statistics, so let's
make that clearer. The national statistics label is simplified as well.

This change doesn't include translations, as we don't have the translated
strings.

Trello: https://trello.com/c/TxBvx7tD/27-make-it-clearer-that-statistics-are-official-or-national-medium

/cc @boffbowsh 