### PR TITLE
Add missing document list details

### DIFF
--- a/app/assets/stylesheets/views/_document-collection.scss
+++ b/app/assets/stylesheets/views/_document-collection.scss
@@ -20,16 +20,20 @@
   }
 
   .group-document-list-item {
-    display: block;
-    list-style: none;
-    margin-bottom: $gutter-half;
-
-    @include media(desktop) {
-      margin-bottom: $gutter-two-thirds;
-    }
+    overflow: hidden;
+    margin-bottom: $gutter-one-third;
+    padding-bottom: $gutter-one-third;
+    border-bottom: 1px solid $border-colour;
   }
 
-  .collection-document-title {
+  .group-document-list-item-title {
     @include bold-19;
+  }
+
+  .group-document-list-item-attributes li {
+    @include core-14;
+    float: left;
+    list-style: none;
+    padding-right: $gutter-two-thirds;
   }
 }

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -22,7 +22,12 @@ class DocumentCollectionPresenter < ContentItemPresenter
 
   def group_document_links(group)
     group_documents(group).map do |link|
-      link_to(link["title"], link["base_path"])
+      {
+        public_updated_at: Time.parse(link["public_updated_at"]),
+        document_type: link["document_type"],
+        title: link["title"],
+        base_path: link["base_path"]
+      }
     end
   end
 

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -46,8 +46,17 @@
       <ol class="group-document-list">
         <% @content_item.group_document_links(group).each do |link| %>
           <li class="group-document-list-item">
-            <h3 class="collection-document-title"><%= link %></h3>
-            <%# TODO: Include document date and type when available %>
+            <h3 class="group-document-list-item-title">
+              <%= link_to(link[:title], link[:base_path]) %>
+            </h3>
+            <ul class="group-document-list-item-attributes">
+              <li>
+                <time datetime="<%= link[:public_updated_at].iso8601 %>">
+                  <%= l(link[:public_updated_at], format: :short_ordinal) %>
+                </time>
+              </li>
+              <li><%= t("content_item.format.#{link[:document_type]}", count: 1) %></li>
+            </ul>
           </li>
         <% end %>
       </ol>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,7 @@
 en:
+  time:
+    formats:
+      short_ordinal: '%e %B %Y'
   language_names:
     ar: Arabic
     de: German

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -48,10 +48,16 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
     documents = @content_item["links"]["documents"]
 
     documents.each do |doc|
-      assert page.has_css?('.collection-document-title a', text: doc["title"])
+      assert page.has_css?('.group-document-list-item-title a', text: doc["title"])
     end
 
     assert page.has_css?('.group-document-list .group-document-list-item', count: documents.count)
+
+    within ".group-document-list:first-of-type .group-document-list-item:first-of-type .group-document-list-item-attributes" do
+      assert page.has_text?('16 March 2007'), "has properly formatted date"
+      assert page.has_css?('[datetime="2007-03-16T15:00:02+00:00"]'), "has iso8601 datetime attribute"
+      assert page.has_text?('Guidance'), "has formatted document_type"
+    end
   end
 
   test "withdrawn collection" do

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -32,11 +32,14 @@ class DocumentCollectionPresenterTest < PresenterTest
 
   test 'presents an ordered list of group documents' do
     documents = [
-      "<a href=\"/government/publications/national-standard-for-driving-cars-and-light-vans\">National standard for driving cars and light vans</a>",
-      "<a href=\"/government/publications/car-and-small-van-driving-syllabus\">Car and light van driving syllabus</a>",
-      "<a href=\"/government/publications/car-and-light-van-driver-competence-framework\">Car and light van driver competence framework</a>",
+      {
+        public_updated_at: Time.parse("2007-03-16 15:00:02 +0000"),
+        document_type: "guidance",
+        title: "National standard for driving cars and light vans",
+        base_path: "/government/publications/national-standard-for-driving-cars-and-light-vans"
+      }
     ]
     document_ids = schema_item["details"]["collection_groups"].first["documents"]
-    assert_equal documents, presented_item.group_document_links("documents" => document_ids)
+    assert_equal documents, presented_item.group_document_links("documents" => [document_ids.first])
   end
 end


### PR DESCRIPTION
Relies on https://github.com/alphagov/govuk-content-schemas/pull/321

As part of https://trello.com/c/ZWU9N8Bc/414-add-missing-details-to-document-list-for-document-collection-format-medium

**Placeholder document_type is still an issue but if you run this with the examples you can check the render as below.**

Preview of update
----
Before:
![image](https://cloud.githubusercontent.com/assets/2445413/15751845/897345e2-28e3-11e6-9bc6-19044a80744e.png)

After:
![image](https://cloud.githubusercontent.com/assets/2445413/15752104/79eddee2-28e4-11e6-8493-8f118fcf6b18.png)

Small viewports:

Before:
![image](https://cloud.githubusercontent.com/assets/2445413/15751861/99a35f7e-28e3-11e6-8e2e-c556d9a39055.png)

After:
![image](https://cloud.githubusercontent.com/assets/2445413/15752113/80b94518-28e4-11e6-9257-27edc968600b.png)


How to test
----

Using the govuk-puppet vagrant instance
```
cd /var/govuk/development
bowl government-frontend --without content-store
```

(Separate instance)
```
cd /var/govuk/govuk-content-schemas
bundle exec dummy_content_store
```

Open up http://government-frontend.dev.gov.uk/government/collections/national-driving-and-riding-standards

(You can compare against https://www.gov.uk/government/collections/national-driving-and-riding-standards)