### PR TITLE
Downgrade rack-cache

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       byebug (~> 8.0)
       pry (~> 0.10)
     rack (1.5.5)
-    rack-cache (1.6.0)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)


### PR DESCRIPTION
1.6.0 was yanked from ruby gems, see:

https://github.com/alphagov/whitehall/pull/2464