### PR TITLE
Render "Take part" format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'rails_translation_manager', '~> 0.0.2'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '20.1.1'
+  gem 'gds-api-adapters', '27.0.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.5.2)
-    gds-api-adapters (20.1.1)
+    gds-api-adapters (27.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -93,7 +93,7 @@ GEM
     null_logger (0.0.1)
     plek (1.11.0)
     rack (1.5.5)
-    rack-cache (1.2)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -178,7 +178,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara
-  gds-api-adapters (= 20.1.1)
+  gds-api-adapters (= 27.0.0)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk_frontend_toolkit (= 2.0.1)
   logstasher (= 0.6.1)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
 // pages specific view imports
 @import "views/case-studies";
 @import "views/coming-soon";
+@import "views/take-part";
 @import "views/unpublishing";
 
 .service-manual-guide {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 @import 'shims';
 
 // helpers for common page elements
+@import "helpers/responsive-bottom-margin";
 @import "helpers/available-languages";
 @import "helpers/description";
 @import "helpers/sidebar-with-body";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@
 
 // helpers for common page elements
 @import "helpers/available-languages";
+@import "helpers/description";
 @import "helpers/sidebar-with-body";
 
 // pages specific view imports

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,9 @@
 @import 'typography';
 @import 'shims';
 
+// helpers for common page elements
+@import "helpers/available-languages";
+
 // pages specific view imports
 @import "views/case-studies";
 @import "views/coming-soon";
@@ -19,7 +22,3 @@
   @import "components/page-contents";
   @import "views/service-manual-guide";
 }
-
-// HELPERS
-// Styles for comment page elements
-@import "helpers/available-languages";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@
 
 // helpers for common page elements
 @import "helpers/available-languages";
+@import "helpers/sidebar-with-body";
 
 // pages specific view imports
 @import "views/case-studies";

--- a/app/assets/stylesheets/helpers/_description.scss
+++ b/app/assets/stylesheets/helpers/_description.scss
@@ -1,10 +1,6 @@
 @mixin description {
   .description {
     @include core-24;
-    margin-bottom: $gutter-half;
-
-    @include media(tablet) {
-      margin-bottom: $gutter * 1.5;
-    }
+    @include responsive-bottom-margin;
   }
 }

--- a/app/assets/stylesheets/helpers/_description.scss
+++ b/app/assets/stylesheets/helpers/_description.scss
@@ -1,0 +1,10 @@
+@mixin description {
+  .description {
+    @include core-24;
+    margin-bottom: $gutter-half;
+
+    @include media(tablet) {
+      margin-bottom: $gutter * 1.5;
+    }
+  }
+}

--- a/app/assets/stylesheets/helpers/_responsive-bottom-margin.scss
+++ b/app/assets/stylesheets/helpers/_responsive-bottom-margin.scss
@@ -1,0 +1,7 @@
+@mixin responsive-bottom-margin {
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-bottom: $gutter * 1.5;
+  }
+}

--- a/app/assets/stylesheets/helpers/_sidebar-with-body.scss
+++ b/app/assets/stylesheets/helpers/_sidebar-with-body.scss
@@ -1,0 +1,24 @@
+@mixin sidebar-with-body {
+  .sidebar-with-body {
+    margin-bottom: $gutter * 1.5;
+  }
+
+  .description {
+    @include core-24;
+    margin-bottom: $gutter-half;
+
+    @include media(tablet) {
+      margin-bottom: $gutter * 1.5;
+    }
+  }
+
+  .sidebar-image {
+    img {
+      max-width: 100%;
+    }
+
+    figcaption {
+      @include core-16;
+    }
+  }
+}

--- a/app/assets/stylesheets/helpers/_sidebar-with-body.scss
+++ b/app/assets/stylesheets/helpers/_sidebar-with-body.scss
@@ -3,15 +3,6 @@
     margin-bottom: $gutter * 1.5;
   }
 
