### PR TITLE
Add Statistical Data Sets

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,3 +34,4 @@
 @import "views/publication";
 @import "views/document-collection";
 @import "views/fatality-notice";
+@import "views/statistical-data-set";

--- a/app/assets/stylesheets/views/_statistical-data-set.scss
+++ b/app/assets/stylesheets/views/_statistical-data-set.scss
@@ -1,3 +1,5 @@
 .statistical-data-set {
-
+  @include description;
+  @include sidebar-with-body;
+  @include history-notice;
 }

--- a/app/assets/stylesheets/views/_statistical-data-set.scss
+++ b/app/assets/stylesheets/views/_statistical-data-set.scss
@@ -1,0 +1,3 @@
+.statistical-data-set {
+
+}

--- a/app/assets/stylesheets/views/_statistical-data-set.scss
+++ b/app/assets/stylesheets/views/_statistical-data-set.scss
@@ -2,4 +2,5 @@
   @include description;
   @include sidebar-with-body;
   @include history-notice;
+  @include withdrawal-notice;
 }

--- a/app/presenters/statistical_data_set_presenter.rb
+++ b/app/presenters/statistical_data_set_presenter.rb
@@ -1,0 +1,2 @@
+class StatisticalDataSetPresenter < ContentItemPresenter
+end

--- a/app/presenters/statistical_data_set_presenter.rb
+++ b/app/presenters/statistical_data_set_presenter.rb
@@ -1,2 +1,18 @@
 class StatisticalDataSetPresenter < ContentItemPresenter
+  include ExtractsHeadings
+  include Political
+  include Withdrawable
+  include Linkable
+  include Updatable
+  include ActionView::Helpers::UrlHelper
+
+  def body
+    content_item["details"]["body"]
+  end
+
+  def contents
+    extract_headings_with_ids(body).map do |heading|
+      link_to(heading[:text], "##{heading[:id]}")
+    end
+  end
 end

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -1,0 +1,12 @@
+<%= content_for :page_class, @content_item.format.dasherize %>
+<%= content_for :title, @content_item.title %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+        context: t("content_item.format.#{@content_item.document_type}", count: 1),
+        title: @content_item.title %>
+  </div>
+</div>
+
+<%= render 'shared/description', description: @content_item.description %>

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -5,8 +5,44 @@
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
         context: t("content_item.format.#{@content_item.document_type}", count: 1),
-        title: @content_item.title %>
+        title: @content_item.title,
+        average_title_length: "long" %>
   </div>
 </div>
 
+<%= render 'shared/withdrawal_notice', content_item: @content_item %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/metadata',
+        from: @content_item.from,
+        part_of: @content_item.part_of,
+        first_published: @content_item.published,
+        last_updated: @content_item.updated,
+        see_updates_link: true
+    %>
+  </div>
+</div>
+<%= render 'shared/history_notice', content_item: @content_item %>
+
 <%= render 'shared/description', description: @content_item.description %>
+
+<div class="grid-row sidebar-with-body">
+  <% if @content_item.contents.any? %>
+    <div class="column-third">
+      <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
+    </div>
+  <% end %>
+  <div class="column-two-thirds <% unless @content_item.contents.any? %>offset-one-third<% end %>">
+    <%= render 'govuk_component/govspeak', content: @content_item.body %>
+  </div>
+</div>
+
+<%= render 'govuk_component/document_footer',
+    from: @content_item.from,
+    updated: @content_item.updated,
+    history: @content_item.history,
+    published: @content_item.published,
+    part_of: @content_item.part_of,
+    direction: page_text_direction
+%>

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
-<%= content_for :title, @content_item.title %>
+<%= content_for :title, @content_item.page_title %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/lib/generators/format/templates/format_presenter_test.rb.erb
+++ b/lib/generators/format/templates/format_presenter_test.rb.erb
@@ -3,7 +3,7 @@ require 'presenter_test_helper'
 class <%= "#{@camel_name}PresenterTest" %>
   class <%= "Presented#{@camel_name}" %> < PresenterTestCase
     def format_name
