### PR TITLE
Enable service manual guide rendering, remove feature flag

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -22,14 +22,11 @@ private
   end
 
   def present(content_item)
-    if ENV["FLAG_ENABLE_SERVICE_MANUAL"].present? && content_item['format'] == 'service_manual_guide'
-      return ServiceManualGuidePresenter.new(content_item)
-    end
-
     case content_item['format']
       when 'case_study' then CaseStudyPresenter.new(content_item)
       when 'unpublishing' then UnpublishingPresenter.new(content_item)
       when 'coming_soon' then ComingSoonPresenter.new(content_item)
+      when 'service_manual_guide' then ServiceManualGuidePresenter.new(content_item)
       else raise "No support for format \"#{content_item['format']}\""
     end
   end

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -97,16 +97,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_select '.sidebar-image img[src="/government-frontend/placeholder.jpg"]', count: 1
   end
 
-  test 'when feature flag is NOT set, it does not get service manual content' do
-    content_item = content_store_has_schema_example('service_manual_guide', 'basic_with_related_discussions')
-
-    assert_raises do
-      get :show, path: path_for(content_item)
-    end
-  end
-
-  test 'when feature flag is set, it gets service manual content' do
-    ENV["FLAG_ENABLE_SERVICE_MANUAL"] = "yes"
+  test 'renders service manual guides' do
     content_item = content_store_has_schema_example('service_manual_guide', 'basic_with_related_discussions')
 
     get :show, path: path_for(content_item)

--- a/test/integration/phase_label_test.rb
+++ b/test/integration/phase_label_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class PhaseLabelTest < ActionDispatch::IntegrationTest
   test "Beta phase label is displayed for a Service Manual Guide in phase 'beta'" do
-    ENV["FLAG_ENABLE_SERVICE_MANUAL"] = 'yes'
     guide_sample = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('service_manual_guide', 'basic_with_related_discussions'))
     guide_sample.merge!("phase" => "beta")
     content_store_has_item("/service-manual/agile", guide_sample.to_json)
@@ -10,7 +9,6 @@ class PhaseLabelTest < ActionDispatch::IntegrationTest
     visit "/service-manual/agile"
 
     assert_has_phase_label "beta"
-    ENV.delete("FLAG_ENABLE_SERVICE_MANUAL")
   end
 
   test "Alpha phase label is displayed for a Case Study in phase 'alpha'" do


### PR DESCRIPTION
We're deploying service manual publisher to production and it no longer makes
sense to have this feature-flagged.

We're not planning to publish any content yet, but we will need preview
functionality on the draft stack.