### PR TITLE
Fix brand for executive office orgs in html pubs.

### DIFF
--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -30,6 +30,15 @@ class HtmlPublicationPresenter < ContentItemPresenter
     content_item["links"]["organisations"].sort_by { |o| o["title"] }
   end
 
+  # HACK: Replaces the organisation_brand for executive office organisations.
+  # Remove this in the future after migrating organisations to the content store API,
+  # and updating them with the correct brand in the actual store.
+  def organisation_brand(organisation)
+    brand = organisation["brand"]
+    brand = "executive-office" if organisation["logo"]["crest"] == "eo"
+    brand
+  end
+
 private
 
   def parent

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -12,7 +12,7 @@
           organisation: {
             name: organisation["logo"]["formatted_title"],
             url: organisation["base_path"],
-            brand: organisation["brand"],
+            brand: @content_item.organisation_brand(organisation),
             crest: organisation["logo"]["crest"]
           }
         } %>

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -22,9 +22,20 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
     assert_has_component_govspeak_html_publication(@content_item["details"]["body"])
   end
 
+  test "prime minister office organisation html publication" do
+    setup_and_visit_content_item("prime_ministers_office")
+    assert_has_component_organisation_logo_with_brand("executive-office", 4)
+  end
+
   def assert_has_component_govspeak_html_publication(content)
     within shared_component_selector("govspeak_html_publication") do
       assert_equal content, JSON.parse(page.text).fetch("content")
+    end
+  end
+
+  def assert_has_component_organisation_logo_with_brand(brand, index = 1)
+    within("li.organisation-logo:nth-of-type(#{index}) #{shared_component_selector('organisation_logo')}") do
+      assert_equal brand, JSON.parse(page.text).fetch("organisation").fetch("brand")
     end
   end
 end

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -30,6 +30,24 @@ class HtmlPublicationPresenterTest < ActiveSupport::TestCase
     assert_equal organisation_titles, presented_organisations
   end
 
+  test "presents the branding for organisations" do
+    mo_presented_html_publication = presented_html_publication("multiple_organisations")
+    mo_presented_html_publication.organisations.each do |organisation|
+      assert_equal mo_presented_html_publication.organisation_brand(organisation), organisation["brand"]
+    end
+  end
+
+  test "alters the branding for executive office organisations" do
+    organisation = {
+      "brand" => "cabinet-office",
+      "logo" => {
+        "formatted_title" => "Prime Minister's Office, 10 Downing Street",
+        "crest" => "eo"
+      }
+    }
+    assert_equal presented_html_publication("prime_ministers_office").organisation_brand(organisation), "executive-office"
+  end
+
   def presented_html_publication(type = 'published')
     content_item = html_publication(type)
     HtmlPublicationPresenter.new(content_item)


### PR DESCRIPTION
This will pass through the correct brand that the `organisation_logo` component in `static` expects in order to display the `executive-office` organisation correctly in HTML publications. More precisely, it will
trigger this class and its effects: https://github.com/alphagov/static/blob/500d2fafc7280ba5cc295b28b03c1e85fdf3e95a/app/assets/stylesheets/govuk-component/_organisation-logo.scss#L45.

This is a hack that should be removed once organisations are migrated to the content store.

Part of fixing this visual regression:

![prime-minister s-office](https://cloud.githubusercontent.com/assets/1650875/13926409/1b086e36-ef84-11e5-9436-892eef189e61.png)

Relevant Trello ticket: https://trello.com/c/cJGrtnc1/286-5-html-publications-migration-front-end-work-large