### PR TITLE
Prevent widows in descriptions

### DIFF
--- a/app/helpers/typography_helper.rb
+++ b/app/helpers/typography_helper.rb
@@ -1,0 +1,5 @@
+module TypographyHelper
+  def nbsp_between_last_two_words(text)
+    text.sub(/\s([\w\.\?\!]+)$/, '&nbsp;\1').html_safe
+  end
+end

--- a/app/views/shared/_description.html.erb
+++ b/app/views/shared/_description.html.erb
@@ -1,3 +1,3 @@
 <p class="description">
-  <%= description %>
+  <%= nbsp_between_last_two_words(description) %>
 </p>

--- a/test/helpers/typography_helper_test.rb
+++ b/test/helpers/typography_helper_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class TypographyHelperTest < ActionView::TestCase
+  test "nbsp_between_last_two_words" do
+    assert_equal "this", nbsp_between_last_two_words("this")
+    assert_equal "this and&nbsp;that", nbsp_between_last_two_words("this and that")
+    assert_equal "this and&nbsp;that.", nbsp_between_last_two_words("this and that.")
+    assert_equal "this and&nbsp;that\n\n", nbsp_between_last_two_words("this and that\n\n")
+    assert_equal "multiline\nthis and&nbsp;that", nbsp_between_last_two_words("multiline\nthis and that")
+
+    assert_equal "NCS is for 16 and 17 year&nbsp;olds.", nbsp_between_last_two_words("NCS is for 16 and 17 year olds.")
+  end
+end


### PR DESCRIPTION
Stop widows by putting a `&nbsp;` between the last two words in a description

## Before
![screen shot 2016-02-01 at 16 21 34](https://cloud.githubusercontent.com/assets/319055/12723115/f323456c-c8ff-11e5-98b9-3c09e47f4c81.png)

## After
![screen shot 2016-02-01 at 16 21 43](https://cloud.githubusercontent.com/assets/319055/12723117/f5d0cb7c-c8ff-11e5-9bd7-f8c040cfc26a.png)
