### PR TITLE
Use schema_name instead of format

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -21,11 +21,11 @@ private
   end
 
   def present(content_item)
-    presenter_name = content_item['format'].classify + 'Presenter'
+    presenter_name = content_item['schema_name'].classify + 'Presenter'
     presenter_class = Object.const_get(presenter_name)
     presenter_class.new(content_item)
   rescue NameError
-    raise "No support for format \"#{content_item['format']}\""
+    raise "No support for schema \"#{content_item['schema_name']}\""
   end
 
   def content_item_template

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -7,7 +7,7 @@ class ContentItemPresenter
     @content_item = content_item
     @title = content_item["title"]
     @description = content_item["description"]
-    @format = content_item["format"]
+    @format = content_item["schema_name"]
     @locale = content_item["locale"] || "en"
     @phase = content_item["phase"]
     @document_type = content_item["document_type"]

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -10,7 +10,7 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
   end
 
   test "#format" do
-    assert_equal "Format", ContentItemPresenter.new("format" => "Format").format
+    assert_equal "Format", ContentItemPresenter.new("schema_name" => "Format").format
   end
 
   test "#locale" do


### PR DESCRIPTION
format sometimes matches the document_type. format is actually
deprecated now, so we should use schema_name when we mean schema_name.

/cc @steventux @danielroseman 