### PR TITLE
Add per example integration testing

### DIFF
--- a/test/integration/case_study_test.rb
+++ b/test/integration/case_study_test.rb
@@ -18,9 +18,7 @@ class CaseStudyTest < ActionDispatch::IntegrationTest
 
     within ".withdrawal-notice" do
       assert page.has_text?('This case study was withdrawn'), "is withdrawn"
-      within shared_component_selector("govspeak") do
-        assert_equal @content_item["details"]["withdrawn_notice"]["explanation"], JSON.parse(page.text).fetch("content")
-      end
+      assert_has_component_govspeak(@content_item["details"]["withdrawn_notice"]["explanation"])
     end
   end
 end

--- a/test/integration/case_study_test.rb
+++ b/test/integration/case_study_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class CaseStudyTest < ActionDispatch::IntegrationTest
+  test "translated case study" do
+    setup_and_visit_content_item('translated')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+
+    assert page.has_css?('.available-languages')
+  end
+
+  test "withdrawn case study" do
+    setup_and_visit_content_item('archived')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+
+    within ".withdrawal-notice" do
+      assert page.has_text?('This case study was withdrawn'), "is withdrawn"
+      within shared_component_selector("govspeak") do
+        assert_equal @content_item["details"]["withdrawn_notice"]["explanation"], JSON.parse(page.text).fetch("content")
+      end
+    end
+  end
+end

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -4,20 +4,20 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
   test "official statistics" do
     setup_and_visit_content_item('official_statistics')
 
-    assert_has_component_title('Diagnostic imaging dataset for September 2015')
+    assert_has_component_title(@content_item["title"])
   end
 
   test "national statistics" do
     setup_and_visit_content_item('national_statistics')
 
-    assert_has_component_title('UK armed forces quarterly personnel report: 1 October 2015')
+    assert_has_component_title(@content_item["title"])
     assert page.has_css?('.national-statistics-logo img')
   end
 
   test "cancelled statistics" do
     setup_and_visit_content_item('cancelled_official_statistics')
 
-    assert_has_component_title('Diagnostic imaging dataset for September 2015')
+    assert_has_component_title(@content_item["title"])
     assert page.has_text?('Statistics release cancelled'), "is cancelled"
   end
 
@@ -28,7 +28,7 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
   end
 
   def setup_and_visit_content_item(name)
-    JSON.parse(get_content_example(name)).tap do |item|
+    @content_item = JSON.parse(get_content_example(name)).tap do |item|
       content_store_has_item(item["base_path"], item.to_json)
       visit item["base_path"]
     end

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
+  test "official statistics" do
+    item = GovukContentSchemaTestHelpers::Examples.new.get('statistics_announcement', 'official_statistics')
+    content_store_has_item("/government/statistics/announcements/diagnostic-imaging-dataset-for-september-2015--2", item)
+
+    visit "/government/statistics/announcements/diagnostic-imaging-dataset-for-september-2015--2"
+
+    assert page.has_text?('Diagnostic imaging dataset for September 2015')
+  end
+
+  test "national statistics" do
+    item = GovukContentSchemaTestHelpers::Examples.new.get('statistics_announcement', 'national_statistics')
+    content_store_has_item("/government/statistics/announcements/uk-armed-forces-quarterly-personnel-report-october-2015", item)
+
+    visit "/government/statistics/announcements/uk-armed-forces-quarterly-personnel-report-october-2015"
+
+    assert page.has_text?('UK armed forces quarterly personnel report: 1 October 2015')
+    assert page.has_css?('.national-statistics-logo img')
+  end
+
+  test "cancelled statistics" do
+    item = GovukContentSchemaTestHelpers::Examples.new.get('statistics_announcement', 'cancelled_official_statistics')
+    content_store_has_item("/government/statistics/announcements/diagnostic-imaging-dataset-for-september-2015", item)
+
+    visit "/government/statistics/announcements/diagnostic-imaging-dataset-for-september-2015"
+
+    assert page.has_text?('Diagnostic imaging dataset for September 2015')
+    assert page.has_text?('Statistics release cancelled'), "is cancelled"
+  end
+end

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -5,20 +5,42 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('official_statistics')
 
     assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+    within shared_component_selector("metadata") do
