### PR TITLE
Add further publication features

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
 @import "helpers/dash-list";
 @import "helpers/description";
 @import "helpers/sidebar-with-body";
+@import "helpers/national_statistics_logo";
 @import "helpers/notice";
 @import "helpers/history-notice";
 @import "helpers/withdrawal-notice";

--- a/app/assets/stylesheets/helpers/_national_statistics_logo.scss
+++ b/app/assets/stylesheets/helpers/_national_statistics_logo.scss
@@ -1,0 +1,5 @@
+@mixin national-statistics-logo {
+  .national-statistics-logo {
+    margin-top: $gutter * 1.5;
+  }
+}

--- a/app/assets/stylesheets/views/_publication.scss
+++ b/app/assets/stylesheets/views/_publication.scss
@@ -3,6 +3,7 @@
   @include sidebar-with-body;
   @include history-notice;
   @include withdrawal-notice;
+  @include national-statistics-logo;
 
   .section-title {
     @include bold-27;

--- a/app/assets/stylesheets/views/_statistics_announcement.scss
+++ b/app/assets/stylesheets/views/_statistics_announcement.scss
@@ -1,9 +1,6 @@
 .statistics-announcement {
   @include description;
-
-  .national-statistics-logo {
-    margin-top: $gutter;
-  }
+  @include national-statistics-logo;
 
   .cancellation-notice {
     @include notice;

--- a/app/presenters/case_study_presenter.rb
+++ b/app/presenters/case_study_presenter.rb
@@ -4,12 +4,11 @@ class CaseStudyPresenter < ContentItemPresenter
   include Updatable
   include Withdrawable
 
-  attr_reader :body, :format_display_type
+  attr_reader :body
 
   def initialize(content_item)
     super
     @body = content_item["details"]["body"]
-    @format_display_type = content_item["details"]["format_display_type"]
   end
 
   def image

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,5 +1,5 @@
 class ContentItemPresenter
-  attr_reader :content_item, :title, :description, :format, :locale, :phase
+  attr_reader :content_item, :title, :description, :format, :locale, :phase, :document_type
 
   def initialize(content_item)
     @content_item = content_item
@@ -8,6 +8,7 @@ class ContentItemPresenter
     @format = content_item["format"]
     @locale = content_item["locale"] || "en"
     @phase = content_item["phase"]
+    @document_type = content_item["document_type"]
   end
 
   def available_translations

--- a/app/presenters/linkable.rb
+++ b/app/presenters/linkable.rb
@@ -17,6 +17,7 @@ module Linkable
       world_locations
       topics
       topical_events
+      related_statistical_data_sets
     })
   end
 

--- a/app/presenters/linkable.rb
+++ b/app/presenters/linkable.rb
@@ -1,17 +1,21 @@
 module Linkable
   def from
-    links("lead_organisations") +
-      links("organisations") +
-      links("supporting_organisations") +
-      links("worldwide_organisations")
+    links_group(%w{
+      lead_organisations
+      organisations
+      supporting_organisations
+      worldwide_organisations
+    })
   end
 
   def part_of
-    links("document_collections") +
-      links("related_policies") +
-      links("policies") +
-      links("world_locations") +
-      links("topics")
+    links_group(%w{
+      document_collections
+      related_policies
+      policies
+      world_locations
+      topics
+    })
   end
 
 private
@@ -21,5 +25,9 @@ private
     content_item["links"][type].map do |link|
       link_to(link["title"], link["base_path"])
     end
+  end
+
+  def links_group(types)
+    types.flat_map { |type| links(type) }.uniq
   end
 end

--- a/app/presenters/linkable.rb
+++ b/app/presenters/linkable.rb
@@ -5,6 +5,7 @@ module Linkable
       organisations
       supporting_organisations
       worldwide_organisations
+      ministers
     })
   end
 
@@ -15,6 +16,7 @@ module Linkable
       policies
       world_locations
       topics
+      topical_events
     })
   end
 

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -17,6 +17,10 @@ class PublicationPresenter < ContentItemPresenter
     documents_list.size
   end
 
