### PR TITLE
Add withdrawn notice to detailed guides

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@
 @import "helpers/description";
 @import "helpers/sidebar-with-body";
 @import "helpers/notice";
+@import "helpers/withdrawal-notice";
 
 // pages specific view imports
 @import "views/case-studies";

--- a/app/assets/stylesheets/helpers/_notice.scss
+++ b/app/assets/stylesheets/helpers/_notice.scss
@@ -15,5 +15,9 @@
 
   p {
     @include core-19;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 }

--- a/app/assets/stylesheets/helpers/_withdrawal-notice.scss
+++ b/app/assets/stylesheets/helpers/_withdrawal-notice.scss
@@ -1,0 +1,5 @@
+@mixin withdrawal-notice {
+  .withdrawal-notice {
+    @include notice;
+  }
+}

--- a/app/assets/stylesheets/views/_case-studies.scss
+++ b/app/assets/stylesheets/views/_case-studies.scss
@@ -1,13 +1,10 @@
 .case-studies {
   @include description;
   @include sidebar-with-body;
+  @include withdrawal-notice;
 
   .direction-rtl & {
     direction: rtl;
     text-align: start;
-  }
-
-  .withdrawal-notice {
-    @include notice;
   }
 }

--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -1,6 +1,7 @@
 .detailed-guide {
   @include description;
   @include sidebar-with-body;
+  @include withdrawal-notice;
 
   .offset-one-third {
     margin-left: percentage(1 / 3);

--- a/app/presenters/case_study_presenter.rb
+++ b/app/presenters/case_study_presenter.rb
@@ -2,6 +2,7 @@ class CaseStudyPresenter < ContentItemPresenter
   include ActionView::Helpers::UrlHelper
   include Linkable
   include Updatable
+  include Withdrawable
 
   attr_reader :body, :format_display_type
 
@@ -13,23 +14,5 @@ class CaseStudyPresenter < ContentItemPresenter
 
   def image
     content_item["details"]["image"]
-  end
-
-  def withdrawn?
-    content_item["details"].include?("withdrawn_notice")
-  end
-
-  def page_title
-    withdrawn? ? "[Withdrawn] #{title}" : title
-  end
-
-  def withdrawal_notice
-    notice = content_item["details"]["withdrawn_notice"]
-    if notice
-      {
-        time: content_tag(:time, display_time(notice["withdrawn_at"]), datetime: notice["withdrawn_at"]),
-        explanation: notice["explanation"]
-      }
-    end
   end
 end

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -10,6 +10,8 @@ class DetailedGuidePresenter < ContentItemPresenter
   end
 
   def breadcrumbs
+    return [] unless parent
+
     e = parent
     res = []
 

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -2,6 +2,7 @@ class DetailedGuidePresenter < ContentItemPresenter
   include ExtractsHeadings
   include Linkable
   include Updatable
+  include Withdrawable
   include ActionView::Helpers::UrlHelper
 
   def body

--- a/app/presenters/withdrawable.rb
+++ b/app/presenters/withdrawable.rb
@@ -1,0 +1,19 @@
+module Withdrawable
+  def withdrawn?
+    content_item["details"].include?("withdrawn_notice")
+  end
+
+  def page_title
+    withdrawn? ? "[Withdrawn] #{title}" : title
+  end
+
+  def withdrawal_notice
+    notice = content_item["details"]["withdrawn_notice"]
+    if notice
+      {
+        time: content_tag(:time, display_time(notice["withdrawn_at"]), datetime: notice["withdrawn_at"]),
+        explanation: notice["explanation"]
+      }
+    end
+  end
+end

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -15,12 +15,9 @@
   %>
   </div>
 </div>
-  <% if @content_item.withdrawn? %>
-    <div class="withdrawal-notice">
-      <h2>This <%= t("content_item.format.#{@content_item.format_display_type}", count: 1).downcase %> was withdrawn on <%= @content_item.withdrawal_notice[:time] %></h2>
-      <%= render 'govuk_component/govspeak', content: @content_item.withdrawal_notice[:explanation] %>
-    </div>
-  <% end %>
+
+<%= render 'shared/withdrawal_notice', content_item: @content_item %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/metadata',

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,7 +1,9 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
 
-<%= render 'govuk_component/breadcrumbs', breadcrumbs: @content_item.breadcrumbs %>
+<% if @content_item.breadcrumbs.any? %>
+  <%= render 'govuk_component/breadcrumbs', breadcrumbs: @content_item.breadcrumbs %>
+<% end %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -7,7 +7,8 @@
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
         context: t("content_item.format.#{@content_item.format}", count: 1),
-        title: @content_item.title %>
+        title: @content_item.title,
+        average_title_length: "long" %>
   </div>
 </div>
 

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -20,10 +20,10 @@
   <div class="column-two-thirds">
     <%= render 'govuk_component/metadata',
         from: @content_item.from,
+        part_of: @content_item.part_of,
         other: {
           "First published" => @content_item.published,
-          "Last updated" => [@content_item.updated,"<a href=\"#history\">see all updates</a>"].join(", "),
-          "Part of" => @content_item.part_of #doing this to preserve the ordering but if part_of, at the same level as from and other
+          "Last updated" => [@content_item.updated,"<a href=\"#history\">see all updates</a>"].join(", ")
         }
     %>
   </div>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
-<%= content_for :title, @content_item.title %>
+<%= content_for :title, @content_item.page_title %>
 
 <%= render 'govuk_component/breadcrumbs', breadcrumbs: @content_item.breadcrumbs %>
 
@@ -11,6 +11,8 @@
         average_title_length: "long" %>
   </div>
 </div>
+
+<%= render 'shared/withdrawal_notice', content_item: @content_item %>
 
 <div class="grid-row">
   <div class="column-two-thirds">
@@ -24,7 +26,6 @@
     %>
   </div>
 </div>
-
 <%= render 'shared/description', description: @content_item.description %>
 
 <div class="grid-row sidebar-with-body">

--- a/app/views/shared/_withdrawal_notice.html.erb
+++ b/app/views/shared/_withdrawal_notice.html.erb
@@ -1,0 +1,6 @@
+<% if content_item.withdrawn? %>
+  <div class="withdrawal-notice">
+    <h2>This <%= t("content_item.format.#{content_item.format}", count: 1).downcase %> was withdrawn on <%= content_item.withdrawal_notice[:time] %></h2>
+    <%= render 'govuk_component/govspeak', content: content_item.withdrawal_notice[:explanation] %>
+  </div>
+<% end %>

--- a/lib/generators/format/format_generator.rb
+++ b/lib/generators/format/format_generator.rb
@@ -4,17 +4,17 @@ class FormatGenerator < Rails::Generators::NamedBase
   source_root File.expand_path('../templates', __FILE__)
 
   def copy_format_files
-    format_name = file_name.underscore
-    @dashed_name = format_name.dasherize
-    @camel_name = format_name.camelize
+    @format_name = file_name.underscore
+    @dashed_name = @format_name.dasherize
+    @camel_name = @format_name.camelize
 
-    template 'format_presenter.rb.erb', "app/presenters/#{format_name}_presenter.rb"
-    template 'format_presenter_test.rb.erb', "test/presenters/#{format_name}_presenter_test.rb"
-    template 'format_integration_test.rb.erb', "test/integration/#{format_name}_test.rb"
+    template 'format_presenter.rb.erb', "app/presenters/#{@format_name}_presenter.rb"
+    template 'format_presenter_test.rb.erb', "test/presenters/#{@format_name}_presenter_test.rb"
+    template 'format_integration_test.rb.erb', "test/integration/#{@format_name}_test.rb"
 
     template '_format.scss', "app/assets/stylesheets/views/_#{@dashed_name}.scss"
     append_to_file "app/assets/stylesheets/application.scss", "@import \"views/#{@dashed_name}\";\n"
 
-    template 'format.html.erb', "app/views/content_items/#{format_name}.html.erb"
+    template 'format.html.erb', "app/views/content_items/#{@format_name}.html.erb"
   end
 end

--- a/lib/generators/format/templates/format_presenter_test.rb.erb
+++ b/lib/generators/format/templates/format_presenter_test.rb.erb
@@ -1,4 +1,7 @@
-require 'test_helper'
+require 'presenter_test_helper'
 
-class <%= "#{@camel_name}PresenterTest" %> < ActiveSupport::TestCase
+class <%= "#{@camel_name}PresenterTest" %> < PresenterTest
+  def format_name
+    "<%= @format_name %>"
+  end
 end

--- a/test/integration/case_study_test.rb
+++ b/test/integration/case_study_test.rb
@@ -19,6 +19,7 @@ class CaseStudyTest < ActionDispatch::IntegrationTest
     within ".withdrawal-notice" do
       assert page.has_text?('This case study was withdrawn'), "is withdrawn"
       assert_has_component_govspeak(@content_item["details"]["withdrawn_notice"]["explanation"])
+      assert page.has_css?("time[datetime='#{@content_item['details']['withdrawn_notice']['withdrawn_at']}']")
     end
   end
 end

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -11,7 +11,7 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     assert_has_component_metadata_pair("Last updated", "18 February 2016, <a href=\"#history\">see all updates</a>")
     link1 = "<a href=\"/topic/business-tax/paye\">PAYE</a>"
     link2 = "<a href=\"/topic/business-tax\">Business tax</a>"
-    assert_has_component_metadata_pair("Part of", [link1, link2])
+    assert_has_component_metadata_pair("part_of", [link1, link2])
   end
 
   test "withdrawn detailed guide" do

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -13,4 +13,17 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     link2 = "<a href=\"/topic/business-tax\">Business tax</a>"
     assert_has_component_metadata_pair("Part of", [link1, link2])
   end
+
+  test "withdrawn detailed guide" do
+    setup_and_visit_content_item('withdrawn_detailed_guide')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+
+    within ".withdrawal-notice" do
+      assert page.has_text?('This guidance was withdrawn'), "is withdrawn"
+      assert_has_component_govspeak(@content_item["details"]["withdrawn_notice"]["explanation"])
+      assert page.has_css?("time[datetime='#{@content_item['details']['withdrawn_notice']['withdrawn_at']}']")
+    end
+  end
 end

--- a/test/presenter_test_helper.rb
+++ b/test/presenter_test_helper.rb
@@ -7,12 +7,12 @@ class PresenterTest < ActiveSupport::TestCase
 
 private
 
-  def presented_example_content_item(type = format_name)
-    content_item = example_content_item(type)
-    "#{format_name.classify}Presenter".safe_constantize.new(content_item)
+  def presented_item(type = format_name, overrides = {})
+    schema_example_content_item = schema_item(type)
+    "#{format_name.classify}Presenter".safe_constantize.new(schema_example_content_item.merge(overrides))
   end
 
-  def example_content_item(type = format_name)
+  def schema_item(type = format_name)
     govuk_content_schema_example(format_name, type)
   end
 end

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -1,23 +1,27 @@
-require 'test_helper'
+require 'presenter_test_helper'
 
-class CaseStudyPresenterTest < ActiveSupport::TestCase
+class CaseStudyPresenterTest < PresenterTest
   include ActionView::Helpers::UrlHelper
 
+  def format_name
+    "case_study"
+  end
+
   test 'presents the basic details of a content item' do
-    assert_equal case_study['description'], presented_case_study.description
-    assert_equal case_study['format'], presented_case_study.format
-    assert_equal case_study['locale'], presented_case_study.locale
-    assert_equal case_study['title'], presented_case_study.title
-    assert_equal case_study['details']['body'], presented_case_study.body
-    assert_equal case_study['details']['format_display_type'], presented_case_study.format_display_type
+    assert_equal schema_item['description'], presented_item.description
+    assert_equal schema_item['format'], presented_item.format
+    assert_equal schema_item['locale'], presented_item.locale
+    assert_equal schema_item['title'], presented_item.title
+    assert_equal schema_item['details']['body'], presented_item.body
+    assert_equal schema_item['details']['format_display_type'], presented_item.format_display_type
   end
 
   test '#published returns a formatted date of the day the content item became public' do
-    assert_equal '17 December 2012', presented_case_study.published
+    assert_equal '17 December 2012', presented_item.published
   end
 
   test '#updated returns nil if the content item has no updates' do
-    assert_nil presented_case_study.updated
+    assert_nil presented_item.updated
   end
 
   test '#updated returns a formatted date of the last day the content item was updated' do
@@ -25,7 +29,7 @@ class CaseStudyPresenterTest < ActiveSupport::TestCase
   end
 
   test '#short_history returns the published day of a non-updated content item' do
-    assert_equal 'Published 17 December 2012', presented_case_study.short_history
+    assert_equal 'Published 17 December 2012', presented_item.short_history
   end
 
   test '#short_history returns the last update day for a content item that has updates' do
@@ -33,7 +37,7 @@ class CaseStudyPresenterTest < ActiveSupport::TestCase
   end
 
   test '#from returns links to lead organisations, supporting organisations and worldwide organisations' do
-    with_organisations = case_study
+    with_organisations = schema_item
     with_organisations['links']['lead_organisations'] = [
       { "title" => 'Lead org', "base_path" => '/orgs/lead' }
     ]
@@ -47,11 +51,11 @@ class CaseStudyPresenterTest < ActiveSupport::TestCase
       link_to('DFID Pakistan', '/government/world/organisations/dfid-pakistan'),
     ]
 
-    assert_equal expected_from_links, presented_case_study(with_organisations).from
+    assert_equal expected_from_links, presented_item(format_name, with_organisations).from
   end
 
   test '#part_of returns an array of document_collections, related policies and world locations' do
-    with_extras = case_study
+    with_extras = schema_item
     with_extras['links']['document_collections'] = [
       { "title" => "Work Programme real life stories", "base_path" => "/government/collections/work-programme-real-life-stories" }
     ]
@@ -64,11 +68,11 @@ class CaseStudyPresenterTest < ActiveSupport::TestCase
       link_to('Cheese', '/policy/cheese'),
       link_to('Pakistan', '/government/world/pakistan'),
     ]
