### PR TITLE
Service manual frontend improvements

### DIFF
--- a/app/assets/stylesheets/views/_service-manual-topic.scss
+++ b/app/assets/stylesheets/views/_service-manual-topic.scss
@@ -10,7 +10,11 @@
   .lede {
     @include core-24;
     margin-top: $gutter;
-    margin-bottom: $gutter * 1.5;
+    margin-bottom: $gutter;
+
+    @include media(tablet) {
+      margin-bottom: $gutter * 1.5;
+    }
   }
 
   // Topic subsections

--- a/app/assets/stylesheets/views/_service-manual-topic.scss
+++ b/app/assets/stylesheets/views/_service-manual-topic.scss
@@ -3,14 +3,14 @@
   // Lede text
   .lede {
     @include core-24;
-    margin-top: 30px;
-    margin-bottom: 60px;
+    margin-top: $gutter;
+    margin-bottom: $gutter * 1.5;
   }
 
   // Topic subsections
   .subsection {
     width: 100%;
-    margin-bottom: 30px;
+    margin-bottom: $gutter;
   }
 
   .subsection-title {
@@ -18,21 +18,21 @@
   }
 
   .subsection-description {
-    @include core-16;
     color: $secondary-text-colour;
-    margin-bottom: .9375em;   // 15px
+    margin-bottom: $gutter-one-quarter;
+
     @include media(tablet) {
-      margin-bottom: .625em;  // 20px
+      margin-bottom: $gutter-half;
     }
   }
 
   .subsection-list {
-    margin-bottom: 0.5em;
-    padding-left: 1.25em;
+    margin-bottom: $gutter-one-quarter;
+    padding-left: $gutter-two-thirds;
   }
 
   .subsection-list-item {
-    margin-bottom: .3125em;
+    margin-bottom: 5px;
   }
 
   .subsection-list-item a {

--- a/app/assets/stylesheets/views/_service-manual-topic.scss
+++ b/app/assets/stylesheets/views/_service-manual-topic.scss
@@ -1,5 +1,11 @@
 .service-manual-topic {
 
+  margin-bottom: $gutter;
+
+  @include media(tablet) {
+    margin-bottom: $gutter * 2;
+  }
+
   // Lede text
   .lede {
     @include core-24;

--- a/app/assets/stylesheets/views/_service-manual.scss
+++ b/app/assets/stylesheets/views/_service-manual.scss
@@ -7,7 +7,8 @@
   }
 
   .community-contact {
-    margin-top: 1.875em; // 30/16
+    margin-top: $gutter;
+    margin-bottom: $gutter;
   }
 
   // Lede text

--- a/app/assets/stylesheets/views/_service-manual.scss
+++ b/app/assets/stylesheets/views/_service-manual.scss
@@ -1,5 +1,11 @@
 .service-manual {
 
+  margin-bottom: $gutter;
+
+  @include media(tablet) {
+    margin-bottom: $gutter * 2;
+  }
+
   .community-contact {
     margin-top: 1.875em; // 30/16
   }

--- a/app/assets/stylesheets/views/_service-manual.scss
+++ b/app/assets/stylesheets/views/_service-manual.scss
@@ -79,11 +79,13 @@
 
   .page-contents-title {
     @include bold-16;
-    margin-bottom: 0.3125em;
+    margin-bottom: 5px;
   }
 
   .page-contents-list li {
+    @include core-16;
     list-style-type: none;
+    margin-bottom: 5px;
     margin-left: $gutter-half;
     padding-right: $gutter-half;
 


### PR DESCRIPTION
- Use the $gutter variables from the front end toolkit
- Add a margin at the bottom of the main content area
- Reduce the bottom margin for lede text at smaller screen widths
- Increase the spacing between list items for page contents

cc. @AndrewVos, @thehenster.