### PR TITLE
Small refactor to Document Collection presenter

### DIFF
--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -48,6 +48,6 @@ private
   end
 
   def documents_hash
-    @documents_hash ||= (content_item["links"]["documents"] || []).map { |d| [d["content_id"], d] }.to_h
+    @documents_hash ||= Array(content_item["links"]["documents"]).map { |d| [d["content_id"], d] }.to_h
   end
 end


### PR DESCRIPTION
Use `Array()` rather than `array || []`.

Minor amendment suggested after https://github.com/alphagov/government-frontend/pull/197 was merged.

/cc @andrewgarner 