### PR TITLE
Display translations for detailed guides if available

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -14,6 +14,7 @@ class ContentItemPresenter
   end
 
   def available_translations
+    return [] if @content_item["links"]["available_translations"].nil?
     sorted_locales(@content_item["links"]["available_translations"])
   end
 

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -12,6 +12,11 @@
         title: @content_item.title,
         average_title_length: "long" %>
   </div>
+  <div class="column-third">
+    <%= render 'shared/available_languages',
+      translations: @content_item.available_translations
+    %>
+  </div>
 </div>
 
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -60,4 +60,13 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
 
     assert_has_component_metadata_pair('Applies to', 'England, Scotland, and Wales (see guidance for <a href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for" rel="external">Northern Ireland</a>)')
   end
+
+  test "translated detailed guide" do
+    setup_and_visit_content_item('translated_detailed_guide')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+
+    assert page.has_css?('.available-languages')
+  end
 end


### PR DESCRIPTION
Part of migrating detailed guides.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/337.

# Before

![screen shot 2016-06-30 at 14 58 52](https://cloud.githubusercontent.com/assets/1650875/16491134/a21e34b0-3ed4-11e6-81d8-a8bde5d02f6e.png)

# After

![screen shot 2016-06-30 at 14 59 05](https://cloud.githubusercontent.com/assets/1650875/16491141/a5c3d0ca-3ed4-11e6-9015-9ea0865b1500.png)

cc @nickcolley 