### PR TITLE
Base presenter

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -27,7 +27,7 @@ private
     end
 
     case content_item['format']
-      when 'case_study' then ContentItemPresenter.new(content_item)
+      when 'case_study' then CaseStudyPresenter.new(content_item)
       when 'unpublishing' then UnpublishingPresenter.new(content_item)
       when 'coming_soon' then ComingSoonPresenter.new(content_item)
       else raise "No support for format \"#{content_item['format']}\""

--- a/app/presenters/case_study_presenter.rb
+++ b/app/presenters/case_study_presenter.rb
@@ -1,0 +1,91 @@
+class CaseStudyPresenter < ContentItemPresenter
+  include ActionView::Helpers::UrlHelper
+
+  attr_reader :body, :format_display_type
+
+  def initialize(content_item)
+    super
+    @body = content_item["details"]["body"]
+    @format_display_type = content_item["details"]["format_display_type"]
+  end
+
+  def from
+    links("lead_organisations") + links("supporting_organisations") + links("worldwide_organisations")
+  end
+
+  def part_of
+    links("document_collections") + links("related_policies") + links("worldwide_priorities") + links("world_locations")
+  end
+
+  def history
+    return [] unless any_updates?
+    content_item["details"]["change_history"].map do |item|
+      {
+        display_time: display_time(item["public_timestamp"]),
+        note: item["note"],
+        timestamp: item["public_timestamp"]
+      }
+    end
+  end
+
+  def published
+    display_time(content_item["details"]["first_public_at"])
+  end
+
+  def updated
+    if any_updates?
+      display_time(content_item["public_updated_at"])
+    end
+  end
+
+  def short_history
+    if any_updates?
+      "#{I18n.t('content_item.metadata.updated')} #{updated}"
+    else
+      "#{I18n.t('content_item.metadata.published')} #{published}"
+    end
+  end
+
+  def image
+    content_item["details"]["image"]
+  end
+
+  def withdrawn?
+    content_item["details"].include?("withdrawn_notice")
+  end
+
+  def page_title
+    withdrawn? ? "[Withdrawn] #{title}" : title
+  end
+
+
+  def withdrawal_notice
+    if notice = content_item["details"]["withdrawn_notice"]
+      {
+        time: content_tag(:time, display_time(notice["withdrawn_at"]), datetime: notice["withdrawn_at"]),
+        explanation: notice["explanation"]
+      }
+    end
+  end
+
+private
+
+  def display_time(timestamp)
+    I18n.l(Date.parse(timestamp), format: "%-d %B %Y") if timestamp
+  end
+
+  def any_updates?
+    if (first_public_at = content_item["details"]["first_public_at"]).present?
+      DateTime.parse(content_item["public_updated_at"]) != DateTime.parse(first_public_at)
+    else
+      false
+    end
+  end
+
+  def links(type)
+    return [] unless content_item["links"][type]
+    content_item["links"][type].map do |link|
+      link_to(link["title"], link["base_path"])
+    end
+  end
+end

--- a/app/presenters/coming_soon_presenter.rb
+++ b/app/presenters/coming_soon_presenter.rb
@@ -1,12 +1,8 @@
-class ComingSoonPresenter
-  attr_reader :content_item, :title, :format, :locale, :publish_time
+class ComingSoonPresenter < ContentItemPresenter
+  attr_reader :publish_time
 
   def initialize(content_item)
-    @content_item = content_item
-
-    @title = content_item["title"]
-    @format = content_item["format"]
-    @locale = content_item["locale"] || "en"
+    super
     @publish_time = content_item["details"]["publish_time"]
   end
 

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,80 +1,16 @@
 class ContentItemPresenter
-  include ActionView::Helpers::UrlHelper
-
-  attr_reader :content_item, :title, :description, :body, :format, :format_display_type, :locale
+  attr_reader :content_item, :title, :description, :format, :locale
 
   def initialize(content_item)
     @content_item = content_item
-
     @title = content_item["title"]
     @description = content_item["description"]
-    @body = content_item["details"]["body"]
     @format = content_item["format"]
-    @format_display_type = content_item["details"]["format_display_type"]
     @locale = content_item["locale"] || "en"
-  end
-
-  def from
-    links("lead_organisations") + links("supporting_organisations") + links("worldwide_organisations")
-  end
-
-  def part_of
-    links("document_collections") + links("related_policies") + links("worldwide_priorities") + links("world_locations")
   end
 
   def available_translations
     sorted_locales(@content_item["links"]["available_translations"])
