### PR TITLE
Detailed guides migration

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,3 +28,4 @@
 @import "views/topical-event-about-page";
 @import "views/unpublishing";
 @import "views/working-group";
+@import "views/detailed-guide";

--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -1,0 +1,3 @@
+.detailed-guide {
+
+}

--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -1,3 +1,8 @@
 .detailed-guide {
+  @include description;
+  @include sidebar-with-body;
 
+  .offset-one-third {
+    margin-left: percentage(1 / 3);
+  }
 }

--- a/app/presenters/case_study_presenter.rb
+++ b/app/presenters/case_study_presenter.rb
@@ -1,5 +1,6 @@
 class CaseStudyPresenter < ContentItemPresenter
   include ActionView::Helpers::UrlHelper
+  include CommonSections
 
   attr_reader :body, :format_display_type
 
@@ -7,41 +8,6 @@ class CaseStudyPresenter < ContentItemPresenter
     super
     @body = content_item["details"]["body"]
     @format_display_type = content_item["details"]["format_display_type"]
-  end
-
-  def from
-    links("lead_organisations") + links("supporting_organisations") + links("worldwide_organisations")
-  end
-
-  def part_of
-    links("document_collections") + links("related_policies") + links("worldwide_priorities") + links("world_locations")
-  end
-
-  def history
-    return [] unless any_updates?
-    content_item["details"]["change_history"].map do |item|
-      {
-        display_time: display_time(item["public_timestamp"]),
-        note: item["note"],
-        timestamp: item["public_timestamp"]
-      }
-    end
-  end
-
-  def published
-    display_time(content_item["details"]["first_public_at"])
-  end
-
-  def updated
-    display_time(content_item["public_updated_at"]) if any_updates?
-  end
-
-  def short_history
-    if any_updates?
-      "#{I18n.t('content_item.metadata.updated')} #{updated}"
-    else
-      "#{I18n.t('content_item.metadata.published')} #{published}"
-    end
   end
 
   def image
@@ -56,6 +22,10 @@ class CaseStudyPresenter < ContentItemPresenter
     withdrawn? ? "[Withdrawn] #{title}" : title
   end
 
+  def part_of
+    links("document_collections") + links("related_policies") + links("worldwide_priorities") + links("world_locations")
+  end
+
   def withdrawal_notice
     notice = content_item["details"]["withdrawn_notice"]
     if notice
@@ -63,23 +33,6 @@ class CaseStudyPresenter < ContentItemPresenter
         time: content_tag(:time, display_time(notice["withdrawn_at"]), datetime: notice["withdrawn_at"]),
         explanation: notice["explanation"]
       }
-    end
-  end
-
-private
-
-  def any_updates?
-    if (first_public_at = content_item["details"]["first_public_at"]).present?
-      DateTime.parse(content_item["public_updated_at"]) != DateTime.parse(first_public_at)
-    else
-      false
-    end
-  end
-
-  def links(type)
-    return [] unless content_item["links"][type]
-    content_item["links"][type].map do |link|
-      link_to(link["title"], link["base_path"])
     end
   end
 end

--- a/app/presenters/common_sections.rb
+++ b/app/presenters/common_sections.rb
@@ -1,0 +1,49 @@
+module CommonSections
+  def from
+    links("lead_organisations") + links("supporting_organisations") + links("worldwide_organisations")
+  end
+
+  def published
+    display_time(content_item["details"]["first_public_at"])
+  end
+
+  def updated
+    display_time(content_item["public_updated_at"]) if any_updates?
+  end
+
+  def short_history
+    if any_updates?
+      "#{I18n.t('content_item.metadata.updated')} #{updated}"
+    else
+      "#{I18n.t('content_item.metadata.published')} #{published}"
+    end
+  end
+
+  def history
+    return [] unless any_updates?
+    content_item["details"]["change_history"].map do |item|
+      {
+        display_time: display_time(item["public_timestamp"]),
+        note: item["note"],
+        timestamp: item["public_timestamp"]
+      }
+    end
+  end
+
+private
+
+  def any_updates?
+    if (first_public_at = content_item["details"]["first_public_at"]).present?
+      DateTime.parse(content_item["public_updated_at"]) != DateTime.parse(first_public_at)
+    else
+      false
+    end
+  end
+
+  def links(type)
+    return [] unless content_item["links"][type]
+    content_item["links"][type].map do |link|
+      link_to(link["title"], link["base_path"])
+    end
+  end
+end

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -28,7 +28,7 @@ class DetailedGuidePresenter < ContentItemPresenter
   end
 
   def part_of