-    assert_equal expected_part_of_links, presented_case_study(with_extras).part_of
+    assert_equal expected_part_of_links, presented_item(format_name, with_extras).part_of
   end
 
   test '#history returns an empty array if the content item has no updates' do
-    assert_equal [], presented_case_study.history
+    assert_equal [], presented_item.history
   end
 
   test '#history returns a formatted history if the content item has updates' do
@@ -80,26 +84,18 @@ class CaseStudyPresenterTest < ActiveSupport::TestCase
   end
 
   test '#history returns an empty array if the content item is not published' do
-    never_published = case_study
+    never_published = schema_item
     never_published['details'].delete('first_public_at')
     presented = CaseStudyPresenter.new(never_published)
     assert_equal [], presented.history
   end
 
-  def presented_case_study(overrides = {})
-    CaseStudyPresenter.new(case_study.merge(overrides))
-  end
-
   def presented_case_study_with_updates
     march_21_2013 = DateTime.new(2013, 3, 21).to_s
-    with_history = case_study
+    with_history = schema_item
     with_history['details']['change_history'] = [{ 'note' => 'Something changed', 'public_timestamp' => march_21_2013 }]
     with_history['public_updated_at'] = march_21_2013
 
-    presented_case_study(with_history)
-  end
-
-  def case_study
-    govuk_content_schema_example('case_study', 'case_study')
+    presented_item(format_name, with_history)
   end
 end

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -90,6 +90,16 @@ class CaseStudyPresenterTest < PresenterTest
     assert_equal [], presented.history
   end
 
