### PR TITLE
Handle nil descriptions

### DIFF
--- a/app/helpers/typography_helper.rb
+++ b/app/helpers/typography_helper.rb
@@ -1,5 +1,6 @@
 module TypographyHelper
   def nbsp_between_last_two_words(text)
+    return text if text.nil?
     escaped_text = html_escape_once(text.strip)
     escaped_text.sub(/\s([\w\.\?\!]+)$/, '&nbsp;\1').html_safe
   end

--- a/test/helpers/typography_helper_test.rb
+++ b/test/helpers/typography_helper_test.rb
@@ -21,4 +21,10 @@ class TypographyHelperTest < ActionView::TestCase
     assert_equal "&lt;b&gt;this&lt;b&gt; &amp; that&nbsp;thing", nbsp_between_last_two_words("<b>this<b> & that thing")
     assert_equal "&lt;b&gt;this&lt;b&gt; &amp;&nbsp;that", nbsp_between_last_two_words("<b>this<b> &amp; that")
   end
+
+  test "nbsp_between_last_two_words handles nil descriptions" do
+    assert_nothing_raised do
+      assert_equal nil, nbsp_between_last_two_words(nil)
+    end
+  end
 end


### PR DESCRIPTION
Descriptions can be null, so we need to handle that. Here's where that's
defined in the schema:
https://github.com/alphagov/govuk-content-schemas/blob/master/formats/metadata.json#L20-L29