### PR TITLE
Upgrade rack-cache to 1.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       byebug (~> 8.0)
       pry (~> 0.10)
     rack (1.5.5)
-    rack-cache (1.5.1)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)


### PR DESCRIPTION
1.6.0 has been yanked:
https://rubygems.org/gems/rack-cache/versions/1.6.0