+  test 'presents withdrawn notices' do
+    example = schema_item("archived")
+    presented = presented_item("archived")
+
+    assert example["details"].include?("withdrawn_notice")
+    assert presented.withdrawn?
+    assert_equal example["details"]["withdrawn_notice"]["explanation"], presented.withdrawal_notice[:explanation]
+    assert_equal '<time datetime="2014-08-22T10:29:02+01:00">22 August 2014</time>', presented.withdrawal_notice[:time]
+  end
+
   def presented_case_study_with_updates
     march_21_2013 = DateTime.new(2013, 3, 21).to_s
     with_history = schema_item

--- a/test/presenters/coming_soon_presenter_test.rb
+++ b/test/presenters/coming_soon_presenter_test.rb
@@ -1,26 +1,22 @@
-require 'test_helper'
+require 'presenter_test_helper'
 
-class ComingSoonPresenterTest < ActiveSupport::TestCase
+class ComingSoonPresenterTest < PresenterTest
+  def format_name
+    "coming_soon"
+  end
+
   test 'presents the basic details required to display a coming soon item' do
-    assert_equal coming_soon['title'], presented_coming_soon.title
-    assert_equal coming_soon['format'], presented_coming_soon.format
-    assert_equal coming_soon['locale'], presented_coming_soon.locale
-    assert_equal coming_soon['details']['publish_time'], presented_coming_soon.publish_time
+    assert_equal schema_item['title'], presented_item.title
+    assert_equal schema_item['format'], presented_item.format
+    assert_equal schema_item['locale'], presented_item.locale
+    assert_equal schema_item['details']['publish_time'], presented_item.publish_time
   end
 
   test '#formatted_publish_time' do
