### PR TITLE
Fix Fatality Notice title length

### DIFF
--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -6,7 +6,9 @@
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
         context: "Operations in #{@content_item.field_of_operation.title}",
-        title: @content_item.title %>
+        title: @content_item.title,
+        average_title_length: "long"
+      %>
   </div>
 </div>
 


### PR DESCRIPTION
Adds `average_title_length: 'long'` to the title component to handle long titles appropriately.