### PR TITLE
Add wraith for visual regression testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+
+# Wraith
+shots
+shots_history

--- a/test/wraith/config.yaml
+++ b/test/wraith/config.yaml
@@ -1,0 +1,62 @@
+# Wraith
+# You will need wraith, imagemagick, and phantomsjs or similar.
+#
+# gem install wraith
+# brew install phantomjs
+# brew install imagemagick
+#
+# Take a baseline of the current version
+#
+# wraith history config.yaml
+#
+# Switch to your feature branch and make changes.
+#
+# wraith latest config.yaml
+#
+# This should generate a gallery containing diffs of the pages, at
+# various resolutions.
+
+#Headless browser option
+browser:
+  phantomjs: "phantomjs"
+  # slimerjs: "slimerjs"
+
+#If you want to have multiple snapping files, set the file name here
+snap_file: "snap.js"
+
+# Type the name of the directory that shots will be stored in
+directory: 'shots'
+history_dir: 'shots_history'
+
+# Add only 2 domains, key will act as a label
+domains:
+  dev: "http://www.dev.gov.uk:3000"
+
+#Type screen widths below, here are a couple of examples
+screen_widths:
+  - 320
+  - 600
+  - 768
+  - 1024
+  - 1280
+
+#Type page URL paths below, here are a couple of examples
+paths:
+  case_study: '/government/case-studies/doing-business-in-spain.es'
+  case_study_withdrawn: '/government/case-studies/terence-age-33-stoke-on-trent'
+  take_part: '/government/get-involved/take-part/become-a-councillor'
+
+#Amount of fuzz ImageMagick will use
+fuzz: '20%'
+
+#Set the number of days to keep the site spider file
+spider_days:
+  - 10
+
+#Choose how results are displayed, by default alphanumeric. Different screen widths are always grouped.
+#alphanumeric - all paths (with, and without, a difference) are shown, sorted by path
+#diffs_first - all paths (with, and without, a difference) are shown, sorted by difference size (largest first)
+#diffs_only - only paths with a difference are shown, sorted by difference size (largest first)
+mode: diffs_first
+
+threshold: 5

--- a/test/wraith/snap.js
+++ b/test/wraith/snap.js
@@ -1,0 +1,78 @@
+var system = require('system');
+var page = require('webpage').create();
+var fs = require('fs');
+
+if (system.args.length === 3) {
+    console.log('Usage: snap.js <some URL> <view port width> <target image name>');
+    phantom.exit();
+}
+
+var url = system.args[1];
+var image_name = system.args[3];
+var view_port_width = system.args[2];
+var current_requests = 0;
+var last_request_timeout;
+var final_timeout;
+
+page.viewportSize = { width: view_port_width, height: 1500};
+page.settings = { loadImages: true, javascriptEnabled: true };
+
+// If you want to use additional phantomjs commands, place them here
+page.settings.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.17';
+
+// You can place custom headers here, example below.
+// page.customHeaders = {
+
+//      'X-Candy-OVERRIDE': 'https://api.live.bbc.co.uk/'
+
+//  };
+
+// If you want to set a cookie, just add your details below in the following way.
+
+phantom.addCookie({
+    'name': 'seen_cookie_message',
+    'value': 'yes',
+    'domain': 'localhost'
+});
+
+page.onResourceRequested = function(req) {
+  current_requests += 1;
+};
+
+page.onResourceReceived = function(res) {
+  if (res.stage === 'end') {
+    current_requests -= 1;
+    debounced_render();
+  }
+};
+
+page.open(url, function(status) {
+  if (status !== 'success') {
+    console.log('Error with page ' + url);
+    phantom.exit();
+  }
+});
+
+function debounced_render() {
+  clearTimeout(last_request_timeout);
+  clearTimeout(final_timeout);
+
+  // If there's no more ongoing resource requests, wait for 1 second before
+  // rendering, just in case the page kicks off another request
+  if (current_requests < 1) {
+      clearTimeout(final_timeout);
+      last_request_timeout = setTimeout(function() {
+          console.log('Snapping ' + url + ' at width ' + view_port_width);
+          page.render(image_name);
+          phantom.exit();
+      }, 1000);
+  }
+
+  // Sometimes, straggling requests never make it back, in which
+  // case, timeout after 5 seconds and render the page anyway
+  final_timeout = setTimeout(function() {
+    console.log('Snapping ' + url + ' at width ' + view_port_width);
+    page.render(image_name);
+    phantom.exit();
+  }, 5000);
+}


### PR DESCRIPTION
Add Wraith so that regressions can be easily spotted. Runs against a set of supported examples. Run while pointing government-frontend at the dummy content store.

After running:
` PLEK_SERVICE_CONTENT_STORE_URI=https://govuk-content-store-examples.herokuapp.com bundle exec rails s`

Usage:
On master run: `wraith history config.yaml`
On local branch run: `wraith latest config.yaml`

Based on https://github.com/alphagov/govuk_elements/commit/3484ddc8903ccf83d52dbf4e99a9c178d7190351

# Example output

![320_phantomjs_dev](https://cloud.githubusercontent.com/assets/319055/12458787/6a1cc1ea-bfa3-11e5-81b6-3581f91cb586.png)
![600_phantomjs_dev](https://cloud.githubusercontent.com/assets/319055/12458786/6a1c648e-bfa3-11e5-903c-4f7e4a4f8269.png)
![768_phantomjs_dev](https://cloud.githubusercontent.com/assets/319055/12458790/6a2865c2-bfa3-11e5-9884-566fa5d6241f.png)
![1024_phantomjs_dev](https://cloud.githubusercontent.com/assets/319055/12458788/6a1d4bec-bfa3-11e5-8450-190cda6da6af.png)
![1280_phantomjs_dev](https://cloud.githubusercontent.com/assets/319055/12458789/6a20a184-bfa3-11e5-9451-72075d538c88.png)