### PR TITLE
Fix breadcrumb presenter

### DIFF
--- a/app/presenters/breadcrumbs.rb
+++ b/app/presenters/breadcrumbs.rb
@@ -10,7 +10,7 @@ module Breadcrumbs
         title: direct_parent["title"],
         url: direct_parent["base_path"],
       )
-      direct_parent = direct_parent["parent"] && direct_parent["parent"].first
+      direct_parent = direct_parent = direct_parent.dig("links", "parent", 0)
     end
 
     ordered_parents.unshift(title: "Home", url: "/")

--- a/test/presenters/breadcrumbs_test.rb
+++ b/test/presenters/breadcrumbs_test.rb
@@ -33,10 +33,12 @@ class BreadcrumbsTest < ActionView::TestCase
         {
           "title" => "A-parent",
           "base_path" => "/a-parent",
-          "parent" => [{
-            "title" => "Another-parent",
-            "base_path" => "/another-parent",
-          }]
+          "links" => {
+            "parent" => [{
+              "title" => "Another-parent",
+              "base_path" => "/another-parent",
+            }]
+          }
         }
       ]
     }


### PR DESCRIPTION
This fixes a bug in the breadcrumbs presenter.

The presenter is tested with an example from govuk-content-schemas. But the example contains an error: it uses a structure like `links -> parent -> parent`. This is not how the publishing-api expands the links, it nests it like `links -> parent -> links -> parent`.

However, because the liberal way the frontend `links` hash is validated, the example was considered valid. This is tackled in https://github.com/alphagov/govuk-content-schemas/pull/389.