+  def national_statistics?
+    document_type === "national_statistics"
+  end
+
 private
 
   def documents_list

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -1,10 +1,10 @@
 <%= content_for :page_class, @content_item.format.dasherize.pluralize %>
-<%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.format_display_type}", count: 1)}" %>
+<%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
 
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.format_display_type}", count: 1),
+        context: t("content_item.format.#{@content_item.document_type}", count: 1),
         title: @content_item.title,
         average_title_length: 'long' %>
   </div>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -8,7 +8,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.format}", count: 1),
+        context: t("content_item.format.#{@content_item.document_type}", count: 1),
         title: @content_item.title,
         average_title_length: "long" %>
   </div>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -8,6 +8,9 @@
         title: @content_item.title,
         average_title_length: "long" %>
   </div>
+  <% if @content_item.national_statistics? %>
+    <%= render 'shared/national_statistics_logo' %>
+  <% end %>
 </div>
 
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -4,7 +4,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.format}", count: 1),
+        context: t("content_item.format.#{@content_item.document_type}", count: 1),
         title: @content_item.title,
         average_title_length: "long" %>
   </div>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -10,11 +10,7 @@
   </div>
 
   <% if @content_item.national_statistics? %>
-  <div class="column-third">
-    <div class="national-statistics-logo">
-      <%= image_tag 'national-statistics.png', alt: 'National Statistics' %>
-    </div>
-  </div>
+    <%= render 'shared/national_statistics_logo' %>
   <% end %>
 </div>
 

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -1,10 +1,10 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
-<%= content_for :title, "#{@content_item.title} - #{t("content_item.format.#{@content_item.format}", count: 1)}" %>
+<%= content_for :title, "#{@content_item.title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
 
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.format}", count: 1),
+        context: t("content_item.format.#{@content_item.document_type}", count: 1),
         title: @content_item.title,
         average_title_length: "long" %>
   </div>

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -4,7 +4,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.format}", count: 1),
+        context: t("content_item.format.#{@content_item.document_type}", count: 1),
         title: @content_item.title %>
   </div>
 </div>

--- a/app/views/shared/_national_statistics_logo.html.erb
+++ b/app/views/shared/_national_statistics_logo.html.erb
@@ -1,0 +1,5 @@
+<div class="column-third">
+  <div class="national-statistics-logo">
+    <%= image_tag 'national-statistics.png', alt: 'National Statistics' %>
+  </div>
+</div>

--- a/lib/generators/format/templates/format.html.erb
+++ b/lib/generators/format/templates/format.html.erb
@@ -4,7 +4,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.format}", count: 1),
+        context: t("content_item.format.#{@content_item.document_type}", count: 1),
         title: @content_item.title %>
   </div>
 </div>

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -10,11 +10,19 @@ class PublicationTest < ActionDispatch::IntegrationTest
     within '[aria-labelledby="details-title"]' do
       assert_has_component_govspeak(@content_item["details"]["body"])
     end
+  end
+
+  test "renders metadata and document footer" do
+    setup_and_visit_content_item('publication')
 
     assert_has_component_metadata_pair("first_published", "3 May 2016")
     link1 = "<a href=\"/government/organisations/environment-agency\">Environment Agency</a>"
-    assert_has_component_metadata_pair("from", [link1])
-    assert_has_component_document_footer_pair("from", [link1])
+    link2 = "<a href=\"/government/people/eric-pickles\">The Rt Hon Sir Eric Pickles MP</a>"
+    assert_has_component_metadata_pair("from", [link1, link2])
+    assert_has_component_document_footer_pair("from", [link1, link2])
+
+    assert_has_component_metadata_pair("part_of", ["<a href=\"/government/topical-events/anti-corruption-summit-london-2016\">Anti-Corruption Summit: London 2016</a>"])
+    assert_has_component_document_footer_pair("part_of", ["<a href=\"/government/topical-events/anti-corruption-summit-london-2016\">Anti-Corruption Summit: London 2016</a>"])
   end
 
   test "renders a govspeak block for attachments" do

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -50,4 +50,9 @@ class PublicationTest < ActionDispatch::IntegrationTest
       assert page.has_text?('This publication was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government')
     end
   end
