### PR TITLE
Display logo image for Detailed guides if provided

### DIFF
--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -30,4 +30,13 @@
   .back-to-content {
     margin-left: $gutter-half;
   }
+
+  .logo-image {
+    max-width: 70%;
+
+    @include media(tablet) {
+      max-width: 100%;
+      margin-top: 45px;
+    }
+  }
 }

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -27,4 +27,8 @@ class DetailedGuidePresenter < ContentItemPresenter
   def related_mainstream_content
     links("related_mainstream_content")
   end
+
+  def image
+    content_item["details"]["image"]["url"] if content_item["details"]["image"]
+  end
 end

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -15,6 +15,9 @@
     <%= render 'shared/available_languages',
       translations: @content_item.available_translations
     %>
+    <% if @content_item.image.present? %>
+      <%= image_tag @content_item.image, class: "logo-image" %>
+    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
One Detailed guide has a European Structural and Investment Fund logo
which must be displayed for regulatory reasons. This was missed during
migration.

How it looked in Whitehall: http://webarchive.nationalarchives.gov.uk/20160806171559/https://www.gov.uk/guidance/england-2014-to-2020-european-structural-and-investment-funds

Screenshots of Government Frontend at various break points:

<img width="908" alt="screen shot 2016-10-13 at 12 02 20" src="https://cloud.githubusercontent.com/assets/18276/19346829/5be20e02-913d-11e6-8967-bd63f89be854.png">
<img width="637" alt="screen shot 2016-10-13 at 12 02 34" src="https://cloud.githubusercontent.com/assets/18276/19346830/5be3d20a-913d-11e6-8435-fc0ea19345cd.png">
<img width="498" alt="screen shot 2016-10-13 at 12 02 47" src="https://cloud.githubusercontent.com/assets/18276/19346831/5be8d32c-913d-11e6-9ba4-c592b6ef52c1.png">