-    links("document_collections") + links("related_policies") + links("worldwide_priorities") + links("world_locations")
+    links("document_collections") + links("related_policies") + links("worldwide_priorities") + links("world_locations") + links("topics")
   end
 
   def history

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -1,2 +1,14 @@
 class DetailedGuidePresenter < ContentItemPresenter
+  include ExtractsHeadings
+  include ActionView::Helpers::UrlHelper
+
+  def body
+    content_item["details"]["body"]
+  end
+
+  def contents
+    extract_headings_with_ids(body).map do |heading|
+      link_to(heading[:text], "##{heading[:id]}")
+    end
+  end
 end

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -11,4 +11,71 @@ class DetailedGuidePresenter < ContentItemPresenter
       link_to(heading[:text], "##{heading[:id]}")
     end
   end
+
+  def context
+    parent["title"]
+  end
+
+  def breadcrumbs
+    [
+      { title: "Home", url: "/" },
+      { title: context, url: parent["base_path"] }
+    ]
+  end
+
+  def from
+    links("lead_organisations") + links("supporting_organisations") + links("worldwide_organisations")
+  end
+
+  def part_of
+    links("document_collections") + links("related_policies") + links("worldwide_priorities") + links("world_locations")
+  end
+
+  def history
+    return [] unless any_updates?
+    content_item["details"]["change_history"].map do |item|
+      {
+        display_time: display_time(item["public_timestamp"]),
+        note: item["note"],
+        timestamp: item["public_timestamp"]
+      }
+    end
+  end
+
+  def published
+    display_time(content_item["details"]["first_public_at"])
+  end
+
+  def updated
+    display_time(content_item["public_updated_at"]) if any_updates?
+  end
+
+  def short_history
+    if any_updates?
+      "#{I18n.t('content_item.metadata.updated')} #{updated}"
+    else
+      "#{I18n.t('content_item.metadata.published')} #{published}"
+    end
+  end
+
+private
+
+  def parent
+    content_item["links"]["parent"][0]
+  end
+
+  def any_updates?
+    if (first_public_at = content_item["details"]["first_public_at"]).present?
+      DateTime.parse(content_item["public_updated_at"]) != DateTime.parse(first_public_at)
+    else
+      false
+    end
+  end
+
+  def links(type)
+    return [] unless content_item["links"][type]
+    content_item["links"][type].map do |link|
+      link_to(link["title"], link["base_path"])
+    end
+  end
 end

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -1,9 +1,17 @@
 class DetailedGuidePresenter < ContentItemPresenter
   include ExtractsHeadings
   include ActionView::Helpers::UrlHelper
+  include CommonSections
 
   def body
     content_item["details"]["body"]
+  end
+
+  def breadcrumbs
+    [
+      { title: "Home", url: "/" },
+      { title: context, url: parent["base_path"] }
+    ]
   end
 
   def contents
@@ -16,66 +24,13 @@ class DetailedGuidePresenter < ContentItemPresenter
     parent["title"]
   end
 
-  def breadcrumbs
-    [
-      { title: "Home", url: "/" },
-      { title: context, url: parent["base_path"] }
-    ]
-  end
-
-  def from
-    links("lead_organisations") + links("supporting_organisations") + links("worldwide_organisations")
-  end
-
   def part_of
     links("document_collections") + links("related_policies") + links("worldwide_priorities") + links("world_locations") + links("topics")
-  end
-
-  def history
-    return [] unless any_updates?
-    content_item["details"]["change_history"].map do |item|
-      {
-        display_time: display_time(item["public_timestamp"]),
-        note: item["note"],
-        timestamp: item["public_timestamp"]
-      }
-    end
-  end
-
-  def published
-    display_time(content_item["details"]["first_public_at"])
-  end
-
-  def updated
-    display_time(content_item["public_updated_at"]) if any_updates?
-  end
-
-  def short_history
-    if any_updates?
-      "#{I18n.t('content_item.metadata.updated')} #{updated}"
-    else
-      "#{I18n.t('content_item.metadata.published')} #{published}"
-    end
   end
 
 private
 
   def parent
     content_item["links"]["parent"][0]
