### PR TITLE
Support Statistics announcements with changed date

### DIFF
--- a/app/assets/stylesheets/views/_statistics_announcement.scss
+++ b/app/assets/stylesheets/views/_statistics_announcement.scss
@@ -9,4 +9,11 @@
   .cancellation-notice {
     @include notice;
   }
+
+  .release-date-change-notice {
+    h2 {
+      font-weight: bold;
+      margin-bottom: $gutter-half;
+    }
+  }
 }

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -22,6 +22,14 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
     release_date
   end
 
+  def previous_release_date
+    content_item["details"]["previous_display_date"]
+  end
+
+  def release_date_changed?
+    content_item["details"].include?("previous_display_date")
+  end
+
   def other_metadata
     if cancelled?
       {
@@ -48,6 +56,10 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
 
   def cancellation_reason
     content_item["details"]["cancellation_reason"]
+  end
+
+  def release_date_change_reason
+    content_item["details"]["latest_change_note"]
   end
 
 private

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 </div>
 
-<div class="grid-row">
+<div class="grid-row primary-metadata">
   <div class="column-two-thirds">
     <%= render 'govuk_component/metadata',
         other: @content_item.other_metadata,
@@ -34,3 +34,17 @@
   </div>
 <% end %>
 <%= render 'shared/description', description: @content_item.description %>
+
+<% if @content_item.release_date_changed? %>
+<div class="grid-row">
+  <div class="column-two-thirds release-date-change-notice">
+    <h2>The release date has been changed</h2>
+    <%= render 'govuk_component/metadata',
+        other: {
+          "Previous date" => @content_item.previous_release_date,
+          "Reason for change" => @content_item.release_date_change_reason,
+        }
+    %>
+  </div>
+</div>
+<% end %>

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -31,4 +31,21 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
     assert_has_component_metadata_pair("Proposed release", "20 January 2016 9:30am")
     assert_has_component_metadata_pair("Cancellation date", "17 January 2016 2:19pm")
   end
+
+  test "statistics with a changed release date" do
+    setup_and_visit_content_item('release_date_changed')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+
+    within '.primary-metadata' do
+      assert_has_component_metadata_pair("Release date", "20 January 2016 9:30am (confirmed)")
+    end
+
+    within '.release-date-change-notice' do
+      assert page.has_text?("The release date has been changed")
+      assert_has_component_metadata_pair("Previous date", "19 January 2016 9:30am")
+      assert_has_component_metadata_pair("Reason for change", @content_item["details"]["latest_change_note"])
+    end
+  end
 end

--- a/test/presenters/statistics_announcement_presenter_test.rb
+++ b/test/presenters/statistics_announcement_presenter_test.rb
@@ -21,6 +21,10 @@ class StatisticsAnnouncementPresenterTest < ActiveSupport::TestCase
     assert_equal '20 January 2016 9:30am', statistics_announcement.release_date
   end
 
+  test 'presents previous_release_date' do
+    assert_equal '19 January 2016 9:30am', statistics_announcement_date_changed.previous_release_date
+  end
+
   test 'presents release_date_and_status when confirmed' do
     assert_equal '20 January 2016 9:30am (confirmed)', statistics_announcement.release_date_and_status
   end
@@ -58,6 +62,11 @@ class StatisticsAnnouncementPresenterTest < ActiveSupport::TestCase
     assert statistics_announcement_national.national_statistics?
   end
 
+  test 'knows if the release date has changed' do
+    assert statistics_announcement_date_changed.release_date_changed?
+    assert_not statistics_announcement_national.release_date_changed?
+  end
+
   def statistics_announcement_cancelled
     statistics_announcement('cancelled_official_statistics')
   end
@@ -68,6 +77,10 @@ class StatisticsAnnouncementPresenterTest < ActiveSupport::TestCase
 
   def statistics_announcement_national
     statistics_announcement('national_statistics')
+  end
+
+  def statistics_announcement_date_changed
+    statistics_announcement('release_date_changed')
   end
 
   def statistics_announcement(type = 'official_statistics')


### PR DESCRIPTION
This applies when a 'confirmed' announcement has it's release date
edited, which should not normally happen. When it does it must be
disclosed, and the reason explained.

![diagnostic imaging dataset for september 2015 statistics release announcement gov uk](https://cloud.githubusercontent.com/assets/63201/12682725/ec32c0c0-c6ac-11e5-887f-52f359896e5e.png)


In WH this disclosure is done as a separate headed section, with
a second 'metadata'-style block to format the date and reason.

Long term this may not be the right pattern for the page, and may
be consolidated into the main metadata block, or otherwise be
made more consistent with other document formats.

To get the feature migrated in the short term i've included a second
call to the metadata component, which causes some complexity in the
integration test, where there is now two metadata components when
asserting. In order to avoid the conflict, i've scoped the metadata
asserts for the `release_date_changed` example only, as the others
don't have multiple metadata blocks.

This does add a slightly spurious class to distinguish the first/
main metadata block, but it feels better than adding a lot of
complexity to the tests or test helpers. If this is a pattern we
encounter in more formats in the future, then we should look at
adding support to the test helpers for cases like this.