+      assert page.has_text?('20 January 2016 9:30am (confirmed)'), "displays a confirmed release date"
+      assert page.has_text?('Release date'), "is laballed with a release date"
+    end
   end
 
   test "national statistics" do
     setup_and_visit_content_item('national_statistics')
 
     assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
     assert page.has_css?('.national-statistics-logo img')
+
+    within shared_component_selector("metadata") do
+      assert page.has_text?('January 2016 (provisional)'), "displays a provisional release date"
+      assert page.has_text?('Release date'), "is laballed with a release date"
+    end
   end
 
   test "cancelled statistics" do
     setup_and_visit_content_item('cancelled_official_statistics')
 
     assert_has_component_title(@content_item["title"])
-    assert page.has_text?('Statistics release cancelled'), "is cancelled"
+    assert page.has_text?(@content_item["description"])
+    within '.cancellation-notice' do
+      assert page.has_text?('Statistics release cancelled'), "is cancelled"
+      assert page.has_text?(@content_item["details"]["cancellation_reason"]), "displays cancelleation reason"
+    end
+
+    within shared_component_selector("metadata") do
+      assert page.has_text?('20 January 2016 9:30am'), "displays the proposed release date"
+      assert page.has_text?('Proposed release'), "is laballed 'proposed release'"
+      assert page.has_text?('17 January 2016 2:19pm'), "displays the cancellation date"
+      assert page.has_text?('Cancellation date'), "is laballed as cancelled'"
+    end
   end
 
   def assert_has_component_title(title)

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -2,31 +2,33 @@ require 'test_helper'
 
 class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
   test "official statistics" do
-    item = GovukContentSchemaTestHelpers::Examples.new.get('statistics_announcement', 'official_statistics')
-    content_store_has_item("/government/statistics/announcements/diagnostic-imaging-dataset-for-september-2015--2", item)
-
-    visit "/government/statistics/announcements/diagnostic-imaging-dataset-for-september-2015--2"
+    setup_and_visit_content_item('official_statistics')
 
     assert page.has_text?('Diagnostic imaging dataset for September 2015')
   end
 
   test "national statistics" do
-    item = GovukContentSchemaTestHelpers::Examples.new.get('statistics_announcement', 'national_statistics')
-    content_store_has_item("/government/statistics/announcements/uk-armed-forces-quarterly-personnel-report-october-2015", item)
-
-    visit "/government/statistics/announcements/uk-armed-forces-quarterly-personnel-report-october-2015"
+    setup_and_visit_content_item('national_statistics')
 
     assert page.has_text?('UK armed forces quarterly personnel report: 1 October 2015')
     assert page.has_css?('.national-statistics-logo img')
   end
 
   test "cancelled statistics" do
-    item = GovukContentSchemaTestHelpers::Examples.new.get('statistics_announcement', 'cancelled_official_statistics')
-    content_store_has_item("/government/statistics/announcements/diagnostic-imaging-dataset-for-september-2015", item)
-
-    visit "/government/statistics/announcements/diagnostic-imaging-dataset-for-september-2015"
+    setup_and_visit_content_item('cancelled_official_statistics')
 
     assert page.has_text?('Diagnostic imaging dataset for September 2015')
     assert page.has_text?('Statistics release cancelled'), "is cancelled"
+  end
+
+  def setup_and_visit_content_item(name)
+    JSON.parse(get_content_example(name)).tap do |item|
+      content_store_has_item(item["base_path"], item.to_json)
+      visit item["base_path"]
+    end
+  end
+
+  def get_content_example(name)
+    GovukContentSchemaTestHelpers::Examples.new.get('statistics_announcement', name)
   end
 end

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -31,31 +31,4 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
     assert_has_component_metadata_pair("Proposed release", "20 January 2016 9:30am")
     assert_has_component_metadata_pair("Cancellation date", "17 January 2016 2:19pm")
   end
