### PR TITLE
Add .back-to-content link to detailed guide presenter

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@
 
 // helpers for common page elements
 @import "helpers/available-languages";
+@import "helpers/back-to-content";
 @import "helpers/dash-list";
 @import "helpers/description";
 @import "helpers/sidebar-with-body";

--- a/app/assets/stylesheets/helpers/_back-to-content.scss
+++ b/app/assets/stylesheets/helpers/_back-to-content.scss
@@ -1,0 +1,13 @@
+.back-to-content {
+  @include core-19;
+  display: block;
+  padding-bottom: $gutter-half;
+
+  &:before {
+    content: "\2191";
+  }
+
+  @media print {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -19,4 +19,14 @@
       margin: 0 0 $gutter-half $gutter-half;
     }
   }
+
+  // To allow .back-to-content to settle in at the bottom after scrolling past.
+  .sidebar-with-body {
+    position: relative;
+  }
+
+  // To compensate for the -$gutter from @include sidebar-with-body.
+  .back-to-content {
+    margin-left: $gutter;
+  }
 }

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -137,18 +137,4 @@
       text-decoration: underline;
     }
   }
-
-  .back-to-content {
-    @include core-19;
-    display: block;
-    padding-bottom: $gutter-half;
-
-    &:before {
-      content: "\2191";
-    }
-
-    @media print {
-      display: none;
-    }
-  }
 }

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -33,7 +33,11 @@
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 
-<div class="grid-row sidebar-with-body">
+<div
+  class="grid-row sidebar-with-body"
+  data-module="sticky-element-container"
+  id="contents"
+>
   <% if @content_item.contents.any? %>
     <div class="column-third">
       <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
@@ -53,6 +57,9 @@
     <%= render 'govuk_component/govspeak',
         content: @content_item.body,
         direction: page_text_direction %>
+  </div>
+  <div data-sticky-element class="sticky-element">
+    <a class="back-to-content" href="#contents"><%= t("content_item.contents") %></a>
   </div>
 </div>
 

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -13,6 +13,7 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     link2 = "<a href=\"/topic/business-tax\">Business tax</a>"
     assert_has_component_metadata_pair("part_of", [link1, link2])
     assert_has_component_document_footer_pair("part_of", [link1, link2])
+    assert page.has_css?(".back-to-content")
   end
 
   test "withdrawn detailed guide" do


### PR DESCRIPTION
Re-uses existing styles from `.html-publication .back-to-content`.

# After

![screen shot 2016-06-30 at 16 07 58](https://cloud.githubusercontent.com/assets/1650875/16493395/3a06ce10-3edd-11e6-8997-0cd8dc11b666.png)

cc @nickcolley 