### PR TITLE
Use GOV.UK Govspeak component for rendering SM guide body

### DIFF
--- a/app/assets/stylesheets/views/_service-manual-guide.scss
+++ b/app/assets/stylesheets/views/_service-manual-guide.scss
@@ -2,49 +2,9 @@
   margin-top: 1.875em; // 30/16
 }
 
-.prose {
-
-  margin-top: 1em;
-  margin-bottom: 2em;
+.govspeak-wrapper {
+  padding-top: 0.9375em;
   @include media(tablet) {
-    margin-top: 2em;
-    margin-bottom: 4em;
-  }
-
-  h2 {
-    @include bold-24();
-    margin-top: 1.875em; // 45/24
-    margin-bottom: 0.833333333em; // 20/24
-  }
-
-  h3 {
-    @include bold-19();
-    margin-top: 1.052631579em; // 20/19
-  }
-
-  ol,
-  ul {
-    @include core-19;
-    padding-left: 1.052631579em; // 20/19
-    margin-bottom: 1.052631579em; // 20/19
-  }
-
-  ul {
-    list-style-type: disc;
-  }
-
-  ol {
-    list-style-type: decimal;
-  }
-
-  ul li,
-  ol li {
-    margin-bottom: 0.263157895em // 5/19
-  }
-
-  p {
-    @include core-19;
-    margin-top: 0.263157895em; // 5/19
-    margin-bottom: 1.052631579em; // 20/19
+    padding-top: 1.875em;
   }
 }

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -78,8 +78,8 @@
   </div>
   <div class="column-two-thirds">
 
-    <div class="prose">
-      <%= @content_item.body.html_safe %>
+    <div class="govspeak-wrapper">
+      <%= render 'govuk_component/govspeak', content: @content_item.body.html_safe %>
     </div>
 
   </div>


### PR DESCRIPTION
Use the component because it has support for automatic youtube video link
embedding. It modifies the styling of text slightly, which is not ideal, but we
decided it's better than overwriting the components styles.

The long term plan is to list the discrepancies and update the component with
improvements that have been discovered through Service Manual user research.

[Compare. Left: Before. Right: After.](https://cloud.githubusercontent.com/assets/218239/12582503/7b16c5d6-c435-11e5-99d0-fd774309a372.png)