### PR TITLE
Use 'refute' instead of 'assert_not' in tests

### DIFF
--- a/test/presenters/statistics_announcement_presenter_test.rb
+++ b/test/presenters/statistics_announcement_presenter_test.rb
@@ -58,13 +58,13 @@ class StatisticsAnnouncementPresenterTest < ActiveSupport::TestCase
   end
 
   test 'knows if an item is a national statistic' do
-    assert_not statistics_announcement.national_statistics?
+    refute statistics_announcement.national_statistics?
     assert statistics_announcement_national.national_statistics?
   end
 
   test 'knows if the release date has changed' do
     assert statistics_announcement_date_changed.release_date_changed?
-    assert_not statistics_announcement_national.release_date_changed?
+    refute statistics_announcement_national.release_date_changed?
   end
 
   def statistics_announcement_cancelled


### PR DESCRIPTION
Flagged in https://github.com/alphagov/government-frontend/pull/85

Searching Github @alphagov uses `refute` exclusively, the only result for
`assert_not` is the instance being removed here.

[1] https://github.com/search?q=refute+%40alphagov&ref=searchresults&type=Code&utf8=%E2%9C%93
[2] https://github.com/search?utf8=%E2%9C%93&q=assert_not+%40alphagov&type=Code&ref=searchresults