### PR TITLE
Display applicable nations for detailed guides.

### DIFF
--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -43,7 +43,34 @@ class DetailedGuidePresenter < ContentItemPresenter
     links("related_mainstream")
   end
 
+  def applies_to
+    return nil if !national_applicability
+    all_nations = national_applicability.values
+    applicable_nations = all_nations.select { |n| n["applicable"] }
+    inapplicable_nations = all_nations - applicable_nations
+
+    applies_to = applicable_nations.map { |n| n["label"] }.to_sentence
+
+    if inapplicable_nations.any?
+      nations_with_alt_urls = inapplicable_nations.select { |n| n["alternative_url"].present? }
+      if nations_with_alt_urls.any?
+        additional_guidance_links = nations_with_alt_urls
+          .map { |n| link_to(n['label'], n['alternative_url'], rel: :external) }
+          .to_sentence
+        # TODO: Translation for `see detailed guidance for` below?
+        additional_guidance = " (see detailed guidance for #{additional_guidance_links})"
+        applies_to += additional_guidance
+      end
+    end
+
+    applies_to
+  end
+
 private
+
+  def national_applicability
+    content_item["details"]["national_applicability"]
+  end
 
   def parent
     if content_item["links"].include?("parent")

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -23,7 +23,10 @@
         part_of: @content_item.part_of,
         first_published: @content_item.published,
         last_updated: @content_item.updated,
-        see_updates_link: true
+        see_updates_link: true,
+        other: {
+          'Applies to' => @content_item.applies_to
+        }
     %>
   </div>
 </div>

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -48,4 +48,16 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
       assert page.has_text?('This guidance was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government')
     end
   end
+
+  test 'detailed guide that only applies to a set of nations' do
+    setup_and_visit_content_item('national_applicability_detailed_guide')
+
+    assert_has_component_metadata_pair('Applies to', 'England')
+  end
+
+  test 'detailed guide that only applies to a set of nations, with alternative urls' do
+    setup_and_visit_content_item('national_applicability_alternative_url_detailed_guide')
+
+    assert_has_component_metadata_pair('Applies to', 'England, Scotland, and Wales (see detailed guidance for <a href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for" rel="external">Northern Ireland</a>)')
+  end
 end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -66,4 +66,20 @@ class DetailedGuidePresenterTest < PresenterTest
 
     assert presented.historically_political?
   end
+
+  test 'content can apply only to a set of nations' do
+    example = schema_item('national_applicability_detailed_guide')
+    presented = presented_item('national_applicability_detailed_guide')
+
+    assert example['details'].include?('national_applicability')
+    assert_equal presented.applies_to, 'England'
+  end
+
+  test 'content can apply only to a set of nations with alternative urls' do
+    example = schema_item('national_applicability_alternative_url_detailed_guide')
+    presented = presented_item('national_applicability_alternative_url_detailed_guide')
+
+    assert example['details'].include?('national_applicability')
+    assert_equal presented.applies_to, 'England, Scotland, and Wales (see detailed guidance for <a href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for" rel="external">Northern Ireland</a>)'
+  end
 end


### PR DESCRIPTION
This implements a missing feature for the detailed guides migration.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/300 for the tests to pass, I think.

### After ("Applies to" displays)

![screen shot 2016-05-05 at 16 46 25](https://cloud.githubusercontent.com/assets/1650875/15048637/42ddd5f0-12e2-11e6-92a8-eb9a921702ff.png)

cc @fofr 