### PR TITLE
Add related guides, collections and mainstream content to detailed guides

### DIFF
--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -7,4 +7,16 @@
   .offset-one-third {
     margin-left: percentage(1 / 3);
   }
+
+  .related-mainstream-content {
+    background: $panel-colour;
+    padding: $gutter-half;
+    margin-bottom: $gutter;
+
+    @include media(desktop) {
+      width: percentage(1 / 3);
+      float: right;
+      margin: 0 0 $gutter-half $gutter-half;
+    }
+  }
 }

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -42,6 +42,8 @@ class DetailedGuidePresenter < ContentItemPresenter
 private
 
   def parent
-    content_item["links"]["parent"][0]
+    if content_item["links"].include?("parent")
+      content_item["links"]["parent"][0]
+    end
   end
 end

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -35,6 +35,10 @@ class DetailedGuidePresenter < ContentItemPresenter
     parent["title"]
   end
 
+  def related_guides
+    links("related_guides")
+  end
+
 private
 
   def parent

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -39,6 +39,10 @@ class DetailedGuidePresenter < ContentItemPresenter
     links("related_guides")
   end
 
+  def related_mainstream
+    links("related_mainstream")
+  end
+
 private
 
   def parent

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -48,6 +48,7 @@
     updated: @content_item.updated,
     history: @content_item.history,
     published: @content_item.published,
