### PR TITLE
[do-not-merge] Show service manual guide change history

### DIFF
--- a/app/assets/stylesheets/views/_service-manual.scss
+++ b/app/assets/stylesheets/views/_service-manual.scss
@@ -143,4 +143,22 @@
     margin-bottom: 0.5em;
   }
 
+  // Change history
+  .change-history {
+    @include core-19;
+  }
+
+  .change-history-published-by {
+    @include bold-24;
+  }
+
+  .change-history-public-timestamp {
+    @include bold-24;
+  }
+
+  .change-history-note {
+    @include core-19;
+    color: $secondary-text-colour;
+  }
+
 }

--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -1,6 +1,7 @@
 class ServiceManualGuidePresenter < ContentItemPresenter
   ContentOwner = Struct.new(:title, :href)
   RelatedDiscussion = Struct.new(:title, :href)
+  ChangeHistory = Struct.new(:public_timestamp, :note)
 
   include ActionView::Helpers::DateHelper
   attr_reader :body, :publish_time, :header_links
@@ -56,6 +57,16 @@ class ServiceManualGuidePresenter < ContentItemPresenter
     crumbs << { title: main_topic["title"], url: main_topic["base_path"] } if main_topic
     crumbs << { title: content_item["title"] }
     crumbs
+  end
+
+  def change_history
+    change_history = Array(@content_item["details"]["change_history"])
+    change_history.map do |c|
+      ChangeHistory.new(
+        Time.parse(c["public_timestamp"]),
+        c["note"],
+      )
+    end
   end
 
 private

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -76,3 +76,31 @@
 
   </div>
 </div>
+
+<% if @content_item.change_history.any? %>
+  <div class="grid-row change-history">
+    <div>
+      Published by:
+    </div>
+
+    <% @content_item.content_owners.each do |content_owner| %>
+      <div class="change-history-published-by">
+        <%= link_to content_owner.title, content_owner.href %>
+      </div>
+    <% end %>
+
+    <div>
+      Last update:
+    </div>
+
+    <% @content_item.change_history.each do |change_history| %>
+      <div class="change-history-public-timestamp">
+        <%= change_history.public_timestamp.strftime("%d %B %Y") %>
+      </div>
+      <div class="change-history-note">
+        <%= change_history.note.html_safe %>
+      </div>
+    <% end %>
+
+  </div>
+<% end %>

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -79,28 +79,33 @@
 
 <% if @content_item.change_history.any? %>
   <div class="grid-row change-history">
-    <div>
-      Published by:
+    <div class="column-one-third">
+      &nbsp;
     </div>
-
-    <% @content_item.content_owners.each do |content_owner| %>
-      <div class="change-history-published-by">
-        <%= link_to content_owner.title, content_owner.href %>
+    <div class="column-two-thirds">
+      <div>
+        Published by:
       </div>
-    <% end %>
 
-    <div>
-      Last update:
+      <% @content_item.content_owners.each do |content_owner| %>
+        <div class="change-history-published-by">
+          <%= link_to content_owner.title, content_owner.href %>
+        </div>
+      <% end %>
+
+      <div>
+        Last update:
+      </div>
+
+      <% @content_item.change_history.each do |change_history| %>
+        <div class="change-history-public-timestamp">
+          <%= change_history.public_timestamp.strftime("%d %B %Y") %>
+        </div>
+        <div class="change-history-note">
+          <%= change_history.note.html_safe %>
+        </div>
+      <% end %>
     </div>
-
-    <% @content_item.change_history.each do |change_history| %>
-      <div class="change-history-public-timestamp">
-        <%= change_history.public_timestamp.strftime("%d %B %Y") %>
-      </div>
-      <div class="change-history-note">
-        <%= change_history.note.html_safe %>
-      </div>
-    <% end %>
 
   </div>
 <% end %>

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -16,4 +16,21 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
       refute page.has_content?('Published by')
     end
   end
+
+  test "service manual guide shows change history" do
+    setup_and_visit_content_item('with_change_history')
+    within ".change-history" do
+      within ".change-history-published-by" do
+        assert page.has_content? "Agile delivery community"
+      end
+
+      expected_timestamps = ["09 October 2015", "09 January 2016"]
+      timestamps = all(".change-history-public-timestamp").map(&:text)
+      assert_equal expected_timestamps, timestamps
+
+      expected_notes = ["This is a change", "This is another change"]
+      notes = all(".change-history-note").map(&:text)
+      assert_equal expected_notes, notes
+    end
+  end
 end

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -87,6 +87,23 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
     assert_equal expected, guide.content_owners
   end
 
+  test "#change_history outputs change history" do
+    expected_time = Time.now
+    guide = presented_guide(
+      "details" => {
+        "change_history" => [
+          "public_timestamp" => expected_time.iso8601,
+          "note" => "A Change Note",
+        ],
+      }
+    )
+
+    refute_empty guide.change_history
+    first_change = guide.change_history.first
+    assert_equal "A Change Note", first_change.note
+    assert_equal expected_time.to_i, first_change.public_timestamp.to_i
+  end
+
 private
 
   def presented_guide(overriden_attributes = {})


### PR DESCRIPTION
Do not merge, this still needs some styling. 

https://trello.com/c/qzHbv9S9/181-show-change-notes-and-page-history-at-the-bottom-of-guidance-page

Dependent on:

https://github.com/alphagov/government-frontend/pull/129
https://github.com/alphagov/service-manual-publisher/pull/209
https://github.com/alphagov/govuk-content-schemas/pull/274

![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-30-03-2016-12-54-09-aepaijoo.png)