### PR TITLE
Fetch content owner info from the links hash

### DIFF
--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -13,8 +13,12 @@ class ServiceManualGuidePresenter < ContentItemPresenter
   end
 
   def content_owner
-    content_owner_data = content_item["details"]["content_owner"]
-    ContentOwner.new(content_owner_data["title"], content_owner_data["href"])
+    content_owner_data = Array(content_item["links"] && content_item["links"]["content_owners"]).first
+    if content_owner_data.present?
+      ContentOwner.new(content_owner_data["title"], content_owner_data["base_path"])
+    else
+      content_owner_fallback
+    end
   end
 
   def related_discussion
@@ -33,7 +37,7 @@ class ServiceManualGuidePresenter < ContentItemPresenter
   end
 
   def main_topic
-    @main_topic ||= Array(content_item["links"].try(:[], "topics")).first
+    @main_topic ||= Array(content_item["links"] && content_item["links"]["topics"]).first
   end
 
   def breadcrumbs
@@ -47,5 +51,11 @@ private
 
   def updated_at
     DateTime.parse(content_item["public_updated_at"])
+  end
+
+  # Remove this method after switching (see commit message)
+  def content_owner_fallback
+    content_owner_data = content_item["details"]["content_owner"]
+    ContentOwner.new(content_owner_data["title"], content_owner_data["href"])
   end
 end

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -45,6 +45,24 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
                  presented_guide.breadcrumbs
   end
 
+  test '#content_owner fetches the first content owner info from the links' do
+    guide = presented_guide(
+      'details' => {'content_owner' => nil},
+      'links' => {'content_owners' => [{'title' => 'Design Community', 'base_path' => '/example/dc'}]}
+    )
+    assert_equal 'Design Community', guide.content_owner.title
+    assert_equal '/example/dc', guide.content_owner.href
+  end
+
+  test '#content_owner falls back to using deprecated content owner info in details' do
+    guide = presented_guide(
+      'details' => {'content_owner' => {'title' => 'Agile Community', 'href' => 'http://example.com/ac'}},
+      'links' => {'content_owners' => []}
+    )
+    assert_equal 'Agile Community', guide.content_owner.title
+    assert_equal 'http://example.com/ac', guide.content_owner.href
+  end
+
 private
 
   def presented_guide(overriden_attributes = {})


### PR DESCRIPTION
As a part of an effort to reference everything using content_ids allow
Service manual guides to use information about the service manual guide content
owner from the links hash (see [1]) but fall back to the old way when the links
hash is not present.

This will allow us to migrate to the new format without breaking anything.

The fallback code should be removed once the migration process is complete.

[1] - https://github.com/alphagov/govuk-content-schemas/pull/219