### PR TITLE
Fix document collection scoping

### DIFF
--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -38,7 +38,7 @@ class DocumentCollectionPresenter < ContentItemPresenter
 private
 
   def group_documents(group)
-    group["documents"].map { |id| documents_hash[id] }
+    group["documents"].map { |id| documents_hash[id] }.compact
   end
 
   def group_title_id(title)

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -16,7 +16,9 @@ class DocumentCollectionPresenter < ContentItemPresenter
   end
 
   def groups
-    content_item["details"]["collection_groups"]
+    content_item["details"]["collection_groups"].reject do |group|
+      group_document_links(group).empty?
+    end
   end
 
   def group_document_links(group)

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -43,3 +43,26 @@ class DocumentCollectionPresenterTest < PresenterTest
     assert_equal documents, presented_item.group_document_links("documents" => [document_ids.first])
   end
 end
+
+class DocumentCollectionWithGroupContainingMissingDocumentLinkPresenterTest < PresenterTest
+  def format_name
+    "document_collection"
+  end
+
+  test "does not present the withdrawn document" do
+    presenter = presented_item("document_collection_with_single_missing_document")
+
+    group_with_missing_document = presenter
+      .groups
+      .select { |g| g["title"] == "One document missing from links" }
+      .first
+
+    presented_links = presenter.group_document_links(group_with_missing_document)
+    presented_links_base_paths = presented_links.collect { |link| link[:base_path] }
+
+    assert_equal(
+      ["/government/publications/national-standard-for-developed-driving-competence"],
+      presented_links_base_paths
+    )
+  end
+end

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -67,6 +67,22 @@ class DocumentCollectionWithGroupContainingMissingDocumentLinkPresenterTest < Pr
   end
 end
 
+class DocumentCollectionWithGroupContainingNoDocumentsPresenterTest < PresenterTest
+  def format_name
+    "document_collection"
+  end
+
+  test "does not present a group which contains no documents" do
+    presenter = presented_item("document_collection_with_no_documents")
+
+    group_with_missing_documents = presenter
+      .groups
+      .select { |g| g["title"] == "No documents" }
+
+    assert_empty group_with_missing_documents
+  end
+end
+
 class DocumentCollectionWithGroupContainingOnlyMissingDocumentLinksPresenterTest < PresenterTest
   def format_name
     "document_collection"

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -66,3 +66,21 @@ class DocumentCollectionWithGroupContainingMissingDocumentLinkPresenterTest < Pr
     )
   end
 end
+
+class DocumentCollectionWithGroupContainingOnlyMissingDocumentLinksPresenterTest < PresenterTest
+  def format_name
+    "document_collection"
+  end
+
+  test "does not present the group" do
+    presenter = presented_item(
+      "document_collection_with_missing_links_documents"
+    )
+
+    group_with_missing_documents = presenter
+      .groups
+      .select { |g| g["title"] == "All documents missing from links" }
+
+    assert_empty group_with_missing_documents
+  end
+end


### PR DESCRIPTION
Add functionality to DocumentCollectionPresenter to mimic current behaviour in Whitehall.

* Don't present documents that are in the groups but not in the links.
* Don't present groups that have empty collections.

[Trello](https://trello.com/c/DoIbAkZB/428-11-document-collection-migration-implement-publishing-of-format-to-publishing-api)
Mobbed on with @andrewgarner @bevanloon @gpeng @mgrassotti @Rosa-Fox
