### PR TITLE
Fix jenkins status reporting back to GitHub

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export REPO_NAME="alphagov/govuk-content-schemas"
+export INITIATING_REPO_NAME="alphagov/govuk-content-schemas"
 export CONTEXT_MESSAGE="Verify government-frontend against content schemas"
 
 exec ./jenkins.sh


### PR DESCRIPTION
Because `INITIATING_REPO_NAME ` is not set in jenkins.sh (https://github.com/alphagov/government-frontend/blob/85e28836f873df4cdbcaf4b317eb42c67d2ce81a/jenkins.sh#L3), jenkins sends a message to GitHub about the wrong repository. This causes the gouk-content-schema branch tests to look like they’re not finished.