### PR TITLE
Upgrade slimmer to 9.3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'sass-rails', '~> 5.0.4'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '9.3.1'
+  gem 'slimmer', '9.3.2'
 end
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
     scss_lint (0.44.0)
       rake (~> 10.0)
       sass (~> 3.4.15)
-    slimmer (9.3.1)
+    slimmer (9.3.2)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -239,7 +239,7 @@ DEPENDENCIES
   rails-i18n (>= 4.0.4)
   rails_translation_manager (~> 0.0.2)
   sass-rails (~> 5.0.4)
-  slimmer (= 9.3.1)
+  slimmer (= 9.3.2)
   uglifier (>= 1.3.0)
   unicorn (= 4.8)
   webmock (~> 1.18.0)

--- a/README.md
+++ b/README.md
@@ -25,10 +25,18 @@ This is a Ruby on Rails application that fetches documents from
 
 ### Running the application
 
-`./startup.sh`
+```
+./startup.sh
+```
 
 The app should start on http://localhost:3090 or
 http://government-frontend.dev.gov.uk on GOV.UK development machines.
+
+```
+./startup.sh --live
+```
+
+This will run the app and point it at the production GOV.UK `content-store` and `static` instances.
 
 ### Running the test suite
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
 
 bundle install
-bundle exec rails s -p 3090
+
+if [[ $1 == "--live" ]] ; then
+  GOVUK_APP_DOMAIN=www.gov.uk \
+  GOVUK_WEBSITE_ROOT=https://www.gov.uk \
+  PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api \
+  PLEK_SERVICE_STATIC_URI=assets.publishing.service.gov.uk \
+  bundle exec rails s -p 3090
+else
+  bundle exec rails s -p 3090
+fi


### PR DESCRIPTION
Fixes SystemStackError issues in production

Also add `--live` option to `startup.sh` to easily run the app against live content store and static.