### PR TITLE
Use real data when rendering service manual frontend guides

### DIFF
--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -1,4 +1,5 @@
 class ServiceManualGuidePresenter
+  include ActionView::Helpers::DateHelper
   attr_reader :content_item, :title, :body, :format, :locale, :publish_time, :header_links
 
   def initialize(content_item)
@@ -9,5 +10,19 @@ class ServiceManualGuidePresenter
     @header_links = content_item["details"]["header_links"]
                       .map{|h| ActiveSupport::HashWithIndifferentAccess.new(h)}
     @format = content_item["format"]
+  end
+
+  def last_updated_ago_in_words
+    "#{time_ago_in_words(updated_at)} ago"
+  end
+
+  def last_update_timestamp
+    updated_at.strftime("%e %B %Y %H:%M")
+  end
+
+private
+
+  def updated_at
+    DateTime.parse(content_item["public_updated_at"])
   end
 end

--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -1,4 +1,7 @@
 class ServiceManualGuidePresenter
+  ContentOwner = Struct.new(:title, :href)
+  RelatedDiscussion = Struct.new(:title, :href)
+
   include ActionView::Helpers::DateHelper
   attr_reader :content_item, :title, :body, :format, :locale, :publish_time, :header_links
 
@@ -10,6 +13,18 @@ class ServiceManualGuidePresenter
     @header_links = Array(content_item["details"]["header_links"])
                       .map{ |h| ActiveSupport::HashWithIndifferentAccess.new(h) }
     @format = content_item["format"]
+  end
+
+  def content_owner
+    content_owner_data = content_item["details"]["content_owner"]
+    ContentOwner.new(content_owner_data["title"], content_owner_data["href"])
+  end
+
+  def related_discussion
+    if content_item["details"]["related_discussion"]
+      discussion_data = content_item["details"]["related_discussion"]
+      RelatedDiscussion.new(discussion_data['title'], discussion_data['href'])
+    end
   end
 
   def last_updated_ago_in_words

--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -7,8 +7,8 @@ class ServiceManualGuidePresenter
 
     @title = content_item["title"]
     @body = content_item["details"]["body"]
-    @header_links = content_item["details"]["header_links"]
-                      .map{|h| ActiveSupport::HashWithIndifferentAccess.new(h)}
+    @header_links = Array(content_item["details"]["header_links"])
+                      .map{ |h| ActiveSupport::HashWithIndifferentAccess.new(h) }
     @format = content_item["format"]
   end
 

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -46,7 +46,9 @@
         <dt>Related discussion:</dt>
         <dd><a href="/government/topics/arts-and-culture" rel="external">Arts and culture</a></dd>
         <dt>Last updated:</dt>
-        <dd><a href="#">Updated 2 weeks ago</a></dd>
+        <dd>
+          <%= link_to @content_item.last_updated_ago_in_words, "#", title: @content_item.last_update_timestamp %>
+        </dd>
       </dl>
     </div>
 

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -42,9 +42,15 @@
     <div class="metadata">
       <dl>
         <dt>Published by:</dt>
-        <dd><a href="#">Design community</a></dd>
-        <dt>Related discussion:</dt>
-        <dd><a href="/government/topics/arts-and-culture" rel="external">Arts and culture</a></dd>
+        <dd>
+          <%= link_to @content_item.content_owner.title, @content_item.content_owner.href %>
+        </dd>
+        <% if @content_item.related_discussion %>
+          <dt>Related discussion:</dt>
+          <dd>
+            <%= link_to @content_item.related_discussion.title, @content_item.related_discussion.href, rel: 'external' %>
+          </dd>
+        <% end %>
         <dt>Last updated:</dt>
         <dd>
           <%= link_to @content_item.last_updated_ago_in_words, "#", title: @content_item.last_update_timestamp %>

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_class, "service-manual-guide" %>
+<%= content_for :title, "#{@content_item.title} - Digital Service Manual" %>
 
 <!-- Breadcrumb -->
 <div class="breadcrumb">

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -1,20 +1,28 @@
 require 'test_helper'
 
 class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
-  test 'presents the basic details required to display a short text item' do
-    assert_equal "the title", presented_short_text.title
-    assert_equal "the format", presented_short_text.format
-    assert_equal "the body", presented_short_text.body
-    assert_equal [{"title" => "title", "href" => "href"}], presented_short_text.header_links
+  test 'presents the basic details required to display a Service Manual Guide' do
+    assert_equal "Agile", presented_guide.title
+    assert_equal "service_manual_guide", presented_guide.format
+    assert presented_guide.body.size > 10
+    assert presented_guide.header_links.size >= 1
   end
 
-  private
+  test '#last_updated_ago_in_words outputs a human readable definition of time ago' do
+    guide = presented_guide('public_updated_at' => 1.year.ago.iso8601)
+    assert_equal 'about 1 year ago', guide.last_updated_ago_in_words
+  end
 
-  def presented_short_text
-    ServiceManualGuidePresenter.new({
-      "title"  => "the title",
-      "details" => { "body" => "the body", "header_links" => [{"title" => "title", "href" => "href"}]},
-      "format" => "the format",
-    })
+  test '#last_update_timestamp outputs a nicely formatted timestamp' do
+    guide = presented_guide('public_updated_at' => '2014-10-26T10:27:34Z')
+    assert_equal '26 October 2014 10:27', guide.last_update_timestamp
+  end
+
+private
+
+  def presented_guide(overriden_attributes = {})
+    ServiceManualGuidePresenter.new(
+      JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('service_manual_guide', 'basic_with_related_discussions')).merge(overriden_attributes)
+    )
   end
 end

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -6,6 +6,14 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
     assert_equal "service_manual_guide", presented_guide.format
     assert presented_guide.body.size > 10
     assert presented_guide.header_links.size >= 1
+
+    content_owner = presented_guide.content_owner
+    assert content_owner.title.present?
+    assert content_owner.href.present?
+
+    related_discussion = presented_guide.related_discussion
+    assert related_discussion.title.present?
+    assert related_discussion.href.present?
   end
 
   test '#last_updated_ago_in_words outputs a human readable definition of time ago' do


### PR DESCRIPTION
We had a couple of placeholders on the guides page. Real data is being published now, so we can display it on the page.