### PR TITLE
Update available-languages to fix the spacing on smaller viewports

### DIFF
--- a/app/assets/stylesheets/helpers/_available-languages.scss
+++ b/app/assets/stylesheets/helpers/_available-languages.scss
@@ -1,29 +1,28 @@
 .available-languages {
-  margin-top: $gutter-half;
+  margin-bottom: $gutter;
+  border-bottom: 1px solid $border-colour;
+
+  // The following mixin usage could be a composable class in the future
+  // as components should not have layout that prevents reusability.
+  @include responsive-top-margin;
+  @include core-16;
 
   ul {
     @extend %contain-floats;
     list-style: none;
-    padding: $gutter-half 0 $gutter-one-third;
-    border-bottom: 1px solid $border-colour;
+    margin-left: -$gutter-one-third;
+    margin-right: -$gutter-one-third;
 
     li {
       float: left;
-      display: block;
+      padding-left: $gutter-one-third;
+      padding-right: $gutter-one-third;
+      margin-bottom: $gutter-one-third;
       border-right: 1px solid $border-colour;
-      padding: 0 $gutter-one-third 0 0;
       height: 16px;
-      margin: 3px $gutter-one-third 2px 0;
 
       &.last {
         border-right: 0;
-      }
-
-      a,
-      span {
-        display: block;
-        margin-top: -1px;
-        @include core-16;
       }
 
       .direction-rtl & {
@@ -32,8 +31,6 @@
         text-align: start;
         border-left: 1px solid $border-colour;
         border-right: 0;
-        margin: 3px 0 2px $gutter-one-third;
-        padding: 0 0 0 $gutter-one-third;
 
         &.last {
           border-left: 0;

--- a/app/views/shared/_available_languages.html.erb
+++ b/app/views/shared/_available_languages.html.erb
@@ -4,7 +4,7 @@
       <% translations.each.with_index do |translation, i| %>
         <li class="translation<%= ' last' if i == translations.length-1 %>">
           <% if translation["locale"] == I18n.locale.to_s %>
-            <span><%= native_language_name_for(translation["locale"]) %></span>
+            <%= native_language_name_for(translation["locale"]) %>
           <% else %>
             <%= link_to native_language_name_for(translation["locale"]), translation["base_path"] %>
           <% end %>


### PR DESCRIPTION
- Adds a margin to the bottom
- Fixes the top margin so it is inline with the govuk-title (this shouldn't be part of the component long term, since it ties it to the overall view)
- Updates styles so they're not using magic numbers and replace with gutters.

Before

![image](https://cloud.githubusercontent.com/assets/2445413/16562531/6a33951c-41f5-11e6-908a-06c95cce3530.png)

After

![image](https://cloud.githubusercontent.com/assets/2445413/16562601/b1d29d6e-41f5-11e6-9c9d-66dde5bce02e.png)

![image](https://cloud.githubusercontent.com/assets/2445413/16562625/d102af12-41f5-11e6-8245-b371ae1a3f75.png)


### How to test
- Check this branch (`avaliable-languages-component-fix-spacing`)
- Open http://government-frontend.dev.gov.uk/guidance/prepare-a-charity-annual-return
- Change the viewport size
- Spacing should be consistent with https://gov.uk/guidance/prepare-a-charity-annual-return
- Change the viewport size

