### PR TITLE
Revert the reordering of the SASS helper imports

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,12 +7,12 @@
 @import 'typography';
 
 // helpers for common page elements
+@import "helpers/responsive-bottom-margin";
 @import "helpers/available-languages";
 @import "helpers/dash-list";
 @import "helpers/description";
-@import "helpers/notice";
-@import "helpers/responsive-bottom-margin";
 @import "helpers/sidebar-with-body";
+@import "helpers/notice";
 
 // pages specific view imports
 @import "views/case-studies";


### PR DESCRIPTION
The `@imports` were ordered alphabetically but, while it didn't error due to the lazy evalulation of `@mixin`, we lost some meaning because "helpers/responsive-bottom-margin" was a dependency of some of the other helpers.

/cc @fofr 