-
-  def assert_has_component_metadata_pair(label, value)
-    within shared_component_selector("metadata") do
-      # Flatten top level / "other" args, for consistent hash access
-      component_args = JSON.parse(page.text).tap do |args|
-        args.merge!(args.delete("other"))
-      end
-      assert_equal value, component_args.fetch(label)
-    end
-  end
-
-  def assert_has_component_title(title)
-    within shared_component_selector("title") do
-      assert_equal title, JSON.parse(page.text).fetch("title")
-    end
-  end
-
-  def setup_and_visit_content_item(name)
-    @content_item = JSON.parse(get_content_example(name)).tap do |item|
-      content_store_has_item(item["base_path"], item.to_json)
-      visit item["base_path"]
-    end
-  end
-
-  def get_content_example(name)
-    GovukContentSchemaTestHelpers::Examples.new.get('statistics_announcement', name)
-  end
 end

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -4,21 +4,27 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
   test "official statistics" do
     setup_and_visit_content_item('official_statistics')
 
-    assert page.has_text?('Diagnostic imaging dataset for September 2015')
+    assert_has_component_title('Diagnostic imaging dataset for September 2015')
   end
 
   test "national statistics" do
     setup_and_visit_content_item('national_statistics')
 
-    assert page.has_text?('UK armed forces quarterly personnel report: 1 October 2015')
+    assert_has_component_title('UK armed forces quarterly personnel report: 1 October 2015')
     assert page.has_css?('.national-statistics-logo img')
   end
 
   test "cancelled statistics" do
     setup_and_visit_content_item('cancelled_official_statistics')
 
-    assert page.has_text?('Diagnostic imaging dataset for September 2015')
+    assert_has_component_title('Diagnostic imaging dataset for September 2015')
     assert page.has_text?('Statistics release cancelled'), "is cancelled"
+  end
+
+  def assert_has_component_title(title)
+    within shared_component_selector("title") do
+      assert_equal title, JSON.parse(page.text).fetch("title")
+    end
   end
 
   def setup_and_visit_content_item(name)

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -6,10 +6,7 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
 
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
-    within shared_component_selector("metadata") do
-      assert page.has_text?('20 January 2016 9:30am (confirmed)'), "displays a confirmed release date"
-      assert page.has_text?('Release date'), "is laballed with a release date"
-    end
+    assert_has_component_metadata_pair("Release date", "20 January 2016 9:30am (confirmed)")
   end
 
   test "national statistics" do
@@ -18,11 +15,7 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
     assert page.has_css?('.national-statistics-logo img')
-
-    within shared_component_selector("metadata") do
-      assert page.has_text?('January 2016 (provisional)'), "displays a provisional release date"
-      assert page.has_text?('Release date'), "is laballed with a release date"
-    end
+    assert_has_component_metadata_pair("Release date", "January 2016 (provisional)")
   end
 
   test "cancelled statistics" do
@@ -35,11 +28,17 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
       assert page.has_text?(@content_item["details"]["cancellation_reason"]), "displays cancelleation reason"
     end
 
+    assert_has_component_metadata_pair("Proposed release", "20 January 2016 9:30am")
+    assert_has_component_metadata_pair("Cancellation date", "17 January 2016 2:19pm")
+  end
+
+  def assert_has_component_metadata_pair(label, value)
     within shared_component_selector("metadata") do
-      assert page.has_text?('20 January 2016 9:30am'), "displays the proposed release date"
-      assert page.has_text?('Proposed release'), "is laballed 'proposed release'"
-      assert page.has_text?('17 January 2016 2:19pm'), "displays the cancellation date"
-      assert page.has_text?('Cancellation date'), "is laballed as cancelled'"
+      # Flatten top level / "other" args, for consistent hash access
+      component_args = JSON.parse(page.text).tap do |args|
+        args.merge!(args.delete("other"))
+      end
+      assert_equal value, component_args.fetch(label)
     end
   end
 

--- a/test/integration/take_part_test.rb
+++ b/test/integration/take_part_test.rb
@@ -6,5 +6,7 @@ class TakePartTest < ActionDispatch::IntegrationTest
 
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
+
+    assert_has_component_govspeak(@content_item["details"]["body"])
   end
 end

