### PR TITLE
Make organisations test more robust

### DIFF
--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -36,13 +36,13 @@ class CaseStudyPresenterTest < PresenterTest
   end
 
   test '#from returns links to lead organisations, supporting organisations and worldwide organisations' do
-    with_organisations = schema_item
-    with_organisations['links']['lead_organisations'] = [
-      { "title" => 'Lead org', "base_path" => '/orgs/lead' }
-    ]
-    with_organisations['links']['supporting_organisations'] = [
-      { "title" => 'Supporting org', "base_path" => '/orgs/supporting' }
-    ]
+    with_organisations = {
+      "links" => {
+        "lead_organisations" => [{ "title" => 'Lead org', "base_path" => '/orgs/lead' }],
+        "worldwide_organisations" => [{ "title" => 'DFID Pakistan', "base_path" => '/government/world/organisations/dfid-pakistan' }],
+        "supporting_organisations" => [{ "title" => 'Supporting org', "base_path" => '/orgs/supporting' }],
+      }
+    }
 
     expected_from_links = [
       link_to('Lead org', '/orgs/lead'),


### PR DESCRIPTION
Master is currently failing on CI because this test uses example data, which has recently changed. The reason that this wasn’t picked up in the PR on govuk-content-schemas is that CI doesn’t run all the tests for those builds. We will fix this in a separate PR.

cc @fofr 