-  end
-
-  def any_updates?
-    if (first_public_at = content_item["details"]["first_public_at"]).present?
-      DateTime.parse(content_item["public_updated_at"]) != DateTime.parse(first_public_at)
-    else
-      false
-    end
-  end
-
-  def links(type)
-    return [] unless content_item["links"][type]
-    content_item["links"][type].map do |link|
-      link_to(link["title"], link["base_path"])
-    end
   end
 end

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -8,10 +8,15 @@ class DetailedGuidePresenter < ContentItemPresenter
   end
 
   def breadcrumbs
-    [
-      { title: "Home", url: "/" },
-      { title: context, url: parent["base_path"] }
-    ]
+    e = parent
+    res = []
+
+    while e
+      res << { title: e["title"], url: e["base_path"] }
+      e = e["parent"] && e["parent"].first
+    end
+
+    res.reverse
   end
 
   def contents

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -1,0 +1,2 @@
+class DetailedGuidePresenter < ContentItemPresenter
+end

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -16,6 +16,7 @@ class DetailedGuidePresenter < ContentItemPresenter
       e = e["parent"] && e["parent"].first
     end
 
+    res << { title: "Home", url: "/" }
     res.reverse
   end
 

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -6,7 +6,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
-        context: "Guidance",
+        context: t("content_item.format.#{@content_item.format}", count: 1),
         title: @content_item.title %>
   </div>
 </div>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -6,7 +6,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
-        context: "#{@content_item.context} — guidance",
+        context: "Guidance",
         title: @content_item.title %>
   </div>
 </div>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,11 +1,26 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.title %>
 
+<%= render 'govuk_component/breadcrumbs', breadcrumbs: @content_item.breadcrumbs %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.format}", count: 1),
+        context: "#{@content_item.context} — guidance",
         title: @content_item.title %>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/metadata',
+        from: @content_item.from,
+        updated: @content_item.updated,
+        history: @content_item.short_history,
+        published: @content_item.published,
+        direction: page_text_direction,
+        part_of: @content_item.part_of
+    %>
   </div>
 </div>
 
@@ -23,3 +38,12 @@
         direction: page_text_direction %>
   </div>
 </div>
+
+<%= render 'govuk_component/document_footer',
+    from: @content_item.from,
+    updated: @content_item.updated,
+    history: @content_item.history,
+    published: @content_item.published,
+    direction: page_text_direction,
+    part_of: @content_item.part_of
+%>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -10,3 +10,16 @@
 </div>
 
 <%= render 'shared/description', description: @content_item.description %>
+
+<div class="grid-row sidebar-with-body">
+  <% if @content_item.contents.any? %>
+    <div class="column-third">
+      <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
+    </div>
+  <% end %>
+  <div class="column-two-thirds <% unless @content_item.contents.any? %>offset-one-third<% end %>">
+    <%= render 'govuk_component/govspeak',
+        content: @content_item.body,
+        direction: page_text_direction %>
+  </div>
+</div>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,0 +1,12 @@
+<%= content_for :page_class, @content_item.format.dasherize %>
+<%= content_for :title, @content_item.title %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+        context: t("content_item.format.#{@content_item.format}", count: 1),
+        title: @content_item.title %>
+  </div>
+</div>
+
+<%= render 'shared/description', description: @content_item.description %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -15,11 +15,11 @@
   <div class="column-two-thirds">
     <%= render 'govuk_component/metadata',
         from: @content_item.from,
-        updated: @content_item.updated,
-        history: @content_item.short_history,
-        published: @content_item.published,
-        direction: page_text_direction,
-        part_of: @content_item.part_of
+        other: {
+          "First published" => @content_item.published,
+          "Last updated" => @content_item.updated,
+          "Part of" => @content_item.part_of #doing this to preserve the ordering but if part_of, at the same level as from and other
+        }
     %>
   </div>
 </div>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -17,7 +17,7 @@
         from: @content_item.from,
         other: {
           "First published" => @content_item.published,
-          "Last updated" => @content_item.updated,
+          "Last updated" => [@content_item.updated,"<a href=\"#history\">see all updates</a>"].join(", "),
           "Part of" => @content_item.part_of #doing this to preserve the ordering but if part_of, at the same level as from and other
         }
     %>
