### PR TITLE
Revert "Revert "Add breadcrumbs where needed""

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ end
 
 group :development, :test do
   gem 'govuk-lint'
+  gem 'pry-byebug'
   gem 'wraith', '~> 3.1'
 end
 
@@ -38,5 +39,4 @@ group :test do
   gem 'capybara'
   gem 'webmock', '~> 1.18.0', require: false
   gem 'govuk-content-schema-test-helpers', '1.1.0'
-  gem 'pry-byebug'
 end

--- a/app/presenters/breadcrumbs.rb
+++ b/app/presenters/breadcrumbs.rb
@@ -1,0 +1,18 @@
+module Breadcrumbs
+  def breadcrumbs
+    return [] unless parent
+
+    direct_parent = parent
+    ordered_parents = []
+
+    while direct_parent
+      ordered_parents.unshift(
+        title: direct_parent["title"],
+        url: direct_parent["base_path"],
+      )
+      direct_parent = direct_parent["parent"] && direct_parent["parent"].first
+    end
+
+    ordered_parents.unshift(title: "Home", url: "/")
+  end
+end

--- a/app/presenters/case_study_presenter.rb
+++ b/app/presenters/case_study_presenter.rb
@@ -2,6 +2,7 @@ class CaseStudyPresenter < ContentItemPresenter
   include ActionView::Helpers::UrlHelper
   include Linkable
   include Updatable
+  include Breadcrumbs
 
   attr_reader :body
 

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -18,6 +18,12 @@ class ContentItemPresenter
     sorted_locales(@content_item["links"]["available_translations"])
   end
 
+  def parent
+    if content_item["links"].include?("parent")
+      content_item["links"]["parent"][0]
+    end
+  end
+
 private
 
   def display_time(timestamp)

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -1,28 +1,14 @@
 class DetailedGuidePresenter < ContentItemPresenter
-  include Political
+  include Breadcrumbs
   include ExtractsHeadings
   include Linkable
-  include Updatable
   include NationalApplicability
+  include Political
+  include Updatable
   include ActionView::Helpers::UrlHelper
 
   def body
     content_item["details"]["body"]
-  end
-
-  def breadcrumbs
-    return [] unless parent
-
-    e = parent
-    res = []
-
-    while e
-      res << { title: e["title"], url: e["base_path"] }
-      e = e["parent"] && e["parent"].first
-    end
-
-    res << { title: "Home", url: "/" }
-    res.reverse
   end
 
   def contents
@@ -41,13 +27,5 @@ class DetailedGuidePresenter < ContentItemPresenter
 
   def related_mainstream
     links("related_mainstream")
-  end
-
-private
-
-  def parent
-    if content_item["links"].include?("parent")
-      content_item["links"]["parent"][0]
-    end
   end
 end

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -1,6 +1,7 @@
 class DocumentCollectionPresenter < ContentItemPresenter
-  include Political
+  include Breadcrumbs
   include Linkable
+  include Political
   include Updatable
   include ActionView::Helpers::UrlHelper
 

--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -38,10 +38,4 @@ class HtmlPublicationPresenter < ContentItemPresenter
     brand = "executive-office" if organisation["details"]["logo"]["crest"] == "eo"
     brand
   end
-
-private
-
-  def parent
-    content_item["links"]["parent"][0]
-  end
 end

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -1,8 +1,9 @@
 class PublicationPresenter < ContentItemPresenter
-  include Political
+  include Breadcrumbs
   include Linkable
-  include Updatable
   include NationalApplicability
+  include Political
+  include Updatable
   include ActionView::Helpers::UrlHelper
 
   def details

--- a/app/presenters/topical_event_about_page_presenter.rb
+++ b/app/presenters/topical_event_about_page_presenter.rb
@@ -1,4 +1,5 @@
 class TopicalEventAboutPagePresenter < ContentItemPresenter
+  include Breadcrumbs
   include ExtractsHeadings
   include ActionView::Helpers::UrlHelper
 
@@ -12,27 +13,15 @@ class TopicalEventAboutPagePresenter < ContentItemPresenter
     end
   end
 