-  end
-
-  def history
-    return [] unless any_updates?
-    content_item["details"]["change_history"].map do |item|
-      {
-        display_time: display_time(item["public_timestamp"]),
-        note: item["note"],
-        timestamp: item["public_timestamp"]
-      }
-    end
-  end
-
-  def published
-    display_time(content_item["details"]["first_public_at"])
-  end
-
-  def updated
-    if any_updates?
-      display_time(content_item["public_updated_at"])
-    end
-  end
-
-  def short_history
-    if any_updates?
-      "#{I18n.t('content_item.metadata.updated')} #{updated}"
-    else
-      "#{I18n.t('content_item.metadata.published')} #{published}"
-    end
-  end
-
-  def image
-    content_item["details"]["image"]
-  end
-
-  def withdrawn?
-    content_item["details"].include?("withdrawn_notice")
-  end
-
-  def page_title
-    withdrawn? ? "[Withdrawn] #{title}" : title
-  end
-
-
-  def withdrawal_notice
-    if notice = content_item["details"]["withdrawn_notice"]
-      {
-        time: content_tag(:time, display_time(notice["withdrawn_at"]), datetime: notice["withdrawn_at"]),
-        explanation: notice["explanation"]
-      }
-    end
   end
 
 private
@@ -82,23 +18,5 @@ private
   def sorted_locales(translations)
     translations.sort_by { |t| t["locale"] == I18n.default_locale.to_s ? '' : t["locale"] }
   end
-
-  def display_time(timestamp)
-    I18n.l(Date.parse(timestamp), format: "%-d %B %Y") if timestamp
-  end
-
-  def any_updates?
-    if (first_public_at = content_item["details"]["first_public_at"]).present?
-      DateTime.parse(content_item["public_updated_at"]) != DateTime.parse(first_public_at)
-    else
-      false
-    end
-  end
-
-  def links(type)
-    return [] unless content_item["links"][type]
-    content_item["links"][type].map do |link|
-      link_to(link["title"], link["base_path"])
-    end
-  end
 end
+

--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -1,18 +1,15 @@
-class ServiceManualGuidePresenter
+class ServiceManualGuidePresenter < ContentItemPresenter
   ContentOwner = Struct.new(:title, :href)
   RelatedDiscussion = Struct.new(:title, :href)
 
   include ActionView::Helpers::DateHelper
-  attr_reader :content_item, :title, :body, :format, :locale, :publish_time, :header_links
+  attr_reader :body, :publish_time, :header_links
 
   def initialize(content_item)
-    @content_item = content_item
-
-    @title = content_item["title"]
+    super
     @body = content_item["details"]["body"]
     @header_links = Array(content_item["details"]["header_links"])
                       .map{ |h| ActiveSupport::HashWithIndifferentAccess.new(h) }
-    @format = content_item["format"]
   end
 
   def content_owner

--- a/app/presenters/unpublishing_presenter.rb
+++ b/app/presenters/unpublishing_presenter.rb
@@ -1,11 +1,8 @@
-class UnpublishingPresenter
-  attr_reader :alternative_url, :content_item, :explanation, :format, :locale
+class UnpublishingPresenter < ContentItemPresenter
+  attr_reader :alternative_url, :explanation
 
   def initialize(content_item)
