### PR TITLE
Run the ruby and sass linters when the default rake task is run

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -42,16 +42,6 @@ git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-sc
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
 
-if [[ ${GIT_BRANCH} != "origin/master" ]]; then
-  bundle exec govuk-lint-ruby \
-    --diff \
-    --format html --out rubocop-${GIT_COMMIT}.html \
-    --format clang \
-    Gemfile app test config
-
-  bundle exec govuk-lint-sass app
-fi
-
 GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas bundle exec rake
 bundle exec rake assets:precompile
 

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,11 @@
+desc "run ruby and sass linters"
+task :lint do
+  if ENV["JENKINS"]
+    sh "govuk-lint-ruby --format html --out rubocop-${GIT_COMMIT}.html --format clang Gemfile app test config"
+  else
+    sh "govuk-lint-ruby --format clang Gemfile app test config"
+  end
+  sh "govuk-lint-sass app"
+end
+
+Rake::Task[:default].enhance [:lint]


### PR DESCRIPTION
This should help us stop committing code that will fail the linter under CI.