### PR TITLE
Remove extra spacing above lede text

### DIFF
--- a/app/assets/stylesheets/views/_service-manual-topic.scss
+++ b/app/assets/stylesheets/views/_service-manual-topic.scss
@@ -9,7 +9,6 @@
   // Lede text
   .lede {
     @include core-24;
-    margin-top: $gutter;
     margin-bottom: $gutter;
 
     @include media(tablet) {


### PR DESCRIPTION
This is causing the lead paragraph to sit too far below the title. Removing
this additional margin fixes this.

Before:

![before - agile delivery gov uk](https://cloud.githubusercontent.com/assets/417754/13249315/8981d7d6-da1b-11e5-9334-f9582e18e21c.png)


After:

![after - agile delivery gov uk](https://cloud.githubusercontent.com/assets/417754/13249314/881ef5fe-da1b-11e5-89e7-f624bb544037.png)

cc. @fofr.