### PR TITLE
Change to a known-working version of jenkins.sh

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export INITIATING_REPO_NAME="alphagov/govuk-content-schemas"
+export REPO_NAME="alphagov/govuk-content-schemas"
 export CONTEXT_MESSAGE="Verify government-frontend against content schemas"
 
 exec ./jenkins.sh

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 set -x
-GH_STATUS_REPO_NAME=${INITIATING_REPO_NAME:-"alphagov/government-frontend"}
+
+REPO_NAME=${REPO_NAME:-"alphagov/government-frontend"}
 CONTEXT_MESSAGE=${CONTEXT_MESSAGE:-"default"}
-GH_STATUS_GIT_COMMIT=${INITIATING_GIT_COMMIT:-${GIT_COMMIT}}
+GH_STATUS_GIT_COMMIT=${SCHEMA_GIT_COMMIT:-${GIT_COMMIT}}
+env
 
 function github_status {
-  STATUS="$1"
-  MESSAGE="$2"
-  gh-status "$GH_STATUS_REPO_NAME" "$GH_STATUS_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
+  REPO_NAME="$1"
+  STATUS="$2"
+  MESSAGE="$3"
+  gh-status "$REPO_NAME" "$GH_STATUS_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
 }
 
 function error_handler {
@@ -20,12 +23,12 @@ function error_handler {
   else
     echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
   fi
-  github_status error "errored on Jenkins"
+  github_status "$REPO_NAME" error "errored on Jenkins"
   exit "${code}"
 }
 
 trap 'error_handler ${LINENO}' ERR
-github_status pending "is running on Jenkins"
+github_status "$REPO_NAME" pending "is running on Jenkins"
 
 # Cleanup anything left from previous test runs
 git clean -fdx
@@ -35,19 +38,22 @@ git clean -fdx
 # is master.
 git merge --no-commit origin/master || git merge --abort
 
-export RAILS_ENV=test
-bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
-
 # Clone govuk-content-schemas depedency for contract tests
 rm -rf tmp/govuk-content-schemas
 git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+(
+  cd tmp/govuk-content-schemas
+  git checkout ${SCHEMA_GIT_COMMIT:-"master"}
+)
 export GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas
 
+export RAILS_ENV=test
+bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
 bundle exec rake assets:precompile
 
 if bundle exec rake ${TEST_TASK:-"default"}; then
-  github_status success "succeeded on Jenkins"
+  github_status "$REPO_NAME" success "succeeded on Jenkins"
 else
-  github_status failure "failed on Jenkins"
+  github_status "$REPO_NAME" failure "failed on Jenkins"
   exit 1
 fi


### PR DESCRIPTION
So, argh. In previous commits I’ve changed the jenkins.sh to a more modern version, taken from the govuk_rails_template. This actually broke schema tests (because it always tested against
govuk-content-schemas/master, not the thing being tested).

This version is copied from collections-publisher, which currently works. I really hope that it works here too.