### PR TITLE
Customise the phase banner message for service manual guides

### DIFF
--- a/app/helpers/phase_label_helper.rb
+++ b/app/helpers/phase_label_helper.rb
@@ -1,7 +1,9 @@
 module PhaseLabelHelper
-  def render_phase_label(presented_object)
+  def render_phase_label(presented_object, message)
     if presented_object.respond_to?(:phase) && %w(alpha beta).include?(presented_object.phase)
-      render partial: "govuk_component/#{presented_object.phase}_label"
+      render partial: "govuk_component/#{presented_object.phase}_label", locals: {
+        message: message
+      }
     end
   end
 end

--- a/app/helpers/phase_label_helper.rb
+++ b/app/helpers/phase_label_helper.rb
@@ -1,9 +1,9 @@
 module PhaseLabelHelper
   def render_phase_label(presented_object, message)
     if presented_object.respond_to?(:phase) && %w(alpha beta).include?(presented_object.phase)
-      render partial: "govuk_component/#{presented_object.phase}_label", locals: {
-        message: message
-      }
+      locals = {}
+      locals[:message] = message if message.present?
+      render partial: "govuk_component/#{presented_object.phase}_label", locals: locals
     end
   end
 end

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :page_class, "service-manual" %>
 <%= content_for :title, "#{@content_item.title} - Digital Service Manual" %>
+<%= content_for :phase_message, "This is the <a href='https://www.gov.uk/help/beta'>beta</a> version of the manual for building government services. <a href='https://www.gov.uk/contact/govuk'>Tell us what you think.</a>"  %>
 
 <%= render 'govuk_component/breadcrumbs', breadcrumbs: @content_item.breadcrumbs %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
 
   <div id="wrapper" class="<%= wrapper_class %>">
     <main role="main" id="content" class="<%= yield(:page_class) %>" lang="<%= I18n.locale %>">
-      <%= render_phase_label @content_item %>
+      <%= render_phase_label @content_item, content_for(:phase_message) %>
       <%= yield %>
     </main>
   </div>


### PR DESCRIPTION
Using the phase label helper, set the message for service manual guide pages. 

http://govuk-component-guide.herokuapp.com/components/beta_label

cc. @dsingleton.