### PR TITLE
Fix display of contact details on policy groups

### DIFF
--- a/app/assets/stylesheets/views/_topical-event-about-page.scss
+++ b/app/assets/stylesheets/views/_topical-event-about-page.scss
@@ -3,7 +3,6 @@
   @include sidebar-with-body;
 
   .offset-one-third {
-    // scss-lint:disable SpaceAroundOperator
-    margin-left: percentage(1/3);
+    margin-left: percentage(1 / 3);
   }
 }

--- a/app/assets/stylesheets/views/_working-group.scss
+++ b/app/assets/stylesheets/views/_working-group.scss
@@ -1,3 +1,7 @@
 .working-group {
   @include description;
+
+  .offset-one-third {
+    margin-left: percentage(1 / 3);
+  }
 }

--- a/app/presenters/working_group_presenter.rb
+++ b/app/presenters/working_group_presenter.rb
@@ -29,7 +29,7 @@ private
   def extra_headings
     extra_headings = []
     extra_headings << { id: "policies", text: "Policies" } if policies.any?
-    extra_headings << { id: "contact-details", text: "Contact details" } if email
+    extra_headings << { id: "contact-details", text: "Contact details" } if email.present?
     extra_headings
   end
 end

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -19,9 +19,6 @@
     </div>
   <% end %>
   <div class="column-two-thirds <% unless @content_item.contents.any? %>offset-one-third<% end %>">
-    <%= render 'govuk_component/govspeak',
-        content: @content_item.body,
-        direction: page_text_direction %>
 
     <% @additional_body = capture do %>
       <% if @content_item.policies.any? %>
@@ -39,7 +36,7 @@
       <% end %>
     <% end %>
     <%= render 'govuk_component/govspeak',
-        content: @additional_body,
+        content: "#{@content_item.body} #{@additional_body}",
         direction: page_text_direction %>
   </div>
 </div>

--- a/test/integration/working_group_test.rb
+++ b/test/integration/working_group_test.rb
@@ -7,7 +7,6 @@ class WorkingGroupTest < ActionDispatch::IntegrationTest
     assert page.has_text?(@content_item["description"])
     assert page.has_text?("Contact details")
     assert page.has_text?(@content_item["details"]["email"])
-    assert_has_component_govspeak(@content_item["details"]["body"])
 
     assert_has_contents_list([
       { text: "Membership",         id: "membership" },
@@ -15,8 +14,11 @@ class WorkingGroupTest < ActionDispatch::IntegrationTest
       { text: "Meeting Minutes",    id: "meeting-minutes" },
       { text: "Contact details",    id: "contact-details" },
     ])
-    within_component_govspeak(index: 2) do |component_args|
-      html = Nokogiri::HTML.parse(component_args.fetch("content"))
+    within_component_govspeak do |component_args|
+      content = component_args.fetch("content")
+      assert content.include? @content_item["details"]["body"]
+
+      html = Nokogiri::HTML.parse(content)
       assert_not_nil html.at_css("h2#contact-details")
     end
   end
@@ -32,7 +34,7 @@ class WorkingGroupTest < ActionDispatch::IntegrationTest
     assert_has_contents_list([
       { text: "Policies", id: "policies" },
     ])
-    within_component_govspeak(index: 2) do |component_args|
+    within_component_govspeak do |component_args|
       html = Nokogiri::HTML.parse(component_args.fetch("content"))
       assert_not_nil html.at_css("h2#policies")
     end


### PR DESCRIPTION
### Don't show contact in contents when no email

When an email is excluded it’s sent as an empty string in the content item, rather than being omitted. The template checks for `email.present?` but the contents logic doesn’t, which creates a discrepancy.

![screen shot 2016-04-01 at 14 27 25](https://cloud.githubusercontent.com/assets/319055/14208168/e880600a-f815-11e5-8cc2-87528af7f9e7.png)

--

### Use single govspeak component

When using separate components the vertical rhythm of content could break. We apply special rules to the first element in govspeak, eg removing headings from the first H2.

The second govspeak component would remove the margin from the “Contact details” heading, so its content would appear closer to the body than it should.

Rather than wrap that content and give it some margin, concatenate the two bodies and pass to a single component.

#### Before
![screen shot 2016-04-01 at 14 27 11](https://cloud.githubusercontent.com/assets/319055/14208171/ed8ce42e-f815-11e5-8252-ae97f29d3f2d.png)

#### After
![screen shot 2016-04-01 at 14 26 55](https://cloud.githubusercontent.com/assets/319055/14208173/f051c698-f815-11e5-8473-96017557df5b.png)