-    @content_item = content_item
-
-    @format = content_item['format']
-    @locale = content_item['locale']
+    super
     @explanation = content_item['details']['explanation']
     @alternative_url = content_item['details']['alternative_url']
   end

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -1,0 +1,111 @@
+require 'test_helper'
+
+class CaseStudyPresenterTest < ActiveSupport::TestCase
+  include ActionView::Helpers::UrlHelper
+
+  test 'presents the basic details of a content item' do
+    assert_equal case_study['description'], presented_case_study.description
+    assert_equal case_study['format'], presented_case_study.format
+    assert_equal case_study['locale'], presented_case_study.locale
+    assert_equal case_study['title'], presented_case_study.title
+    assert_equal case_study['details']['body'], presented_case_study.body
+    assert_equal case_study['details']['format_display_type'], presented_case_study.format_display_type
+  end
+
+  test '#published returns a formatted date of the day the content item became public' do
+    assert_equal '17 December 2012', presented_case_study.published
+  end
+
+  test '#updated returns nil if the content item has no updates' do
+    assert_nil presented_case_study.updated
+  end
+
+  test '#updated returns a formatted date of the last day the content item was updated' do
+    assert_equal '21 March 2013', presented_case_study_with_updates.updated
+  end
+
+  test '#short_history returns the published day of a non-updated content item' do
+    assert_equal 'Published 17 December 2012', presented_case_study.short_history
+  end
+
+  test '#short_history returns the last update day for a content item that has updates' do
+    assert_equal 'Updated 21 March 2013', presented_case_study_with_updates.short_history
+  end
+
+  test '#from returns links to lead organisations, supporting organisations and worldwide organisations' do
+    with_organisations = case_study
+    with_organisations['links']['lead_organisations'] = [
+      { "title" => 'Lead org', "base_path" => '/orgs/lead'}
+    ]
+    with_organisations['links']['supporting_organisations'] = [
+      { "title" => 'Supporting org', "base_path" => '/orgs/supporting' }
+    ]
+
+    expected_from_links = [
+      link_to('Lead org', '/orgs/lead'),
+      link_to('Supporting org', '/orgs/supporting'),
+      link_to('DFID Pakistan', '/government/world/organisations/dfid-pakistan'),
+    ]
+
+    assert_equal expected_from_links, presented_case_study(with_organisations).from
+  end
+
+  test '#part_of returns an array of document_collections, related policies, worldwide priorities and world locations' do
+    with_extras = case_study
+    with_extras['links']['document_collections'] = [
+      { "title" => "Work Programme real life stories", "base_path" => "/government/collections/work-programme-real-life-stories" }
+    ]
+    with_extras['links']['related_policies'] = [
+      { "title" => "Cheese", "base_path" => "/policy/cheese" }
+    ]
+    with_extras['links']['worldwide_priorities'] = [
+      { "title" => "Cheese around the world", "base_path" => "/world_prior/cheese" }
+    ]
+
+    expected_part_of_links = [
+      link_to('Work Programme real life stories', '/government/collections/work-programme-real-life-stories'),
+      link_to('Cheese', '/policy/cheese'),
+      link_to('Cheese around the world', '/world_prior/cheese'),
+      link_to('Pakistan', '/government/world/pakistan'),
+    ]
+    assert_equal expected_part_of_links, presented_case_study(with_extras).part_of
+  end
+
+  test '#history returns an empty array if the content item has no updates' do
+    assert_equal [], presented_case_study.history
+  end
+
+  test '#history returns a formatted history if the content item has updates' do
+    expected_history = [
+      { display_time: '21 March 2013', note: 'Something changed', timestamp: '2013-03-21T00:00:00+00:00'},
+    ]
+
+    assert_equal expected_history, presented_case_study_with_updates.history
+  end
+
+  test '#history returns an empty array if the content item is not published' do
+    never_published = case_study
+    never_published['details'].delete('first_public_at')
+    presented = CaseStudyPresenter.new(never_published)
+    assert_equal [], presented.history
+  end
+
+private
+
+  def presented_case_study(overrides={})
+    CaseStudyPresenter.new(case_study.merge(overrides))
+  end
+
+  def presented_case_study_with_updates
+    march_21_2013 = DateTime.new(2013, 3, 21).to_s
+    with_history = case_study
+    with_history['details']['change_history'] = [{ 'note' => 'Something changed', 'public_timestamp' => march_21_2013 }]
+    with_history['public_updated_at'] = march_21_2013
+
+    presented_case_study(with_history)
+  end
+
+  def case_study
+    govuk_content_schema_example('case_study', 'case_study')
+  end
+end

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -1,117 +1,25 @@
 require 'test_helper'
 
 class ContentItemPresenterTest < ActiveSupport::TestCase
-  include ActionView::Helpers::UrlHelper
-
-  test 'presents the basic details of a content item' do
-    assert_equal case_study['description'], presented_case_study.description
-    assert_equal case_study['format'], presented_case_study.format
-    assert_equal case_study['locale'], presented_case_study.locale
-    assert_equal case_study['title'], presented_case_study.title
-    assert_equal case_study['details']['body'], presented_case_study.body
-    assert_equal case_study['details']['format_display_type'], presented_case_study.format_display_type
+  test "#title" do
+    assert_equal "Title", ContentItemPresenter.new("title" => "Title").title
   end
 
-  test '#published returns a formatted date of the day the content item became public' do
-    assert_equal '17 December 2012', presented_case_study.published
+  test "#description" do
+    assert_equal "Description", ContentItemPresenter.new("description" => "Description").description
   end
 
-  test '#updated returns nil if the content item has no updates' do
-    assert_nil presented_case_study.updated
+  test "#format" do
+    assert_equal "Format", ContentItemPresenter.new("format" => "Format").format
   end
 