-    assert_equal '09:30', presented_coming_soon.formatted_publish_time
+    assert_equal '09:30', presented_item.formatted_publish_time
   end
 
   test '#formatted_publish_date' do
-    assert_equal '17 December 2014', presented_coming_soon.formatted_publish_date
-  end
-
-  def presented_coming_soon(overrides = {})
-    ComingSoonPresenter.new(coming_soon.merge(overrides))
-  end
-
-  def coming_soon
-    govuk_content_schema_example('coming_soon', 'coming_soon')
+    assert_equal '17 December 2014', presented_item.formatted_publish_date
   end
 end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -29,6 +29,10 @@ class DetailedGuidePresenterTest < PresenterTest
     assert_equal "/topic/business-tax/paye", presented_item.breadcrumbs[2][:url]
   end
 
+  test 'no breadcrumbs show if there is no parent' do
+    assert_equal [], presented_item("withdrawn_detailed_guide").breadcrumbs
+  end
+
   test 'presents withdrawn notices' do
     example = schema_item("withdrawn_detailed_guide")
     presented = presented_item("withdrawn_detailed_guide")

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -28,4 +28,14 @@ class DetailedGuidePresenterTest < PresenterTest
     assert_equal "PAYE", presented_item.breadcrumbs[2][:title]
     assert_equal "/topic/business-tax/paye", presented_item.breadcrumbs[2][:url]
   end
