### PR TITLE
Improve HTML publications RTL rendering.

### DIFF
--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -31,6 +31,21 @@
           right: $gutter-half;
         }
       }
+
+      &.direction-rtl {
+        direction: rtl;
+        text-align: start;
+
+        // Chrome (and probably other browsers) does a weird thing where it changes
+        // the font kerning ever so slightly when RTL rendering latin characters,
+        // which will cause the glyphs to become slightly wider, which will cause
+        // them to collapse over multiple rows even though they do have enough space to fit.
+        // It's reproducible only for specific character strings, such as "See More".
+        // This is a sheepish fix, by giving the element much more space than it needs.
+        .see-more-about {
+          width: 100%;
+        }
+      }
     }
   }
 

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -56,6 +56,11 @@
 
     background: $light-blue;
     padding: $gutter $gutter $gutter / 3;
+
+    &.direction-rtl {
+      direction: rtl;
+      text-align: start;
+    }
   }
 
   .in-page-navigation {

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -3,6 +3,10 @@
   content_for :title, @content_item.title
   content_for :simple_header, true
 %>
+<%
+  publication_header_direction_class = ""
+  publication_header_direction_class = " direction-#{page_text_direction}" if page_text_direction
+%>
 
 <div class="publication-external">
   <ol class="organisation-logos">
@@ -27,7 +31,7 @@
   </div>
 </div>
 
-<header class="publication-header" id="contents">
+<header class="publication-header<%= publication_header_direction_class %>" id="contents">
   <div class="headings">
     <div class="html-publication-title">
       <p class="context"><%= I18n.t("content_item.format.#{@content_item.format_sub_type}", count: 1) %></p>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -2,10 +2,9 @@
   content_for :page_class, @content_item.format.dasherize
   content_for :title, @content_item.title
   content_for :simple_header, true
-%>
-<%
-  publication_header_direction_class = ""
-  publication_header_direction_class = " direction-#{page_text_direction}" if page_text_direction
+
+  direction_css_class = ""
+  direction_css_class = " direction-#{page_text_direction}" if page_text_direction
 %>
 
 <div class="publication-external">
@@ -24,14 +23,14 @@
     <% end %>
   </ol>
 
-  <div class="see-more-about-container">
+  <div class="see-more-about-container<%= direction_css_class %>">
     <p class="see-more-about">
       <%= link_to t('html_publication.see_more', document_type: t("content_item.format.#{@content_item.format_sub_type}", count: 1)), @content_item.parent_base_path %>
     </p>
   </div>
 </div>
 
-<header class="publication-header<%= publication_header_direction_class %>" id="contents">
+<header class="publication-header<%= direction_css_class %>" id="contents">
   <div class="headings">
     <div class="html-publication-title">
       <p class="context"><%= I18n.t("content_item.format.#{@content_item.format_sub_type}", count: 1) %></p>

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -27,6 +27,11 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
     assert_has_component_organisation_logo_with_brand("executive-office", 4)
   end
 
+  test "html publication with rtl text direction" do
+    setup_and_visit_content_item("arabic_translation")
+    assert page.has_css?(".publication-header.direction-rtl"), "has .direction-rtl class on .publication-header element"
+  end
+
   def assert_has_component_govspeak_html_publication(content)
     within shared_component_selector("govspeak_html_publication") do
       assert_equal content, JSON.parse(page.text).fetch("content")

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -30,6 +30,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   test "html publication with rtl text direction" do
     setup_and_visit_content_item("arabic_translation")
     assert page.has_css?(".publication-header.direction-rtl"), "has .direction-rtl class on .publication-header element"
+    assert page.has_css?(".see-more-about-container.direction-rtl"), "has .direction-rtl class on .see-more-about-container element"
   end
 
   def assert_has_component_govspeak_html_publication(content)


### PR DESCRIPTION
Part of the addressing the final unintended changes introduced with migrating HTML publications in https://trello.com/c/cJGrtnc1/286-5-html-publications-migration-front-end-work-large.

This fixes the rendering for the header and the see more about link. Changes are grouped in this PR because they are very similar.

### Before

![screen shot 2016-03-23 at 19 14 13](https://cloud.githubusercontent.com/assets/1650875/13997787/aa0da6de-f12b-11e5-9a0b-86dee1462ced.png)

### After

![screen shot 2016-03-23 at 19 14 32](https://cloud.githubusercontent.com/assets/1650875/13997794/b244dcc8-f12b-11e5-9ced-dc66f51dc9fc.png)
