### PR TITLE
Use govspeak component for video embed

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,5 +23,6 @@
   @import "components/page-title";
   @import "components/metadata";
   @import "components/page-contents";
+  @import "components/govspeak-service-manual";
   @import "views/service-manual-guide";
 }

--- a/app/assets/stylesheets/components/_govspeak-service-manual.scss
+++ b/app/assets/stylesheets/components/_govspeak-service-manual.scss
@@ -1,8 +1,4 @@
-.community-contact {
-  margin-top: 1.875em; // 30/16
-}
-
-.prose {
+.govuk-govspeak--service-manual {
 
   margin-top: 1em;
   margin-bottom: 2em;

--- a/app/assets/stylesheets/views/_service-manual-guide.scss
+++ b/app/assets/stylesheets/views/_service-manual-guide.scss
@@ -1,0 +1,3 @@
+.community-contact {
+  margin-top: 1.875em; // 30/16
+}

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -78,7 +78,7 @@
   </div>
   <div class="column-two-thirds">
 
-    <div class="prose">
+    <div class="govuk-govspeak govuk-govspeak--service-manual">
       <%= @content_item.body.html_safe %>
     </div>
 


### PR DESCRIPTION
- Move the govspeak styles for the service manual to a new partial
- Rename the prose text wrapper

This enables the govspeak youtube embedding to work, while maintaining the styles for service manual content pages. 