### PR TITLE
Fix DocumentCollection contents styling

### DIFF
--- a/app/assets/stylesheets/helpers/_sidebar-with-body.scss
+++ b/app/assets/stylesheets/helpers/_sidebar-with-body.scss
@@ -14,4 +14,8 @@
       @include core-16;
     }
   }
+
+  .offset-one-third {
+    margin-left: percentage(1 / 3);
+  }
 }

--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -4,10 +4,6 @@
   @include history-notice;
   @include withdrawal-notice;
 
-  .offset-one-third {
-    margin-left: percentage(1 / 3);
-  }
-
   .related-mainstream-content {
     background: $panel-colour;
     padding: $gutter-half;

--- a/app/assets/stylesheets/views/_topical-event-about-page.scss
+++ b/app/assets/stylesheets/views/_topical-event-about-page.scss
@@ -1,8 +1,4 @@
 .topical-event-about-page {
   @include description;
   @include sidebar-with-body;
-
-  .offset-one-third {
-    margin-left: percentage(1 / 3);
-  }
 }

--- a/app/assets/stylesheets/views/_working-group.scss
+++ b/app/assets/stylesheets/views/_working-group.scss
@@ -1,7 +1,4 @@
 .working-group {
   @include description;
-
-  .offset-one-third {
-    margin-left: percentage(1 / 3);
-  }
+  @include sidebar-with-body;
 }

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -30,10 +30,12 @@
 <%= render 'shared/description', description: @content_item.description %>
 
 <div class="grid-row sidebar-with-body">
-  <div class="column-third">
-    <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
-  </div>
-  <div class="column-two-thirds">
+  <% if @content_item.contents.any? %>
+    <div class="column-third">
+      <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
+    </div>
+  <% end %>
+  <div class="column-two-thirds <% unless @content_item.contents.any? %>offset-one-third<% end %>">
     <% if @content_item.body.present? %>
       <%= render 'govuk_component/govspeak',
           content: @content_item.body,


### PR DESCRIPTION
This protects the first 'third' column in the event that there are no contents entries.

Also refactors the relevant class out into the `sidebar-with-body` helper which fixes a bug in working groups and removes some duplication.