### PR TITLE
Add `gone` format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,4 +40,5 @@ group :test do
   gem 'capybara'
   gem 'webmock', '~> 1.18.0', require: false
   gem 'govuk-content-schema-test-helpers', '1.1.0'
+  gem 'mocha'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,10 +109,13 @@ GEM
       PriorityQueue (~> 0.1.2)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (2.99.2)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
     multi_json (1.12.1)
     netrc (0.11.0)
     nio4r (1.2.1)
@@ -260,6 +263,7 @@ DEPENDENCIES
   govuk-lint
   govuk_frontend_toolkit (= 2.0.1)
   logstasher (= 0.6.1)
+  mocha
   plek (= 1.11)
   pry-byebug
   rails (~> 5.0)

--- a/app/helpers/gone_helper.rb
+++ b/app/helpers/gone_helper.rb
@@ -1,0 +1,6 @@
+module GoneHelper
+  def alternative_path_link(request, alternative_path)
+    alternative_url = File.join(request.protocol, request.host, alternative_path)
+    link_to(alternative_url, alternative_path)
+  end
+end

--- a/app/presenters/gone_presenter.rb
+++ b/app/presenters/gone_presenter.rb
@@ -1,0 +1,9 @@
+class GonePresenter < ContentItemPresenter
+  attr_reader :alternative_path, :explanation
+
+  def initialize(content_item)
+    super
+    @explanation = content_item['details']['explanation']
+    @alternative_path = content_item['details']['alternative_path']
+  end
+end

--- a/app/views/content_items/gone.html.erb
+++ b/app/views/content_items/gone.html.erb
@@ -1,0 +1,24 @@
+<%= content_for :page_class, "unpublishing" %>
+<%= content_for :title, "No longer available - GOV.UK" %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title', title: 'The page you\'re looking for is no longer available' %>
+
+    <p class="summary">
+      The information on this page has been removed because it was published in error.
+    </p>
+
+    <%= render 'govuk_component/govspeak', content: @content_item.explanation %>
+
+    <% if @content_item.alternative_path.present? %>
+      <p class="alternative">
+<<<<<<< HEAD
+      Visit: <%= alternative_path_link %>
+=======
+      Visit: <%= alernative_path_link %>
+>>>>>>> 53ded35... Add mocha gem
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/content_items/gone.html.erb
+++ b/app/views/content_items/gone.html.erb
@@ -13,11 +13,7 @@
 
     <% if @content_item.alternative_path.present? %>
       <p class="alternative">
-<<<<<<< HEAD
-      Visit: <%= alternative_path_link %>
-=======
-      Visit: <%= alernative_path_link %>
->>>>>>> 53ded35... Add mocha gem
+        Visit: <%= alternative_path_link(request, @content_item.alternative_path)%>
       </p>
     <% end %>
   </div>

--- a/test/helpers/gone_helper_test.rb
+++ b/test/helpers/gone_helper_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class GoneHelperTest < ActionView::TestCase
+  test "it renders a link to the full url" do
+    request = stub(protocol: "http://", host: "www.dev.gov.uk")
+    expected_html = link_to("http://www.dev.gov.uk/government/example", "/government/example")
+    assert_equal(expected_html, alternative_path_link(request, "/government/example"))
+  end
+end

--- a/test/presenters/gone_presenter_test.rb
+++ b/test/presenters/gone_presenter_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class GonePresenterTest < ActiveSupport::TestCase
+  test 'presents the basic details required to display an gone' do
+    assert_equal gone['details']['explanation'], presented_gone.explanation
+    assert_equal gone['details']['alternative_path'], presented_gone.alternative_path
+  end
+
+  def gone
+    govuk_content_schema_example('gone', 'gone')
+  end
+
+  def presented_gone
+    GonePresenter.new(gone)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require 'webmock/minitest'
 require 'support/govuk_content_schema_examples'
 require 'capybara/rails'
 require 'slimmer/test_helpers/shared_templates'
+require 'mocha/mini_test'
 
 class ActiveSupport::TestCase
   include GovukContentSchemaExamples


### PR DESCRIPTION
This has been added to allow `gone` items with an `explanation` or `alternative_path` to be rendered.

These are created by unpublishing within Whitehall when the reason is 'Published in error' but 'redirect?' is not selected.

This will require https://github.com/alphagov/govuk-content-schemas/pull/372 to be merged before the tests will pass.