### PR TITLE
Render phase labels

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development do
 end
 
 group :test do
+  gem 'capybara'
   gem 'webmock', '~> 1.18.0', :require => false
   gem 'govuk-content-schema-test-helpers', '1.1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,12 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
+    capybara (2.5.0)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     coderay (1.1.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
@@ -161,6 +167,8 @@ GEM
     webmock (1.18.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -169,6 +177,7 @@ DEPENDENCIES
   airbrake (= 4.0)
   better_errors
   binding_of_caller
+  capybara
   gds-api-adapters (= 20.1.1)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk_frontend_toolkit (= 2.0.1)

--- a/app/helpers/phase_label_helper.rb
+++ b/app/helpers/phase_label_helper.rb
@@ -1,0 +1,7 @@
+module PhaseLabelHelper
+  def render_phase_label(presented_object)
+    if presented_object.respond_to?(:phase) && %w(alpha beta).include?(presented_object.phase)
+      render partial: "govuk_component/#{presented_object.phase}_label"
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,5 +1,5 @@
 class ContentItemPresenter
-  attr_reader :content_item, :title, :description, :format, :locale
+  attr_reader :content_item, :title, :description, :format, :locale, :phase
 
   def initialize(content_item)
     @content_item = content_item
@@ -7,6 +7,7 @@ class ContentItemPresenter
     @description = content_item["description"]
     @format = content_item["format"]
     @locale = content_item["locale"] || "en"
+    @phase = content_item["phase"]
   end
 
   def available_translations

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,8 @@
 
   <div id="wrapper" class="<%= wrapper_class %>">
     <main role="main" id="content" class="<%= yield(:page_class) %>" lang="<%= I18n.locale %>">
-        <%= yield %>
+      <%= render_phase_label @content_item %>
+      <%= yield %>
     </main>
   </div>
 </body>

--- a/test/integration/phase_label_test.rb
+++ b/test/integration/phase_label_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class PhaseLabelTest < ActionDispatch::IntegrationTest
+  test "Beta phase label is displayed for a Service Manual Guide in phase 'beta'" do
+    ENV["FLAG_ENABLE_SERVICE_MANUAL"] = 'yes'
+    guide_sample = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('service_manual_guide', 'basic_with_related_discussions'))
+    guide_sample.merge!("phase" => "beta")
+    content_store_has_item("/service-manual/agile", guide_sample.to_json)
+
+    visit "/service-manual/agile"
+
+    assert_has_phase_label "beta"
+    ENV.delete("FLAG_ENABLE_SERVICE_MANUAL")
+  end
+
+  test "Alpha phase label is displayed for a Case Study in phase 'alpha'" do
+    case_study = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('case_study', 'case_study'))
+    case_study.merge!("phase" => "alpha")
+    content_store_has_item("/government/case-studies/get-britain-building-carlisle-park", case_study.to_json)
+
+    visit "/government/case-studies/get-britain-building-carlisle-park"
+
+    assert_has_phase_label "alpha"
+  end
+
+  test "No phase label is displayed for a Content item without a phase field" do
+    content_item = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('case_study', 'case_study'))
+    content_item.delete("phase")
+    content_store_has_item("/government/case-studies/get-britain-building-carlisle-park", content_item.to_json)
+
+    visit "/government/case-studies/get-britain-building-carlisle-park"
+
+    assert page.has_no_css?("[data-template='govuk_component-alpha_label']")
+    assert page.has_no_css?("[data-template='govuk_component-beta_label']")
+  end
+
+private
+
+  def assert_has_phase_label(phase)
+    within "[data-template='govuk_component-#{phase}_label']" do
+      assert page.has_content?("#{phase}_label"), "Expected the page to have an '#{phase.titleize}' label"
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'webmock/minitest'
 require 'support/govuk_content_schema_examples'
+require 'capybara/rails'
 
 class ActiveSupport::TestCase
   include GovukContentSchemaExamples
@@ -14,4 +15,9 @@ class ActionController::Base
   before_filter proc {
     response.headers[Slimmer::Headers::SKIP_HEADER] = "true" unless ENV["USE_SLIMMER"]
   }
+end
+
+class ActionDispatch::IntegrationTest
+  # Make the Capybara DSL available in all integration tests
+  include Capybara::DSL
 end


### PR DESCRIPTION
If a content item responds to `#phase` and it has a value of either 'alpha' or 'beta' render a component with the corresponding label. ~~Currently only Service Manual Guide presenter responds to `#phase` so only this format will be affected. I chose to not expose `phase` in ContentItemPresenter (used by Case Studies atm), because I don't know if the team that owns this format expects the `phase` field value to trigger this feature.~~

~~I'm not particularly happy with the helper test: Rails helpers fail when `render` is invoked on them in test environment. The default Rails test does not have tools for stubbed expectations, so I ended up overwriting `render` method in the test class to serve my purpose.~~

~~Alternatives I can think of: do not use a helper, just have a conditional in the application layout. Test setup would be a bit more difficult for this alternative though.~~

~~Any other ideas?~~

Update: see updated commit and its note.

Closes #65 

/cc @jamiecobbett 