+    part_of: @content_item.part_of,
     direction: page_text_direction,
     other: {
       "Related guides" => @content_item.related_guides

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -37,6 +37,16 @@
     </div>
   <% end %>
   <div class="column-two-thirds <% unless @content_item.contents.any? %>offset-one-third<% end %>">
+    <% if @content_item.related_mainstream.any? %>
+      <aside class="related-mainstream-content" role="complementary">
+        <h4>
+          <%= raw( t('detailed_guide.related_mainstream_content') ) %>
+        </h4>
+        <% @content_item.related_mainstream.each do |link| %>
+          <%= link %><br />
+        <% end %>
+      </aside>
+    <% end %>
     <%= render 'govuk_component/govspeak',
         content: @content_item.body,
         direction: page_text_direction %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -48,5 +48,8 @@
     updated: @content_item.updated,
     history: @content_item.history,
     published: @content_item.published,
-    direction: page_text_direction
+    direction: page_text_direction,
+    other: {
+      "Related guides" => @content_item.related_guides
+    }
 %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -61,6 +61,6 @@
     part_of: @content_item.part_of,
     direction: page_text_direction,
     other: {
-      "Related guides" => @content_item.related_guides
+      t('detailed_guide.related_guides') => @content_item.related_guides
     }
 %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -319,5 +319,6 @@ ar:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -317,3 +317,5 @@ ar:
       published: "نشر"
       updated: "تحديث"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -319,3 +319,5 @@ ar:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -141,3 +141,5 @@ az:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -141,5 +141,6 @@ az:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -139,3 +139,5 @@ az:
       published: dərc olunub
       updated: yenilənib
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -229,3 +229,5 @@ be:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -227,3 +227,5 @@ be:
       published: "Апублікаваны"
       updated: "Адноўлена"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -229,5 +229,6 @@ be:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -141,5 +141,6 @@ bg:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -139,3 +139,5 @@ bg:
       published: "Публикувано"
       updated: "обновено"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -141,3 +141,5 @@ bg:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -141,3 +141,5 @@ bn:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -141,5 +141,6 @@ bn:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -139,3 +139,5 @@ bn:
       published:
       updated:
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -185,5 +185,6 @@ cs:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -183,3 +183,5 @@ cs:
       published: Publikováno
       updated: Aktualizováno
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -185,3 +185,5 @@ cs:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -315,3 +315,6 @@ cy:
       published: cyhoeddwyd
       updated: diweddarwyd
     contents: Cynnwys
+  detailed_guide:
+    related_mainstream_content: Gormod o fanylion?<br/>Edrychwch ar y canllawiau cyflym
+      hyn

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -318,5 +318,6 @@ cy:
   detailed_guide:
     related_mainstream_content: Gormod o fanylion?<br/>Edrychwch ar y canllawiau cyflym
       hyn
+    related_guides: Arweiniad manwl perthnasol
   html_publication:
     see_more:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -318,3 +318,5 @@ cy:
   detailed_guide:
     related_mainstream_content: Gormod o fanylion?<br/>Edrychwch ar y canllawiau cyflym
       hyn
+  html_publication:
+    see_more:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -141,5 +141,6 @@ de:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -139,3 +139,5 @@ de:
       published: Veröffentlicht
       updated: Aktualisiert
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -141,3 +141,5 @@ de:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -139,3 +139,5 @@ dr:
       published: "نشر شده"
       updated: "به روز شده"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -141,5 +141,6 @@ dr:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -141,3 +141,5 @@ dr:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -141,5 +141,6 @@ el:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -139,3 +139,5 @@ el:
       published: "Δημοσιευμένο"
       updated: "ανανεωμένο "
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -141,3 +141,5 @@ el:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,3 +196,5 @@ en:
     contents: Contents
   html_publication:
     see_more: See more information about this %{document_type}
+  detailed_guide:
+    related_mainstream_content: Too much detail?<br/>See these quick guides

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,4 +197,5 @@ en:
   html_publication:
     see_more: See more information about this %{document_type}
   detailed_guide:
+    related_guides: "Related guides"
     related_mainstream_content: Too much detail?<br/>See these quick guides

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -141,3 +141,5 @@ es-419:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -141,5 +141,6 @@ es-419:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -139,3 +139,5 @@ es-419:
       published: publicado
       updated: actualizado
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -141,3 +141,5 @@ es:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -139,3 +139,5 @@ es:
       published: Publicado
       updated: Actualizado
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -141,5 +141,6 @@ es:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -143,3 +143,4 @@ et:
     see_more: 'Loe lähemalt: %{document_type}'
   detailed_guide:
     related_mainstream_content: 'Liiga detailne?<br/>Vt. neid kokkuvõtlikke juhendeid? '
+    related_guides: Seotud detailne juhend

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -141,3 +141,5 @@ et:
     contents: Sisukord
   html_publication:
     see_more: 'Loe lähemalt: %{document_type}'
+  detailed_guide:
+    related_mainstream_content: 'Liiga detailne?<br/>Vt. neid kokkuvõtlikke juhendeid? '

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -141,5 +141,6 @@ fa:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -141,3 +141,5 @@ fa:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -139,3 +139,5 @@ fa:
       published: "منتشر شده"
       updated: "به روز رسانی شده"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -139,3 +139,5 @@ fr:
       published: publié
       updated: mise à  jour
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -141,3 +141,5 @@ fr:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -141,5 +141,6 @@ fr:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -229,5 +229,6 @@ he:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -227,3 +227,5 @@ he:
       published: "פורסם"
       updated: "מעודכן"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -229,3 +229,5 @@ he:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -141,3 +141,5 @@ hi:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -141,5 +141,6 @@ hi:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -139,3 +139,5 @@ hi:
       published: "प्रकाशित"
       updated: "अद्यतन"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -141,5 +141,6 @@ hu:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -139,3 +139,5 @@ hu:
       published: közzététel dátuma
       updated: 'Utolsó frissítés:'
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -141,3 +141,5 @@ hu:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -141,3 +141,5 @@ hy:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -141,5 +141,6 @@ hy:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -139,3 +139,5 @@ hy:
       published: "հրապարակված"
       updated: "Թարմացված"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -139,3 +139,5 @@ id:
       published: Diterbitkan
       updated: Terkini
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -141,5 +141,6 @@ id:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -141,3 +141,5 @@ id:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -141,3 +141,5 @@ it:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -141,5 +141,6 @@ it:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -139,3 +139,5 @@ it:
       published: pubblicato
       updated: aggiornato
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -141,5 +141,6 @@ ja:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -139,3 +139,5 @@ ja:
       published: "掲載日"
       updated: "更新"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -141,3 +141,5 @@ ja:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -139,3 +139,5 @@ ka:
       published:
       updated:
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -141,3 +141,5 @@ ka:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -141,5 +141,6 @@ ka:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -141,5 +141,6 @@ ko:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -141,3 +141,5 @@ ko:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -139,3 +139,5 @@ ko:
       published: "발행"
       updated: "업데이트"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -183,3 +183,5 @@ lt:
       published: publikuota
       updated: atnaujinta
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -185,5 +185,6 @@ lt:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -185,3 +185,5 @@ lt:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -139,3 +139,5 @@ lv:
       published: publicēts
       updated: atjaunināts
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -141,3 +141,5 @@ lv:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -141,5 +141,6 @@ lv:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -141,5 +141,6 @@ ms:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -141,3 +141,5 @@ ms:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -139,3 +139,5 @@ ms:
       published:
       updated:
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -227,3 +227,5 @@ pl:
       published: opublikowano
       updated: Zaktualizowany
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -229,3 +229,5 @@ pl:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -229,5 +229,6 @@ pl:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -141,3 +141,5 @@ ps:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -141,5 +141,6 @@ ps:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -139,3 +139,5 @@ ps:
       published: "خپور شوی"
       updated: "تازه شوي"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -141,5 +141,6 @@ pt:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -139,3 +139,5 @@ pt:
       published: publicado
       updated: Atualizado
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -141,3 +141,5 @@ pt:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -185,3 +185,5 @@ ro:
     contents: Conținut
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -185,5 +185,6 @@ ro:
     contents: Conținut
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -183,3 +183,5 @@ ro:
       published: Data publicării
       updated: Actualizat
     contents: Conținut
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -227,3 +227,5 @@ ru:
       published: "Опубликовано"
       updated: "обновлено"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -229,3 +229,5 @@ ru:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -229,5 +229,6 @@ ru:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -141,5 +141,6 @@ si:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -139,3 +139,5 @@ si:
       published: "පල කරන ලදී"
       updated: "යාවත්කාලීන කල"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -141,3 +141,5 @@ si:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -183,3 +183,5 @@ sk:
       published:
       updated:
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -185,3 +185,5 @@ sk:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -185,5 +185,6 @@ sk:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -139,3 +139,5 @@ so:
       published: La-daabacay/nashriyey
       updated: Wax lagu kordhiyey
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -141,3 +141,5 @@ so:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -141,5 +141,6 @@ so:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -139,3 +139,5 @@ sq:
       published: publikuar
       updated: rifreskuar
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -141,5 +141,6 @@ sq:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -141,3 +141,5 @@ sq:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -229,3 +229,5 @@ sr:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -229,5 +229,6 @@ sr:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -227,3 +227,5 @@ sr:
       published: objavljeno
       updated: ažurirano
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -141,3 +141,5 @@ sw:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -141,5 +141,6 @@ sw:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -139,3 +139,5 @@ sw:
       published:
       updated:
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -141,3 +141,5 @@ ta:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -139,3 +139,5 @@ ta:
       published: "பிரசுரிக்கப்பட்டது"
       updated: "இற்றைப்படுத்தப்பட்டது"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -141,5 +141,6 @@ ta:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -141,3 +141,5 @@ th:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -141,5 +141,6 @@ th:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -139,3 +139,5 @@ th:
       published: "ตีพิมพ์"
       updated: "ปรับปรุง"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -141,5 +141,6 @@ tk:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -139,3 +139,5 @@ tk:
       published:
       updated:
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -141,3 +141,5 @@ tk:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -139,3 +139,5 @@ tr:
       published: Yayında
       updated: Güncellendi
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -141,3 +141,5 @@ tr:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -141,5 +141,6 @@ tr:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -229,5 +229,6 @@ uk:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -229,3 +229,5 @@ uk:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -227,3 +227,5 @@ uk:
       published: "опубліковано"
       updated: "оновлено"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -143,5 +143,6 @@ ur:
     ur: "اردو"
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -141,3 +141,5 @@ ur:
     contents:
   language_names:
     ur: "اردو"
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -143,3 +143,5 @@ ur:
     ur: "اردو"
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -141,3 +141,5 @@ uz:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -141,5 +141,6 @@ uz:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -139,3 +139,5 @@ uz:
       published: nashr qilindi
       updated: yangilandi
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -141,5 +141,6 @@ vi:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -139,3 +139,5 @@ vi:
       published: "Đã xuất bản"
       updated: Cập nhật
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -141,3 +141,5 @@ vi:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -141,5 +141,6 @@ zh-hk:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -139,3 +139,5 @@ zh-hk:
       published: "已發布"
       updated: "已更新"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -141,3 +141,5 @@ zh-hk:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -141,3 +141,5 @@ zh-tw:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -139,3 +139,5 @@ zh-tw:
       published: "發行"
       updated: "更新"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -141,5 +141,6 @@ zh-tw:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -143,5 +143,6 @@ zh:
     contents:
   detailed_guide:
     related_mainstream_content:
+    related_guides:
   html_publication:
     see_more:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -141,3 +141,5 @@ zh:
       published: "已发布"
       updated: "已更新"
     contents:
+  detailed_guide:
+    related_mainstream_content:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -143,3 +143,5 @@ zh:
     contents:
   detailed_guide:
     related_mainstream_content:
+  html_publication:
+    see_more:

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -27,6 +27,11 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "shows related detailed guides" do
+    setup_and_visit_content_item('political_detailed_guide')
+    assert_has_component_document_footer_pair("Related guides", ['<a href="/guidance/offshore-wind-part-of-the-uks-energy-mix">Offshore wind: part of the UK&#39;s energy mix</a>'])
+  end
+
   test "historically political detailed guide" do
     setup_and_visit_content_item('political_detailed_guide')
 

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -33,6 +33,16 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     assert_has_component_document_footer_pair("Related guides", ['<a href="/guidance/offshore-wind-part-of-the-uks-energy-mix">Offshore wind: part of the UK&#39;s energy mix</a>'])
   end
 
+  test "shows related mainstream content" do
+    setup_and_visit_content_item('related_mainstream_detailed_guide')
+
+    within ".related-mainstream-content" do
+      assert page.has_text?('Too much detail?')
+      assert page.has_css?('a[href="/overseas-passports"]', text: 'Overseas British passport applications')
+      assert page.has_css?('a[href="/report-a-lost-or-stolen-passport"]', text: 'Cancel a lost or stolen passport')
+    end
+  end
+
   test "historically political detailed guide" do
     setup_and_visit_content_item('political_detailed_guide')
 

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -12,6 +12,7 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     link1 = "<a href=\"/topic/business-tax/paye\">PAYE</a>"
     link2 = "<a href=\"/topic/business-tax\">Business tax</a>"
     assert_has_component_metadata_pair("part_of", [link1, link2])
+    assert_has_component_document_footer_pair("part_of", [link1, link2])
   end
 
   test "withdrawn detailed guide" do

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -47,6 +47,10 @@ class DetailedGuidePresenterTest < PresenterTest
     assert_equal schema_item["details"]["government"]["title"], presented_item.publishing_government
   end
 
+  test 'presents related detailed guides' do
+    assert_equal ['<a href="/guidance/offshore-wind-part-of-the-uks-energy-mix">Offshore wind: part of the UK&#39;s energy mix</a>'], presented_item("political_detailed_guide").related_guides
+  end
+
   test 'content can be historically political' do
     example = schema_item("political_detailed_guide")
     presented = presented_item("political_detailed_guide")

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -51,6 +51,12 @@ class DetailedGuidePresenterTest < PresenterTest
     assert_equal ['<a href="/guidance/offshore-wind-part-of-the-uks-energy-mix">Offshore wind: part of the UK&#39;s energy mix</a>'], presented_item("political_detailed_guide").related_guides
   end
 
+  test 'presents related mainstream content' do
+    assert_equal [
+      '<a href="/overseas-passports">Overseas British passport applications</a>',
+      '<a href="/report-a-lost-or-stolen-passport">Cancel a lost or stolen passport</a>'], presented_item("related_mainstream_detailed_guide").related_mainstream
+  end
+
   test 'content can be historically political' do
     example = schema_item("political_detailed_guide")
     presented = presented_item("political_detailed_guide")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,7 +24,15 @@ class ActionDispatch::IntegrationTest
   include Slimmer::TestHelpers::SharedTemplates
 
   def assert_has_component_metadata_pair(label, value)
-    within shared_component_selector("metadata") do
+    assert_component_parameter("metadata", label, value)
+  end
+
+  def assert_has_component_document_footer_pair(label, value)
+    assert_component_parameter("document_footer", label, value)
+  end
+
+  def assert_component_parameter(component, label, value)
+    within shared_component_selector(component) do
       # Flatten top level / "other" args, for consistent hash access
       component_args = JSON.parse(page.text).tap do |args|
         args.merge!(args.delete("other")) if args.key?("other")


### PR DESCRIPTION
* Add related guides to detailed guides
* Add `part_of` to document footer, to match what's included in metadata
* Add related mainstream content to detailed guides
* Steal new translations from Whitehall

Depends on https://github.com/alphagov/govuk-content-schemas/pull/293 for passing tests.

<img width="1030" alt="screen shot 2016-04-27 at 16 46 28" src="https://cloud.githubusercontent.com/assets/319055/14858425/fa8c8d1e-0c97-11e6-8441-f768cf045417.png">
<img width="818" alt="screen shot 2016-04-27 at 16 46 37" src="https://cloud.githubusercontent.com/assets/319055/14858426/faa0e584-0c97-11e6-95f6-42ef6dee70d7.png">