### PR TITLE
Add minimum viable publication rendering

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,3 +31,4 @@
 @import "views/unpublishing";
 @import "views/working-group";
 @import "views/detailed-guide";
+@import "views/publication";

--- a/app/assets/stylesheets/views/_publication.scss
+++ b/app/assets/stylesheets/views/_publication.scss
@@ -1,0 +1,3 @@
+.publication {
+
+}

--- a/app/assets/stylesheets/views/_publication.scss
+++ b/app/assets/stylesheets/views/_publication.scss
@@ -1,3 +1,10 @@
 .publication {
+  @include description;
+  @include sidebar-with-body;
+  @include history-notice;
+  @include withdrawal-notice;
 
+  .section-title {
+    @include bold-27;
+  }
 }

--- a/app/presenters/linkable.rb
+++ b/app/presenters/linkable.rb
@@ -1,10 +1,17 @@
 module Linkable
   def from
-    links("lead_organisations") + links("supporting_organisations") + links("worldwide_organisations")
+    links("lead_organisations") +
+      links("organisations") +
+      links("supporting_organisations") +
+      links("worldwide_organisations")
   end
 
   def part_of
-    links("document_collections") + links("related_policies") + links("world_locations") + links("topics")
+    links("document_collections") +
+      links("related_policies") +
+      links("policies") +
+      links("world_locations") +
+      links("topics")
   end
 
 private

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -8,4 +8,18 @@ class PublicationPresenter < ContentItemPresenter
   def details
     content_item["details"]["body"]
   end
+
+  def documents
+    documents_list.join('')
+  end
+
+  def documents_count
+    documents_list.size
+  end
+
+private
+
+  def documents_list
+    content_item["details"]["documents"]
+  end
 end

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -1,2 +1,11 @@
 class PublicationPresenter < ContentItemPresenter
+  include Political
+  include Linkable
+  include Updatable
+  include Withdrawable
+  include ActionView::Helpers::UrlHelper
+
+  def details
+    content_item["details"]["body"]
+  end
 end

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -1,0 +1,2 @@
+class PublicationPresenter < ContentItemPresenter
+end

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -5,8 +5,41 @@
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
         context: t("content_item.format.#{@content_item.format}", count: 1),
-        title: @content_item.title %>
+        title: @content_item.title,
+        average_title_length: "long" %>
   </div>
 </div>
 
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/metadata',
+        from: @content_item.from,
+        part_of: @content_item.part_of,
+        first_published: @content_item.published,
+        last_updated: @content_item.updated,
+        see_updates_link: true
+    %>
+  </div>
+</div>
+<%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
+
+<div class="grid-row sidebar-with-body">
+  <div class="column-third">
+    <h1 class="section-title" id="details-title">Details</h1>
+  </div>
+  <div class="column-two-thirds" aria-labelledby="details-title">
+    <%= render 'govuk_component/govspeak',
+        content: @content_item.details,
+        direction: page_text_direction %>
+  </div>
+</div>
+
+<%= render 'govuk_component/document_footer',
+    from: @content_item.from,
+    updated: @content_item.updated,
+    history: @content_item.history,
+    published: @content_item.published,
+    part_of: @content_item.part_of,
+    direction: page_text_direction
+%>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -1,0 +1,12 @@
+<%= content_for :page_class, @content_item.format.dasherize %>
+<%= content_for :title, @content_item.title %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+        context: t("content_item.format.#{@content_item.format}", count: 1),
+        title: @content_item.title %>
+  </div>
+</div>
+
+<%= render 'shared/description', description: @content_item.description %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -26,7 +26,22 @@
 
 <div class="grid-row sidebar-with-body">
   <div class="column-third">