-  def breadcrumbs
-    parent = topical_event
-    title = archived_topical_event? ? "#{parent['title']} (Archived)" : parent["title"]
-
-    [
-      { title: "Home", url: "/" },
-      { title: title, url: parent["base_path"] }
-    ]
-  end
-
 private
 
-  def topical_event
-    content_item["links"]["parent"][0]
-  end
+  def parent
+    topical_event_end_date = super["details"]["end_date"]
 
-  def topical_event_end_date
-    topical_event["details"]["end_date"]
-  end
-
-  def archived_topical_event?
-    topical_event_end_date && DateTime.parse(topical_event_end_date) <= Date.today
+    if topical_event_end_date && DateTime.parse(topical_event_end_date) <= Date.today
+      super.merge("title" => "#{super['title']} (Archived)")
+    else
+      super
+    end
   end
 end

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -1,6 +1,8 @@
 <%= content_for :page_class, @content_item.format.dasherize.pluralize %>
 <%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
 
+<%= render "shared/breadcrumbs" %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,9 +1,7 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
 
-<% if @content_item.breadcrumbs.any? %>
-  <%= render 'govuk_component/breadcrumbs', breadcrumbs: @content_item.breadcrumbs %>
-<% end %>
+<%= render "shared/breadcrumbs" %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -1,6 +1,8 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
 
+<%= render "shared/breadcrumbs" %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -1,6 +1,8 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
 
+<%= render "shared/breadcrumbs" %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.title %>
 
-<%= render 'govuk_component/breadcrumbs', breadcrumbs: @content_item.breadcrumbs %>
+<%= render "shared/breadcrumbs" %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,0 +1,3 @@
+<% if @content_item.breadcrumbs.any? %>
+  <%= render 'govuk_component/breadcrumbs', breadcrumbs: @content_item.breadcrumbs %>
+<% end %>

--- a/test/presenters/breadcrumbs_test.rb
+++ b/test/presenters/breadcrumbs_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class BreadcrumbsTest < ActionView::TestCase
+  test "returns empty breadcrumbs when parent is not specified" do
+    content_item = build_content_item
+    assert_equal [], content_item.breadcrumbs
+  end
+
+  test "returns empty breadcrumbs when parent is empty" do
+    links = { parent: [] }
+    content_item = build_content_item(links)
+    assert_equal [], content_item.breadcrumbs
+  end
+
+  test "returns breadcrumbs when there is a parent" do
+    links = {
+      "parent" => [
+        { "title" => "A-parent", "base_path" => "/a-parent" }
+      ]
+    }
+
+    content_item = build_content_item(links)
+
+    assert_equal [
+      { title: "Home", url: "/" },
+      { title: "A-parent", url: "/a-parent" },
+    ], content_item.breadcrumbs
+  end
+
+  test "returns breadcrumbs when there is more than one parent" do
+    links = {
+      "parent" => [
+        {
+          "title" => "A-parent",
+          "base_path" => "/a-parent",
+          "parent" => [{
+            "title" => "Another-parent",
+            "base_path" => "/another-parent",
+          }]
+        }
+      ]
+    }
+
+    content_item = build_content_item(links)
+
+    assert_equal [
+      { title: "Home", url: "/" },
+      { title: "Another-parent", url: "/another-parent" },
+      { title: "A-parent", url: "/a-parent" },
+    ], content_item.breadcrumbs
+  end
+
+private
+
+  def build_content_item(links = [])
+    ItemWithBreadrumbs.new(
+      "title" => "a title",
+      "description" => "a description",
+      "format" => "a format",
+      "phase" => "live",
+      "document_type" => "content_item",
+      "links" => links,
+    )
+  end
+end
+
+class ItemWithBreadrumbs < ContentItemPresenter
+  include Breadcrumbs
+end


### PR DESCRIPTION
This reverts commit 4a55298a211c542ac9f790ebf15a5c8f56d07f10, reinstating the Breadcrumb functionality originally added by @jackscotti & @MatMoore in https://github.com/alphagov/government-frontend/commit/d51d8f48e59adfde2a64b068f47910e9e0534cd9