-  .description {
-    @include core-24;
-    margin-bottom: $gutter-half;
-
-    @include media(tablet) {
-      margin-bottom: $gutter * 1.5;
-    }
-  }
-
   .sidebar-image {
     img {
       max-width: 100%;

--- a/app/assets/stylesheets/helpers/_sidebar-with-body.scss
+++ b/app/assets/stylesheets/helpers/_sidebar-with-body.scss
@@ -4,6 +4,8 @@
   }
 
   .sidebar-image {
+    @include responsive-bottom-margin;
+
     img {
       max-width: 100%;
     }

--- a/app/assets/stylesheets/views/_case-studies.scss
+++ b/app/assets/stylesheets/views/_case-studies.scss
@@ -1,4 +1,6 @@
 .case-studies {
+  @include sidebar-with-body;
+
   .direction-rtl & {
     direction: rtl;
     text-align: start;
@@ -10,7 +12,7 @@
     padding: 15px 10px;
     border: 5px solid $govuk-blue;
 
-    @include media(tablet){
+    @include media(tablet) {
       padding: 25px 10px;
       margin-bottom: $gutter;
     }
@@ -24,24 +26,14 @@
   }
 
   .description {
-    @include core-24;
-    margin: $gutter-half 0;
+    margin-top: $gutter-half;
 
-    @include media(tablet){
-      margin: ($gutter*1.5) 0;
-    }
-  }
-
-  .sidebar-image {
-    img {
-      max-width: 100%;
-    }
-    figcaption {
-      @include core-16;
+    @include media(tablet) {
+      margin-top: $gutter * 1.5;
     }
   }
 
   .govuk-document-footer {
-    margin-bottom: $gutter*2;
+    margin-bottom: $gutter * 1.5;
   }
 }

--- a/app/assets/stylesheets/views/_case-studies.scss
+++ b/app/assets/stylesheets/views/_case-studies.scss
@@ -26,12 +26,8 @@
     }
   }
 
-  .description {
-    margin-top: $gutter-half;
-
-    @include media(tablet) {
-      margin-top: $gutter * 1.5;
-    }
+  .govuk-metadata {
+    @include responsive-bottom-margin;
   }
 
   .govuk-document-footer {

--- a/app/assets/stylesheets/views/_case-studies.scss
+++ b/app/assets/stylesheets/views/_case-studies.scss
@@ -1,4 +1,5 @@
 .case-studies {
+  @include description;
   @include sidebar-with-body;
 
   .direction-rtl & {

--- a/app/assets/stylesheets/views/_take-part.scss
+++ b/app/assets/stylesheets/views/_take-part.scss
@@ -1,25 +1,3 @@
 .take-part {
-
-  .description {
-    @include core-24;
-    margin: 0 0 $gutter-half;
-
-    @include media(tablet){
-      margin: 0 0 ($gutter*1.5);
-    }
-  }
-
-  .sidebar-image {
-    img {
-      max-width: 100%;
-    }
-    figcaption {
-      @include core-16;
-    }
-  }
-
-  .govuk-document-footer {
-    margin-bottom: $gutter*2;
-  }
-  
+  @include sidebar-with-body;
 }

--- a/app/assets/stylesheets/views/_take-part.scss
+++ b/app/assets/stylesheets/views/_take-part.scss
@@ -1,3 +1,4 @@
 .take-part {
+  @include description;
   @include sidebar-with-body;
 }

--- a/app/assets/stylesheets/views/_take-part.scss
+++ b/app/assets/stylesheets/views/_take-part.scss
@@ -1,0 +1,25 @@
+.take-part {
+
+  .description {
+    @include core-24;
+    margin: 0 0 $gutter-half;
+
+    @include media(tablet){
+      margin: 0 0 ($gutter*1.5);
+    }
+  }
+
+  .sidebar-image {
+    img {
+      max-width: 100%;
+    }
+    figcaption {
+      @include core-16;
+    }
+  }
+
+  .govuk-document-footer {
+    margin-bottom: $gutter*2;
+  }
+  
+}

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -24,6 +24,7 @@ private
   def present(content_item)
     case content_item['format']
       when 'case_study' then CaseStudyPresenter.new(content_item)
+      when 'take_part' then TakePartPresenter.new(content_item)
       when 'unpublishing' then UnpublishingPresenter.new(content_item)
       when 'coming_soon' then ComingSoonPresenter.new(content_item)
       when 'service_manual_guide' then ServiceManualGuidePresenter.new(content_item)

--- a/app/presenters/case_study_presenter.rb
+++ b/app/presenters/case_study_presenter.rb
@@ -58,7 +58,6 @@ class CaseStudyPresenter < ContentItemPresenter
     withdrawn? ? "[Withdrawn] #{title}" : title
   end
 
-
   def withdrawal_notice
     if notice = content_item["details"]["withdrawn_notice"]
       {
@@ -69,7 +68,6 @@ class CaseStudyPresenter < ContentItemPresenter
   end
 
 private
-
   def display_time(timestamp)
     I18n.l(Date.parse(timestamp), format: "%-d %B %Y") if timestamp
   end

--- a/app/presenters/take_part_presenter.rb
+++ b/app/presenters/take_part_presenter.rb
@@ -1,0 +1,3 @@
+class TakePartPresenter < ContentItemPresenter
+
+end

--- a/app/presenters/take_part_presenter.rb
+++ b/app/presenters/take_part_presenter.rb
@@ -1,3 +1,9 @@
 class TakePartPresenter < ContentItemPresenter
+  def body
+    content_item["details"]["body"]
+  end
 
+  def image
+    content_item["details"]["image"]
+  end
 end

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -33,25 +33,8 @@
   </div>
 </div>
 
-<p class="description"><%= @content_item.description %></p>
-
-<div class="grid-row">
-  <div class="column-third">
-    <% if (image = @content_item.image) %>
-      <figure class="sidebar-image">
-        <img src="<%= image["url"] %>" alt="<%= image["alt_text"] %>">
-        <% if image["caption"].present? %><figcaption><%= image["caption"] %></figcaption><% end %>
-      </figure>
-    <% else %>
-      <div class="sidebar-image"><%= image_tag 'placeholder.jpg', alt: '' %></div>
-    <% end %>
-  </div>
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/govspeak',
-        content: @content_item.body,
-        direction: page_text_direction %>
-  </div>
-</div>
+<%= render 'shared/description', description: @content_item.description %>
+<%= render 'shared/sidebar_with_body', content_item: @content_item %>
 
 <%= render 'govuk_component/document_footer',
         from: @content_item.from,

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -9,20 +9,5 @@
   </div>
 </div>
 
-<p class="description"><%= @content_item.description %></p>
-
-<div class="grid-row">
-  <% if (image = @content_item.image) %>
-  <div class="column-third">
-    <figure class="sidebar-image">
-      <img src="<%= image["url"] %>" alt="<%= image["alt_text"] %>">
-      <% if image["caption"].present? %><figcaption><%= image["caption"] %></figcaption><% end %>
-    </figure>
-  </div>
-  <% end %>
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/govspeak',
-        content: @content_item.body,
-        direction: page_text_direction %>
-  </div>
-</div>
+<%= render 'shared/description', description: @content_item.description %>
+<%= render 'shared/sidebar_with_body', content_item: @content_item %>

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -1,0 +1,28 @@
+<%= content_for :page_class, @content_item.format.dasherize %>
+<%= content_for :title, "#{@content_item.title}" %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+        context: t("content_item.format.#{@content_item.format}", count: 1),
+        title: @content_item.title %>
+  </div>
+</div>
+
+<p class="description"><%= @content_item.description %></p>
+
+<div class="grid-row">
+  <% if (image = @content_item.image) %>
+  <div class="column-third">
+    <figure class="sidebar-image">
+      <img src="<%= image["url"] %>" alt="<%= image["alt_text"] %>">
+      <% if image["caption"].present? %><figcaption><%= image["caption"] %></figcaption><% end %>
+    </figure>
+  </div>
+  <% end %>
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/govspeak',
+        content: @content_item.body,
+        direction: page_text_direction %>
+  </div>
+</div>

--- a/app/views/shared/_description.html.erb
+++ b/app/views/shared/_description.html.erb
@@ -1,0 +1,3 @@
+<p class="description">
+  <%= description %>
+</p>

--- a/app/views/shared/_sidebar_image.html.erb
+++ b/app/views/shared/_sidebar_image.html.erb
@@ -1,0 +1,10 @@
+<% if image %>
+  <figure class="sidebar-image">
+    <img src="<%= image["url"] %>" alt="<%= image["alt_text"] %>">
+    <% if image["caption"].present? %><figcaption><%= image["caption"] %></figcaption><% end %>
+  </figure>
+<% else %>
+  <div class="sidebar-image">
+    <%= image_tag 'placeholder.jpg', alt: '' %>
+  </div>
+<% end %>

--- a/app/views/shared/_sidebar_with_body.html.erb
+++ b/app/views/shared/_sidebar_with_body.html.erb
@@ -1,0 +1,10 @@
+<div class="grid-row sidebar-with-body">
+  <div class="column-third">
+    <%= render 'shared/sidebar_image', image: content_item.image %>
+  </div>
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/govspeak',
+        content: content_item.body,
+        direction: page_text_direction %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,6 +175,9 @@ en:
       official_statistics:
         one: Official Statistics
         other: Official Statistics
+      take_part:
+        one: Take part
+        other: Take part
       transcript:
         one: Transcript
         other: Transcripts

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -91,8 +91,7 @@ class CaseStudyPresenterTest < ActiveSupport::TestCase
   end
 
 private
-
-  def presented_case_study(overrides={})
+  def presented_case_study(overrides = {})
     CaseStudyPresenter.new(case_study.merge(overrides))
   end
 

--- a/test/presenters/take_part_presenter_test.rb
+++ b/test/presenters/take_part_presenter_test.rb
@@ -1,6 +1,21 @@
 require 'test_helper'
 
 class TakePartPresenterTest < ActiveSupport::TestCase
-  include ActionView::Helpers::UrlHelper
 
+  test 'presents the basic details of a content item' do
+    assert_equal take_part['description'], presented_take_part.description
+    assert_equal take_part['format'], presented_take_part.format
+    assert_equal take_part['locale'], presented_take_part.locale
+    assert_equal take_part['title'], presented_take_part.title
+    assert_equal take_part['details']['body'], presented_take_part.body
+  end
+
+private
+  def presented_take_part(overrides = {})
+    TakePartPresenter.new(take_part.merge(overrides))
+  end
+
+  def take_part
+    govuk_content_schema_example('take_part', 'take_part')
+  end
 end

--- a/test/presenters/take_part_presenter_test.rb
+++ b/test/presenters/take_part_presenter_test.rb
@@ -1,0 +1,6 @@
+require 'test_helper'
+
+class TakePartPresenterTest < ActiveSupport::TestCase
+  include ActionView::Helpers::UrlHelper
+
+end

--- a/test/support/govuk_content_schema_examples.rb
+++ b/test/support/govuk_content_schema_examples.rb
@@ -47,6 +47,7 @@ module GovukContentSchemaExamples
         case_study
         coming_soon
         redirect
+        take_part
         unpublishing
       }
     end


### PR DESCRIPTION
https://trello.com/c/P1IYhe0C/242-take-part-migrate-front-end-work-large

* Add Take Part template, styles and presenter
  * Use `format` rather than `format_display_type` for gathering title context
  * Copy markup patterns from case study where similar/the same
* Don’t port the strange “underline” take part headings, the take part contents are purposefully left out, and the description has been moved above the image to match other formats.
* Extract styles and markup common to Case Studies and Take Part into partials and mixins
* When an image is omitted it will show a generic government placeholder image

# Before
![screen shot 2016-01-19 at 16 22 09](https://cloud.githubusercontent.com/assets/319055/12424635/fc166870-bec8-11e5-8ef0-26387f2008a0.png)

# After
![screen shot 2016-01-19 at 15 31 13](https://cloud.githubusercontent.com/assets/319055/12424569/b174d374-bec8-11e5-8dc1-af81a1d75bb7.png)

cc @dsingleton @boffbowsh @benlovell @gpeng 