-    <h1 class="section-title" id="details-title">Details</h1>
+    <h1 class="section-title" id="documents-title">
+      <%= t("publications.documents", count: @content_item.documents_count) %>
+    </h1>
+  </div>
+  <div class="column-two-thirds" aria-labelledby="documents-title">
+    <%= render 'govuk_component/govspeak',
+        content: @content_item.documents,
+        direction: page_text_direction %>
+  </div>
+</div>
+
+<div class="grid-row sidebar-with-body">
+  <div class="column-third">
+    <h1 class="section-title" id="details-title">
+      <%= t("publications.details") %>
+    </h1>
   </div>
   <div class="column-two-thirds" aria-labelledby="details-title">
     <%= render 'govuk_component/govspeak',

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
-<%= content_for :title, @content_item.title %>
+<%= content_for :title, @content_item.page_title %>
 
 <div class="grid-row">
   <div class="column-two-thirds">
@@ -9,6 +9,8 @@
         average_title_length: "long" %>
   </div>
 </div>
+
+<%= render 'shared/withdrawal_notice', content_item: @content_item %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -322,3 +322,11 @@ ar:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      zero:
+      one: "وثيقة"
+      two:
+      few:
+      many:
+      other: "وثائق"

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -144,3 +144,7 @@ az:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one:
+      other:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -232,3 +232,9 @@ be:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "Дакумент"
+      few:
+      many:
+      other: "Дакументы"

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -144,3 +144,7 @@ bg:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "Документ"
+      other: "Документи"

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -144,3 +144,7 @@ bn:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one:
+      other:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -188,3 +188,8 @@ cs:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Dokument
+      few:
+      other: Dokumenty

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -321,3 +321,11 @@ cy:
     related_guides: Arweiniad manwl perthnasol
   html_publication:
     see_more:
+  publication:
+    documents:
+      zero:
+      one: Dogfen
+      two:
+      few:
+      many:
+      other: Dogfennau

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -144,3 +144,7 @@ de:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Dokument
+      other: Dokumente

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -144,3 +144,7 @@ dr:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "سند"
+      other: "اسناد"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -144,3 +144,7 @@ el:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "Έγγραφο"
+      other: "Έγγραφα"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -199,3 +199,8 @@ en:
   detailed_guide:
     related_guides: "Related guides"
     related_mainstream_content: Too much detail?<br/>See these quick guides
+  publication:
+    documents:
+      one: Document
+      other: Documents
+    details: Details

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -144,3 +144,7 @@ es-419:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Documento
+      other: Documentos

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -144,3 +144,7 @@ es:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Documento
+      other: Documentos

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -144,3 +144,7 @@ et:
   detailed_guide:
     related_mainstream_content: 'Liiga detailne?<br/>Vt. neid kokkuvõtlikke juhendeid? '
     related_guides: Seotud detailne juhend
+  publication:
+    documents:
+      one: Dokument
+      other: Dokumendid

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -144,3 +144,7 @@ fa:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "مدرک"
+      other: "مدارک"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -144,3 +144,7 @@ fr:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Document
+      other: Documents

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -232,3 +232,9 @@ he:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "מסמך"
+      two:
+      many:
+      other: "מסמכים"

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -144,3 +144,7 @@ hi:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "दस्तावेज़"
+      other: "दस्तावेजों"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -144,3 +144,7 @@ hu:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Dokumentum
+      other: Dokumentumok

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -144,3 +144,7 @@ hy:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "Փաստաթուղթ"
+      other: "Փաստաթղթեր"

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -144,3 +144,7 @@ id:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Dokumen
+      other: Dokumen-dokumen

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -144,3 +144,7 @@ it:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Documento
+      other: Documenti

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -144,3 +144,7 @@ ja:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "お知らせ"
+      other: "お知らせ"

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -144,3 +144,7 @@ ka:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one:
+      other:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -144,3 +144,7 @@ ko:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "문서"
+      other: "문서"

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -188,3 +188,8 @@ lt:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Dokumentas
+      few:
+      other: Dokumentai

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -144,3 +144,7 @@ lv:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Dokuments
+      other: Dokumenti

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -144,3 +144,7 @@ ms:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one:
+      other:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -232,3 +232,9 @@ pl:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Dokument
+      few:
+      many:
+      other: Dokumenty

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -144,3 +144,7 @@ ps:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "سند"
+      other: "سندونه"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -144,3 +144,7 @@ pt:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Documento
+      other: Documentos

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -188,3 +188,8 @@ ro:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Document
+      few:
+      other: Documente

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -232,3 +232,9 @@ ru:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "Документ"
+      few:
+      many:
+      other: "Документы"

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -144,3 +144,7 @@ si:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "ලේඛණය"
+      other: "ලේඛණ"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -188,3 +188,8 @@ sk:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one:
+      few:
+      other:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -144,3 +144,7 @@ so:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Dokumenti
+      other: Dokumentiyo

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -144,3 +144,7 @@ sq:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Dokument
+      other: Dokumente

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -232,3 +232,9 @@ sr:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Dokument
+      few:
+      many:
+      other: Dokumenti

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -144,3 +144,7 @@ sw:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one:
+      other:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -144,3 +144,7 @@ ta:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: " ஆவணம்"
+      other: "ஆவணங்கள்"

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -144,3 +144,7 @@ th:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "เอกสาร"
+      other: "เอกสารต่างๆ"

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -144,3 +144,7 @@ tk:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one:
+      other:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -144,3 +144,7 @@ tr:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Belge
+      other: Belgeler

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -232,3 +232,9 @@ uk:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "Документ"
+      few:
+      many:
+      other: "Документи"

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -146,3 +146,7 @@ ur:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "دستاویز"
+      other: "دستاویزات"

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -144,3 +144,7 @@ uz:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Hujjat
+      other: Hujjatlar

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -144,3 +144,7 @@ vi:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: Tài liệu
+      other: Tài liệu

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -144,3 +144,7 @@ zh-hk:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "文件"
+      other: "其他文件"

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -144,3 +144,7 @@ zh-tw:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "文件"
+      other: "其他文件"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -146,3 +146,7 @@ zh:
     related_guides:
   html_publication:
     see_more:
