### PR TITLE
Use sticky_footer_html in html publications.

### DIFF
--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -91,4 +91,17 @@
     }
   }
 
+  .back-to-content {
+    @include core-19;
+    display: block;
+    padding-bottom: $gutter-half;
+
+    &:before {
+      content: "\2191";
+    }
+
+    @media print {
+      display: none;
+    }
+  }
 }

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -28,4 +28,5 @@
     locals: {
       content: @content_item.body,
       direction: page_text_direction,
+      sticky_footer_html: %(<a class="back-to-content" href="#contents">Contents</a>)
     } %>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -28,5 +28,5 @@
     locals: {
       content: @content_item.body,
       direction: page_text_direction,
-      sticky_footer_html: %(<a class="back-to-content" href="#contents">Contents</a>)
+      sticky_footer_html: %(<a class="back-to-content" href="#contents">#{ t("content_item.contents") }</a>)
     } %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -323,3 +323,4 @@ ar:
     metadata:
       published: "نشر"
       updated: "تحديث"
+    contents:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -141,3 +141,4 @@ az:
     metadata:
       published: dərc olunub
       updated: yenilənib
+    contents:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -231,3 +231,4 @@ be:
     metadata:
       published: "Апублікаваны"
       updated: "Адноўлена"
+    contents:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -141,3 +141,4 @@ bg:
     metadata:
       published: "Публикувано"
       updated: "обновено"
+    contents:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -141,3 +141,4 @@ bn:
     metadata:
       published:
       updated:
+    contents:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -186,3 +186,4 @@ cs:
     metadata:
       published: Publikováno
       updated: Aktualizováno
+    contents:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -321,3 +321,4 @@ cy:
     metadata:
       published: cyhoeddwyd
       updated: diweddarwyd
+    contents: Cynnwys

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -141,3 +141,4 @@ de:
     metadata:
       published: Veröffentlicht
       updated: Aktualisiert
+    contents:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -141,3 +141,4 @@ dr:
     metadata:
       published: "نشر شده"
       updated: "به روز شده"
+    contents:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -141,3 +141,4 @@ el:
     metadata:
       published: "Δημοσιευμένο"
       updated: "ανανεωμένο "
+    contents:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -141,3 +141,4 @@ es-419:
     metadata:
       published: publicado
       updated: actualizado
+    contents:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -141,3 +141,4 @@ es:
     metadata:
       published: Publicado
       updated: Actualizado
+    contents:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -141,5 +141,6 @@ et:
     metadata:
       published: avaldatud
       updated: Täiendatud
+    contents: Sisukord
   html_publication:
     see_more: 'Loe lähemalt: %{document_type}'

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -141,3 +141,4 @@ fa:
     metadata:
       published: "منتشر شده"
       updated: "به روز رسانی شده"
+    contents:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -141,3 +141,4 @@ fr:
     metadata:
       published: publié
       updated: mise à  jour
+    contents:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -231,3 +231,4 @@ he:
     metadata:
       published: "פורסם"
       updated: "מעודכן"
+    contents:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -141,3 +141,4 @@ hi:
     metadata:
       published: "प्रकाशित"
       updated: "अद्यतन"
+    contents:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -141,3 +141,4 @@ hu:
     metadata:
       published: közzététel dátuma
       updated: 'Utolsó frissítés:'
+    contents:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -141,3 +141,4 @@ hy:
     metadata:
       published: "հրապարակված"
       updated: "Թարմացված"
+    contents:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -141,3 +141,4 @@ id:
     metadata:
       published: Diterbitkan
       updated: Terkini
+    contents:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -141,3 +141,4 @@ it:
     metadata:
       published: pubblicato
       updated: aggiornato
+    contents:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -141,3 +141,4 @@ ja:
     metadata:
       published: "掲載日"
       updated: "更新"
+    contents:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -141,3 +141,4 @@ ka:
     metadata:
       published:
       updated:
+    contents:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -141,3 +141,4 @@ ko:
     metadata:
       published: "발행"
       updated: "업데이트"
+    contents:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -186,3 +186,4 @@ lt:
     metadata:
       published: publikuota
       updated: atnaujinta
+    contents:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -141,3 +141,4 @@ lv:
     metadata:
       published: publicēts
       updated: atjaunināts
+    contents:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -141,3 +141,4 @@ ms:
     metadata:
       published:
       updated:
+    contents:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -231,3 +231,4 @@ pl:
     metadata:
       published: opublikowano
       updated: Zaktualizowany
+    contents:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -141,3 +141,4 @@ ps:
     metadata:
       published: "خپور شوی"
       updated: "تازه شوي"
+    contents:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -141,3 +141,4 @@ pt:
     metadata:
       published: publicado
       updated: Atualizado
+    contents:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -186,3 +186,4 @@ ro:
     metadata:
       published: Data publicării
       updated: Actualizat
+    contents:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -186,4 +186,4 @@ ro:
     metadata:
       published: Data publicării
       updated: Actualizat
-    contents:
+    contents: Conținut

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -231,3 +231,4 @@ ru:
     metadata:
       published: "Опубликовано"
       updated: "обновлено"
+    contents:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -141,3 +141,4 @@ si:
     metadata:
       published: "පල කරන ලදී"
       updated: "යාවත්කාලීන කල"
+    contents:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -186,3 +186,4 @@ sk:
     metadata:
       published:
       updated:
+    contents:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -141,3 +141,4 @@ so:
     metadata:
       published: La-daabacay/nashriyey
       updated: Wax lagu kordhiyey
+    contents:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -141,3 +141,4 @@ sq:
     metadata:
       published: publikuar
       updated: rifreskuar
+    contents:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -231,3 +231,4 @@ sr:
     metadata:
       published: objavljeno
       updated: ažurirano
+    contents:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -141,3 +141,4 @@ sw:
     metadata:
       published:
       updated:
+    contents:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -141,3 +141,4 @@ ta:
     metadata:
       published: "பிரசுரிக்கப்பட்டது"
       updated: "இற்றைப்படுத்தப்பட்டது"
+    contents:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -141,3 +141,4 @@ th:
     metadata:
       published: "ตีพิมพ์"
       updated: "ปรับปรุง"
+    contents:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -141,3 +141,4 @@ tk:
     metadata:
       published:
       updated:
+    contents:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -141,3 +141,4 @@ tr:
     metadata:
       published: Yayında
       updated: Güncellendi
+    contents:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -231,3 +231,4 @@ uk:
     metadata:
       published: "опубліковано"
       updated: "оновлено"
+    contents:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -141,5 +141,6 @@ ur:
     metadata:
       published: "شائع شدہ"
       updated: "تجدید شدہ"
+    contents:
   language_names:
     ur: "اردو"

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -141,3 +141,4 @@ uz:
     metadata:
       published: nashr qilindi
       updated: yangilandi
+    contents:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -141,3 +141,4 @@ vi:
     metadata:
       published: "Đã xuất bản"
       updated: Cập nhật
+    contents:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -141,3 +141,4 @@ zh-hk:
     metadata:
       published: "已發布"
       updated: "已更新"
+    contents:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -141,3 +141,4 @@ zh-tw:
     metadata:
       published: "發行"
       updated: "更新"
+    contents:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -143,3 +143,4 @@ zh:
     metadata:
       published: "已发布"
       updated: "已更新"
+    contents:


### PR DESCRIPTION
Uses the new module developed in https://github.com/alphagov/static/pull/757. Do not merge until that PR is ready.

Relevant Trello ticket: https://trello.com/c/cJGrtnc1/286-5-html-publications-migration-front-end-work-large.

Previous implementation to play around with, on live Whitehall: http://www.gov.uk/government/publications/dwp-single-departmental-plan-2015-to-2020/dwp-single-departmental-plan-2015-to-2020.

Looks just as before (red added for emphasis, first screenshot is "hiding" it as per the desired behaviour):

![screen shot 2016-03-15 at 17 12 07](https://cloud.githubusercontent.com/assets/1650875/13786918/b568e648-ead1-11e5-929e-30232ac9caf8.png)
![screen shot 2016-03-15 at 17 12 09](https://cloud.githubusercontent.com/assets/1650875/13786919/b57286a8-ead1-11e5-8118-9604e5b08f01.png)
![screen shot 2016-03-15 at 17 12 21](https://cloud.githubusercontent.com/assets/1650875/13786917/b565fb72-ead1-11e5-8550-6ada84e32da5.png)
