### PR TITLE
Show correct publish time on guide pages

### DIFF
--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -35,11 +35,11 @@ class ServiceManualGuidePresenter < ContentItemPresenter
     end
   end
 
-  def last_updated_ago_in_words
+  def last_published_time_in_words
     "#{time_ago_in_words(updated_at)} ago"
   end
 
-  def last_update_timestamp
+  def last_published_time_timestamp
     updated_at.strftime("%e %B %Y %H:%M")
   end
 
@@ -61,7 +61,7 @@ class ServiceManualGuidePresenter < ContentItemPresenter
 private
 
   def updated_at
-    DateTime.parse(content_item["public_updated_at"])
+    DateTime.parse(content_item["updated_at"])
   end
 
   def links_content_owners_attributes

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -46,7 +46,7 @@
         <% end %>
         <dt>Last updated:</dt>
         <dd>
-          <%= @content_item.last_updated_ago_in_words %>
+          <%= @content_item.last_published_time_in_words %>
         </dd>
       </dl>
     </div>

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -16,14 +16,14 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
     assert related_discussion.href.present?
   end
 
-  test '#last_updated_ago_in_words outputs a human readable definition of time ago' do
-    guide = presented_guide('public_updated_at' => 1.year.ago.iso8601)
-    assert_equal 'about 1 year ago', guide.last_updated_ago_in_words
+  test '#last_published_time_in_words outputs a human readable definition of time ago' do
+    guide = presented_guide('updated_at' => 1.year.ago.iso8601)
+    assert_equal 'about 1 year ago', guide.last_published_time_in_words
   end
 
-  test '#last_update_timestamp outputs a nicely formatted timestamp' do
-    guide = presented_guide('public_updated_at' => '2014-10-26T10:27:34Z')
-    assert_equal '26 October 2014 10:27', guide.last_update_timestamp
+  test '#last_published_time_timestamp outputs a nicely formatted timestamp' do
+    guide = presented_guide('updated_at' => '2014-10-26T10:27:34Z')
+    assert_equal '26 October 2014 10:27', guide.last_published_time_timestamp
   end
 
   test 'breadcrumbs have a root and a topic link' do


### PR DESCRIPTION
public_updated_at only shows the last time an item had a "major" change.
For "minor" changes this timestamp is not touched. Instead, use the
"updated_at" field, which is a field that comes out of mongo directly.