### PR TITLE
Improve whitespace on withdrawn/cancelled notices

### DIFF
--- a/app/assets/stylesheets/helpers/_notice.scss
+++ b/app/assets/stylesheets/helpers/_notice.scss
@@ -1,17 +1,18 @@
 @mixin notice {
   clear: both;
-  margin: 15px 0;
-  padding: 15px 10px;
+  @include responsive-bottom-margin;
+  padding: $gutter-two-thirds;
   border: 5px solid $govuk-blue;
 
-  @include media(tablet) {
-    padding: 25px 10px;
-    margin-bottom: $gutter;
+  @include media(mobile) {
+    padding: $gutter-half;
   }
 
   h2 {
     @include bold-36;
+    margin-bottom: $gutter-one-third;
   }
+
   p {
     @include core-19;
   }

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -14,13 +14,14 @@
     translations: @content_item.available_translations
   %>
   </div>
+</div>
   <% if @content_item.withdrawn? %>
     <div class="withdrawal-notice">
       <h2>This <%= t("content_item.format.#{@content_item.format_display_type}", count: 1).downcase %> was withdrawn on <%= @content_item.withdrawal_notice[:time] %></h2>
       <%= render 'govuk_component/govspeak', content: @content_item.withdrawal_notice[:explanation] %>
     </div>
   <% end %>
-
+<div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/metadata',
         from: @content_item.from,


### PR DESCRIPTION
👀   &nbsp;   **[Before, after and diff of affected pages](https://dl.dropboxusercontent.com/u/262911/government-frontend-notice-spacing/index.html)** &nbsp;  👀

The mixin that powers both of these had poor padding of elements
inside the blue box, and between the title and p/govspeak.

Use standard gutters, tweaked for smaller screens to match spacing
on smaller devices. Use the responsive margin mixin to ensure the
space following the notice looks even compared to other parts of
the page.

Tweak the HTML for case studies, as the notice appeared between
grid columns, but not marked up as a column, so in single-column
(mobile) mode it clung to the edge of the page. Instead, break it
out in to it's own grid row, as it is for statistics announcement
and it will flow to the edge of the grid normally.