### PR TITLE
Remove access modifier in tests

### DIFF
--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -106,8 +106,6 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_equal content_item['title'], assigns[:content_item].title
   end
 
-private
-
   def path_for(content_item)
     content_item['base_path'].sub(/^\//, '')
   end

--- a/test/integration/phase_label_test.rb
+++ b/test/integration/phase_label_test.rb
@@ -32,8 +32,6 @@ class PhaseLabelTest < ActionDispatch::IntegrationTest
     assert page.has_no_css?("[data-template='govuk_component-beta_label']")
   end
 
-private
-
   def assert_has_phase_label(phase)
     within "[data-template='govuk_component-#{phase}_label']" do
       assert page.has_content?("#{phase}_label"), "Expected the page to have an '#{phase.titleize}' label"

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -90,7 +90,6 @@ class CaseStudyPresenterTest < ActiveSupport::TestCase
     assert_equal [], presented.history
   end
 
-private
   def presented_case_study(overrides = {})
     CaseStudyPresenter.new(case_study.merge(overrides))
   end

--- a/test/presenters/coming_soon_presenter_test.rb
+++ b/test/presenters/coming_soon_presenter_test.rb
@@ -16,7 +16,6 @@ class ComingSoonPresenterTest < ActiveSupport::TestCase
     assert_equal '17 December 2014', presented_coming_soon.formatted_publish_date
   end
 
-private
   def presented_coming_soon(overrides={})
     ComingSoonPresenter.new(coming_soon.merge(overrides))
   end

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -26,8 +26,6 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
     assert_equal '26 October 2014 10:27', guide.last_update_timestamp
   end
 
-private
-
   def presented_guide(overriden_attributes = {})
     ServiceManualGuidePresenter.new(
       JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('service_manual_guide', 'basic_with_related_discussions')).merge(overriden_attributes)

--- a/test/presenters/take_part_presenter_test.rb
+++ b/test/presenters/take_part_presenter_test.rb
@@ -10,7 +10,6 @@ class TakePartPresenterTest < ActiveSupport::TestCase
     assert_equal take_part['details']['body'], presented_take_part.body
   end
 
-private
   def presented_take_part(overrides = {})
     TakePartPresenter.new(take_part.merge(overrides))
   end

--- a/test/presenters/unpublishing_presenter_test.rb
+++ b/test/presenters/unpublishing_presenter_test.rb
@@ -9,8 +9,6 @@ class UnpublishingPresenterTest < ActiveSupport::TestCase
     assert_equal unpublishing['details']['alternative_url'], presented_unpublishing.alternative_url
   end
 
-private
-
   def unpublishing
     govuk_content_schema_example('unpublishing', 'unpublishing')
   end


### PR DESCRIPTION
As per @benlovell's [comment](https://github.com/alphagov/government-frontend/pull/75#discussion-diff-50845288R109) on PR #75, they're not worth using in tests.