### PR TITLE
Communities in service manual topic sidebar

### DIFF
--- a/app/assets/stylesheets/mixins/_service-manual-related.scss
+++ b/app/assets/stylesheets/mixins/_service-manual-related.scss
@@ -1,0 +1,25 @@
+@mixin service-manual-related {
+  // Related content
+  .related {
+    border-top: 1px solid $border-colour;
+    padding-top: 1em;
+  }
+
+  .related-title {
+    @include bold-19;
+    margin-bottom: 0.5em;
+  }
+
+  .related-description {
+    margin-bottom: 0.5em;
+  }
+
+  .related-list {
+    @include core-16;
+    list-style: none;
+  }
+
+  .related-list-item {
+    margin-bottom: 0.5em;
+  }
+}

--- a/app/assets/stylesheets/views/_service-manual-topic.scss
+++ b/app/assets/stylesheets/views/_service-manual-topic.scss
@@ -1,3 +1,5 @@
+@import "mixins/service-manual-related";
+
 .service-manual-topic {
 
   margin-bottom: $gutter;
@@ -53,5 +55,7 @@
   .subsection-list-item a {
     text-decoration: underline;
   }
+
+  @include service-manual-related;
 
 }

--- a/app/assets/stylesheets/views/_service-manual.scss
+++ b/app/assets/stylesheets/views/_service-manual.scss
@@ -1,3 +1,5 @@
+@import "mixins/service-manual-related";
+
 .service-manual {
 
   margin-bottom: $gutter;
@@ -119,28 +121,6 @@
     }
   }
 
-  // Related content
-  .related {
-    border-top: 1px solid $border-colour;
-    padding-top: 1em;
-  }
-
-  .related-title {
-    @include bold-19;
-    margin-bottom: 0.5em;
-  }
-
-  .related-description {
-    margin-bottom: 0.5em;
-  }
-
-  .related-list {
-    @include core-16;
-    list-style: none;
-  }
-
-  .related-list-item {
-    margin-bottom: 0.5em;
-  }
+  @include service-manual-related;
 
 }

--- a/app/helpers/service_manual_topic_helper.rb
+++ b/app/helpers/service_manual_topic_helper.rb
@@ -1,0 +1,9 @@
+module ServiceManualTopicHelper
+  def service_manual_topic_related_communities_title(communities)
+    if communities.length == 1
+      "Join the #{communities.first[:title]}"
+    else
+      "Join the community"
+    end
+  end
+end

--- a/app/views/content_items/service_manual_topic.html.erb
+++ b/app/views/content_items/service_manual_topic.html.erb
@@ -45,11 +45,11 @@
         <p class="related-description">
           Discuss the work you're doing with other service teams across government.
         </p>
-        <nav role="navigation" aria-labelledby="related-communities">
+        <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
           <ul class="related-list">
             <% @content_item.content_owners.each do |content_owner| %>
               <li class="related-list-item">
-                <%= link_to @content_owner.title, @content_owner.href %>
+                <%= link_to content_owner.title, content_owner.href %>
               </li>
             <% end %>
           </ul>

--- a/app/views/content_items/service_manual_topic.html.erb
+++ b/app/views/content_items/service_manual_topic.html.erb
@@ -41,9 +41,11 @@
   <div class="column-third">
     <% if @content_item.content_owners.any? %>
       <aside class="related">
-        <h2 class="related-title" id="related-communities">Join the conversation</h2>
+        <h2 class="related-title" id="related-communities">
+          <%= service_manual_topic_related_communities_title(@content_item.content_owners) -%>
+        </h2>
         <p class="related-description">
-          Discuss the work you're doing with other service teams across government.
+          Find out what the cross-government community does and how to get involved.
         </p>
         <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
           <ul class="related-list">

--- a/test/helpers/service_manual_topic_helper_test.rb
+++ b/test/helpers/service_manual_topic_helper_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class ServiceManualTopicHelperTest < ActionView::TestCase
+  test "service_manual_topic_related_communities_title invites you to join the only related community" do
+    communities = [{ title: "Agile delivery community" }]
+
+    assert_equal "Join the Agile delivery community",
+      service_manual_topic_related_communities_title(communities)
+  end
+
+  test "service_manual_topic_related_communities_title invites you to join the community as a " \
+    "whole if there are multiple communities" do
+    communities = [{ title: "Agile delivery community" }, { title: "User research community" }]
+
+    assert_equal "Join the community",
+      service_manual_topic_related_communities_title(communities)
+  end
+end

--- a/test/integration/service_manual_topic_test.rb
+++ b/test/integration/service_manual_topic_test.rb
@@ -28,4 +28,15 @@ class ServiceManualTopicTest < ActionDispatch::IntegrationTest
 
     refute page.has_css?('meta[name="description"]', visible: false)
   end
+
+  test "it lists communities in the sidebar" do
+    setup_and_visit_content_item('service_manual_topic')
+
+    within('.related-communities') do
+      assert page.has_link?("Agile delivery community",
+        href: "/service-manual/communities/agile-delivery-community")
+      assert page.has_link?("User research community",
+        href: "/service-manual/communities/user-research-community")
+    end
+  end
 end


### PR DESCRIPTION
List the communities related to the guides included in a topic in the sidebar and invite visitors to join the community.

https://trello.com/c/rZlsL4Am/152-add-communities-sidebar-to-the-topic-pages

Related content schemas PR: https://github.com/alphagov/govuk-content-schemas/pull/277