### PR TITLE
Configure asset host in development mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,4 +31,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  if ENV['GOVUK_ASSET_ROOT'].present?
+    config.asset_host = ENV['GOVUK_ASSET_ROOT']
+  end
 end


### PR DESCRIPTION
When run under `govuk_setenv`, this configures the asset host to point at the assets-origin on the dev VM.  This will give us better dev-prod parity, and enable running this behind the router in dev.

See also: https://github.com/alphagov/finder-frontend/commit/d8f25e9afc1fefbd28adb30ccc358622f8bf5f23