### PR TITLE
Add document collections format

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,3 +32,4 @@
 @import "views/detailed-guide";
 @import "views/publication";
 @import "views/fatality-notice";
+@import "views/document-collection";

--- a/app/assets/stylesheets/views/_document-collection.scss
+++ b/app/assets/stylesheets/views/_document-collection.scss
@@ -1,3 +1,35 @@
 .document-collection {
+  @include description;
+  @include sidebar-with-body;
+  @include history-notice;
+  @include withdrawal-notice;
 
+  .group-title {
+    @include bold-27;
+    margin-top: $gutter;
+    margin-bottom: $gutter-half;
+
+    @include media(desktop) {
+      margin-top: $gutter * 1.5;
+      margin-bottom: $gutter-two-thirds;
+    }
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  .group-document-list-item {
+    display: block;
+    list-style: none;
+    margin-bottom: $gutter-half;
+
+    @include media(desktop) {
+      margin-bottom: $gutter-two-thirds;
+    }
+  }
+
+  .collection-document-title {
+    @include bold-19;
+  }
 }

--- a/app/assets/stylesheets/views/_document-collection.scss
+++ b/app/assets/stylesheets/views/_document-collection.scss
@@ -1,0 +1,3 @@
+.document-collection {
+
+}

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -1,2 +1,43 @@
 class DocumentCollectionPresenter < ContentItemPresenter
+  include Political
+  include Linkable
+  include Updatable
+  include Withdrawable
+  include ActionView::Helpers::UrlHelper
+
+  def contents
+    groups.map do |group|
+      title = group["title"]
+      link_to(title, "##{group_title_id(title)}")
+    end
+  end
+
+  def groups
+    content_item["details"]["collection_groups"]
+  end
+
+  def group_document_links(group)
+    group_documents(group).map do |link|
+      link_to(link["title"], link["base_path"])
+    end
+  end
+
+  def group_heading(group)
+    title = group["title"]
+    content_tag :h3, title, class: "group-title", id: group_title_id(title)
+  end
+
+private
+
+  def group_documents(group)
+    group["documents"].map { |id| documents_hash[id] }
+  end
+
+  def group_title_id(title)
+    title.tr(' ', '-').downcase
+  end
+
+  def documents_hash
+    @documents_hash ||= content_item["links"]["documents"].map { |d| [d["content_id"], d] }.to_h
+  end
 end

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -1,0 +1,2 @@
+class DocumentCollectionPresenter < ContentItemPresenter
+end

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -5,6 +5,10 @@ class DocumentCollectionPresenter < ContentItemPresenter
   include Withdrawable
   include ActionView::Helpers::UrlHelper
 
+  def body
+    content_item["details"]["body"]
+  end
+
   def contents
     groups.map do |group|
       title = group["title"]

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -1,0 +1,12 @@
+<%= content_for :page_class, @content_item.format.dasherize %>
+<%= content_for :title, @content_item.title %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+        context: t("content_item.format.#{@content_item.document_type}", count: 1),
+        title: @content_item.title %>
+  </div>
+</div>
+
+<%= render 'shared/description', description: @content_item.description %>

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -1,12 +1,60 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
-<%= content_for :title, @content_item.title %>
+<%= content_for :title, @content_item.page_title %>
 
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
         context: t("content_item.format.#{@content_item.document_type}", count: 1),
-        title: @content_item.title %>
+        title: @content_item.title,
+        average_title_length: "long" %>
   </div>
 </div>
 
+<%= render 'shared/withdrawal_notice', content_item: @content_item %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/metadata',
+        from: @content_item.from,
+        part_of: @content_item.part_of,
+        first_published: @content_item.published,
+        last_updated: @content_item.updated,
+        see_updates_link: true
+    %>
+  </div>
+</div>
+<%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
+
+<div class="grid-row sidebar-with-body">
+  <div class="column-third">
+    <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
+  </div>
+  <div class="column-two-thirds">
+    <% @content_item.groups.each do |group| %>
+      <%= @content_item.group_heading(group) %>
+      <% if group["body"].present? %>
+        <%= render 'govuk_component/govspeak',
+            content: group["body"],
+            direction: page_text_direction %>
+      <% end %>
+      <ol class="group-document-list">
+        <% @content_item.group_document_links(group).each do |link| %>
+          <li class="group-document-list-item">
+            <h3 class="collection-document-title"><%= link %></h3>
+            <%# TODO: Include document date and type when available %>
+          </li>
+        <% end %>
+      </ol>
+    <% end %>
+  </div>
+</div>
+
+<%= render 'govuk_component/document_footer',
+    from: @content_item.from,
+    updated: @content_item.updated,
+    history: @content_item.history,
+    published: @content_item.published,
+    part_of: @content_item.part_of,
+    direction: page_text_direction
+%>

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -31,6 +31,11 @@
     <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
   </div>
   <div class="column-two-thirds">
+    <% if @content_item.body.present? %>
+      <%= render 'govuk_component/govspeak',
+          content: @content_item.body,
+          direction: page_text_direction %>
+    <% end %>
     <% @content_item.groups.each do |group| %>
       <%= @content_item.group_heading(group) %>
       <% if group["body"].present? %>

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class DocumentCollectionTest < ActionDispatch::IntegrationTest
+end

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -16,6 +16,11 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
     assert_has_component_document_footer_pair("from", from)
   end
 
+  test "renders body when provided" do
+    setup_and_visit_content_item('document_collection_with_body')
+    assert_has_component_govspeak(@content_item["details"]["body"])
+  end
+
   test "renders contents with link to each collection group" do
     setup_and_visit_content_item('document_collection')
     @content_item["details"]["collection_groups"].each do |group|

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -1,4 +1,70 @@
 require 'test_helper'
 
 class DocumentCollectionTest < ActionDispatch::IntegrationTest
+  test "document collection" do
+    setup_and_visit_content_item('document_collection')
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+  end
+
+  test "renders metadata and document footer" do
+    setup_and_visit_content_item('document_collection')
+    assert_has_component_metadata_pair("first_published", "29 February 2016")
+
+    from = ["<a href=\"/government/organisations/driver-and-vehicle-standards-agency\">Driver and Vehicle Standards Agency</a>"]
+    assert_has_component_metadata_pair("from", from)
+    assert_has_component_document_footer_pair("from", from)
+  end
+
+  test "renders contents with link to each collection group" do
+    setup_and_visit_content_item('document_collection')
+    @content_item["details"]["collection_groups"].each do |group|
+      assert page.has_css?('nav a', text: group["title"])
+    end
+  end
+
+  test "renders each collection group" do
+    setup_and_visit_content_item('document_collection')
+    groups = @content_item["details"]["collection_groups"]
+    group_count = groups.count
+
+    groups.each do |group|
+      assert page.has_css?('.group-title', text: group["title"])
+    end
+
+    within ".sidebar-with-body" do
+      assert page.has_css?(shared_component_selector("govspeak"), count: group_count)
+      assert page.has_css?('.group-document-list', count: group_count)
+    end
+  end
+
+  test "renders all collection documents" do
+    setup_and_visit_content_item('document_collection')
+    documents = @content_item["links"]["documents"]
+
+    documents.each do |doc|
+      assert page.has_css?('.collection-document-title a', text: doc["title"])
+    end
+
+    assert page.has_css?('.group-document-list .group-document-list-item', count: documents.count)
+  end
+
+  test "withdrawn collection" do
+    setup_and_visit_content_item('document_collection')
+    assert page.has_css?('title', text: "[Withdrawn]", visible: false)
+
+    within ".withdrawal-notice" do
+      assert page.has_text?('This collection was withdrawn'), "is withdrawn"
+      assert_has_component_govspeak(@content_item["details"]["withdrawn_notice"]["explanation"])
+      assert page.has_css?("time[datetime='#{@content_item['details']['withdrawn_notice']['withdrawn_at']}']")
+    end
+  end
+
+  test "historically political collection" do
+    setup_and_visit_content_item('document_collection')
+
+    within ".history-notice" do
+      assert page.has_text?('This collection was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government')
+    end
+  end
 end

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -9,6 +9,7 @@ class DocumentCollectionPresenterTest < PresenterTest
     assert_equal schema_item['description'], presented_item.description
     assert_equal schema_item['format'], presented_item.format
     assert_equal schema_item['title'], presented_item.title
+    assert_equal schema_item('document_collection_with_body')['details']['body'], presented_item('document_collection_with_body').body
   end
 
   test 'presents a contents list based on collection groups' do

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -1,0 +1,7 @@
+require 'presenter_test_helper'
+
+class DocumentCollectionPresenterTest < PresenterTest
+  def format_name
+    "document_collection"
+  end
+end

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -4,4 +4,38 @@ class DocumentCollectionPresenterTest < PresenterTest
   def format_name
     "document_collection"
   end
+
+  test 'presents the basic details of a content item' do
+    assert_equal schema_item['description'], presented_item.description
+    assert_equal schema_item['format'], presented_item.format
+    assert_equal schema_item['title'], presented_item.title
+  end
+
+  test 'presents a contents list based on collection groups' do
+    contents = [
+      "<a href=\"#car-and-light-van\">Car and light van</a>",
+      "<a href=\"#moped-and-motorcycle\">Moped and motorcycle</a>",
+      "<a href=\"#lorry\">Lorry</a>",
+      "<a href=\"#bus-and-coach\">Bus and coach</a>",
+      "<a href=\"#driver-and-rider-trainer\">Driver and rider trainer</a>",
+      "<a href=\"#developed-driving-competence\">Developed driving competence</a>"
+    ]
+
+    assert_equal contents, presented_item.contents
+  end
+
+  test 'presents a group heading with generated ID' do
+    heading = '<h3 class="group-title" id="heading-with-spaces">Heading with Spaces</h3>'
+    assert_equal heading, presented_item.group_heading("title" => "Heading with Spaces")
+  end
+
+  test 'presents an ordered list of group documents' do
+    documents = [
+      "<a href=\"/government/publications/national-standard-for-driving-cars-and-light-vans\">National standard for driving cars and light vans</a>",
+      "<a href=\"/government/publications/car-and-small-van-driving-syllabus\">Car and light van driving syllabus</a>",
+      "<a href=\"/government/publications/car-and-light-van-driver-competence-framework\">Car and light van driver competence framework</a>",
+    ]
+    document_ids = schema_item["details"]["collection_groups"].first["documents"]
+    assert_equal documents, presented_item.group_document_links("documents" => document_ids)
+  end
 end


### PR DESCRIPTION
Depends on https://github.com/alphagov/govuk-content-schemas/pull/312

* List each collection group with its ordered document list
* List the contents of the collection based on groups
* Generate an ID for each group heading, using hyphens to match the pattern in Whitehall and to keep existing fragment links working
* __List of each group’s documents is simpler than on Whitehall because document type and date are not easily available yet__

![withdrawn national standards for driving and riding - gov uk 20160524](https://cloud.githubusercontent.com/assets/319055/15502188/57a4f15e-21aa-11e6-85a7-b6077565093a.png)

![financial sanctions-regime-specific lists and releases - gov uk 20160524](https://cloud.githubusercontent.com/assets/319055/15502153/219be00e-21aa-11e6-9045-20d37778676d.png)


Include examples based on:
https://www.gov.uk/government/collections/national-driving-and-riding-standards
https://www.gov.uk/government/collections/financial-sanctions-regime-specific-consolidated-lists-and-releases

https://trello.com/c/PMeMQb5E/410-11-document-collection-migration-mvp-content-schema-examples-and-front-end-work