### PR TITLE
Show service manual guide change history at the bottom of the page

### DIFF
--- a/app/assets/stylesheets/views/_service-manual.scss
+++ b/app/assets/stylesheets/views/_service-manual.scss
@@ -123,4 +123,22 @@
 
   @include service-manual-related;
 
+  // Change history
+  .change-history {
+    @include core-19;
+  }
+
+  .change-history-published-by {
+    @include bold-24;
+  }
+
+  .change-history-public-timestamp {
+    @include bold-24;
+  }
+
+  .change-history-note {
+    @include core-19;
+    color: $secondary-text-colour;
+  }
+
 }

--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -1,6 +1,7 @@
 class ServiceManualGuidePresenter < ContentItemPresenter
   ContentOwner = Struct.new(:title, :href)
   RelatedDiscussion = Struct.new(:title, :href)
+  ChangeHistory = Struct.new(:public_timestamp, :note, :reason_for_change)
 
   include ActionView::Helpers::DateHelper
   attr_reader :body, :publish_time, :header_links
@@ -56,6 +57,17 @@ class ServiceManualGuidePresenter < ContentItemPresenter
     crumbs << { title: main_topic["title"], url: main_topic["base_path"] } if main_topic
     crumbs << { title: content_item["title"] }
     crumbs
+  end
+
+  def change_history
+    change_history = Array(@content_item["details"]["change_history"])
+    change_history.map do |c|
+      ChangeHistory.new(
+        DateTime.parse(c["public_timestamp"]),
+        c["note"],
+        c["reason_for_change"],
+      )
+    end
   end
 
 private

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -76,3 +76,43 @@
 
   </div>
 </div>
+
+<% if @content_item.change_history.any? %>
+  <div class="grid-row change-history" data-module="toggle">
+    <div class="column-one-third">
+      &nbsp;
+    </div>
+    <div class="column-two-thirds">
+      <div>
+        Published by:
+      </div>
+
+      <% @content_item.content_owners.each do |content_owner| %>
+        <div class="change-history-published-by">
+          <%= link_to content_owner.title, content_owner.href %>
+        </div>
+      <% end %>
+
+      <div>
+        Last update:
+      </div>
+
+      <% first_change, *rest_of_changes = @content_item.change_history %>
+
+      <%= render "shared/change_history_item", change_history_item: first_change %>
+
+      <% if rest_of_changes.any? %>
+        <a href="#change-history-hidden" data-expanded="false" data-controls="change-history-hidden">
+          + full page history
+        </a>
+
+        <div id="change-history-hidden" class="js-hidden">
+          <% rest_of_changes.each do |change_history| %>
+            <%= render "shared/change_history_item", change_history_item: change_history %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+  </div>
+<% end %>

--- a/app/views/shared/_change_history_item.html.erb
+++ b/app/views/shared/_change_history_item.html.erb
@@ -1,0 +1,9 @@
+<div class="change-history-public-timestamp">
+  <%= change_history_item.public_timestamp.strftime("%d %B %Y") %>
+</div>
+<div class="change-history-note">
+  <%= change_history_item.note %>
+</div>
+<div class="change-history-reason">
+  <%= change_history_item.reason_for_change %>
+</div>

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -16,4 +16,48 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
       refute page.has_content?('Published by')
     end
   end
+
+  test "service manual guide shows latest change history" do
+    setup_and_visit_content_item('with_change_history')
+    within ".change-history" do
+      within ".change-history-published-by" do
+        assert page.has_content? "Agile delivery community"
+      end
+
+      notes = all(".change-history-note").map(&:text)
+      assert_includes notes, "This is a change"
+
+      reasons = all(".change-history-reason").map(&:text)
+      assert_includes reasons, "This is our latest change"
+
+      timestamps = all(".change-history-public-timestamp").map(&:text)
+      assert_includes timestamps, "09 October 2017"
+    end
+  end
+
+  test "service manual guide hides older change history" do
+    setup_and_visit_content_item('with_change_history')
+
+    module_container = find(".change-history")
+    assert_equal "toggle", module_container["data-module"]
+    assert_equal "toggle", module_container["data-module"]
+
+    hidden_container = find(".change-history #change-history-hidden")
+    assert_equal "js-hidden", hidden_container["class"]
+
+    expand_link = find(".change-history a", text: "+ full page history")
+    assert_equal "false", expand_link["data-expanded"]
+    assert_equal "change-history-hidden", expand_link["data-controls"]
+
+    within ".change-history #change-history-hidden" do
+      notes = all(".change-history-note").map(&:text)
+      assert_includes notes, "This is another change"
+
+      reasons = all(".change-history-reason").map(&:text)
+      assert_includes reasons, "This is why we made this change and it has a second line of text"
+
+      timestamps = all(".change-history-public-timestamp").map(&:text)
+      assert_includes timestamps, "09 January 2016"
+    end
+  end
 end

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -87,6 +87,23 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
     assert_equal expected, guide.content_owners
   end
 
+  test "#change_history outputs change history" do
+    expected_time = Time.now
+    guide = presented_guide(
+      "details" => {
+        "change_history" => [
+          "public_timestamp" => expected_time.iso8601,
+          "note" => "A Change Note",
+        ],
+      }
+    )
+
+    refute_empty guide.change_history
+    first_change = guide.change_history.first
+    assert_equal "A Change Note", first_change.note
+    assert_equal expected_time.to_i, first_change.public_timestamp.to_i
+  end
+
 private
 
   def presented_guide(overriden_attributes = {})


### PR DESCRIPTION
https://trello.com/c/qzHbv9S9/181-show-change-notes-and-page-history-at-the-bottom-of-guidance-page

## On initial page load

![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-08-04-2016-10-37-48-cheetaot.png)

## After clicking that link

![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-08-04-2016-10-38-07-ahzaeroe.png)