-      " <%= @format_name %> "
+      "<%= @format_name %>"
     end
 
     test 'presents the format' do

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -20,4 +20,19 @@ class StatisticalDataSetTest < ActionDispatch::IntegrationTest
     assert_has_component_metadata_pair("part_of", ["<a href=\"/government/collections/transport-statistics-great-britain\">Transport Statistics Great Britain</a>"])
     assert_has_component_document_footer_pair("part_of", ["<a href=\"/government/collections/transport-statistics-great-britain\">Transport Statistics Great Britain</a>"])
   end
+
+  test "renders withdrawn notification" do
+    setup_and_visit_content_item("statistical_data_set_withdrawn")
+
+    assert page.has_css?('title', text: "[Withdrawn]", visible: false)
+
+    withdrawn_notice_explanation = @content_item["withdrawn_notice"]["explanation"]
+    withdrawn_at = @content_item["withdrawn_notice"]["withdrawn_at"]
+
+    within ".withdrawal-notice" do
+      assert page.has_text?("This statistical data set was withdrawn"), "is withdrawn"
+      assert_has_component_govspeak(withdrawn_notice_explanation)
+      assert page.has_css?("time[datetime='#{withdrawn_at}']")
+    end
+  end
 end

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class StatisticalDataSetTest < ActionDispatch::IntegrationTest
+end

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -1,4 +1,23 @@
 require 'test_helper'
 
 class StatisticalDataSetTest < ActionDispatch::IntegrationTest
+  test "renders title, description and body" do
+    setup_and_visit_content_item('statistical_data_set')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+    assert_has_component_govspeak(@content_item["details"]["body"])
+  end
+
+  test "renders metadata and document footer" do
+    setup_and_visit_content_item('statistical_data_set')
+
+    assert_has_component_metadata_pair("first_published", "13 December 2012")
+    link1 = "<a href=\"/government/organisations/department-for-transport\">Department for Transport</a>"
+    assert_has_component_metadata_pair("from", [link1])
+    assert_has_component_document_footer_pair("from", [link1])
+
+    assert_has_component_metadata_pair("part_of", ["<a href=\"/government/collections/transport-statistics-great-britain\">Transport Statistics Great Britain</a>"])
+    assert_has_component_document_footer_pair("part_of", ["<a href=\"/government/collections/transport-statistics-great-britain\">Transport Statistics Great Britain</a>"])
+  end
 end

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -35,4 +35,12 @@ class StatisticalDataSetTest < ActionDispatch::IntegrationTest
       assert page.has_css?("time[datetime='#{withdrawn_at}']")
     end
   end
+
+  test "historically political statistical data set" do
+    setup_and_visit_content_item('statistical_data_set_political')
+
+    within ".history-notice" do
+      assert page.has_text?('This statistical data set was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government')
+    end
+  end
 end

--- a/test/presenters/statistical_data_set_presenter_test.rb
+++ b/test/presenters/statistical_data_set_presenter_test.rb
@@ -3,11 +3,29 @@ require 'presenter_test_helper'
 class StatisticalDataSetPresenterTest
   class PresentedStatisticalDataSet < PresenterTestCase
     def format_name
-      " statistical_data_set "
+      "statistical_data_set"
     end
 
     test 'presents the format' do
       assert_equal schema_item['format'], presented_item.format
+    end
+
+    test 'presents a list of contents extracted from headings in the body' do
+      assert_equal '<a href="#olympics">Olympics</a>', presented_item.contents[0]
+    end
+
+    test '#published returns a formatted date of the day the content item became public' do
+      assert_equal "13 December 2012", presented_item.published
+    end
+
+    test 'presents a description' do
+      assert_equal schema_item["description"], presented_item.description
+    end
+
+    test 'presents the body' do
+      expected_body = schema_item['details']['body']
+
+      assert_equal expected_body, presented_item.body
     end
   end
 end

