### PR TITLE
Escape HTML before preventing widows

### DIFF
--- a/app/helpers/typography_helper.rb
+++ b/app/helpers/typography_helper.rb
@@ -1,5 +1,6 @@
 module TypographyHelper
   def nbsp_between_last_two_words(text)
-    text.sub(/\s([\w\.\?\!]+)$/, '&nbsp;\1').html_safe
+    escaped_text = html_escape_once(text.strip)
+    escaped_text.sub(/\s([\w\.\?\!]+)$/, '&nbsp;\1').html_safe
   end
 end

--- a/test/helpers/typography_helper_test.rb
+++ b/test/helpers/typography_helper_test.rb
@@ -1,13 +1,24 @@
 require 'test_helper'
 
 class TypographyHelperTest < ActionView::TestCase
-  test "nbsp_between_last_two_words" do
-    assert_equal "this", nbsp_between_last_two_words("this")
-    assert_equal "this and&nbsp;that", nbsp_between_last_two_words("this and that")
-    assert_equal "this and&nbsp;that.", nbsp_between_last_two_words("this and that.")
-    assert_equal "this and&nbsp;that\n\n", nbsp_between_last_two_words("this and that\n\n")
-    assert_equal "multiline\nthis and&nbsp;that", nbsp_between_last_two_words("multiline\nthis and that")
+  include ERB::Util
 
+  test "nbsp_between_last_two_words" do
+    assert_equal "this and&nbsp;that", nbsp_between_last_two_words("this and that")
+    assert_equal "this and&nbsp;that", nbsp_between_last_two_words("this and that ")
+    assert_equal "this and&nbsp;that.", nbsp_between_last_two_words("this and that.")
+    assert_equal "this and&nbsp;that.", nbsp_between_last_two_words("this and that. ")
+    assert_equal "this and&nbsp;that", nbsp_between_last_two_words("this and that\n\n")
+    assert_equal "multiline\nthis and&nbsp;that", nbsp_between_last_two_words("multiline\nthis and that")
     assert_equal "NCS is for 16 and 17 year&nbsp;olds.", nbsp_between_last_two_words("NCS is for 16 and 17 year olds.")
+  end
+
+  test "nbsp_between_last_two_words leaves alone single words" do
+    assert_equal "this", nbsp_between_last_two_words("this")
+  end
+
+  test "nbsp_between_last_two_words isn't unsafe" do
+    assert_equal "&lt;b&gt;this&lt;b&gt; &amp; that&nbsp;thing", nbsp_between_last_two_words("<b>this<b> & that thing")
+    assert_equal "&lt;b&gt;this&lt;b&gt; &amp;&nbsp;that", nbsp_between_last_two_words("<b>this<b> &amp; that")
   end
 end


### PR DESCRIPTION
To add a `nbsp` we need to return an html_safe string, but we shouldn’t assume there’s no unsafe HTML in the text passed through.

* Strip whitespace, escape the HTML then add the non-breaking space and mark as html_safe.

This addresses @dsingleton's feedback from the already merged #88 

cc @jamiecobbett 