### PR TITLE
Log to STDOUT and STDERR in production mode.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,6 +53,7 @@ Rails.application.configure do
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  config.logger = ActiveSupport::TaggedLogging.new(Logger.new($stderr))
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -81,7 +82,9 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  $real_stdout = $stdout.clone
+  $stdout.reopen($stderr)
   config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
+  config.logstasher.logger = Logger.new($real_stdout)
   config.logstasher.suppress_app_log = true
 end


### PR DESCRIPTION
To bring this more in line with 12-facgtor principals, this changes the
logging to go to STDOUT(json), and STDERR(everything else).

Precedent: https://github.com/alphagov/publishing-api/pull/109
Needed Puppet change: https://github.com/alphagov/govuk-puppet/pull/3998