### PR TITLE
[WIP] Show a custom header for service manual guides

### DIFF
--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -1,6 +1,12 @@
 <%= content_for :page_class, "service-manual" %>
 <%= content_for :title, "#{@content_item.title} - Digital Service Manual" %>
 
+<% content_for :simple_header do %>
+    <nav id='proposition-menu'>
+      <a href='/service-manual' id='proposition-name'>Digital service manual</a>
+    </nav>
+<% end %>
+
 <% content_for :phase_message do %>
   <%= render 'shared/service_manual_custom_phase_message', phase: @content_item.phase %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,12 @@
   <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item.content_item } %>
 </head>
 <body>
-  <%= render partial: 'govuk_component/government_navigation', locals: { active: active_proposition } %>
+
+  <% if content_for(:simple_header).present? %>
+    <%= content_for(:simple_header) %>
+  <% else %>
+      <%= render partial: 'govuk_component/government_navigation', locals: { active: active_proposition } %>
+  <% end %>
 
   <div id="wrapper" class="<%= wrapper_class %>">
     <main role="main" id="content" class="<%= yield(:page_class) %>" lang="<%= I18n.locale %>">

--- a/test/integration/service_manual_test.rb
+++ b/test/integration/service_manual_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class ServiceManualTest < ActionDispatch::IntegrationTest
+  test "it displays a custom header" do
+    guide_sample = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('service_manual_guide', 'basic_with_related_discussions'))
+    content_store_has_item("/service-manual/agile", guide_sample.to_json)
+    visit "/service-manual/agile"
+    within "#proposition-menu" do
+      assert page.has_link? "Digital service manual", href: "/service-manual"
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/8LMnQ2eE/176-gov-uk-header-remove-standard-navigation-and-replace-with-single-link-to-service-manual-homepage

![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-23-02-2016-16-40-39-vahngith.png)