### PR TITLE
Use correct data for HTML Publications

### DIFF
--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -34,8 +34,8 @@ class HtmlPublicationPresenter < ContentItemPresenter
   # Remove this in the future after migrating organisations to the content store API,
   # and updating them with the correct brand in the actual store.
   def organisation_brand(organisation)
-    brand = organisation["brand"]
-    brand = "executive-office" if organisation["logo"]["crest"] == "eo"
+    brand = organisation["details"]["brand"]
+    brand = "executive-office" if organisation["details"]["logo"]["crest"] == "eo"
     brand
   end
 

--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -8,7 +8,7 @@ class HtmlPublicationPresenter < ContentItemPresenter
   end
 
   def format_sub_type
-    parent["format_sub_type"]
+    parent["document_type"]
   end
 
   def last_changed

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -13,10 +13,10 @@
       <li class="organisation-logo">
         <%= render partial: 'govuk_component/organisation_logo', locals: {
           organisation: {
-            name: organisation["logo"]["formatted_title"],
+            name: organisation["details"]["logo"]["formatted_title"],
             url: organisation["base_path"],
             brand: @content_item.organisation_brand(organisation),
-            crest: organisation["logo"]["crest"]
+            crest: organisation["details"]["logo"]["crest"]
           }
         } %>
       </li>

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -7,7 +7,7 @@ class HtmlPublicationPresenterTest < PresenterTest
 
   test 'presents the basic details of a content item' do
     assert_equal schema_item("published")['format'], presented_item("published").format
-    assert_equal schema_item("published")['links']['parent'][0]['format_sub_type'], presented_item("published").format_sub_type
+    assert_equal schema_item("published")['links']['parent'][0]['document_type'], presented_item("published").format_sub_type
     assert_equal schema_item("published")['title'], presented_item("published").title
     assert_equal schema_item("published")['details']['body'], presented_item("published").body
   end

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -37,16 +37,18 @@ class HtmlPublicationPresenterTest < PresenterTest
   test "presents the branding for organisations" do
     mo_presented_item = presented_item("multiple_organisations")
     mo_presented_item.organisations.each do |organisation|
-      assert_equal mo_presented_item.organisation_brand(organisation), organisation["brand"]
+      assert_equal mo_presented_item.organisation_brand(organisation), organisation["details"]["brand"]
     end
   end
 
   test "alters the branding for executive office organisations" do
     organisation = {
-      "brand" => "cabinet-office",
-      "logo" => {
-        "formatted_title" => "Prime Minister's Office, 10 Downing Street",
-        "crest" => "eo"
+      "details" => {
+        "brand" => "cabinet-office",
+        "logo" => {
+          "formatted_title" => "Prime Minister's Office, 10 Downing Street",
+          "crest" => "eo"
+        }
       }
     }
     assert_equal presented_item("prime_ministers_office").organisation_brand(organisation), "executive-office"


### PR DESCRIPTION
- Use parent's `document_type` instead of `format_sub_type` key
- Organisation branding information is nested within the linked organisation's `details` hash