@@ -44,6 +44,5 @@
     updated: @content_item.updated,
     history: @content_item.history,
     published: @content_item.published,
-    direction: page_text_direction,
-    part_of: @content_item.part_of
+    direction: page_text_direction
 %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -68,7 +68,7 @@ ar:
         few:
         many:
         other:
-      detailed_guidance:
+      detailed_guide:
         zero:
         one: "توجيه مفصل"
         two:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -30,7 +30,7 @@ az:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "ətraflı məlumat"
         other: "ətraflı məlumat"
       document_collection:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -48,7 +48,7 @@ be:
         few:
         many:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "Падрабязнае кіраўніцтва"
         few:
         many:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -30,7 +30,7 @@ bg:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "Подробна насока"
         other: "Подробни насоки"
       document_collection:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -30,7 +30,7 @@ bn:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one:
         other:
       document_collection:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -39,7 +39,7 @@ cs:
         one:
         few:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Podrobný návod
         few:
         other: Podrobný návod

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -66,7 +66,7 @@ cy:
         few:
         many:
         other:
-      detailed_guidance:
+      detailed_guide:
         zero:
         one: Cyfarwyddyd manwl
         two:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -30,7 +30,7 @@ de:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Detaillierte Hinweise
         other: Detaillierte Hinweise
       document_collection:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -30,7 +30,7 @@ dr:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: " رهنمود مفصل"
         other: "رهنمود های مفصل"
       document_collection:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -30,7 +30,7 @@ el:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "Οδηγίες"
         other: "Οδηγίες"
       document_collection:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,7 +73,7 @@ en:
       correspondence:
         one: Correspondence
         other: Correspondences
-      detailed_guidance:
+      detailed_guide:
         one: Guidance
         other: Guidance
       document_collection:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -30,7 +30,7 @@ es-419:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Orientación detallada
         other: Orientación detallada
       document_collection:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -30,7 +30,7 @@ es:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Orientación detallada
         other: Orientación detallada
       document_collection:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -30,7 +30,7 @@ et:
       decision:
         one: Otsus
         other: Otsused
-      detailed_guidance:
+      detailed_guide:
         one: Juhend
         other: Juhendid
       document_collection:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -30,7 +30,7 @@ fa:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "راهنمای تفصیلی"
         other: "راهنمای تفصیلی"
       document_collection:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -30,7 +30,7 @@ fr:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Instructions détaillées
         other: Instructions détaillées
       document_collection:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -48,7 +48,7 @@ he:
         two:
         many:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "מדריך מפורט"
         two:
         many:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -30,7 +30,7 @@ hi:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "विस्तृत मार्गदर्शन"
         other: "विस्तृत मार्गदर्शन"
       document_collection:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -30,7 +30,7 @@ hu:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Részletes útmutató
         other: Részletes útmutató
       document_collection:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -30,7 +30,7 @@ hy:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "Մանրամասն ուղեցույց"
         other: "Մանրամասն ուղեցույցեր"
       document_collection:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -30,7 +30,7 @@ id:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Panduan lebih lanjut
         other: Panduan lebih lanjut
       document_collection:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -30,7 +30,7 @@ it:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Indicazione dettagliata
         other: Indicazioni dettagliate
       document_collection:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -30,7 +30,7 @@ ja:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "詳細説明"
         other: "詳細説明"
       document_collection:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -30,7 +30,7 @@ ka:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one:
         other:
       document_collection:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -30,7 +30,7 @@ ko:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "상세 안내"
         other: "상세 안내"
       document_collection:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -39,7 +39,7 @@ lt:
         one:
         few:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Detalesnė informacija
         few:
         other: Detalesnė informacija

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -30,7 +30,7 @@ lv:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Detalizētas norādes
         other: Detalizētas norādes
       document_collection:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -30,7 +30,7 @@ ms:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one:
         other:
       document_collection:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -48,7 +48,7 @@ pl:
         few:
         many:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Szczegółowe wskazówki
         few:
         many:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -30,7 +30,7 @@ ps:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "مفصله لارښوونه"
         other: "مفصلی لارښوونی"
       document_collection:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -30,7 +30,7 @@ pt:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Guia detalhado
         other: Guias detalhados
       document_collection:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -39,7 +39,7 @@ ro:
         one:
         few:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Mai multe detalii
         few:
         other: Mai multe detalii

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -48,7 +48,7 @@ ru:
         few:
         many:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "Подробное руководство"
         few:
         many:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -30,7 +30,7 @@ si:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "විස්තරාත්මක උපදෙස්"
         other: "විස්තරාත්මක උපදෙස්"
       document_collection:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -39,7 +39,7 @@ sk:
         one:
         few:
         other:
