### PR TITLE
Increase font sizes for Service Manual topic pages

### DIFF
--- a/app/assets/stylesheets/views/_service-manual-topic.scss
+++ b/app/assets/stylesheets/views/_service-manual-topic.scss
@@ -20,6 +20,10 @@
   .subsection {
     width: 100%;
     margin-bottom: $gutter;
+
+    @include media(tablet) {
+      margin-bottom: $gutter * 1.5;
+    }
   }
 
   .subsection-title {
@@ -39,7 +43,6 @@
 
   .subsection-list {
     @include core-19;
-    margin-bottom: $gutter-one-quarter;
     padding-left: $gutter-two-thirds;
   }
 

--- a/app/assets/stylesheets/views/_service-manual-topic.scss
+++ b/app/assets/stylesheets/views/_service-manual-topic.scss
@@ -23,10 +23,11 @@
   }
 
   .subsection-title {
-    @include bold-19;
+    @include bold-24;
   }
 
   .subsection-description {
+    @include core-19;
     color: $secondary-text-colour;
     margin-bottom: $gutter-one-quarter;
 
@@ -36,6 +37,7 @@
   }
 
   .subsection-list {
+    @include core-19;
     margin-bottom: $gutter-one-quarter;
     padding-left: $gutter-two-thirds;
   }

--- a/app/assets/stylesheets/views/_service-manual-topic.scss
+++ b/app/assets/stylesheets/views/_service-manual-topic.scss
@@ -24,6 +24,7 @@
 
   .subsection-title {
     @include bold-24;
+    margin-bottom: 5px;
   }
 
   .subsection-description {


### PR DESCRIPTION
The text on Service Manual topic pages is too small.

Increase the size of titles to 24px, ensure all body text is 19px.

Increase the bottom margin between subsections.

Before:

![before - agile delivery gov uk](https://cloud.githubusercontent.com/assets/417754/13255386/e3a3ce82-da3d-11e5-88f2-bc5a33b15046.png)

After:

![after - agile delivery gov uk](https://cloud.githubusercontent.com/assets/417754/13255600/bdae4ddc-da3e-11e5-9388-0790c6eacfc7.png)

cc. @AndrewVos @thehenster. 