+
+  test 'presents withdrawn notices' do
+    example = schema_item("withdrawn_detailed_guide")
+    presented = presented_item("withdrawn_detailed_guide")
+
+    assert example["details"].include?("withdrawn_notice")
+    assert presented.withdrawn?
+    assert_equal example["details"]["withdrawn_notice"]["explanation"], presented.withdrawal_notice[:explanation]
+    assert_equal '<time datetime="2015-01-28T13:05:30Z">28 January 2015</time>', presented.withdrawal_notice[:time]
+  end
 end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -1,31 +1,31 @@
 require 'presenter_test_helper'
 
 class DetailedGuidePresenterTest < PresenterTest
+  def format_name
+    "detailed_guide"
+  end
+
   test 'presents the basic details of a content item' do
-    assert_equal example_content_item['description'], presented_example_content_item.description
-    assert_equal example_content_item['format'], presented_example_content_item.format
-    assert_equal example_content_item['title'], presented_example_content_item.title
-    assert_equal example_content_item['details']['body'], presented_example_content_item.body
+    assert_equal schema_item['description'], presented_item.description
+    assert_equal schema_item['format'], presented_item.format
+    assert_equal schema_item['title'], presented_item.title
+    assert_equal schema_item['details']['body'], presented_item.body
   end
 
   test 'presents a list of contents extracted from headings in the body' do
-    assert_equal '<a href="#the-basics">The basics</a>', presented_example_content_item.contents[0]
+    assert_equal '<a href="#the-basics">The basics</a>', presented_item.contents[0]
   end
 
   test '#published returns a formatted date of the day the content item became public' do
