### PR TITLE
Handle missing `links#documents` for Document Collections

### DIFF
--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -48,6 +48,6 @@ private
   end
 
   def documents_hash
-    @documents_hash ||= content_item["links"]["documents"].map { |d| [d["content_id"], d] }.to_h
+    @documents_hash ||= (content_item["links"]["documents"] || []).map { |d| [d["content_id"], d] }.to_h
   end
 end

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -109,4 +109,19 @@ class DocumentCollectionPresenterTest
       assert_empty group_with_missing_documents
     end
   end
+
+  class GroupWithDocumentsWhenThereIsNoLinksDocuments < TestCase
+    test "does not present the group" do
+      presenter = presented_item(
+        "document_collection_with_group_but_no_documents"
+      )
+
+      group_with_missing_documents =
+        presenter
+          .groups
+          .select { |g| g["title"] == "Missing documents" }
+
+      assert_empty group_with_missing_documents
+    end
+  end
 end


### PR DESCRIPTION
When all of the documents in a collection have been unpublished the `links#documents` element is not present in the json. This commit handles that case.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/438