### PR TITLE
Replace active government navigation test

### DIFF
--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -59,15 +59,6 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "includes government navigation and sets the correct active item" do
-    content_item = content_store_has_schema_example('case_study', 'case_study')
-
-    get :show, path: path_for(content_item)
-
-    assert_response :success
-    assert_select shared_component_selector('government_navigation'), match: "case-studies"
-  end
-
   test "returns 404 for item not in content store" do
     path = 'government/case-studies/boost-chocolate-production'
 

--- a/test/integration/government_navigation_test.rb
+++ b/test/integration/government_navigation_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class GovernmentNavigationTest < ActionDispatch::IntegrationTest
+  test "includes government navigation and sets the correct active item" do
+    example_body = get_content_example_by_format_and_name("case_study", "case_study")
+    base_path = JSON.parse(example_body).fetch("base_path")
+    content_store_has_item(base_path, example_body)
+
+    visit base_path
+
+    assert_has_active_government_navigation("case-studies")
+  end
+
+  def assert_has_active_government_navigation(name)
+    within shared_component_selector("government_navigation") do
+      assert_equal name, JSON.parse(page.text).fetch("active")
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -78,7 +78,11 @@ class ActionDispatch::IntegrationTest
   end
 
   def get_content_example(name)
-    GovukContentSchemaTestHelpers::Examples.new.get(schema_format, name)
+    get_content_example_by_format_and_name(schema_format, name)
+  end
+
+  def get_content_example_by_format_and_name(format, name)
+    GovukContentSchemaTestHelpers::Examples.new.get(format, name)
   end
 
   # Override this method if your test file doesn't match the convention


### PR DESCRIPTION
The controller assertion assert_select doesn't have a `match:` argument and always passes no matter what the expected value. Replaced with an integration test to take advantage of #within.