### PR TITLE
Remove margin-bottom on .publication-header.

### DIFF
--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -55,7 +55,6 @@
     color: $white;
 
     background: $light-blue;
-    margin-bottom: $gutter * 1.5;
     padding: $gutter $gutter $gutter / 3;
   }
 


### PR DESCRIPTION
Part of making HTML publications visually consistent with the previous Whitehall ones.

Relevant Trello ticket: https://trello.com/c/cJGrtnc1/286-5-html-publications-migration-front-end-work-large

### Before

![screen shot 2016-03-24 at 11 27 00](https://cloud.githubusercontent.com/assets/1650875/14015783/750f254c-f1b3-11e5-995b-71d0b60c6098.png)

### After

![screen shot 2016-03-24 at 11 25 19](https://cloud.githubusercontent.com/assets/1650875/14015794/8a7cb336-f1b3-11e5-9aa2-fc531453ba44.png)