-  test '#updated returns a formatted date of the last day the content item was updated' do
-    assert_equal '21 March 2013', presented_case_study_with_updates.updated
-  end
-
-  test '#short_history returns the published day of a non-updated content item' do
-    assert_equal 'Published 17 December 2012', presented_case_study.short_history
-  end
-
-  test '#short_history returns the last update day for a content item that has updates' do
-    assert_equal 'Updated 21 March 2013', presented_case_study_with_updates.short_history
-  end
-
-  test '#from returns links to lead organisations, supporting organisations and worldwide organisations' do
-    with_organisations = case_study
-    with_organisations['links']['lead_organisations'] = [
-      { "title" => 'Lead org', "base_path" => '/orgs/lead'}
-    ]
-    with_organisations['links']['supporting_organisations'] = [
-      { "title" => 'Supporting org', "base_path" => '/orgs/supporting' }
-    ]
-
-    expected_from_links = [
-      link_to('Lead org', '/orgs/lead'),
-      link_to('Supporting org', '/orgs/supporting'),
-      link_to('DFID Pakistan', '/government/world/organisations/dfid-pakistan'),
-    ]
-
-    assert_equal expected_from_links, presented_case_study(with_organisations).from
-  end
-
-  test '#part_of returns an array of document_collections, related policies, worldwide priorities and world locations' do
-    with_extras = case_study
-    with_extras['links']['document_collections'] = [
-      { "title" => "Work Programme real life stories", "base_path" => "/government/collections/work-programme-real-life-stories" }
-    ]
-    with_extras['links']['related_policies'] = [
-      { "title" => "Cheese", "base_path" => "/policy/cheese" }
-    ]
-    with_extras['links']['worldwide_priorities'] = [
-      { "title" => "Cheese around the world", "base_path" => "/world_prior/cheese" }
-    ]
-
-    expected_part_of_links = [
-      link_to('Work Programme real life stories', '/government/collections/work-programme-real-life-stories'),
-      link_to('Cheese', '/policy/cheese'),
-      link_to('Cheese around the world', '/world_prior/cheese'),
-      link_to('Pakistan', '/government/world/pakistan'),
-    ]
-    assert_equal expected_part_of_links, presented_case_study(with_extras).part_of
-  end
-
-  test '#history returns an empty array if the content item has no updates' do
-    assert_equal [], presented_case_study.history
-  end
-
-  test '#history returns a formatted history if the content item has updates' do
-    expected_history = [
-      { display_time: '21 March 2013', note: 'Something changed', timestamp: '2013-03-21T00:00:00+00:00'},
-    ]
-
-    assert_equal expected_history, presented_case_study_with_updates.history
-  end
-
-  test '#history returns an empty array if the content item is not published' do
-    never_published = case_study
-    never_published['details'].delete('first_public_at')
-    presented = ContentItemPresenter.new(never_published)
-    assert_equal [], presented.history
+  test "#locale" do
+    assert_equal "ar", ContentItemPresenter.new("locale" => "ar").locale
   end
 
   test "available_translations sorts languages by locale with English first" do
     translated = govuk_content_schema_example('case_study', 'translated')
     locales = ContentItemPresenter.new(translated).available_translations
     assert_equal ['en', 'ar', 'es'], locales.map {|t| t["locale"]}
-  end
-
-private
-
-  def presented_case_study(overrides={})
-    ContentItemPresenter.new(case_study.merge(overrides))
-  end
-
-  def presented_case_study_with_updates
-    march_21_2013 = DateTime.new(2013, 3, 21).to_s
-    with_history = case_study
-    with_history['details']['change_history'] = [{ 'note' => 'Something changed', 'public_timestamp' => march_21_2013 }]
-    with_history['public_updated_at'] = march_21_2013
-
-    presented_case_study(with_history)
-  end
-
-  def case_study
-    govuk_content_schema_example('case_study', 'case_study')
   end
 end


### PR DESCRIPTION
Content item presenter was used to render `CaseStudy` format and had a lot of logic that's specific to this format. In order to make `ContentItemPresenter` useful for rendering other content types, I've extracted generic functionality to `ContentItemPresenter` and moved all case-study-specific functionality to a new `CaseStudyPresenter` class. Then I've made other presenters inherit from `ContentItemPresenter` to remove logic duplication.

__Note: this affects case studies, "unpublishing" pages, coming soon pages and service manual guides.__ It would be nice to thoroughly review the changes in case I've broken anything (I'm not familiar with formats other than Service Manual Guide).

This refactoring has been triggered by a discussion in #66. Once this is merged I'll reintroduce the change there that benefits from this refactoring.

/cc @dsingleton @jamiecobbett 