### PR TITLE
Turn on config.i18n.fallbacks.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,10 @@ module GovernmentFrontend
       :ru, :si, :sk, :so, :sq, :sr, :sw, :ta, :th, :tk, :tr,
       :uk, :ur, :uz, :vi, :zh, 'zh-hk', 'zh-tw']
 
+    # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+    # the I18n.default_locale when a translation can not be found).
+    config.i18n.fallbacks = true
+
     # Disable rack::cache
     config.action_dispatch.rack_cache = nil
 


### PR DESCRIPTION
Part of the addressing the final unintended changes introduced with migrating HTML publications in https://trello.com/c/cJGrtnc1/286-5-html-publications-migration-front-end-work-large.

This brings government-frontend in line with Whitehall with regards to how it handles missing translation keys.


### Before

Rails falls back to capitalising the key.

![screen shot 2016-03-23 at 19 09 56](https://cloud.githubusercontent.com/assets/1650875/13997637/f20f1770-f12a-11e5-9ed6-6bcddbd57464.png)

### After

Rails uses the English translation, as on live Whitehall.

![screen shot 2016-03-23 at 19 10 04](https://cloud.githubusercontent.com/assets/1650875/13997643/f67a4b4a-f12a-11e5-8cdb-3e133ce0b824.png)
