### PR TITLE
Run full suite of tests when contract testing on CI

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,51 +1,6 @@
-#!/bin/bash -xe
-export DISPLAY=:99
-export GITHUB_STATUS_CONTEXT="Verify government-frontend against content format examples"
-env
+#!/bin/bash
 
-function github_status {
-  STATUS="$1"
-  MESSAGE="$2"
-  gh-status alphagov/govuk-content-schemas "$SCHEMA_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$GITHUB_STATUS_CONTEXT" >/dev/null
-}
+export REPO_NAME="alphagov/govuk-content-schemas"
+export CONTEXT_MESSAGE="Verify government-frontend against content schemas"
 
-function error_handler {
-  trap - ERR # disable error trap to avoid recursion
-  local parent_lineno="$1"
-  local message="$2"
-  local code="${3:-1}"
-  if [[ -n "$message" ]] ; then
-    echo "Error on or near line ${parent_lineno}: ${message}; exiting with status ${code}"
-  else
-    echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
-  fi
-  github_status failure "failed on Jenkins"
-  exit "${code}"
-}
-
-trap "error_handler ${LINENO}" ERR
-github_status pending "is running on Jenkins"
-
-# Ensure there are no artefacts left over from previous builds
-git clean -fdx
-
-# Clone govuk-content-schemas depedency for contract tests
-rm -rf tmp/govuk-content-schemas
-git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
-cd tmp/govuk-content-schemas
-git checkout $SCHEMA_GIT_COMMIT
-cd ../..
-
-time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rake test:contracts
-
-EXIT_STATUS=$?
-echo "EXIT STATUS: $EXIT_STATUS"
-
-if [ "$EXIT_STATUS" == "0" ]; then
-  github_status success "succeeded on Jenkins"
-else
-  github_status failure "failed on Jenkins"
-fi
-
-exit $EXIT_STATUS
+exec ./jenkins.sh

--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -xe
 export DISPLAY=:99
-export GOVUK_APP_DOMAIN=test.gov.uk
-export GOVUK_ASSET_ROOT=http://static.test.gov.uk
 export GITHUB_STATUS_CONTEXT="Verify government-frontend against content format examples"
 env
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -x
 export DISPLAY=:99
-export GOVUK_APP_DOMAIN=test.gov.uk
-export GOVUK_ASSET_ROOT=http://static.test.gov.uk
 export REPO_NAME="alphagov/government-frontend"
 export RAILS_ENV=test
 env

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 set -x
-export DISPLAY=:99
-export REPO_NAME="alphagov/government-frontend"
-export RAILS_ENV=test
-env
+GH_STATUS_REPO_NAME=${INITIATING_REPO_NAME:-"alphagov/government-frontend"}
+CONTEXT_MESSAGE=${CONTEXT_MESSAGE:-"default"}
+GH_STATUS_GIT_COMMIT=${INITIATING_GIT_COMMIT:-${GIT_COMMIT}}
 
 function github_status {
-  REPO_NAME="$1"
-  STATUS="$2"
-  MESSAGE="$3"
-  gh-status "$REPO_NAME" "$GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" >/dev/null
+  STATUS="$1"
+  MESSAGE="$2"
+  gh-status "$GH_STATUS_REPO_NAME" "$GH_STATUS_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
 }
 
 function error_handler {
@@ -22,33 +20,34 @@ function error_handler {
   else
     echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
   fi
-  github_status "$REPO_NAME" failure "failed on Jenkins"
+  github_status error "errored on Jenkins"
   exit "${code}"
 }
 
-trap "error_handler ${LINENO}" ERR
-github_status "$REPO_NAME" pending "is running on Jenkins"
+trap 'error_handler ${LINENO}' ERR
+github_status pending "is running on Jenkins"
+
+# Cleanup anything left from previous test runs
+git clean -fdx
 
 # Try to merge master into the current branch, and abort if it doesn't exit
 # cleanly (ie there are conflicts). This will be a noop if the current branch
 # is master.
 git merge --no-commit origin/master || git merge --abort
 
+export RAILS_ENV=test
+bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
+
 # Clone govuk-content-schemas depedency for contract tests
 rm -rf tmp/govuk-content-schemas
 git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+export GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas
 
-bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
-
-GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas bundle exec rake
 bundle exec rake assets:precompile
 
-export EXIT_STATUS=$?
-
-if [ "$EXIT_STATUS" == "0" ]; then
-  github_status "$REPO_NAME" success "succeeded on Jenkins"
+if bundle exec rake ${TEST_TASK:-"default"}; then
+  github_status success "succeeded on Jenkins"
 else
-  github_status "$REPO_NAME" failure "failed on Jenkins"
+  github_status failure "failed on Jenkins"
+  exit 1
 fi
-
-exit $EXIT_STATUS

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -1,13 +1,7 @@
 namespace :test do
-  desc "Runs contract tests"
-  Rails::TestTask.new(contracts: "test:prepare") do |t|
-    t.pattern = "test/contracts/**/*_test.rb"
-  end
-
   Rails::TestTask.new(presenters: "test:prepare") do |t|
     t.pattern = "test/presenters/**/*_test.rb"
   end
 end
 
-Rake::Task["test:run"].enhance ["test:contracts", "test:presenters"]
-Rake::Task[:test].comment = "Includes test:contracts and test:presenters"
+Rake::Task["test:run"].enhance ["test:presenters"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
+ENV['GOVUK_APP_DOMAIN'] = 'test.gov.uk'
+ENV['GOVUK_ASSET_ROOT'] = 'http://static.test.gov.uk'
+
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'webmock/minitest'


### PR DESCRIPTION
Currently this app only runs a specific set of tests when triggered by a new PR on govuk-content-schemas. This tripped us up today because some tests that have been excluded are using the content schema examples in the tests (#147).

The tests for this repo are really fast, so it’s not a problem to run the entire test suite for each change on govuk-content-schemas. This will prevents test runs to pass by accident and makes the build process easier to understand.

This PR also updates `jenkins.sh` to be more modern.

@fofr 