-    assert_equal '12 June 2014', presented_example_content_item.published
+    assert_equal '12 June 2014', presented_item.published
   end
 
   test 'breadcrumbs show the full parent hierarchy' do
-    assert_equal "Home", presented_example_content_item.breadcrumbs[0][:title]
-    assert_equal "/", presented_example_content_item.breadcrumbs[0][:url]
-    assert_equal "Business tax", presented_example_content_item.breadcrumbs[1][:title]
-    assert_equal "/topic/business-tax", presented_example_content_item.breadcrumbs[1][:url]
-    assert_equal "PAYE", presented_example_content_item.breadcrumbs[2][:title]
-    assert_equal "/topic/business-tax/paye", presented_example_content_item.breadcrumbs[2][:url]
-  end
-
-  def format_name
-    "detailed_guide"
+    assert_equal "Home", presented_item.breadcrumbs[0][:title]
+    assert_equal "/", presented_item.breadcrumbs[0][:url]
+    assert_equal "Business tax", presented_item.breadcrumbs[1][:title]
+    assert_equal "/topic/business-tax", presented_item.breadcrumbs[1][:url]
+    assert_equal "PAYE", presented_item.breadcrumbs[2][:title]
+    assert_equal "/topic/business-tax/paye", presented_item.breadcrumbs[2][:url]
   end
 end

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -1,27 +1,31 @@
-require 'test_helper'
+require 'presenter_test_helper'
 
-class HtmlPublicationPresenterTest < ActiveSupport::TestCase
+class HtmlPublicationPresenterTest < PresenterTest
+  def format_name
+    "html_publication"
+  end
+
   test 'presents the basic details of a content item' do
-    assert_equal html_publication['format'], presented_html_publication.format
-    assert_equal html_publication['links']['parent'][0]['format_sub_type'], presented_html_publication.format_sub_type
-    assert_equal html_publication['title'], presented_html_publication.title
-    assert_equal html_publication['details']['body'], presented_html_publication.body
+    assert_equal schema_item("published")['format'], presented_item("published").format
+    assert_equal schema_item("published")['links']['parent'][0]['format_sub_type'], presented_item("published").format_sub_type
+    assert_equal schema_item("published")['title'], presented_item("published").title
+    assert_equal schema_item("published")['details']['body'], presented_item("published").body
   end
 
   test 'presents the last change date' do
-    published = presented_html_publication("published")
+    published = presented_item("published")
     assert_equal "Published 17 January 2016", published.last_changed
 
-    updated = presented_html_publication("updated")
+    updated = presented_item("updated")
     assert_equal "Updated 2 February 2016", updated.last_changed
   end
 
   test 'presents the path to its parent' do
-    assert_equal html_publication["links"]["parent"][0]["base_path"], presented_html_publication.parent_base_path
+    assert_equal schema_item("published")["links"]["parent"][0]["base_path"], presented_item("published").parent_base_path
   end
 
   test 'presents the list of organisations' do
-    multiple_organisations_html_publication = govuk_content_schema_example('html_publication', 'multiple_organisations')
+    multiple_organisations_html_publication = schema_item('multiple_organisations')
     organisation_titles = multiple_organisations_html_publication["links"]["organisations"].map { |o| o["title"] }
 
     presented_unordered_html_publication = HtmlPublicationPresenter.new(multiple_organisations_html_publication)
@@ -31,9 +35,9 @@ class HtmlPublicationPresenterTest < ActiveSupport::TestCase
   end
 
   test "presents the branding for organisations" do
-    mo_presented_html_publication = presented_html_publication("multiple_organisations")
-    mo_presented_html_publication.organisations.each do |organisation|
-      assert_equal mo_presented_html_publication.organisation_brand(organisation), organisation["brand"]
+    mo_presented_item = presented_item("multiple_organisations")
+    mo_presented_item.organisations.each do |organisation|
+      assert_equal mo_presented_item.organisation_brand(organisation), organisation["brand"]
     end
   end
 
