### PR TITLE
Use `emphasised_organisations` to specify important orgs

### DIFF
--- a/app/presenters/linkable.rb
+++ b/app/presenters/linkable.rb
@@ -1,12 +1,6 @@
 module Linkable
   def from
-    links_group(%w{
-      lead_organisations
-      organisations
-      supporting_organisations
-      worldwide_organisations
-      ministers
-    })
+    organisations_ordered_by_importance + links_group(%w{worldwide_organisations ministers})
   end
 
   def part_of
@@ -24,13 +18,30 @@ module Linkable
 private
 
   def links(type)
-    return [] unless content_item["links"][type]
-    content_item["links"][type].map do |link|
+    expanded_links_from_content_item(type).map do |link|
       link_to(link["title"], link["base_path"])
     end
   end
 
+  def expanded_links_from_content_item(type)
+    return [] unless content_item["links"][type]
+    content_item["links"][type]
+  end
+
   def links_group(types)
     types.flat_map { |type| links(type) }.uniq
+  end
+
+  def organisations_ordered_by_importance
+    organisations_with_emphasised_first.map do |link|
+      link_to(link["title"], link["base_path"])
+    end
+  end
+
+  def organisations_with_emphasised_first
+    expanded_links_from_content_item("organisations").sort_by do |organisation|
+      is_emphasised = organisation["content_id"].in?(content_item["details"]["emphasised_organisations"])
+      is_emphasised ? -1 : 1
+    end
   end
 end

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -37,10 +37,15 @@ class CaseStudyPresenterTest < PresenterTest
 
   test '#from returns links to lead organisations, supporting organisations and worldwide organisations' do
     with_organisations = {
+      "details" => {
+        "emphasised_organisations" => ["b56753d2-ae3f-480e-88b0-35b1934dfc5a"],
+      },
       "links" => {
-        "lead_organisations" => [{ "title" => 'Lead org', "base_path" => '/orgs/lead' }],
         "worldwide_organisations" => [{ "title" => 'DFID Pakistan', "base_path" => '/government/world/organisations/dfid-pakistan' }],
-        "supporting_organisations" => [{ "title" => 'Supporting org', "base_path" => '/orgs/supporting' }],
+        "organisations" => [
+          { "title" => 'Supporting org', "base_path" => '/orgs/supporting', 'content_id' => 'dc2beab0-4ee9-41e0-9a6f-9c586d50fa7e' },
+          { "title" => 'Lead org', "base_path" => '/orgs/lead', 'content_id' => 'b56753d2-ae3f-480e-88b0-35b1934dfc5a' },
+        ],
       }
     }
 


### PR DESCRIPTION
Currently the publishing-api contains link types `organisations`, `lead_organisations` and `supporting_organisations`. The leads and supporting orgs are only needed to put certain organisations at the front of the lists in the metadata.

In https://github.com/alphagov/govuk-content-schemas/pull/306 we changed the way this is modelled. This commit makes the frontend changes for that.

Can’t be merged/deployed before https://github.com/alphagov/whitehall/pull/2585 is deployed and all content from whitehall is republished.

Trello: https://trello.com/c/us3MI1n9/602-fix-organisation-tagging