+
+  test "national statistics publication shows a logo" do
+    setup_and_visit_content_item('statistics_publication')
+    assert page.has_css?(".national-statistics-logo img")
+  end
 end

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -13,7 +13,6 @@ class CaseStudyPresenterTest < PresenterTest
     assert_equal schema_item['locale'], presented_item.locale
     assert_equal schema_item['title'], presented_item.title
     assert_equal schema_item['details']['body'], presented_item.body
-    assert_equal schema_item['details']['format_display_type'], presented_item.format_display_type
   end
 
   test '#published returns a formatted date of the day the content item became public' do

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -17,6 +17,10 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     assert_equal "ar", ContentItemPresenter.new("locale" => "ar").locale
   end
 
+  test "#document_type" do
+    assert_equal "Type", ContentItemPresenter.new("document_type" => "Type").document_type
+  end
+
   test "available_translations sorts languages by locale with English first" do
     translated = govuk_content_schema_example('case_study', 'translated')
     locales = ContentItemPresenter.new(translated).available_translations

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -35,6 +35,16 @@ class PublicationPresenterTest < PresenterTest
     assert presented.historically_political?
   end
 
+  test '#from presents ministers' do
+    minister = schema_item["links"]["ministers"][0]
+    assert presented_item.from.include?("<a href=\"#{minister['base_path']}\">#{minister['title']}</a>")
+  end
+
+  test '#part_of presents topical events' do
+    event = schema_item["links"]["topical_events"][0]
+    assert presented_item.part_of.include?("<a href=\"#{event['base_path']}\">#{event['title']}</a>")
+  end
+
   test 'presents withdrawn notices' do
     example = schema_item("withdrawn_publication")
     presented = presented_item("withdrawn_publication")

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -50,6 +50,11 @@ class PublicationPresenterTest < PresenterTest
     assert presented_item("statistics_publication").part_of.include?("<a href=\"#{data_set['base_path']}\">#{data_set['title']}</a>")
   end
 
+  test '#national_statistics? matches national statistics documents' do
+    refute presented_item.national_statistics?
+    assert presented_item("statistics_publication").national_statistics?
+  end
+
   test 'presents withdrawn notices' do
     example = schema_item("withdrawn_publication")
     presented = presented_item("withdrawn_publication")

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -45,6 +45,11 @@ class PublicationPresenterTest < PresenterTest
     assert presented_item.part_of.include?("<a href=\"#{event['base_path']}\">#{event['title']}</a>")
   end
 
+  test '#part_of presents related statistical data sets' do
+    data_set = schema_item("statistics_publication")["links"]["related_statistical_data_sets"][0]
+    assert presented_item("statistics_publication").part_of.include?("<a href=\"#{data_set['base_path']}\">#{data_set['title']}</a>")
+  end
+
   test 'presents withdrawn notices' do
     example = schema_item("withdrawn_publication")
     presented = presented_item("withdrawn_publication")


### PR DESCRIPTION
Depends on https://github.com/alphagov/govuk-content-schemas/pull/304 for passing tests

* Use `document_type` not `format` for title context on all formats. Publications have varying document types which need to be used as the context in the title component. For all formats without varying document types, the value of document_type will match format. Removes the old approach used by Case Studies (“format_display_type”)
* Protect against duplicate links appearing in `part_of` and `from`
* Include ministers in `from`
* Include related statistical data sets and topical events in `part_of`
* Show national statistics logo when document_type is national_statistics

Example based on https://www.gov.uk/government/statistics/affordable-housing-supply-in-england-2011-to-2012

![screen shot 2016-05-09 at 11 37 07](https://cloud.githubusercontent.com/assets/319055/15110714/6de8f1bc-15da-11e6-9ab4-5c70aa61ed41.png)

https://trello.com/c/v85kPiKN/366-9-publications-migration-mvp-content-schema-examples-and-front-end-work-medium