### PR TITLE
Expose the content_id for each content item

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -27,6 +27,10 @@ class ContentItemPresenter
     end
   end
 
+  def content_id
+    content_item.parsed_content["content_id"]
+  end
+
 private
 
   def display_time(timestamp)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
   <% if content_for(:meta_description).present? %>
     <meta name="description" content="<%= content_for(:meta_description) %>" />
   <% end %>
+  <meta name="govuk:content-id" content="<%= @content_item.content_id %>" />
 </head>
 <body>
   <% unless content_for(:simple_header) %>

--- a/test/integration/content_item_test.rb
+++ b/test/integration/content_item_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class ContentItemTest < ActionDispatch::IntegrationTest
+  def test_examples
+    formats = %w( case_study coming_soon detailed_guide document_collection
+                  fatality_notice gone html_publication publication statistics_announcement
+                  take_part topical_event_about_page unpublishing working_group )
+
+    result = formats.inject({}) do |examples, format|
+      examples[format] = format
+      examples
+    end
+    result["html_publication"] = "arabic_translation"
+    result["statistics_announcement"] = "cancelled_official_statistics"
+    result["working_group"] = "long"
+    result
+  end
+
+  test "content id" do
+    test_examples.each do |format, example|
+      define_singleton_method("schema_format") { format }
+
+      setup_and_visit_content_item(example)
+      has_component_metadata("name", "govuk:content-id")
+      has_component_metadata("content", @content_item["content_id"])
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -91,6 +91,10 @@ class ActionDispatch::IntegrationTest
     end
   end
 
+  def has_component_metadata(key, value)
+    assert page.has_css? "meta[#{key}=\"#{value}\"]", visible: false
+  end
+
   def setup_and_visit_content_item(name)
     @content_item = JSON.parse(get_content_example(name)).tap do |item|
       content_store_has_item(item["base_path"], item.to_json)


### PR DESCRIPTION
Trello: https://trello.com/c/nYKudXNT/512-fix-whitehall-admin-bookmarklet-for-migrated-formats-medium

In order to preserve the whitehall admin bookmarklet functionality, we
are going to expose the content_id for each content item. This id will
be used to redirect to the related admin page.