### PR TITLE
Upgrade airbrake and gds-api-adapters gems.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+
+/public/government-frontend

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,9 @@ source 'https://rubygems.org'
 
 ruby File.read(".ruby-version").strip
 
-gem 'airbrake', '4.0'
+gem 'airbrake', '~> 5.5'
+gem 'airbrake-ruby', '1.5'
+
 gem 'govuk_frontend_toolkit', '2.0.1'
 gem 'logstasher', '0.6.1'
 gem 'plek', '1.11'
@@ -11,7 +13,7 @@ gem 'sass-rails', '~> 5.0.4'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '9.5.0'
+  gem 'slimmer', '9.6.0'
 end
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8'
@@ -22,7 +24,7 @@ gem 'rails-controller-testing', '~> 0.1'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '33.1.0'
+  gem "gds-api-adapters", "37.5.1"
 end
 
 gem 'govuk_navigation_helpers', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,9 +40,9 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (4.0.0)
-      builder
-      multi_json
+    airbrake (5.5.0)
+      airbrake-ruby (~> 1.5)
+    airbrake-ruby (1.5.0)
     arel (7.1.1)
     ast (2.3.0)
     better_errors (2.1.1)
@@ -65,17 +65,17 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
-    domain_name (0.5.20160615)
+    domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (33.1.0)
+    gds-api-adapters (37.5.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     govuk-content-schema-test-helpers (1.1.0)
@@ -87,7 +87,7 @@ GEM
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_navigation_helpers (1.0.0)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (2.0.2)
@@ -112,7 +112,6 @@ GEM
     minitest (5.9.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    multi_json (1.12.1)
     netrc (0.11.0)
     nio4r (1.2.1)
     nokogiri (1.6.8)
@@ -173,10 +172,10 @@ GEM
     raindrops (0.17.0)
     rake (11.2.2)
     request_store (1.3.1)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rubocop (0.39.0)
       parser (>= 2.3.0.7, < 3.0)
       powerpack (~> 0.1)
@@ -195,7 +194,7 @@ GEM
     scss_lint (0.49.0)
       rake (>= 0.9, < 12)
       sass (~> 3.4.20)
-    slimmer (9.5.0)
+    slimmer (9.6.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -239,11 +238,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (= 4.0)
+  airbrake (~> 5.5)
+  airbrake-ruby (= 1.5)
   better_errors
   binding_of_caller
   capybara
-  gds-api-adapters (= 33.1.0)
+  gds-api-adapters (= 37.5.1)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
   govuk_frontend_toolkit (= 2.0.1)
@@ -257,7 +257,7 @@ DEPENDENCIES
   rails-i18n (>= 4.0.4)
   rails_translation_manager (~> 0.0.2)
   sass-rails (~> 5.0.4)
-  slimmer (= 9.5.0)
+  slimmer (= 9.6.0)
   uglifier (>= 1.3.0)
   unicorn (= 4.8)
   webmock (~> 1.18.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,5 @@ module GovernmentFrontend
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true
-
-    GdsApi.config.always_raise_for_not_found = true
   end
 end

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,10 @@
+if ENV['ERRBIT_API_KEY'].present?
+  errbit_uri = Plek.find('errbit')
+
+  Airbrake.configure do |config|
+    config.project_key = ENV['ERRBIT_API_KEY']
+    config.project_id = 1 # dummy, not used in Errbit
+    config.host = errbit_uri
+    config.environment = ENV['ERRBIT_ENVIRONMENT_NAME']
+  end
+end

--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,3 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-GdsApi.config.always_raise_for_not_found = true


### PR DESCRIPTION
This fixes some deprecation warnings.

The new version of the Airbrake gem requires a new config, which will
be populated by env vars rather than by overwriting on deployment.

This depends on https://github.com/alphagov/govuk-puppet/pull/5009, https://github.gds/gds/deployment/pull/1130 and https://github.gds/gds/alphagov-deployment/pull/1276
