### PR TITLE
Enable Review Apps for Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: GOVUK_ASSET_ROOT=https://${HEROKU_APP_NAME}.herokuapp.com bin/rails server -p $PORT -e $RAILS_ENV

--- a/app.json
+++ b/app.json
@@ -1,0 +1,37 @@
+{
+  "name": "Government Frontend",
+  "repository": "https://github.com/alphagov/government-frontend",
+  "env": {
+    "GOVUK_APP_DOMAIN": {
+      "value": "www.gov.uk"
+    },
+    "GOVUK_ASSET_ROOT": {
+      "value": "https://government-frontend.herokuapp.com"
+    },
+    "GOVUK_WEBSITE_ROOT": {
+      "value": "https://www.gov.uk"
+    },
+    "PLEK_SERVICE_CONTENT_STORE_URI": {
+      "value": "https://www.gov.uk/api"
+    },
+    "PLEK_SERVICE_STATIC_URI": {
+      "value": "assets.digital.cabinet-office.gov.uk"
+    },
+    "RAILS_SERVE_STATIC_ASSETS": {
+      "value": "yes"
+    },
+    "SECRET_KEY_BASE": {
+      "generator": "secret"
+    },
+    "HEROKU_APP_NAME": {
+      "required": true
+    }
+  },
+  "image": "heroku/ruby",
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-ruby"
+    }
+  ],
+  "addons": []
+}


### PR DESCRIPTION
With this change we can enable [Review Apps](https://devcenter.heroku.com/articles/github-integration-review-apps). This allows new Heroku apps to be automatically created for each PR, allowing us to preview the changes against data from the live content store.

I'll enable Review App creation by default, which will result in all PRs gaining something like this comment:
> boffbowsh deployed to government-frontend-pr-97 25 minutes ago
