### PR TITLE
Use toplevel 'withdrawn notice' property...

### DIFF
--- a/app/presenters/case_study_presenter.rb
+++ b/app/presenters/case_study_presenter.rb
@@ -2,7 +2,6 @@ class CaseStudyPresenter < ContentItemPresenter
   include ActionView::Helpers::UrlHelper
   include Linkable
   include Updatable
-  include Withdrawable
 
   attr_reader :body
 

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,4 +1,6 @@
 class ContentItemPresenter
+  include Withdrawable
+
   attr_reader :content_item, :title, :description, :format, :locale, :phase, :document_type
 
   def initialize(content_item)

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -3,7 +3,6 @@ class DetailedGuidePresenter < ContentItemPresenter
   include ExtractsHeadings
   include Linkable
   include Updatable
-  include Withdrawable
   include NationalApplicability
   include ActionView::Helpers::UrlHelper
 

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -2,7 +2,6 @@ class DocumentCollectionPresenter < ContentItemPresenter
   include Political
   include Linkable
   include Updatable
-  include Withdrawable
   include ActionView::Helpers::UrlHelper
 
   def body

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -2,7 +2,6 @@ class PublicationPresenter < ContentItemPresenter
   include Political
   include Linkable
   include Updatable
-  include Withdrawable
   include NationalApplicability
   include ActionView::Helpers::UrlHelper
 

--- a/app/presenters/withdrawable.rb
+++ b/app/presenters/withdrawable.rb
@@ -1,6 +1,6 @@
 module Withdrawable
   def withdrawn?
-    content_item["details"].include?("withdrawn_notice")
+    content_item["withdrawn_notice"].present?
   end
 
   def page_title
@@ -8,7 +8,7 @@ module Withdrawable
   end
 
   def withdrawal_notice
-    notice = content_item["details"]["withdrawn_notice"]
+    notice = content_item["withdrawn_notice"]
     if notice
       {
         time: content_tag(:time, display_time(notice["withdrawn_at"]), datetime: notice["withdrawn_at"]),

--- a/test/integration/case_study_test.rb
+++ b/test/integration/case_study_test.rb
@@ -18,8 +18,8 @@ class CaseStudyTest < ActionDispatch::IntegrationTest
 
     within ".withdrawal-notice" do
       assert page.has_text?('This case study was withdrawn'), "is withdrawn"
-      assert_has_component_govspeak(@content_item["details"]["withdrawn_notice"]["explanation"])
-      assert page.has_css?("time[datetime='#{@content_item['details']['withdrawn_notice']['withdrawn_at']}']")
+      assert_has_component_govspeak(@content_item["withdrawn_notice"]["explanation"])
+      assert page.has_css?("time[datetime='#{@content_item['withdrawn_notice']['withdrawn_at']}']")
     end
   end
 end

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -21,8 +21,8 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
 
     within ".withdrawal-notice" do
       assert page.has_text?('This guidance was withdrawn'), "is withdrawn"
-      assert_has_component_govspeak(@content_item["details"]["withdrawn_notice"]["explanation"])
-      assert page.has_css?("time[datetime='#{@content_item['details']['withdrawn_notice']['withdrawn_at']}']")
+      assert_has_component_govspeak(@content_item["withdrawn_notice"]["explanation"])
+      assert page.has_css?("time[datetime='#{@content_item['withdrawn_notice']['withdrawn_at']}']")
     end
   end
 

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -38,8 +38,8 @@ class PublicationTest < ActionDispatch::IntegrationTest
 
     within ".withdrawal-notice" do
       assert page.has_text?('This publication was withdrawn'), "is withdrawn"
-      assert_has_component_govspeak(@content_item["details"]["withdrawn_notice"]["explanation"])
-      assert page.has_css?("time[datetime='#{@content_item['details']['withdrawn_notice']['withdrawn_at']}']")
+      assert_has_component_govspeak(@content_item["withdrawn_notice"]["explanation"])
+      assert page.has_css?("time[datetime='#{@content_item['withdrawn_notice']['withdrawn_at']}']")
     end
   end
 

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -98,9 +98,9 @@ class CaseStudyPresenterTest < PresenterTest
     example = schema_item("archived")
     presented = presented_item("archived")
 
-    assert example["details"].include?("withdrawn_notice")
+    assert example.include?("withdrawn_notice")
     assert presented.withdrawn?
-    assert_equal example["details"]["withdrawn_notice"]["explanation"], presented.withdrawal_notice[:explanation]
+    assert_equal example["withdrawn_notice"]["explanation"], presented.withdrawal_notice[:explanation]
     assert_equal '<time datetime="2014-08-22T10:29:02+01:00">22 August 2014</time>', presented.withdrawal_notice[:time]
   end
 

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -37,9 +37,9 @@ class DetailedGuidePresenterTest < PresenterTest
     example = schema_item("withdrawn_detailed_guide")
     presented = presented_item("withdrawn_detailed_guide")
 
-    assert example["details"].include?("withdrawn_notice")
+    assert example.include?("withdrawn_notice")
     assert presented.withdrawn?
-    assert_equal example["details"]["withdrawn_notice"]["explanation"], presented.withdrawal_notice[:explanation]
+    assert_equal example["withdrawn_notice"]["explanation"], presented.withdrawal_notice[:explanation]
     assert_equal '<time datetime="2015-01-28T13:05:30Z">28 January 2015</time>', presented.withdrawal_notice[:time]
   end
 

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -59,9 +59,9 @@ class PublicationPresenterTest < PresenterTest
     example = schema_item("withdrawn_publication")
     presented = presented_item("withdrawn_publication")
 
-    assert example["details"].include?("withdrawn_notice")
+    assert example.include?("withdrawn_notice")
     assert presented.withdrawn?
-    assert_equal example["details"]["withdrawn_notice"]["explanation"], presented.withdrawal_notice[:explanation]
+    assert_equal example["withdrawn_notice"]["explanation"], presented.withdrawal_notice[:explanation]
     assert_equal '<time datetime="2015-01-13T13:05:30Z">13 January 2015</time>', presented.withdrawal_notice[:time]
   end
 


### PR DESCRIPTION
https://trello.com/c/78Q9mrDe/708-make-whitehall-use-unpublishing-endpoint-medium

Any content item can be withdrawn via the unpublish endpoint on the publishing API, this means the `withdrawn_notice` property is a top level metadata property, so change `Withdrawable` to read it.
The notice will continue to be supported until we've ensured no content is affected.

Depends on https://github.com/alphagov/publishing-api/pull/340 so do not merge yet please.