### PR TITLE
Render the consultation format

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,3 +35,4 @@
 @import "views/document-collection";
 @import "views/fatality-notice";
 @import "views/statistical-data-set";
+@import "views/consultation";

--- a/app/assets/stylesheets/helpers/_notice.scss
+++ b/app/assets/stylesheets/helpers/_notice.scss
@@ -11,6 +11,10 @@
   h2 {
     @include bold-36;
     margin-bottom: $gutter-one-third;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 
   p {

--- a/app/assets/stylesheets/views/_consultation.scss
+++ b/app/assets/stylesheets/views/_consultation.scss
@@ -1,3 +1,67 @@
 .consultation {
+  @include sidebar-with-body;
+  @include history-notice;
+  @include withdrawal-notice;
 
+  .section-title {
+    @include bold-27;
+    margin-top: $gutter;
+    margin-bottom: $gutter-half;
+
+    @include media(tablet) {
+      margin-top: 0;
+      margin-bottom: $gutter;
+    }
+  }
+
+  .consultation-notice {
+    @include notice;
+  }
+
+  .consultation-banner {
+    @include responsive-bottom-margin;
+    @include core-19;
+    @include white-links;
+    background-color: $govuk-blue;
+    color: $white;
+    padding: $gutter-half;
+
+    @include media(tablet) {
+      padding: $gutter;
+    }
+
+    h2 {
+      @include bold-27;
+      margin-bottom: $gutter-one-third;
+    }
+
+    .consultation-dates {
+      @include media(tablet) {
+        padding-right: $gutter;
+      }
+    }
+
+    .consultation-summary {
+      margin-top: $gutter-half;
+
+      @include media(tablet) {
+        margin-top: 0;
+        margin-left: -$gutter-one-third;
+        padding-right: 0;
+        border-left: 1px solid $white;
+      }
+    }
+
+    .consultation-date {
+      @include core-24;
+    }
+  }
+
+  .original-consultation {
+    border-top: 1px solid $border-colour;
+
+    @include media(tablet) {
+      padding-top: $gutter;
+    }
+  }
 }

--- a/app/assets/stylesheets/views/_consultation.scss
+++ b/app/assets/stylesheets/views/_consultation.scss
@@ -1,0 +1,3 @@
+.consultation {
+
+}

--- a/app/assets/stylesheets/views/_publication.scss
+++ b/app/assets/stylesheets/views/_publication.scss
@@ -7,5 +7,12 @@
 
   .section-title {
     @include bold-27;
+    margin-top: $gutter;
+    margin-bottom: $gutter-half;
+
+    @include media(tablet) {
+      margin-top: 0;
+      margin-bottom: $gutter;
+    }
   }
 }

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -89,6 +89,30 @@ class ConsultationPresenter < ContentItemPresenter
     documents_list.join('')
   end
 
+  def ways_to_respond?
+    open? && ways_to_respond && (respond_online_url || email || postal_address)
+  end
+
+  def email
+    ways_to_respond["email"]
+  end
+
+  def postal_address
+    ways_to_respond["postal_address"]
+  end
+
+  def respond_online_url
+    ways_to_respond["link_url"]
+  end
+
+  def response_form?
+    attachment_url && (email || postal_address)
+  end
+
+  def attachment_url
+    ways_to_respond["attachment_url"]
+  end
+
 private
 
   def display_date_and_time(date, rollback_midnight = false)
@@ -103,6 +127,10 @@ private
       time = time - 1.second if time.strftime(time_format) == "12:00am"
     end
     I18n.l(time, format: "#{time_format} on #{date_format}").gsub(':00', '').gsub('12pm', 'midday').gsub('12am on ', '').strip
+  end
+
+  def ways_to_respond
+    content_item["details"]["ways_to_respond"]
   end
 
   def final_outcome_documents_list

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -21,8 +21,12 @@ class ConsultationPresenter < ContentItemPresenter
     display_date_and_time(opening_date_time)
   end
 
+  def opening_date_midnight?
+    Time.parse(opening_date_time).strftime("%l:%M%P") == "12:00am"
+  end
+
   def closing_date
-    display_date_and_time(closing_date_time)
+    display_date_and_time(closing_date_time, true)
   end
 
   def open?
@@ -87,16 +91,18 @@ class ConsultationPresenter < ContentItemPresenter
 
 private
 
-  def display_date_and_time(date)
+  def display_date_and_time(date, rollback_midnight = false)
     time = Time.parse(date)
     date_format = "%-e %B %Y"
     time_format = "%l:%M%P"
 
-    # 12am, 12:00am and "midnight on" can all be misinterpreted
-    # Use 11:59pm on the day before to remove ambiguity
-    # 12am on 10 January becomes 11:59pm on 9 January
-    time = time - 1.second if time.strftime(time_format) == "12:00am"
-    I18n.l(time, format: "#{time_format} on #{date_format}").gsub(':00', '').gsub('12pm', 'midday').strip
+    if rollback_midnight
+      # 12am, 12:00am and "midnight on" can all be misinterpreted
+      # Use 11:59pm on the day before to remove ambiguity
+      # 12am on 10 January becomes 11:59pm on 9 January
+      time = time - 1.second if time.strftime(time_format) == "12:00am"
+    end
+    I18n.l(time, format: "#{time_format} on #{date_format}").gsub(':00', '').gsub('12pm', 'midday').gsub('12am on ', '').strip
   end
 
   def final_outcome_documents_list

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -49,6 +49,26 @@ class ConsultationPresenter < ContentItemPresenter
     content_item["details"]["final_outcome_detail"]
   end
 
+  def final_outcome_documents?
+    final_outcome_documents_list.any?
+  end
+
+  def final_outcome_documents
+    final_outcome_documents_list.join('')
+  end
+
+  def public_feedback_documents?
+    public_feedback_documents_list.any?
+  end
+
+  def public_feedback_documents
+    public_feedback_documents_list.join('')
+  end
+
+  def public_feedback_detail
+    content_item["details"]["public_feedback_detail"]
+  end
+
   def held_on_another_website?
     content_item["details"].include?("held_on_another_website_url")
   end
@@ -63,14 +83,6 @@ class ConsultationPresenter < ContentItemPresenter
 
   def documents
     documents_list.join('')
-  end
-
-  def final_outcome_documents?
-    final_outcome_documents_list.any?
-  end
-
-  def final_outcome_documents
-    final_outcome_documents_list.join('')
   end
 
 private
@@ -89,6 +101,10 @@ private
 
   def final_outcome_documents_list
     content_item["details"]["final_outcome_documents"] || []
+  end
+
+  def public_feedback_documents_list
+    content_item["details"]["public_feedback_documents"] || []
   end
 
   def documents_list

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -1,2 +1,84 @@
 class ConsultationPresenter < ContentItemPresenter
+  include Linkable
+  include Updatable
+  include Political
+  include Withdrawable
+
+  def body
+    content_item["details"]["body"]
+  end
+
+  def opening_date_time
+    content_item["details"]["opening_date"]
+  end
+
+  def closing_date_time
+    content_item["details"]["closing_date"]
+  end
+
+  def opening_date
+    display_time(opening_date_time)
+  end
+
+  def closing_date
+    display_time(closing_date_time)
+  end
+
+  def open?
+    document_type == "open_consultation"
+  end
+
+  def closed?
+    %w(closed_consultation consultation_outcome).include? document_type
+  end
+
+  def unopened?
+    !open? && !closed?
+  end
+
+  def pending_final_outcome?
+    closed? && !final_outcome?
+  end
+
+  def final_outcome?
+    document_type == "consultation_outcome"
+  end
+
+  def final_outcome_detail
+    content_item["details"]["final_outcome_detail"]
+  end
+
+  def held_on_another_website?
+    content_item["details"].include?("held_on_another_website_url")
+  end
+
+  def held_on_another_website_url
+    content_item["details"]["held_on_another_website_url"]
+  end
+
+  def documents?
+    documents_list.any?
+  end
+
+  def documents
+    documents_list.join('')
+  end
+
+  def final_outcome_documents?
+    final_outcome_documents_list.any?
+  end
+
+  def final_outcome_documents
+    final_outcome_documents_list.join('')
+  end
+
+private
+
+  def final_outcome_documents_list
+    content_item["details"]["final_outcome_documents"] || []
+  end
+
+  def documents_list
+    content_item["details"]["documents"] || []
+  end
 end

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -1,6 +1,7 @@
 class ConsultationPresenter < ContentItemPresenter
   include Linkable
   include Updatable
+  include NationalApplicability
   include Political
   include Withdrawable
 

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -17,11 +17,11 @@ class ConsultationPresenter < ContentItemPresenter
   end
 
   def opening_date
-    display_time(opening_date_time)
+    display_date_and_time(opening_date_time)
   end
 
   def closing_date
-    display_time(closing_date_time)
+    display_date_and_time(closing_date_time)
   end
 
   def open?
@@ -73,6 +73,18 @@ class ConsultationPresenter < ContentItemPresenter
   end
 
 private
+
+  def display_date_and_time(date)
+    time = Time.parse(date)
+    date_format = "%-e %B %Y"
+    time_format = "%l:%M%P"
+
+    # 12am, 12:00am and "midnight on" can all be misinterpreted
+    # Use 11:59pm on the day before to remove ambiguity
+    # 12am on 10 January becomes 11:59pm on 9 January
+    time = time - 1.second if time.strftime(time_format) == "12:00am"
+    I18n.l(time, format: "#{time_format} on #{date_format}").gsub(':00', '').gsub('12pm', 'midday').strip
+  end
 
   def final_outcome_documents_list
     content_item["details"]["final_outcome_documents"] || []

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -1,0 +1,2 @@
+class ConsultationPresenter < ContentItemPresenter
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -33,8 +33,12 @@ class ContentItemPresenter
 
 private
 
-  def display_date(timestamp)
-    I18n.l(Date.parse(timestamp), format: "%-d %B %Y") if timestamp
+  def display_date(timestamp, format = "%-d %B %Y")
+    I18n.l(Time.parse(timestamp), format: format) if timestamp
+  end
+
+  def display_time(timestamp)
+    display_date(timestamp, "%-d %B %Y %-I:%M%P")
   end
 
   def sorted_locales(translations)

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -33,7 +33,7 @@ class ContentItemPresenter
 
 private
 
-  def display_time(timestamp)
+  def display_date(timestamp)
     I18n.l(Date.parse(timestamp), format: "%-d %B %Y") if timestamp
   end
 

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -37,10 +37,6 @@ private
     I18n.l(Time.parse(timestamp), format: format) if timestamp
   end
 
-  def display_time(timestamp)
-    display_date(timestamp, "%-d %B %Y %-I:%M%P")
-  end
-
   def sorted_locales(translations)
     translations.sort_by { |t| t["locale"] == I18n.default_locale.to_s ? '' : t["locale"] }
   end

--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -12,7 +12,7 @@ class HtmlPublicationPresenter < ContentItemPresenter
   end
 
   def last_changed
-    timestamp = display_time(content_item["details"]["public_timestamp"])
+    timestamp = display_date(content_item["details"]["public_timestamp"])
 
     # This assumes that a translation doesn't need the date to come beforehand.
     if content_item["details"]["first_published_version"]

--- a/app/presenters/updatable.rb
+++ b/app/presenters/updatable.rb
@@ -1,10 +1,10 @@
 module Updatable
   def published
-    display_time(content_item["details"]["first_public_at"])
+    display_date(content_item["details"]["first_public_at"])
   end
 
   def updated
-    display_time(content_item["public_updated_at"]) if any_updates?
+    display_date(content_item["public_updated_at"]) if any_updates?
   end
 
   def short_history
@@ -19,7 +19,7 @@ module Updatable
     return [] unless any_updates?
     content_item["details"]["change_history"].map do |item|
       {
-        display_time: display_time(item["public_timestamp"]),
+        display_time: display_date(item["public_timestamp"]),
         note: item["note"],
         timestamp: item["public_timestamp"]
       }

--- a/app/presenters/withdrawable.rb
+++ b/app/presenters/withdrawable.rb
@@ -11,7 +11,7 @@ module Withdrawable
     notice = content_item["withdrawn_notice"]
     if notice
       {
-        time: content_tag(:time, display_time(notice["withdrawn_at"]), datetime: notice["withdrawn_at"]),
+        time: content_tag(:time, display_date(notice["withdrawn_at"]), datetime: notice["withdrawn_at"]),
         explanation: notice["explanation"]
       }
     end

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -28,16 +28,20 @@
 </div>
 <%= render 'shared/history_notice', content_item: @content_item %>
 
-<% if @content_item.pending_final_outcome? %>
-<div class="consultation-notice">
-  <h2>
-    We are analysing your feedback
-  </h2>
-  <p>Visit this page again soon to download the outcome to this public&nbsp;feedback.</p>
-</div>
-<% end %>
-
-<% if @content_item.final_outcome? %>
+<% if @content_item.unopened? %>
+  <div class="consultation-notice">
+    <h2>
+      This consultation opens at <time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time>
+    </h2>
+  </div>
+<% elsif @content_item.pending_final_outcome? %>
+  <div class="consultation-notice">
+    <h2>
+      We are analysing your feedback
+    </h2>
+    <p>Visit this page again soon to download the outcome to this public&nbsp;feedback.</p>
+  </div>
+<% elsif @content_item.final_outcome? %>
   <div class="consultation-notice">
     <h2>
       This consultation has concluded
@@ -71,9 +75,7 @@
           direction: page_text_direction %>
     </div>
   </div>
-<% end %>
 
-<% if @content_item.final_outcome? %>
   <section class="original-consultation">
     <h2 class="section-title">Original consultation</h2>
 <% end %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -1,0 +1,12 @@
+<%= content_for :page_class, @content_item.format.dasherize %>
+<%= content_for :title, @content_item.title %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+        context: t("content_item.format.#{@content_item.document_type}", count: 1),
+        title: @content_item.title %>
+  </div>
+</div>
+
+<%= render 'shared/description', description: @content_item.description %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -109,7 +109,9 @@
 
 <% if @content_item.final_outcome? %>
   <section class="original-consultation">
-    <h2 class="section-title">Original consultation</h2>
+    <header>
+      <h2 class="section-title">Original consultation</h2>
+    </header>
 <% end %>
 
 <div class="consultation-banner">

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -5,8 +5,144 @@
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
         context: t("content_item.format.#{@content_item.document_type}", count: 1),
-        title: @content_item.title %>
+        title: @content_item.title,
+        average_title_length: 'long' %>
   </div>
 </div>
 
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'shared/withdrawal_notice', content_item: @content_item %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/metadata',
+        from: @content_item.from,
+        part_of: @content_item.part_of,
+        first_published: @content_item.published,
+        last_updated: @content_item.updated,
+        see_updates_link: true
+    %>
+  </div>
+</div>
+<%= render 'shared/history_notice', content_item: @content_item %>
+
+<% if @content_item.pending_final_outcome? %>
+<div class="consultation-notice">
+  <h2>
+    We are analysing your feedback
+  </h2>
+  <p>Visit this page again soon to download the outcome to this public&nbsp;feedback.</p>
+</div>
+<% end %>
+
+<% if @content_item.final_outcome? %>
+  <div class="consultation-notice">
+    <h2>
+      This consultation has concluded
+    </h2>
+  </div>
+
+  <% if @content_item.final_outcome_documents? %>
+    <div class="grid-row sidebar-with-body">
+      <div class="column-third">
+        <h1 class="section-title" id="final-outcome-documents-title">
+          Download the full outcome
+        </h1>
+      </div>
+      <div class="column-two-thirds" aria-labelledby="final-outcome-documents-title">
+        <%= render 'govuk_component/govspeak',
+            content: @content_item.final_outcome_documents,
+            direction: page_text_direction %>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="grid-row sidebar-with-body">
+    <div class="column-third">
+      <h1 class="section-title" id="final-outcome-detail-title">
+        <%= t("consultation.final_outcome_detail") %>
+      </h1>
+    </div>
+    <div class="column-two-thirds" aria-labelledby="final-outcome-detail-title">
+      <%= render 'govuk_component/govspeak',
+          content: @content_item.final_outcome_detail,
+          direction: page_text_direction %>
+    </div>
+  </div>
+<% end %>
+
+<% if @content_item.final_outcome? %>
+  <section class="original-consultation">
+    <h2 class="section-title">Original consultation</h2>
+<% end %>
+
+<div class="consultation-banner">
+  <div class="grid-row">
+    <div class="column-third consultation-dates">
+      <% if @content_item.closed? %>
+        <p>
+          This consultation ran from<br /><span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time> to
+          <time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
+        </p>
+      <% elsif @content_item.open? %>
+        <p>
+          This consultation closes at<br />
+          <span class="consultation-date"><time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
+        </p>
+      <% elsif @content_item.unopened? %>
+        <p>
+          This consultation opens at<br />
+          <span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time></span>
+        </p>
+      <% end %>
+    </div>
+    <div class="column-two-thirds consultation-summary">
+      <h2>Summary</h2>
+      <%= render 'shared/description', description: @content_item.description %>
+
+      <% if @content_item.held_on_another_website? %>
+        <p><strong>This consultation <% if @content_item.closed? %>was<% else %>is being<% end %> held on <a href="<%= @content_item.held_on_another_website_url %>">another website</a>.</strong></p>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<% if @content_item.final_outcome? %>
+  </section>
+<% end %>
+
+<% if @content_item.documents? %>
+  <div class="grid-row sidebar-with-body">
+    <div class="column-third">
+      <h1 class="section-title" id="documents-title">
+        Documents
+      </h1>
+    </div>
+    <div class="column-two-thirds" aria-labelledby="documents-title">
+      <%= render 'govuk_component/govspeak',
+          content: @content_item.documents,
+          direction: page_text_direction %>
+    </div>
+  </div>
+<% end %>
+
+<div class="grid-row sidebar-with-body">
+  <div class="column-third">
+    <h1 class="section-title" id="description-title">
+      <%= t("consultation.description") %>
+    </h1>
+  </div>
+  <div class="column-two-thirds" aria-labelledby="description-title">
+    <%= render 'govuk_component/govspeak',
+        content: @content_item.body,
+        direction: page_text_direction %>
+  </div>
+</div>
+
+<%= render 'govuk_component/document_footer',
+    from: @content_item.from,
+    updated: @content_item.updated,
+    history: @content_item.history,
+    published: @content_item.published,
+    part_of: @content_item.part_of,
+    direction: page_text_direction
+%>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -19,6 +19,9 @@
         part_of: @content_item.part_of,
         first_published: @content_item.published,
         last_updated: @content_item.updated,
+        other: {
+          'Applies to' => @content_item.applies_to
+        },
         see_updates_link: true
     %>
   </div>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -31,7 +31,7 @@
 <% if @content_item.unopened? %>
   <div class="consultation-notice">
     <h2>
-      This consultation opens at <time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time>
+      This consultation opens <% if @content_item.opening_date_midnight? %>on<% else %>at<% end %> <time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time>
     </h2>
   </div>
 <% elsif @content_item.pending_final_outcome? %>
@@ -127,7 +127,7 @@
         </p>
       <% elsif @content_item.unopened? %>
         <p>
-          This consultation opens at<br />
+          This consultation opens <% if @content_item.opening_date_midnight? %>on<% else %>at<% end %><br />
           <span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time></span>
         </p>
       <% end %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -115,22 +115,18 @@
 <div class="consultation-banner">
   <div class="grid-row">
     <div class="column-third consultation-dates">
-      <% if @content_item.closed? %>
-        <p>
+      <p>
+        <% if @content_item.closed? %>
           This consultation ran from<br /><span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time> to
           <time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
-        </p>
-      <% elsif @content_item.open? %>
-        <p>
+        <% elsif @content_item.open? %>
           This consultation closes at<br />
           <span class="consultation-date"><time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
-        </p>
-      <% elsif @content_item.unopened? %>
-        <p>
+        <% elsif @content_item.unopened? %>
           This consultation opens <% if @content_item.opening_date_midnight? %>on<% else %>at<% end %><br />
           <span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time></span>
-        </p>
-      <% end %>
+        <% end %>
+      </p>
     </div>
     <div class="column-two-thirds consultation-summary">
       <h2>Summary</h2>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -66,7 +66,7 @@
   <div class="grid-row sidebar-with-body">
     <div class="column-third">
       <h1 class="section-title" id="final-outcome-detail-title">
-        <%= t("consultation.final_outcome_detail") %>
+        Detail of outcome
       </h1>
     </div>
     <div class="column-two-thirds" aria-labelledby="final-outcome-detail-title">
@@ -81,7 +81,7 @@
   <div class="grid-row sidebar-with-body">
     <div class="column-third">
       <h1 class="section-title" id="public-feedback-documents-title">
-        <%= t("consultation.feedback_received") %>
+        Feedback received
       </h1>
     </div>
     <div class="column-two-thirds" aria-labelledby="public-feedback-documents-title">
@@ -96,7 +96,7 @@
   <div class="grid-row sidebar-with-body">
     <div class="column-third">
       <h1 class="section-title" id="public-feedback-detail-title">
-        <%= t("consultation.public_feedback_detail") %>
+        Detail of feedback received
       </h1>
     </div>
     <div class="column-two-thirds" aria-labelledby="public-feedback-detail-title">
@@ -161,7 +161,7 @@
 <div class="grid-row sidebar-with-body">
   <div class="column-third">
     <h1 class="section-title" id="description-title">
-      <%= t("consultation.description") %>
+      Consultation description
     </h1>
   </div>
   <div class="column-two-thirds" aria-labelledby="description-title">
@@ -175,7 +175,7 @@
   <div class="grid-row sidebar-with-body">
     <div class="column-third">
       <h1 class="section-title" id="ways-to-respond-title">
-        <%= t("consultation.ways_to_respond") %>
+        Ways to respond
       </h1>
     </div>
     <div class="column-two-thirds" aria-labelledby="ways-to-respond-title">

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -175,6 +175,53 @@
   </div>
 </div>
 
+<% if @content_item.ways_to_respond? %>
+  <div class="grid-row sidebar-with-body">
+    <div class="column-third">
+      <h1 class="section-title" id="ways-to-respond-title">
+        <%= t("consultation.ways_to_respond") %>
+      </h1>
+    </div>
+    <div class="column-two-thirds" aria-labelledby="ways-to-respond-title">
+      <% @ways_to_respond_body = capture do %>
+        <% if @content_item.respond_online_url %>
+          <div class="call-to-action">
+            <p><%= link_to 'Respond online', @content_item.respond_online_url %></p>
+          </div>
+
+          <% if @content_item.email || @content_item.postal_address %>
+            <p>or</p>
+          <% end %>
+        <% end %>
+
+        <% if @content_item.response_form? %>
+          <p>
+            Complete a <%= link_to 'response form', @content_item.attachment_url %> and
+            <% if @content_item.email && @content_item.postal_address %>either<% end %>
+          </p>
+        <% end %>
+
+        <% if @content_item.email %>
+          <h3>Email to:</h3>
+          <p><%= mail_to @content_item.email, @content_item.email %></p>
+        <% end %>
+
+        <% if @content_item.postal_address %>
+          <h3>Write to:</h3>
+          <div class="contact">
+            <div class="content">
+              <%= simple_format(@content_item.postal_address) %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+      <%= render 'govuk_component/govspeak',
+          content: @ways_to_respond_body,
+          direction: page_text_direction %>
+    </div>
+  </div>
+<% end %>
+
 <%= render 'govuk_component/document_footer',
     from: @content_item.from,
     updated: @content_item.updated,

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -75,7 +75,39 @@
           direction: page_text_direction %>
     </div>
   </div>
+<% end %>
 
+<% if @content_item.public_feedback_documents? %>
+  <div class="grid-row sidebar-with-body">
+    <div class="column-third">
+      <h1 class="section-title" id="public-feedback-documents-title">
+        <%= t("consultation.feedback_received") %>
+      </h1>
+    </div>
+    <div class="column-two-thirds" aria-labelledby="public-feedback-documents-title">
+      <%= render 'govuk_component/govspeak',
+          content: @content_item.public_feedback_documents,
+          direction: page_text_direction %>
+    </div>
+  </div>
+<% end %>
+
+<% if @content_item.public_feedback_detail %>
+  <div class="grid-row sidebar-with-body">
+    <div class="column-third">
+      <h1 class="section-title" id="public-feedback-detail-title">
+        <%= t("consultation.public_feedback_detail") %>
+      </h1>
+    </div>
+    <div class="column-two-thirds" aria-labelledby="public-feedback-detail-title">
+      <%= render 'govuk_component/govspeak',
+          content: @content_item.public_feedback_detail,
+          direction: page_text_direction %>
+    </div>
+  </div>
+<% end %>
+
+<% if @content_item.final_outcome? %>
   <section class="original-consultation">
     <h2 class="section-title">Original consultation</h2>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,3 +245,6 @@ en:
       one: Document
       other: Documents
     details: Details
+  consultation:
+    description: Consultation description
+    final_outcome_detail: Detail of outcome

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,3 +250,4 @@ en:
     final_outcome_detail: Detail of outcome
     feedback_received: Feedback received
     public_feedback_detail: Detail of feedback received
+    ways_to_respond: Ways to respond

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,9 +245,3 @@ en:
       one: Document
       other: Documents
     details: Details
-  consultation:
-    description: Consultation description
-    final_outcome_detail: Detail of outcome
-    feedback_received: Feedback received
-    public_feedback_detail: Detail of feedback received
-    ways_to_respond: Ways to respond

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,3 +248,5 @@ en:
   consultation:
     description: Consultation description
     final_outcome_detail: Detail of outcome
+    feedback_received: Feedback received
+    public_feedback_detail: Detail of feedback received

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class ConsultationTest < ActionDispatch::IntegrationTest
+end

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -75,11 +75,29 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "public feedback" do
+    setup_and_visit_content_item('consultation_outcome_with_feedback')
+
+    assert page.has_text?("Detail of feedback received")
+    within '[aria-labelledby="public-feedback-detail-title"]' do
+      assert_has_component_govspeak(@content_item["details"]["public_feedback_detail"])
+    end
+  end
+
   test "consultation outcome documents render" do
     setup_and_visit_content_item('consultation_outcome')
 
     within '[aria-labelledby="final-outcome-documents-title"]' do
       assert_has_component_govspeak(@content_item["details"]["final_outcome_documents"].join(''))
+    end
+  end
+
+  test "public feedback documents render" do
+    setup_and_visit_content_item('consultation_outcome_with_feedback')
+
+    assert page.has_text?("Feedback received")
+    within '[aria-labelledby="public-feedback-documents-title"]' do
+      assert_has_component_govspeak(@content_item["details"]["public_feedback_documents"].join(''))
     end
   end
 

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -106,4 +106,32 @@ class ConsultationTest < ActionDispatch::IntegrationTest
 
     assert_has_component_metadata_pair('Applies to', 'England')
   end
+
+  test "ways to respond renders" do
+    setup_and_visit_content_item('open_consultation_with_participation')
+
+    within '[aria-labelledby="ways-to-respond-title"]' do
+      within_component_govspeak do |component_args|
+        content = component_args.fetch("content")
+        html = Nokogiri::HTML.parse(content)
+        assert html.at_css(".call-to-action a[href='https://beisgovuk.citizenspace.com/ukgi/post-office-network-consultation']", text: 'Respond online')
+        assert html.at_css("a[href='mailto:po.consultation@ukgi.gov.uk']", text: 'po.consultation@ukgi.gov.uk')
+        assert html.at_css(".contact", text: '2016 Post Office Network Consultation')
+        assert html.at_css("a[href='https://www.gov.uk/government/uploads/system/uploads/consultation_response_form_data/file/533/beis-16-36rf-post-office-network-consultation-response-form.docx']", text: 'response form')
+      end
+    end
+  end
+
+  test "ways to respond postal address is formatted with line breaks" do
+    setup_and_visit_content_item('open_consultation_with_participation')
+
+    within '[aria-labelledby="ways-to-respond-title"]' do
+      within_component_govspeak do |component_args|
+        content = component_args.fetch("content")
+        html = Nokogiri::HTML.parse(content)
+        assert html.at_css(".contact .content p", text: '2016 Post Office Network Consultation')
+        assert html.at_css(".contact .content p br")
+      end
+    end
+  end
 end

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -44,6 +44,13 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     assert page.has_text?("closes at 4pm on 16 December 2216")
   end
 
+  test "unopened consultation" do
+    setup_and_visit_content_item('unopened_consultation')
+
+    assert page.has_text?("Consultation")
+    assert page.has_css?('.consultation-notice', text: "This consultation opens at 2pm on 5 October 2200")
+  end
+
   test "closed consultation pending outcome" do
     setup_and_visit_content_item('closed_consultation')
 

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -1,4 +1,78 @@
 require 'test_helper'
 
 class ConsultationTest < ActionDispatch::IntegrationTest
+  test "consultation" do
+    setup_and_visit_content_item('open_consultation')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+
+    assert_has_component_metadata_pair("first_published", "4 November 2016")
+    assert_has_component_metadata_pair("last_updated", "7 November 2016")
+
+    link1 = "<a href=\"/topic/higher-education/administration\">Higher education administration</a>"
+    link2 = "<a href=\"/government/organisations/department-for-education\">Department for Education</a>"
+
+    assert_has_component_metadata_pair("part_of", [link1])
+    assert_has_component_document_footer_pair("part_of", [link1])
+    assert_has_component_metadata_pair("from", [link2])
+    assert_has_component_document_footer_pair("from", [link2])
+
+    within '[aria-labelledby="description-title"]' do
+      assert_has_component_govspeak(@content_item["details"]["body"])
+    end
+  end
+
+  test "consultation documents render" do
+    setup_and_visit_content_item('closed_consultation')
+
+    within '[aria-labelledby="documents-title"]' do
+      assert_has_component_govspeak(@content_item["details"]["documents"].join(''))
+    end
+  end
+
+  test "link to external consultations" do
+    setup_and_visit_content_item('open_consultation')
+
+    assert page.has_css?("a[href=\"#{@content_item['details']['held_on_another_website_url']}\"]", text: "another website")
+  end
+
+  test "open consultation" do
+    setup_and_visit_content_item('open_consultation')
+
+    assert page.has_text?("Open consultation")
+    assert page.has_text?("closes at 16 December 2216 4:00pm")
+  end
+
+  test "closed consultation pending outcome" do
+    setup_and_visit_content_item('closed_consultation')
+
+    assert page.has_text?("Closed consultation")
+    assert page.has_css?('.consultation-notice', text: "We are analysing your feedback")
+
+    assert page.has_text?("ran from")
+    assert page.has_text?("5 September 2016 2:00pm to 31 October 2016 5:00pm")
+  end
+
+  test "consultation outcome" do
+    setup_and_visit_content_item('consultation_outcome')
+
+    assert page.has_text?("Consultation outcome")
+    assert page.has_css?('.consultation-notice', text: "This consultation has concluded")
+    assert page.has_css?('h2', text: "Original consultation")
+    assert page.has_text?("ran from")
+    assert page.has_text?("20 April 2016 4:00pm to 13 July 2016 10:45pm")
+
+    within '[aria-labelledby="final-outcome-detail-title"]' do
+      assert_has_component_govspeak(@content_item["details"]["final_outcome_detail"])
+    end
+  end
+
+  test "consultation outcome documents render" do
+    setup_and_visit_content_item('consultation_outcome')
+
+    within '[aria-labelledby="final-outcome-documents-title"]' do
+      assert_has_component_govspeak(@content_item["details"]["final_outcome_documents"].join(''))
+    end
+  end
 end

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -75,4 +75,10 @@ class ConsultationTest < ActionDispatch::IntegrationTest
       assert_has_component_govspeak(@content_item["details"]["final_outcome_documents"].join(''))
     end
   end
+
+  test "consultation that only applies to a set of nations" do
+    setup_and_visit_content_item('consultation_outcome_with_feedback')
+
+    assert_has_component_metadata_pair('Applies to', 'England')
+  end
 end

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -41,7 +41,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('open_consultation')
 
     assert page.has_text?("Open consultation")
-    assert page.has_text?("closes at 16 December 2216 4:00pm")
+    assert page.has_text?("closes at 4pm on 16 December 2216")
   end
 
   test "closed consultation pending outcome" do
@@ -51,7 +51,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     assert page.has_css?('.consultation-notice', text: "We are analysing your feedback")
 
     assert page.has_text?("ran from")
-    assert page.has_text?("5 September 2016 2:00pm to 31 October 2016 5:00pm")
+    assert page.has_text?("2pm on 5 September 2016 to 5pm on 31 October 2016")
   end
 
   test "consultation outcome" do
@@ -61,7 +61,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     assert page.has_css?('.consultation-notice', text: "This consultation has concluded")
     assert page.has_css?('h2', text: "Original consultation")
     assert page.has_text?("ran from")
-    assert page.has_text?("20 April 2016 4:00pm to 13 July 2016 10:45pm")
+    assert page.has_text?("4pm on 20 April 2016 to 10:45pm on 13 July 2016")
 
     within '[aria-labelledby="final-outcome-detail-title"]' do
       assert_has_component_govspeak(@content_item["details"]["final_outcome_detail"])

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -96,5 +96,48 @@ class ConsultationPresenterTest
       assert example['details'].include?('national_applicability')
       assert_equal presented.applies_to, 'England'
     end
+
+    test 'presents ways to respond' do
+      example_ways_to_respond = schema_item('open_consultation_with_participation')['details']['ways_to_respond']
+      presented = presented_item('open_consultation_with_participation')
+
+      assert presented.ways_to_respond?
+      assert_equal example_ways_to_respond['email'], presented.email
+      assert_equal example_ways_to_respond['link_url'], presented.respond_online_url
+      assert_equal example_ways_to_respond['postal_address'], presented.postal_address
+    end
+
+    test 'presents a response form when included with email or postal address' do
+      example_ways_to_respond = schema_item('open_consultation_with_participation')['details']['ways_to_respond']
+      presented = presented_item('open_consultation_with_participation')
+
+      assert presented.response_form?
+      assert_equal example_ways_to_respond['attachment_url'], presented.attachment_url
+
+      example_without_email = schema_item("open_consultation_with_participation")
+      example_without_email['details']['ways_to_respond'].delete('email')
+      example_without_email['details']['ways_to_respond'].delete('postal_address')
+      presented_without_email = presented_item("open_consultation_with_participation", example_without_email)
+
+      refute presented_without_email.response_form?
+    end
+
+    test 'does not show ways to respond when consultation is closed' do
+      example = schema_item("closed_consultation")
+      example['details']['ways_to_respond'] = { 'email' => 'email@email.com' }
+      presented = presented_item("closed_consultation", example)
+
+      refute presented.ways_to_respond?
+    end
+
+    test 'does not show ways to respond when only an attachment url is provided' do
+      example = schema_item("open_consultation_with_participation")
+      example['details']['ways_to_respond'].delete('email')
+      example['details']['ways_to_respond'].delete('postal_address')
+      example['details']['ways_to_respond'].delete('link_url')
+      presented = presented_item("open_consultation_with_participation", example)
+
+      refute presented.ways_to_respond?
+    end
   end
 end

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -12,8 +12,26 @@ class ConsultationPresenterTest
     end
 
     test 'presents friendly dates for opening and closing dates, including time' do
-      assert_equal "4 November 2016 10:00am", presented_item("open_consultation").opening_date
-      assert_equal "16 December 2216 4:00pm", presented_item("open_consultation").closing_date
+      assert_equal "10am on 4 November 2016", presented_item("open_consultation").opening_date
+      assert_equal "4pm on 16 December 2216", presented_item("open_consultation").closing_date
+    end
+
+    test 'presents 12am as 11:59pm on the day before' do
+      schema = schema_item("open_consultation")
+      schema['details']['opening_date'] = "2016-11-04T00:00:00+01:00"
+      schema['details']['closing_date'] = "2016-11-04T00:01:00+01:00"
+      presented = presented_item("open_consultation", schema)
+
+      assert_equal "11:59pm on 3 November 2016", presented.opening_date
+      assert_equal "12:01am on 4 November 2016", presented.closing_date
+    end
+
+    test 'presents 12pm as midday' do
+      schema = schema_item("open_consultation")
+      schema['details']['opening_date'] = "2016-11-04T12:00:00+01:00"
+      presented = presented_item("open_consultation", schema)
+
+      assert_equal "midday on 4 November 2016", presented.opening_date
     end
 
     test 'presents open and closed states' do

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -3,11 +3,52 @@ require 'presenter_test_helper'
 class ConsultationPresenterTest
   class PresentedConsultation < PresenterTestCase
     def format_name
-      " consultation "
+      "consultation"
     end
 
     test 'presents the format' do
-      assert_equal schema_item['format'], presented_item.format
+      assert_equal schema_item("open_consultation")['document_type'], presented_item("open_consultation").document_type
+      assert_equal schema_item("open_consultation")['details']['body'], presented_item("open_consultation").body
+    end
+
+    test 'presents friendly dates for opening and closing dates, including time' do
+      assert_equal "4 November 2016 10:00am", presented_item("open_consultation").opening_date
+      assert_equal "16 December 2216 4:00pm", presented_item("open_consultation").closing_date
+    end
+
+    test 'presents open and closed states' do
+      assert presented_item("open_consultation").open?
+      refute presented_item("open_consultation").closed?
+
+      assert presented_item("closed_consultation").closed?
+      refute presented_item("closed_consultation").open?
+
+      assert presented_item("consultation_outcome").closed?
+      refute presented_item("consultation_outcome").open?
+    end
+
+    test 'presents consultation documents' do
+      presented = presented_item("closed_consultation")
+      schema = schema_item("closed_consultation")
+
+      assert presented.documents?
+      assert_equal schema['details']['documents'].join(''), presented.documents
+    end
+
+    test 'presents final outcome documents' do
+      presented = presented_item("consultation_outcome")
+      schema = schema_item("consultation_outcome")
+
+      assert presented.final_outcome_documents?
+      assert_equal schema['details']['final_outcome_documents'].join(''), presented.final_outcome_documents
+    end
+
+    test 'presents URL for consultations held on another website' do
+      assert presented_item("open_consultation").held_on_another_website?
+      refute presented_item("closed_consultation").held_on_another_website?
+
+      assert_equal "https://consult.education.gov.uk/part-time-maintenance-loans/post-graduate-doctoral-loans/", presented_item("open_consultation").held_on_another_website_url
+      refute presented_item("closed_consultation").held_on_another_website_url
     end
   end
 end

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -64,6 +64,14 @@ class ConsultationPresenterTest
       assert_equal schema['details']['final_outcome_documents'].join(''), presented.final_outcome_documents
     end
 
+    test 'presents public feedback documents' do
+      presented = presented_item("consultation_outcome_with_feedback")
+      schema = schema_item("consultation_outcome_with_feedback")
+
+      assert presented.public_feedback_documents?
+      assert_equal schema['details']['public_feedback_documents'].join(''), presented.public_feedback_documents
+    end
+
     test 'presents URL for consultations held on another website' do
       assert presented_item("open_consultation").held_on_another_website?
       refute presented_item("closed_consultation").held_on_another_website?

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -16,14 +16,23 @@ class ConsultationPresenterTest
       assert_equal "4pm on 16 December 2216", presented_item("open_consultation").closing_date
     end
 
-    test 'presents 12am as 11:59pm on the day before' do
+    test 'presents closing dates at 12am as 11:59pm on the day before' do
       schema = schema_item("open_consultation")
-      schema['details']['opening_date'] = "2016-11-04T00:00:00+01:00"
-      schema['details']['closing_date'] = "2016-11-04T00:01:00+01:00"
+      schema['details']['opening_date'] = "2016-11-03T00:01:00+01:00"
+      schema['details']['closing_date'] = "2016-11-04T00:00:00+01:00"
       presented = presented_item("open_consultation", schema)
 
-      assert_equal "11:59pm on 3 November 2016", presented.opening_date
-      assert_equal "12:01am on 4 November 2016", presented.closing_date
+      assert_equal "12:01am on 3 November 2016", presented.opening_date
+      assert_equal "11:59pm on 3 November 2016", presented.closing_date
+    end
+
+    test 'presents opening dates at 12am as the date without a time' do
+      schema = schema_item("open_consultation")
+      schema['details']['opening_date'] = "2016-11-03T00:00:00+01:00"
+      schema['details']['closing_date'] = "2016-11-04T00:00:00+01:00"
+      presented = presented_item("open_consultation", schema)
+
+      assert_equal "3 November 2016", presented.opening_date
     end
 
     test 'presents 12pm as midday' do

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -1,0 +1,13 @@
+require 'presenter_test_helper'
+
+class ConsultationPresenterTest
+  class PresentedConsultation < PresenterTestCase
+    def format_name
+      " consultation "
+    end
+
+    test 'presents the format' do
+      assert_equal schema_item['format'], presented_item.format
+    end
+  end
+end

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -68,5 +68,13 @@ class ConsultationPresenterTest
       assert_equal "https://consult.education.gov.uk/part-time-maintenance-loans/post-graduate-doctoral-loans/", presented_item("open_consultation").held_on_another_website_url
       refute presented_item("closed_consultation").held_on_another_website_url
     end
+
+    test 'content can apply only to a set of nations' do
+      example = schema_item('consultation_outcome_with_feedback')
+      presented = presented_item('consultation_outcome_with_feedback')
+
+      assert example['details'].include?('national_applicability')
+      assert_equal presented.applies_to, 'England'
+    end
   end
 end

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -43,6 +43,9 @@ class ConsultationPresenterTest
 
       assert presented_item("consultation_outcome").closed?
       refute presented_item("consultation_outcome").open?
+
+      refute presented_item("unopened_consultation").closed?
+      refute presented_item("unopened_consultation").open?
     end
 
     test 'presents consultation documents' do


### PR DESCRIPTION
Tests will fail until the corresponding schema changes have been merged and deployed: https://github.com/alphagov/govuk-content-schemas/pull/445

Main story:
https://trello.com/c/QseqtCaJ/509-consultations-migration-basic-content-schema-examples-and-front-end-work-large

Ports the following features from Whitehall:
* Display of consultation description (the body in content item)
* Display of consultation summary (the description in content item)
* Open and closing date and date ranges
  * Includes fix for showing an unopened consultation as "opening on" rather than already closed
  * Uses a legible date format, "10 June 2015 10:00am" is now "10am on 10 June 2015"
  * When the time is 12:00am, it shows midday
  * When the time is midnight it either hides the time for opening date or rolls back 1 minute for closing – this remove ambiguity
* A list of supporting documents using the same pattern as publications
* A ways to respond section
  * Only displays when open and when a respond online link, email or postal address have been provided. This matches existing logic. If an attachment is uploaded but no email or postal address are provided to return the completed copy it will not display. This is how it is in Whitehall but could be improved.
* An outcomes section
* An outcome documents section
* A public feedback section
* A public feedback documents section
* A notice displaying when a consultation is unopened, pending feedback, or closed with outcome
* National applicability, history mode, withdrawable
* Includes fix for publication titles at thin viewports, the same bug existed for consultations
* Renames `display_time` to `display_date` as the format provided does not include time
* Fixes display and presentation of unopened consultations: https://trello.com/c/GEyT6hzk/518-make-it-obvious-when-a-consultation-starts-small
* Consultation banner colour has been switched from purple to blue

## Ways to respond problems

Port of existing copy which isn’t great. Fixes the problem of "Respond online" looking like a heading, instead using the call to action pattern. Described here: https://trello.com/c/pEccXKHV/517-issue-with-ways-to-respond-section-in-consultations-medium

This highlights a problem with how we render content: this HTML is crafted from values provided by users, rather than govspeak – yet it is still content and must be rendered as content using the same styles. For now this means passing that HTML to the govspeak content for rendering.

An alternative would be some free text the user provides in markdown. This would make the format more flexible but less uniform.

## Headings structure

This has been ported from Whitehall, but has accessibility problems. We use `h1` for each section heading – this is the only way to guarantee that we provide a heading for dynamic content that appears in markdown – eg users could use `## level 2 headings`.

However, for a closed consultation we add an `original consultation` heading, which should wrap the whole of the original consultation. This is currently an h2. It could be an h1 but that would have the same problem. I think this should be looked at separately to this PR.

## Whitehall

If the migration of this format takes a while, which given its complexity I suspect it will, the fixes to this format should be back ported to Whitehall. ie readable date formats, blue box, correct handling of an unopened consultation.

## Omissions

* The share features have been split out into a new story: https://trello.com/c/MaZ7t0zi/753-add-share-buttons-to-consultations-on-government-frontend
* Specific testing for withdrawn state and history mode – some generic test helpers should be written to cover these scenarios without having to rely on examples

## Screenshots

| Feature | Old | New |
| --- | --- | --- |
| Open consultation | ![open_consultation_old](https://cloud.githubusercontent.com/assets/319055/20708913/290770b4-b62a-11e6-9b85-73906e272208.png) | ![open_consultation_new](https://cloud.githubusercontent.com/assets/319055/20708918/2910b4f8-b62a-11e6-983a-b828f20cf0c6.png)
| Closed consultation | ![closed_consultation_old](https://cloud.githubusercontent.com/assets/319055/20708917/290d9bec-b62a-11e6-8bcd-10301f5bb2d3.png) | ![closed_consultation_new](https://cloud.githubusercontent.com/assets/319055/20708914/2907e7c4-b62a-11e6-9fe7-611e0ed611ff.png)
| Unopened consultation | ![unopened_consultation_old](https://cloud.githubusercontent.com/assets/319055/20708921/2925b6f0-b62a-11e6-9363-edb3dee241ea.png) | ![unopened_consultation_new](https://cloud.githubusercontent.com/assets/319055/20708915/290c1c5e-b62a-11e6-864c-8ceddfa856df.png)
| Ways to respond | ![ways_to_respond_consultation_old](https://cloud.githubusercontent.com/assets/319055/20708916/290d7fae-b62a-11e6-8b0d-9a312c85442e.png) | ![ways_to_respond_consultation_new](https://cloud.githubusercontent.com/assets/319055/20708919/291effd6-b62a-11e6-9590-43e2c9d55354.png)
| Pending feedback | ![pending_feedback_consultation_old](https://cloud.githubusercontent.com/assets/319055/20708920/291f86c2-b62a-11e6-84b2-086af5dcef7e.png) | ![pending_feedback_consultation_new](https://cloud.githubusercontent.com/assets/319055/20708922/29274dbc-b62a-11e6-8d3b-6418897432b2.png)
| Mobile | ![consultation_mobile_old](https://cloud.githubusercontent.com/assets/319055/20709366/cecf8f84-b62c-11e6-88d5-d603191625ba.png) | ![consultation_mobile_new](https://cloud.githubusercontent.com/assets/319055/20709367/ced0a144-b62c-11e6-99d6-a4bf237d7913.png)