### PR TITLE
Display the organisation logos in HTML publications.

### DIFF
--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -1,4 +1,38 @@
+@import "grid_layout";
+
 .html-publication {
+  @include responsive-top-margin;
+
+  .publication-external {
+    @extend %grid-row;
+    margin-bottom: $gutter-two-thirds;
+    position: relative;
+
+    .organisation-logos {
+      @include grid-column(1 / 4);
+      list-style-type: none;
+
+      .organisation-logo {
+        padding-bottom: $gutter-one-third;
+      }
+    }
+
+    .see-more-about-container {
+      @include grid-column(3 / 4);
+
+      .see-more-about {
+        @include core-19;
+        padding-top: $gutter-one-third;
+        position: static;
+
+        @include media(tablet) {
+          bottom: 0;
+          position: absolute;
+          right: $gutter-half;
+        }
+      }
+    }
+  }
 
   // Based on the govuk-title component
   .html-publication-title {
@@ -13,12 +47,6 @@
     h1 {
       @include bold-48;
     }
-  }
-
-  .see-more-about {
-    @include core-19;
-    margin-top: $gutter * 1.5;
-    margin-bottom: $gutter-half;
   }
 
   .publication-header {

--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -26,6 +26,10 @@ class HtmlPublicationPresenter < ContentItemPresenter
     parent["base_path"]
   end
 
+  def organisations
+    content_item["links"]["organisations"].sort_by { |o| o["title"] }
+  end
+
 private
 
   def parent

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -4,9 +4,28 @@
   content_for :simple_header, true
 %>
 
-<p class="see-more-about">
-  <%= link_to t('html_publication.see_more', document_type: t("content_item.format.#{@content_item.format_sub_type}", count: 1)), @content_item.parent_base_path %>
-</p>
+<div class="publication-external">
+  <ol class="organisation-logos">
+    <% @content_item.organisations.each do |organisation| %>
+      <li class="organisation-logo">
+        <%= render partial: 'govuk_component/organisation_logo', locals: {
+          organisation: {
+            name: organisation["logo"]["formatted_title"],
+            url: organisation["base_path"],
+            brand: organisation["brand"],
+            crest: organisation["logo"]["crest"]
+          }
+        } %>
+      </li>
+    <% end %>
+  </ol>
+
+  <div class="see-more-about-container">
+    <p class="see-more-about">
+      <%= link_to t('html_publication.see_more', document_type: t("content_item.format.#{@content_item.format_sub_type}", count: 1)), @content_item.parent_base_path %>
+    </p>
+  </div>
+</div>
 
 <header class="publication-header" id="contents">
   <div class="headings">

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -15,6 +15,10 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       assert page.has_css?('ol.unnumbered')
     end
 
+    within ".organisation-logos" do
+      assert page.has_text?(@content_item["links"]["organisations"][0]["title"])
+    end
+
     assert_has_component_govspeak_html_publication(@content_item["details"]["body"])
   end
 

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -20,6 +20,16 @@ class HtmlPublicationPresenterTest < ActiveSupport::TestCase
     assert_equal html_publication["links"]["parent"][0]["base_path"], presented_html_publication.parent_base_path
   end
 
+  test 'presents the list of organisations' do
+    multiple_organisations_html_publication = govuk_content_schema_example('html_publication', 'multiple_organisations')
+    organisation_titles = multiple_organisations_html_publication["links"]["organisations"].map { |o| o["title"] }
+
+    presented_unordered_html_publication = HtmlPublicationPresenter.new(multiple_organisations_html_publication)
+    presented_organisations = presented_unordered_html_publication.organisations.map { |o| o["title"] }
+
+    assert_equal organisation_titles, presented_organisations
+  end
+
   def presented_html_publication(type = 'published')
     content_item = html_publication(type)
     HtmlPublicationPresenter.new(content_item)


### PR DESCRIPTION
This is part of migrating `html_publications` from `whitehall` to `government-frontend`.

Worth mentioning: in the presenter, organisations are sorted because the `content_item["links"]` are not guaranteed to come in a meaningful order.

Relevant Trello ticket: https://trello.com/c/cJGrtnc1/286-5-html-publications-migration-front-end-work-large

Looks like this:

![screen shot 2016-03-16 at 16 40 48](https://cloud.githubusercontent.com/assets/1650875/13822309/0c85b174-eb9d-11e5-9820-a0cf4ad9d599.png)
