### PR TITLE
Capitalising Official and National [S]tatistics

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,8 +122,8 @@ en:
         one: World priority
         other: World priorities
       national_statistics:
-        one: National statistics
-        other: National statistics
+        one: National Statistics
+        other: National Statistics
       news_article:
         one: News article
         other: News articles
@@ -173,8 +173,8 @@ en:
         one: Statistical data set
         other: Statistical data sets
       official_statistics:
-        one: Official statistics
-        other: Official statistics
+        one: Official Statistics
+        other: Official Statistics
       transcript:
         one: Transcript
         other: Transcripts


### PR DESCRIPTION
Changes to bring label in line with the style guide, following feedback from the Content team.

https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#statistics

/cc @boffbowsh 