### PR TITLE
Reimplement content owners for service manual guides

### DIFF
--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -21,7 +21,6 @@
         <%= link_to "Give feedback about this page", "/contact/govuk", class: "feedback" %>
       </p>
     </div>
-
   </div>
 </div>
 
@@ -32,9 +31,11 @@
     <div class="metadata">
       <dl>
         <dt>Published by:</dt>
-        <dd>
-          <%= link_to @content_item.content_owner.title, @content_item.content_owner.href %>
-        </dd>
+        <% @content_item.content_owners.each do |content_owner| %>
+          <dd>
+            <%= link_to content_owner.title, content_owner.href %>
+          </dd>
+        <% end %>
         <% if @content_item.related_discussion %>
           <dt>Related discussion:</dt>
           <dd>

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -30,11 +30,13 @@
 
     <div class="metadata">
       <dl>
-        <dt>Published by:</dt>
-        <% @content_item.content_owners.each do |content_owner| %>
-          <dd>
-            <%= link_to content_owner.title, content_owner.href %>
-          </dd>
+        <% if @content_item.content_owners.any? %>
+          <dt>Published by:</dt>
+          <% @content_item.content_owners.each do |content_owner| %>
+            <dd>
+              <%= link_to content_owner.title, content_owner.href %>
+            </dd>
+          <% end %>
         <% end %>
         <% if @content_item.related_discussion %>
           <dt>Related discussion:</dt>

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -8,4 +8,12 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
       assert page.has_link?('Agile delivery community')
     end
   end
+
+  test "service manual guide does not show published by" do
+    setup_and_visit_content_item('service_manual_guide_community')
+
+    within('.metadata') do
+      refute page.has_content?('Published by')
+    end
+  end
 end

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class ServiceManualGuideTest < ActionDispatch::IntegrationTest
+  test "service manual guide shows content owners" do
+    setup_and_visit_content_item('basic_with_related_discussions')
+
+    within('.metadata') do
+      assert page.has_link?('Agile delivery community')
+    end
+  end
+end

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -7,7 +7,7 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
     assert presented_guide.body.size > 10
     assert presented_guide.header_links.size >= 1
 
-    content_owner = presented_guide.content_owner
+    content_owner = presented_guide.content_owners.first
     assert content_owner.title.present?
     assert content_owner.href.present?
 
@@ -55,22 +55,36 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
     assert_nil guide.main_topic_title
   end
 
-  test '#content_owner fetches the first content owner info from the links' do
+  test '#content_owners when stored in the links' do
     guide = presented_guide(
       'details' => { 'content_owner' => nil },
-      'links' => { 'content_owners' => [{ 'title' => 'Design Community', 'base_path' => '/example/dc' }] }
+      'links' => { 'content_owners' => [{
+        "content_id" => "e5f09422-bf55-417c-b520-8a42cb409814",
+        "title" => "Agile delivery community",
+        "base_path" => "/service-manual/communities/agile-delivery-community",
+      }] }
     )
-    assert_equal 'Design Community', guide.content_owner.title
-    assert_equal '/example/dc', guide.content_owner.href
+
+    expected = [
+      ServiceManualGuidePresenter::ContentOwner.new(
+        "Agile delivery community",
+        "/service-manual/communities/agile-delivery-community")
+    ]
+    assert_equal expected, guide.content_owners
   end
 
   test '#content_owner falls back to using deprecated content owner info in details' do
     guide = presented_guide(
-      'details' => { 'content_owner' => { 'title' => 'Agile Community', 'href' => 'http://example.com/ac' } },
-      'links' => { 'content_owners' => [] }
+      'details' => { 'content_owner' => { 'title' => 'Agile Community', 'href' => '/service-manual/communities/agile-delivery-community' } },
+      'links' => {}
     )
-    assert_equal 'Agile Community', guide.content_owner.title
-    assert_equal 'http://example.com/ac', guide.content_owner.href
+
+    expected = [
+      ServiceManualGuidePresenter::ContentOwner.new(
+        "Agile Community",
+        "/service-manual/communities/agile-delivery-community")
+    ]
+    assert_equal expected, guide.content_owners
   end
 
 private


### PR DESCRIPTION
A bit of to-ing and fro-ing here but this basically the same functionality reimplemented. Content owners can exist in the details or the links but with a preference for the links.

Once all guides have been republished we can remove the code that is trying to find the content owners in the details.