### PR TITLE
Show an alpha banner on the guide page

### DIFF
--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -1,5 +1,7 @@
 <%= content_for :page_class, "service-manual-guide" %>
 
+<%= render partial: 'govuk_component/alpha_label' %>
+
 <!-- Breadcrumb -->
 <div class="breadcrumb">
   <ol>


### PR DESCRIPTION
Use the govuk component - Alpha label, to indicate the content is in an
alpha phase.