+  publication:
+    documents:
+      one: "文件"
+      other: "文件"

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -17,9 +17,7 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
 
   test "withdrawn detailed guide" do
     setup_and_visit_content_item('withdrawn_detailed_guide')
-
-    assert_has_component_title(@content_item["title"])
-    assert page.has_text?(@content_item["description"])
+    assert page.has_css?('title', text: "[Withdrawn]", visible: false)
 
     within ".withdrawal-notice" do
       assert page.has_text?('This guidance was withdrawn'), "is withdrawn"

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -34,4 +34,12 @@ class PublicationTest < ActionDispatch::IntegrationTest
       assert page.has_css?("time[datetime='#{@content_item['details']['withdrawn_notice']['withdrawn_at']}']")
     end
   end
+
+  test "historically political publication" do
+    setup_and_visit_content_item('political_publication')
+
+    within ".history-notice" do
+      assert page.has_text?('This publication was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government')
+    end
+  end
 end

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -1,4 +1,15 @@
 require 'test_helper'
 
 class PublicationTest < ActionDispatch::IntegrationTest
+  test "publication" do
+    setup_and_visit_content_item('publication')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+
+    assert_has_component_metadata_pair("first_published", "3 May 2016")
+    link1 = "<a href=\"/government/organisations/environment-agency\">Environment Agency</a>"
+    assert_has_component_metadata_pair("from", [link1])
+    assert_has_component_document_footer_pair("from", [link1])
+  end
 end

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -7,9 +7,20 @@ class PublicationTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
 
+    within '[aria-labelledby="details-title"]' do
+      assert_has_component_govspeak(@content_item["details"]["body"])
+    end
+
     assert_has_component_metadata_pair("first_published", "3 May 2016")
     link1 = "<a href=\"/government/organisations/environment-agency\">Environment Agency</a>"
     assert_has_component_metadata_pair("from", [link1])
     assert_has_component_document_footer_pair("from", [link1])
+  end
+
+  test "renders a govspeak block for attachments" do
+    setup_and_visit_content_item('publication')
+    within '[aria-labelledby="documents-title"]' do
+      assert_has_component_govspeak(@content_item["details"]["documents"].join(''))
+    end
   end
 end

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class PublicationTest < ActionDispatch::IntegrationTest
+end

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -23,4 +23,15 @@ class PublicationTest < ActionDispatch::IntegrationTest
       assert_has_component_govspeak(@content_item["details"]["documents"].join(''))
     end
   end
