### PR TITLE
Add meta descriptions to content items

### DIFF
--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :page_class, @content_item.format.dasherize.pluralize %>
 <%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
+<%= content_for :meta_description, @content_item.description %>
 
 <%= render "shared/breadcrumbs" %>
 

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
+<%= content_for :meta_description, @content_item.description %>
 
 <%= render "shared/breadcrumbs" %>
 

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
+<%= content_for :meta_description, @content_item.description %>
 
 <%= render "shared/breadcrumbs" %>
 

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -1,6 +1,7 @@
 <%
   content_for :page_class, @content_item.format.dasherize
   content_for :title, @content_item.title
+  content_for :meta_description, @content_item.description
   content_for :simple_header, true
 
   direction_css_class = ""

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
+<%= content_for :meta_description, @content_item.description %>
 
 <%= render "shared/breadcrumbs" %>
 

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, "#{@content_item.title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
+<%= content_for :meta_description, @content_item.description %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.title %>
+<%= content_for :meta_description, @content_item.description %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.title %>
+<%= content_for :meta_description, @content_item.description %>
 
 <%= render "shared/breadcrumbs" %>
 

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.title %>
+<%= content_for :meta_description, @content_item.description %>
 
 <div class="grid-row">
   <div class="column-two-thirds">


### PR DESCRIPTION
The meta description tag is defined in the parent layout, but none of the content items currently use it. This commit adds meta description tags to all content items, the contents of which are set to the `description` associated with the content. This adds descriptions to external search engine results when the pages are re-indexed.

Trello: https://trello.com/c/bbAwFAQ1/108-add-meta-descriptions-to-pages-missing-them