-      detailed_guidance:
+      detailed_guide:
         one:
         few:
         other:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -30,7 +30,7 @@ so:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Hagid faahfaahsan
         other: Hagid faahfaahsan
       document_collection:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -30,7 +30,7 @@ sq:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Udhezim i detajuar
         other: Udhezim i detajuar
       document_collection:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -48,7 +48,7 @@ sr:
         few:
         many:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: detaljno uputstvo
         few:
         many:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -30,7 +30,7 @@ sw:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one:
         other:
       document_collection:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -30,7 +30,7 @@ ta:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "விளக்கமான வழிகாட்டல்"
         other: "விளக்கமான வழிகாட்டல்"
       document_collection:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -30,7 +30,7 @@ th:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "คู่มือโดยละเอียด"
         other: "คู่มือโดยละเอียด"
       document_collection:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -30,7 +30,7 @@ tk:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one:
         other:
       document_collection:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -30,7 +30,7 @@ tr:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Ayrıntılı Kılavuz
         other: Ayrıntılı Kılavuzlar
       document_collection:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -48,7 +48,7 @@ uk:
         few:
         many:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "Детальні інструкції"
         few:
         many:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -30,7 +30,7 @@ ur:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "مفصل رہنمائی"
         other: "مفصل رہنمائی"
       document_collection:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -30,7 +30,7 @@ uz:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Batafsil ko'mak
         other: Batafsil ko'mak
       document_collection:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -30,7 +30,7 @@ vi:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: Hướng dẫn chi tiết
         other: Hướng dẫn chi tiết
       document_collection:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -30,7 +30,7 @@ zh-hk:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "詳細指引"
         other: "其他詳細指引"
       document_collection:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -30,7 +30,7 @@ zh-tw:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "詳細指引"
         other: "詳細指引"
       document_collection:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -32,7 +32,7 @@ zh:
       decision:
         one:
         other:
-      detailed_guidance:
+      detailed_guide:
         one: "详细指导"
         other: "详细指导"
       document_collection:

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -8,7 +8,9 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     assert page.has_text?(@content_item["description"])
 
     assert_has_component_metadata_pair("First published", "12 June 2014")
-    assert_has_component_metadata_pair("Last updated", "18 February 2016") #TODO: add "see all updates"
-    assert_has_component_metadata_pair("Part of", "PAYE") #TODO: add "and Business Tax"
+    assert_has_component_metadata_pair("Last updated", "18 February 2016, <a href=\"#history\">see all updates</a>")
+    link1 = "<a href=\"/topic/business-tax/paye\">PAYE</a>"
+    link2 = "<a href=\"/topic/business-tax\">Business tax</a>"
+    assert_has_component_metadata_pair("Part of", [link1, link2])
   end
 end

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class DetailedGuideTest < ActionDispatch::IntegrationTest
+end

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -1,4 +1,14 @@
 require 'test_helper'
 
 class DetailedGuideTest < ActionDispatch::IntegrationTest
+  test "detailed guide" do
+    setup_and_visit_content_item('detailed_guide')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+
+    assert_has_component_metadata_pair("First published", "12 June 2014")
+    assert_has_component_metadata_pair("Last updated", "18 February 2016") #TODO: add "see all updates"
+    assert_has_component_metadata_pair("Part of", "PAYE") #TODO: add "and Business Tax"
+  end
 end