+
+  test "withdrawn publication" do
+    setup_and_visit_content_item('withdrawn_publication')
+    assert page.has_css?('title', text: "[Withdrawn]", visible: false)
+
+    within ".withdrawal-notice" do
+      assert page.has_text?('This publication was withdrawn'), "is withdrawn"
+      assert_has_component_govspeak(@content_item["details"]["withdrawn_notice"]["explanation"])
+      assert page.has_css?("time[datetime='#{@content_item['details']['withdrawn_notice']['withdrawn_at']}']")
+    end
+  end
 end

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -4,4 +4,19 @@ class PublicationPresenterTest < PresenterTest
   def format_name
     "publication"
   end
+
+  test 'presents the basic details of a content item' do
+    assert_equal schema_item['description'], presented_item.description
+    assert_equal schema_item['format'], presented_item.format
+    assert_equal schema_item['title'], presented_item.title
+    assert_equal schema_item['details']['body'], presented_item.details
+  end
+
+  test '#published returns a formatted date of the day the content item became public' do
+    assert_equal '3 May 2016', presented_item.published
+  end
+
+  test 'presents the title of the publishing government' do
+    assert_equal schema_item["details"]["government"]["title"], presented_item.publishing_government
+  end
 end

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -10,10 +10,15 @@ class PublicationPresenterTest < PresenterTest
     assert_equal schema_item['format'], presented_item.format
     assert_equal schema_item['title'], presented_item.title
     assert_equal schema_item['details']['body'], presented_item.details
+    assert_equal schema_item['details']['documents'].join(''), presented_item.documents
   end
 
   test '#published returns a formatted date of the day the content item became public' do
     assert_equal '3 May 2016', presented_item.published
+  end
+
+  test 'counts documents attached to publication' do
+    assert_equal 2, presented_item.documents_count
   end
 
   test 'presents the title of the publishing government' do

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -1,0 +1,7 @@
+require 'presenter_test_helper'
+
+class PublicationPresenterTest < PresenterTest
+  def format_name
+    "publication"
+  end
+end

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -25,6 +25,16 @@ class PublicationPresenterTest < PresenterTest
     assert_equal schema_item["details"]["government"]["title"], presented_item.publishing_government
   end
 
+  test 'content can be historically political' do
+    example = schema_item("political_publication")
+    presented = presented_item("political_publication")
+
+    refute example["details"]["government"]["current"]
+    assert example["details"]["political"]
+
+    assert presented.historically_political?
+  end
+
   test 'presents withdrawn notices' do
     example = schema_item("withdrawn_publication")
     presented = presented_item("withdrawn_publication")

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -24,4 +24,14 @@ class PublicationPresenterTest < PresenterTest
   test 'presents the title of the publishing government' do
     assert_equal schema_item["details"]["government"]["title"], presented_item.publishing_government
   end
+
+  test 'presents withdrawn notices' do
+    example = schema_item("withdrawn_publication")
+    presented = presented_item("withdrawn_publication")
+
+    assert example["details"].include?("withdrawn_notice")
+    assert presented.withdrawn?
+    assert_equal example["details"]["withdrawn_notice"]["explanation"], presented.withdrawal_notice[:explanation]
+    assert_equal '<time datetime="2015-01-13T13:05:30Z">13 January 2015</time>', presented.withdrawal_notice[:time]
+  end
 end


### PR DESCRIPTION
Render the following example accurately:
https://www.gov.uk/government/publications/d17-9ly-veolia-es-uk-limited-environmental-permit-issued

Built in conjunction with:
https://github.com/alphagov/govuk-content-schemas/pull/298
(tests will fail until that is merged)

Intentionally, but temporarily, omits from this example:
* Format subtype
* Excluded nations

Further features and examples required for:
* History notice
* Withdrawn notice
* Ministers, topical events, related statistical data sets and other links

<img width="1200" alt="publication-format-preview" src="https://cloud.githubusercontent.com/assets/319055/15021446/c91f44c4-121e-11e6-848a-da3c8a4c4e77.png">

Part of:
https://trello.com/c/v85kPiKN/366-9-publications-migration-mvp-content-schema-examples-and-front-end-work-medium