--- a/test/presenters/statistical_data_set_presenter_test.rb
+++ b/test/presenters/statistical_data_set_presenter_test.rb
@@ -1,0 +1,13 @@
+require 'presenter_test_helper'
+
+class StatisticalDataSetPresenterTest
+  class PresentedStatisticalDataSet < PresenterTestCase
+    def format_name
+      " statistical_data_set "
+    end
+
+    test 'presents the format' do
+      assert_equal schema_item['format'], presented_item.format
+    end
+  end
+end

--- a/test/presenters/statistical_data_set_presenter_test.rb
+++ b/test/presenters/statistical_data_set_presenter_test.rb
@@ -59,4 +59,23 @@ class StatisticalDataSetPresenterTest
       assert_equal expected_withdrawn_time_html, presented.withdrawal_notice[:time]
     end
   end
+
+  class PoliticalStatisticalDataSet < StatisticalDataSetTestCase
+    def example_schema_name
+      "statistical_data_set_political"
+    end
+
+    def expected
+      schema_item(example_schema_name)
+    end
+
+    def presented
+      presented_item(example_schema_name)
+    end
+
+    test 'presents the political fields' do
+      assert_equal expected["details"]["political"], presented.historically_political?
+      assert_equal expected["details"]["government"]["title"], presented.publishing_government
+    end
+  end
 end

--- a/test/presenters/statistical_data_set_presenter_test.rb
+++ b/test/presenters/statistical_data_set_presenter_test.rb
@@ -1,11 +1,13 @@
 require 'presenter_test_helper'
 
 class StatisticalDataSetPresenterTest
-  class PresentedStatisticalDataSet < PresenterTestCase
+  class StatisticalDataSetTestCase < PresenterTestCase
     def format_name
       "statistical_data_set"
     end
+  end
 
+  class PresentedStatisticalDataSet < StatisticalDataSetTestCase
     test 'presents the format' do
       assert_equal schema_item['format'], presented_item.format
     end
@@ -26,6 +28,35 @@ class StatisticalDataSetPresenterTest
       expected_body = schema_item['details']['body']
 
       assert_equal expected_body, presented_item.body
+    end
+  end
+
+  class WithdrawnStatisticalDataSet < StatisticalDataSetTestCase
+    def example_schema_name
+      "statistical_data_set_withdrawn"
+    end
+
+    def expected
+      schema_item(example_schema_name)
+    end
+
+    def presented
+      presented_item(example_schema_name)
+    end
+
+    test 'presents the withdrawn notice explanation' do
+      assert_equal expected["withdrawn_notice"]["explanation"], presented.withdrawal_notice[:explanation]
+    end
+
+    test 'presents the withdrawn notification time' do
+      expected_time = expected["withdrawn_notice"]["withdrawn_at"]
+      expected_date_as_string = I18n.l(
+        Date.parse(expected_time),
+        format: "%-d %B %Y"
+      )
+      expected_withdrawn_time_html = "<time datetime=\"#{expected_time}\">#{expected_date_as_string}</time>"
+
+      assert_equal expected_withdrawn_time_html, presented.withdrawal_notice[:time]
     end
   end
 end


### PR DESCRIPTION
Add support for rendering Statistical Data Sets

[Trello](https://trello.com/c/3OZ36DPk)

Paired with @fofr and @tvararu 

Related pull request in [govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas/pull/440)

## Example with inline attachments

### Before 
<img width="1001" alt="statistical-data-set-before" src="https://cloud.githubusercontent.com/assets/647311/20566514/49a54162-b18d-11e6-93a0-0e865265cdc9.png">

### After
![statistical-data-set-after](https://cloud.githubusercontent.com/assets/647311/20566533/525ce8f0-b18d-11e6-991d-b6642e158895.png)

## Example with block attachment
An example with block attachments has also been created - screenshots below show the block attached element:

### Before
<img width="977" alt="before_block_attachment" src="https://cloud.githubusercontent.com/assets/647311/20670005/dce15094-b56e-11e6-83ce-5651032726ad.png">

### After
<img width="975" alt="afetr_block_attachment" src="https://cloud.githubusercontent.com/assets/647311/20670023/ebb38a88-b56e-11e6-93da-02157d8003db.png">


