### PR TITLE
Remove empty #last_updated link in service manual guide

### DIFF
--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -43,7 +43,7 @@
         <% end %>
         <dt>Last updated:</dt>
         <dd>
-          <%= link_to @content_item.last_updated_ago_in_words, "#", title: @content_item.last_update_timestamp %>
+          <%= @content_item.last_updated_ago_in_words %>
         </dd>
       </dl>
     </div>


### PR DESCRIPTION
It doesn't actually link anywhere.