### PR TITLE
Remove margin styles now in components

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,7 +11,6 @@
 @import "helpers/available-languages";
 @import "helpers/description";
 @import "helpers/sidebar-with-body";
-@import "helpers/metadata";
 @import "helpers/notice";
 
 // pages specific view imports

--- a/app/assets/stylesheets/helpers/_metadata.scss
+++ b/app/assets/stylesheets/helpers/_metadata.scss
@@ -1,7 +1,0 @@
-// Consistent margin, should be moved to the component, see:
-// https://trello.com/c/zwYvoQxY/386-standardise-whitespace-margins-on-components
-@mixin metadata {
-  .govuk-metadata {
-    @include responsive-bottom-margin;
-  }
-}

--- a/app/assets/stylesheets/views/_case-studies.scss
+++ b/app/assets/stylesheets/views/_case-studies.scss
@@ -1,5 +1,4 @@
 .case-studies {
-  @include metadata;
   @include description;
   @include sidebar-with-body;
 
@@ -10,9 +9,5 @@
 
   .withdrawal-notice {
     @include notice;
-  }
-
-  .govuk-document-footer {
-    margin-bottom: $gutter * 1.5;
   }
 }

--- a/app/assets/stylesheets/views/_statistics_announcement.scss
+++ b/app/assets/stylesheets/views/_statistics_announcement.scss
@@ -1,5 +1,4 @@
 .statistics-announcement {
-  @include metadata;
   @include description;
 
   .national-statistics-logo {


### PR DESCRIPTION
Depends on https://github.com/alphagov/static/pull/730 being deployed.

* Metadata bottom margin is provided by component
* Document footer bottom margin is provided by component