### PR TITLE
Rename `related_mainstream` for DetailedGuide

### DIFF
--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -24,7 +24,7 @@ class DetailedGuidePresenter < ContentItemPresenter
     links("related_guides")
   end
 
-  def related_mainstream
-    links("related_mainstream")
+  def related_mainstream_content
+    links("related_mainstream_content")
   end
 end

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -48,12 +48,12 @@
     </div>
   <% end %>
   <div class="column-two-thirds <% unless @content_item.contents.any? %>offset-one-third<% end %>">
-    <% if @content_item.related_mainstream.any? %>
+    <% if @content_item.related_mainstream_content.any? %>
       <aside class="related-mainstream-content" role="complementary">
         <h4>
           <%= raw( t('detailed_guide.related_mainstream_content') ) %>
         </h4>
-        <% @content_item.related_mainstream.each do |link| %>
+        <% @content_item.related_mainstream_content.each do |link| %>
           <%= link %><br />
         <% end %>
       </aside>

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -54,7 +54,7 @@ class DetailedGuidePresenterTest < PresenterTest
   test 'presents related mainstream content' do
     assert_equal [
       '<a href="/overseas-passports">Overseas British passport applications</a>',
-      '<a href="/report-a-lost-or-stolen-passport">Cancel a lost or stolen passport</a>'], presented_item("related_mainstream_detailed_guide").related_mainstream
+      '<a href="/report-a-lost-or-stolen-passport">Cancel a lost or stolen passport</a>'], presented_item("related_mainstream_detailed_guide").related_mainstream_content
   end
 
   test 'content can be historically political' do


### PR DESCRIPTION
This has been changed in the schema to `related_mainstream_content` to make it more consisitent.