--- a/test/presenter_test_helper.rb
+++ b/test/presenter_test_helper.rb
@@ -7,12 +7,12 @@ class PresenterTest < ActiveSupport::TestCase
 
 private
 
-  def presented_example_content_item(type)
+  def presented_example_content_item(type = format_name)
     content_item = example_content_item(type)
     "#{format_name.classify}Presenter".safe_constantize.new(content_item)
   end
 
-  def example_content_item(type)
+  def example_content_item(type = format_name)
     govuk_content_schema_example(format_name, type)
   end
 end

--- a/test/presenter_test_helper.rb
+++ b/test/presenter_test_helper.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class PresenterTest < ActiveSupport::TestCase
+  def format_name
+    raise NotImplementedError, "Override this method in your test class"
+  end
+
+private
+
+  def presented_example_content_item(type)
+    content_item = example_content_item(type)
+    "#{format_name.classify}Presenter".safe_constantize.new(content_item)
+  end
+
+  def example_content_item(type)
+    govuk_content_schema_example(format_name, type)
+  end
+end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -1,13 +1,8 @@
 require 'presenter_test_helper'
 
 class DetailedGuidePresenterTest < PresenterTest
-  def format_name
-    "detailed_guide"
-  end
 
   test 'presents the basic details of a content item' do
-    example = example_content_item('detailed_guide')
-    presented_example = presented_example_content_item('detailed_guide')
 
     assert_equal example['description'], presented_example.description
     assert_equal example['format'], presented_example.format
@@ -18,5 +13,21 @@ class DetailedGuidePresenterTest < PresenterTest
   test 'presents a list of contents extracted from headings in the body' do
     presented_example = presented_example_content_item('detailed_guide')
     assert_equal '<a href="#the-basics">The basics</a>', presented_example.contents[0]
+  end
+
+  test '#published returns a formatted date of the day the content item became public' do
+    assert_equal '18 February 2016', presented_example.published
+  end
+
+  def format_name
+    "detailed_guide"
+  end
+
+  def example
+    example_content_item(format_name)
+  end
+
+  def presented_example
+    presented_example_content_item(format_name)
   end
 end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -17,6 +17,15 @@ class DetailedGuidePresenterTest < PresenterTest
     assert_equal '12 June 2014', presented_example.published
   end
 
+  test 'breadcrumbs show the full parent hierarchy' do
+    assert_equal "Home", presented_example.breadcrumbs[0][:title]
+    assert_equal "/", presented_example.breadcrumbs[0][:url]
+    assert_equal "Business tax", presented_example.breadcrumbs[1][:title]
+    assert_equal "/topic/business-tax", presented_example.breadcrumbs[1][:url]
+    assert_equal "PAYE", presented_example.breadcrumbs[2][:title]
+    assert_equal "/topic/business-tax/paye", presented_example.breadcrumbs[2][:url]
+  end
+
   def format_name
     "detailed_guide"
   end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -4,4 +4,19 @@ class DetailedGuidePresenterTest < PresenterTest
   def format_name
     "detailed_guide"
   end
+
+  test 'presents the basic details of a content item' do
+    example = example_content_item('detailed_guide')
+    presented_example = presented_example_content_item('detailed_guide')
+
+    assert_equal example['description'], presented_example.description
+    assert_equal example['format'], presented_example.format
+    assert_equal example['title'], presented_example.title
+    assert_equal example['details']['body'], presented_example.body
+  end
+
+  test 'presents a list of contents extracted from headings in the body' do
+    presented_example = presented_example_content_item('detailed_guide')
+    assert_equal '<a href="#the-basics">The basics</a>', presented_example.contents[0]
+  end
 end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -2,39 +2,30 @@ require 'presenter_test_helper'
 
 class DetailedGuidePresenterTest < PresenterTest
   test 'presents the basic details of a content item' do
-    assert_equal example['description'], presented_example.description
-    assert_equal example['format'], presented_example.format
-    assert_equal example['title'], presented_example.title
-    assert_equal example['details']['body'], presented_example.body
+    assert_equal example_content_item['description'], presented_example_content_item.description
+    assert_equal example_content_item['format'], presented_example_content_item.format
+    assert_equal example_content_item['title'], presented_example_content_item.title
+    assert_equal example_content_item['details']['body'], presented_example_content_item.body
   end
 
   test 'presents a list of contents extracted from headings in the body' do