@@ -45,15 +49,6 @@ class HtmlPublicationPresenterTest < ActiveSupport::TestCase
         "crest" => "eo"
       }
     }
-    assert_equal presented_html_publication("prime_ministers_office").organisation_brand(organisation), "executive-office"
-  end
-
-  def presented_html_publication(type = 'published')
-    content_item = html_publication(type)
-    HtmlPublicationPresenter.new(content_item)
-  end
-
-  def html_publication(type = 'published')
-    govuk_content_schema_example('html_publication', type)
+    assert_equal presented_item("prime_ministers_office").organisation_brand(organisation), "executive-office"
   end
 end

--- a/test/presenters/statistics_announcement_presenter_test.rb
+++ b/test/presenters/statistics_announcement_presenter_test.rb
@@ -1,7 +1,11 @@
-require 'test_helper'
+require 'presenter_test_helper'
 
-class StatisticsAnnouncementPresenterTest < ActiveSupport::TestCase
+class StatisticsAnnouncementPresenterTest < PresenterTest
   include ActionView::Helpers::UrlHelper
+
+  def format_name
+    "statistics_announcement"
+  end
 
   test 'presents from as links to organisations' do
     links = [
@@ -68,23 +72,22 @@ class StatisticsAnnouncementPresenterTest < ActiveSupport::TestCase
   end
 
   def statistics_announcement_cancelled
-    statistics_announcement('cancelled_official_statistics')
+    presented_item('cancelled_official_statistics')
   end
 
   def statistics_announcement_provisional
-    statistics_announcement('national_statistics')
+    presented_item('national_statistics')
   end
 
   def statistics_announcement_national
-    statistics_announcement('national_statistics')
+    presented_item('national_statistics')
   end
 
   def statistics_announcement_date_changed
-    statistics_announcement('release_date_changed')
+    presented_item('release_date_changed')
   end
 
-  def statistics_announcement(type = 'official_statistics')
-    content_item = govuk_content_schema_example('statistics_announcement', type)
-    StatisticsAnnouncementPresenter.new(content_item)
+  def statistics_announcement
+    presented_item('official_statistics')
   end
 end

--- a/test/presenters/take_part_presenter_test.rb
+++ b/test/presenters/take_part_presenter_test.rb
@@ -1,19 +1,15 @@
-require 'test_helper'
+require 'presenter_test_helper'
 
-class TakePartPresenterTest < ActiveSupport::TestCase
+class TakePartPresenterTest < PresenterTest
+  def format_name
+    "take_part"
+  end
+
   test 'presents the basic details of a content item' do
-    assert_equal take_part['description'], presented_take_part.description
-    assert_equal take_part['format'], presented_take_part.format
-    assert_equal take_part['locale'], presented_take_part.locale
-    assert_equal take_part['title'], presented_take_part.title
-    assert_equal take_part['details']['body'], presented_take_part.body
-  end
-
-  def presented_take_part(overrides = {})
-    TakePartPresenter.new(take_part.merge(overrides))
-  end
-
-  def take_part
-    govuk_content_schema_example('take_part', 'take_part')
+    assert_equal schema_item['description'], presented_item.description
+    assert_equal schema_item['format'], presented_item.format
+    assert_equal schema_item['locale'], presented_item.locale
+    assert_equal schema_item['title'], presented_item.title
+    assert_equal schema_item['details']['body'], presented_item.body
   end
 end

--- a/test/presenters/topical_event_about_page_presenter_test.rb
+++ b/test/presenters/topical_event_about_page_presenter_test.rb
@@ -1,11 +1,15 @@
-require 'test_helper'
+require 'presenter_test_helper'
 
-class TopicalEventAboutPagePresenterTest < ActiveSupport::TestCase
+class TopicalEventAboutPagePresenterTest < PresenterTest
+  def format_name
+    "topical_event_about_page"
+  end
+
   test 'presents the basic details of a content item' do
-    assert_equal topical_event_about_page['description'], presented_topical_event_about_page.description
-    assert_equal topical_event_about_page['format'], presented_topical_event_about_page.format
-    assert_equal topical_event_about_page['title'], presented_topical_event_about_page.title
-    assert_equal topical_event_about_page['details']['body'], presented_topical_event_about_page.body
+    assert_equal schema_item['description'], presented_item.description
+    assert_equal schema_item['format'], presented_item.format
+    assert_equal schema_item['title'], presented_item.title
+    assert_equal schema_item['details']['body'], presented_item.body
   end
 
   test 'presents a list of contents extracted from headings in the body' do
@@ -15,11 +19,11 @@ class TopicalEventAboutPagePresenterTest < ActiveSupport::TestCase
                   '<a href="#advice-for-medics">Advice for medics</a>',
                   '<a href="#advice-for-aid-workers">Advice for aid workers</a>',
                   '<a href="#how-you-can-help">How you can help</a>'
-                 ], presented_topical_event_about_page.contents
+                 ], presented_item.contents
   end
 
   test 'presents no contents when no headings in the body' do
