### PR TITLE
Add history notices to detailed guides

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@
 @import "helpers/description";
 @import "helpers/sidebar-with-body";
 @import "helpers/notice";
+@import "helpers/history-notice";
 @import "helpers/withdrawal-notice";
 
 // pages specific view imports

--- a/app/assets/stylesheets/helpers/_history-notice.scss
+++ b/app/assets/stylesheets/helpers/_history-notice.scss
@@ -1,0 +1,17 @@
+@mixin history-notice {
+  .history-notice {
+    @include responsive-bottom-margin;
+    clear: both;
+    padding: $gutter-half;
+    background: $govuk-blue;
+    color: $white;
+
+    @include media(tablet) {
+      padding: $gutter-two-thirds $gutter;
+    }
+
+    h2 {
+      @include bold-36;
+    }
+  }
+}

--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -1,6 +1,7 @@
 .detailed-guide {
   @include description;
   @include sidebar-with-body;
+  @include history-notice;
   @include withdrawal-notice;
 
   .offset-one-third {

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -1,4 +1,5 @@
 class DetailedGuidePresenter < ContentItemPresenter
+  include Political
   include ExtractsHeadings
   include Linkable
   include Updatable

--- a/app/presenters/political.rb
+++ b/app/presenters/political.rb
@@ -1,0 +1,19 @@
+module Political
+  def historically_political?
+    political? && historical?
+  end
+
+  def publishing_government
+    content_item["details"]["government"]["title"]
+  end
+
+private
+
+  def political?
+    content_item["details"].include?("political") && content_item["details"]["political"]
+  end
+
+  def historical?
+    content_item["details"].include?("government") && !content_item["details"]["government"]["current"]
+  end
+end

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -21,10 +21,9 @@
     <%= render 'govuk_component/metadata',
         from: @content_item.from,
         part_of: @content_item.part_of,
-        other: {
-          "First published" => @content_item.published,
-          "Last updated" => [@content_item.updated,"<a href=\"#history\">see all updates</a>"].join(", ")
-        }
+        first_published: @content_item.published,
+        last_updated: @content_item.updated,
+        see_updates_link: true
     %>
   </div>
 </div>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -28,6 +28,7 @@
     %>
   </div>
 </div>
+<%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 
 <div class="grid-row sidebar-with-body">

--- a/app/views/shared/_history_notice.html.erb
+++ b/app/views/shared/_history_notice.html.erb
@@ -1,0 +1,5 @@
+<% if content_item.historically_political? %>
+  <div class="history-notice">
+    <h2>This <%= t("content_item.format.#{content_item.format}", count: 1).downcase %> was published under the <%= content_item.publishing_government %></h2>
+  </div>
+<% end %>

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -26,4 +26,12 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
       assert page.has_css?("time[datetime='#{@content_item['details']['withdrawn_notice']['withdrawn_at']}']")
     end
   end
+
+  test "historically political detailed guide" do
+    setup_and_visit_content_item('political_detailed_guide')
+
+    within ".history-notice" do
+      assert page.has_text?('This guidance was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government')
+    end
+  end
 end

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -7,8 +7,8 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
 
-    assert_has_component_metadata_pair("First published", "12 June 2014")
-    assert_has_component_metadata_pair("Last updated", "18 February 2016, <a href=\"#history\">see all updates</a>")
+    assert_has_component_metadata_pair("first_published", "12 June 2014")
+    assert_has_component_metadata_pair("last_updated", "18 February 2016")
     link1 = "<a href=\"/topic/business-tax/paye\">PAYE</a>"
     link2 = "<a href=\"/topic/business-tax\">Business tax</a>"
     assert_has_component_metadata_pair("part_of", [link1, link2])

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -42,4 +42,18 @@ class DetailedGuidePresenterTest < PresenterTest
     assert_equal example["details"]["withdrawn_notice"]["explanation"], presented.withdrawal_notice[:explanation]
     assert_equal '<time datetime="2015-01-28T13:05:30Z">28 January 2015</time>', presented.withdrawal_notice[:time]
   end
+
+  test 'presents the title of the publishing government' do
+    assert_equal schema_item["details"]["government"]["title"], presented_item.publishing_government
+  end
+
+  test 'content can be historically political' do
+    example = schema_item("political_detailed_guide")
+    presented = presented_item("political_detailed_guide")
+
+    refute example["details"]["government"]["current"]
+    assert example["details"]["political"]
+
+    assert presented.historically_political?
+  end
 end


### PR DESCRIPTION
Depends on https://github.com/alphagov/govuk-content-schemas/pull/290 for passing tests.

* Create a mixin for history notice styles
* Create a partial for history notices
* Create a `Political` module for formats that can be political
* Add mixin, partial and module to detailed guides so that a blue “history mode” banner displays for political content published under a previous government.

Part of:
https://trello.com/c/74ymVfIw/384-6-detailed-guides-migration-front-end-work-for-history-mode-political-status-and-government-small

## Before
<img width="1394" alt="screen shot 2016-04-25 at 19 23 31" src="https://cloud.githubusercontent.com/assets/319055/14794478/4246f2ca-0b1c-11e6-9dac-036577210543.png">

## After
<img width="1394" alt="screen shot 2016-04-25 at 19 21 32" src="https://cloud.githubusercontent.com/assets/319055/14794477/42441906-0b1c-11e6-9888-a54b5d7f6a79.png">