-    presented_example = presented_example_content_item('detailed_guide')
-    assert_equal '<a href="#the-basics">The basics</a>', presented_example.contents[0]
+    assert_equal '<a href="#the-basics">The basics</a>', presented_example_content_item.contents[0]
   end
 
   test '#published returns a formatted date of the day the content item became public' do
-    assert_equal '12 June 2014', presented_example.published
+    assert_equal '12 June 2014', presented_example_content_item.published
   end
 
   test 'breadcrumbs show the full parent hierarchy' do
-    assert_equal "Home", presented_example.breadcrumbs[0][:title]
-    assert_equal "/", presented_example.breadcrumbs[0][:url]
-    assert_equal "Business tax", presented_example.breadcrumbs[1][:title]
-    assert_equal "/topic/business-tax", presented_example.breadcrumbs[1][:url]
-    assert_equal "PAYE", presented_example.breadcrumbs[2][:title]
-    assert_equal "/topic/business-tax/paye", presented_example.breadcrumbs[2][:url]
+    assert_equal "Home", presented_example_content_item.breadcrumbs[0][:title]
+    assert_equal "/", presented_example_content_item.breadcrumbs[0][:url]
+    assert_equal "Business tax", presented_example_content_item.breadcrumbs[1][:title]
+    assert_equal "/topic/business-tax", presented_example_content_item.breadcrumbs[1][:url]
+    assert_equal "PAYE", presented_example_content_item.breadcrumbs[2][:title]
+    assert_equal "/topic/business-tax/paye", presented_example_content_item.breadcrumbs[2][:url]
   end
 
   def format_name
     "detailed_guide"
-  end
-
-  def example
-    example_content_item(format_name)
-  end
-
-  def presented_example
-    presented_example_content_item(format_name)
   end
 end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -1,9 +1,7 @@
 require 'presenter_test_helper'
 
 class DetailedGuidePresenterTest < PresenterTest
-
   test 'presents the basic details of a content item' do
-
     assert_equal example['description'], presented_example.description
     assert_equal example['format'], presented_example.format
     assert_equal example['title'], presented_example.title
@@ -16,7 +14,7 @@ class DetailedGuidePresenterTest < PresenterTest
   end
 
   test '#published returns a formatted date of the day the content item became public' do
-    assert_equal '18 February 2016', presented_example.published
+    assert_equal '12 June 2014', presented_example.published
   end
 
   def format_name

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -1,4 +1,7 @@
-require 'test_helper'
+require 'presenter_test_helper'
 
-class DetailedGuidePresenterTest < ActiveSupport::TestCase
+class DetailedGuidePresenterTest < PresenterTest
+  def format_name
+    "detailed_guide"
+  end
 end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class DetailedGuidePresenterTest < ActiveSupport::TestCase
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,7 +27,7 @@ class ActionDispatch::IntegrationTest
     within shared_component_selector("metadata") do
       # Flatten top level / "other" args, for consistent hash access
       component_args = JSON.parse(page.text).tap do |args|
-        args.merge!(args.delete("other"))
+        args.merge!(args.delete("other")) if args.key?("other")
       end
       assert_equal value, component_args.fetch(label)
     end


### PR DESCRIPTION
Detailed guides are now rendered from Government Frontend.
Trello: https://trello.com/c/k6H9gNKF/316-6-detailed-guides-migration-front-end-work-small

Please note that some differences are still in place, comparing the 2 rendered versions. 
I.e., using this example:
https://www.gov.uk/guidance/salary-sacrifice-and-the-effects-on-paye

**Part of** - footer
There are some differences about the positioning of the link "Full page history" and some character style differences. 
This is related to some changes of [document_footer](https://github.com/alphagov/static/blob/master/app/views/govuk_component/document_footer.raw.html.erb) in [static](https://github.com/alphagov/static). The PR will follow.
![image](https://cloud.githubusercontent.com/assets/6908677/14605184/b9dcbfc2-0577-11e6-933e-6b9c6a8e1a35.png)