-    assert_equal [], presented_topical_event_about_page('slim').contents
+    assert_equal [], presented_item('slim').contents
   end
 
   test 'presents a breadcrumb and indicates the archive state of the parent topical event' do
@@ -29,12 +33,12 @@ class TopicalEventAboutPagePresenterTest < ActiveSupport::TestCase
     ]
 
     travel_to(topical_event_end_date - 1) do
-      assert_equal breadcrumbs, presented_topical_event_about_page.breadcrumbs
+      assert_equal breadcrumbs, presented_item.breadcrumbs
     end
 
     travel_to(topical_event_end_date) do
       breadcrumbs[1].merge!(title: "Ebola virus: UK government response (Archived)")
-      assert_equal breadcrumbs, presented_topical_event_about_page.breadcrumbs
+      assert_equal breadcrumbs, presented_item.breadcrumbs
     end
   end
 
@@ -44,22 +48,13 @@ class TopicalEventAboutPagePresenterTest < ActiveSupport::TestCase
       { title: "Battle of the Somme Centenary", url: "/government/topical-events/battle-of-the-somme-centenary-commemorations" }
     ]
 
-    refute topical_event_about_page('slim')['links']['parent'][0]['details']['end_date']
-    assert_equal breadcrumbs, presented_topical_event_about_page('slim').breadcrumbs
+    refute schema_item('slim')['links']['parent'][0]['details']['end_date']
+    assert_equal breadcrumbs, presented_item('slim').breadcrumbs
   end
 
 private
 
   def topical_event_end_date
-    Date.parse(topical_event_about_page['links']['parent'][0]['details']['end_date'])
-  end
-
-  def presented_topical_event_about_page(type = 'topical_event_about_page')
-    content_item = topical_event_about_page(type)
-    TopicalEventAboutPagePresenter.new(content_item)
-  end
-
-  def topical_event_about_page(type = 'topical_event_about_page')
-    govuk_content_schema_example('topical_event_about_page', type)
+    Date.parse(schema_item['links']['parent'][0]['details']['end_date'])
   end
 end


### PR DESCRIPTION
See also https://github.com/alphagov/govuk-content-schemas/pull/288

* Extract withdraw presenter logic into module, use in case studies and detailed guides
* Add withdrawn presenter and integration tests for both formats
* Extract withdrawn template into re-usable partial
* Extract withdrawn styles into re-usable helper mixin

Includes some minor bug fixes:
* Fix margins on withdrawal notices
* Avoid an empty "Part of" from showing in metadata component (example has no links)
* Avoid an empty breadcrumb from showing (example has no parent)
* Update titles to use average length, so they appear smaller and match what's currently live

Includes some refactoring:
* Updates presenter tests to all extend PresenterTest – DRY up loading the content item example and presenting the example item, and allows tests to share helper methods

https://trello.com/c/P2CLsRtp/383-6-detailed-guides-migration-front-end-work-withdrawing-documents-small

Compare screenshot below with live example: https://www.gov.uk/guidance/eu-rules-on-the-use-of-chemicals

<img width="1394" alt="screen shot 2016-04-22 at 11 38 53" src="https://cloud.githubusercontent.com/assets/319055/14739333/cf4d51a0-087e-11e6-93ca-2bbb7591dac1.png">