--- a/test/integration/take_part_test.rb
+++ b/test/integration/take_part_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class TakePartTest < ActionDispatch::IntegrationTest
+  test "take part pages" do
+    setup_and_visit_content_item('take_part')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,12 @@ class ActionDispatch::IntegrationTest
     end
   end
 
+  def assert_has_component_govspeak(content)
+    within shared_component_selector("govspeak") do
+      assert_equal content, JSON.parse(page.text).fetch("content")
+    end
+  end
+
   def setup_and_visit_content_item(name)
     @content_item = JSON.parse(get_content_example(name)).tap do |item|
       content_store_has_item(item["base_path"], item.to_json)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,4 +22,36 @@ class ActionDispatch::IntegrationTest
   # Make the Capybara DSL available in all integration tests
   include Capybara::DSL
   include Slimmer::TestHelpers::SharedTemplates
+
+  def assert_has_component_metadata_pair(label, value)
+    within shared_component_selector("metadata") do
+      # Flatten top level / "other" args, for consistent hash access
+      component_args = JSON.parse(page.text).tap do |args|
+        args.merge!(args.delete("other"))
+      end
+      assert_equal value, component_args.fetch(label)
+    end
+  end
+
+  def assert_has_component_title(title)
+    within shared_component_selector("title") do
+      assert_equal title, JSON.parse(page.text).fetch("title")
+    end
+  end
+
+  def setup_and_visit_content_item(name)
+    @content_item = JSON.parse(get_content_example(name)).tap do |item|
+      content_store_has_item(item["base_path"], item.to_json)
+      visit item["base_path"]
+    end
+  end
+
+  def get_content_example(name)
+    GovukContentSchemaTestHelpers::Examples.new.get(schema_format, name)
+  end
+
+  # Override this method if your test file doesn't match the convention
+  def schema_format
+    self.class.to_s.gsub('Test', '').underscore
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require 'rails/test_help'
 require 'webmock/minitest'
 require 'support/govuk_content_schema_examples'
 require 'capybara/rails'
+require 'slimmer/test_helpers/shared_templates'
 
 class ActiveSupport::TestCase
   include GovukContentSchemaExamples
@@ -20,4 +21,5 @@ end
 class ActionDispatch::IntegrationTest
   # Make the Capybara DSL available in all integration tests
   include Capybara::DSL
+  include Slimmer::TestHelpers::SharedTemplates
 end


### PR DESCRIPTION
Government Frontend already has _some_ [integration tests](https://github.com/alphagov/government-frontend/blob/master/test/contracts/govuk_content_schemas_test.rb), that ensure none of the content examples for supported formats return a non-200. This gives some coverage, but when working on Statistics Announcement @binaryberry and I felt that we were missing proper integration coverage, and that it was hard to approach adding a format by TDD.

This PR adds integration tests that be run per format/example, specifically asserting the behaviour of the different examples. The commits show a slight evolution of how I approached this, so read them if you want to know the decisions leading to the overall diff.

I've added some quite basic tests for Take Part and Case Study to illustrate usage, and make sure the code wasn't tightly coupled with Statistics Announcements. They're not exhaustive, but at least new formats can follow this pattern.

The overall pattern is an integration test per format, with a test per example. Each example should exercise some combination of features of that format and should be tested. Simpler formats, like Take Part, have few variations and only have one test.

I've also tried to reduce the boilerplate in the actual tests to make them easier to read, hopefully.

**Thoughts:**

- There's a growing collection of component based asserts in `test_helper`, which have some duplicated logic, but not _quite_ enough to generalise it _yet_. Also, as that list grows it'll make less sense to move that out in to a `component_asserts` type module, but again, not there yet.
- For formats with many examples, there is a lot of duplication in "basic" behaviours, like titles, descriptions, etc. I wonder if this might be better done in test per-format that runs across all examples for that format, testing the common behaviours, leaving the per-example tests to deal with example specific logic. Or we could only include the common behaviours tests in the first/happy-case example and omit them in other examples.
- Some of the component test helpers would be useful in other apps, and longer term I think we'll want to extract them out into `slimmer`, but in a way thats aware of different test frameworks.