### PR TITLE
Enable videos to be embedded in Service Manual guide pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,5 +23,6 @@
   @import "components/page-title";
   @import "components/metadata";
   @import "components/page-contents";
+  @import "components/govspeak-service-manual";
   @import "views/service-manual-guide";
 }

--- a/app/assets/stylesheets/components/_govspeak-service-manual.scss
+++ b/app/assets/stylesheets/components/_govspeak-service-manual.scss
@@ -1,46 +1,51 @@
 .govuk-govspeak--service-manual {
 
-  margin-top: 1em;
-  margin-bottom: 2em;
+  padding-top: 1em;
+
+  margin-bottom: (30/19)+em;
   @include media(tablet) {
-    margin-top: 2em;
-    margin-bottom: 4em;
+    margin-bottom: (45/19)+em;
+  }
+
+  > h2:first-of-type {
+    padding-top: (15/24)+em;
   }
 
   h2 {
     @include bold-24();
-    margin-top: 1.875em; // 45/24
-    margin-bottom: 0.833333333em; // 20/24
+    padding-top: (20/24)+em;
+    margin-bottom: (15/24)+em;
+    @include media(tablet) {
+      margin-bottom: (20/24)+em;
+    }
   }
 
   h3 {
     @include bold-19();
-    margin-top: 1.052631579em; // 20/19
+    margin-bottom: (15/19)+em;
+    @include media(tablet) {
+      margin-bottom:(20/19)+em;
+    }
+  }
+
+  p {
+    margin-bottom: (15/19)+em;
+    @include media(tablet) {
+      margin-bottom: (20/19)+em;
+    }
   }
 
   ol,
   ul {
-    @include core-19;
-    padding-left: 1.052631579em; // 20/19
-    margin-bottom: 1.052631579em; // 20/19
+    margin-top: 0;
+    margin-bottom: (15/19)+em;
+    @include media(tablet) {
+      margin-bottom: (20/19)+em;
+    }
   }
 
-  ul {
-    list-style-type: disc;
+  li {
+    margin-bottom: (10/19)+em;
   }
 
-  ol {
-    list-style-type: decimal;
-  }
-
-  ul li,
-  ol li {
-    margin-bottom: 0.263157895em // 5/19
-  }
-
-  p {
-    @include core-19;
-    margin-top: 0.263157895em; // 5/19
-    margin-bottom: 1.052631579em; // 20/19
-  }
 }

--- a/app/assets/stylesheets/components/_govspeak-service-manual.scss
+++ b/app/assets/stylesheets/components/_govspeak-service-manual.scss
@@ -1,8 +1,4 @@
-.community-contact {
-  margin-top: 1.875em; // 30/16
-}
-
-.prose {
+.govuk-govspeak--service-manual {
 
   margin-top: 1em;
   margin-bottom: 2em;

--- a/app/assets/stylesheets/views/_service-manual-guide.scss
+++ b/app/assets/stylesheets/views/_service-manual-guide.scss
@@ -1,0 +1,3 @@
+.community-contact {
+  margin-top: 1.875em; // 30/16
+}

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -78,7 +78,7 @@
   </div>
   <div class="column-two-thirds">
 
-    <div class="prose">
+    <div class="govuk-govspeak govuk-govspeak--service-manual">
       <%= @content_item.body.html_safe %>
     </div>
 


### PR DESCRIPTION
This functionality already exists as part of the govspeak component.

Use the `.govuk-govspeak` class to ensure that video links are expanded to the accessible video player. 

Also add a modifier, `.govuk-govspeak--service-manual` to set consistent spacing between HTML elements within the govspeak wrapper. 

cc. @tadast 