### PR TITLE
Use `schema_name` consistently

### DIFF
--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -9,7 +9,7 @@ class CaseStudyPresenterTest < PresenterTestCase
 
   test 'presents the basic details of a content item' do
     assert_equal schema_item['description'], presented_item.description
-    assert_equal schema_item['format'], presented_item.format
+    assert_equal schema_item['schema_name'], presented_item.format
     assert_equal schema_item['locale'], presented_item.locale
     assert_equal schema_item['title'], presented_item.title
     assert_equal schema_item['details']['body'], presented_item.body

--- a/test/presenters/coming_soon_presenter_test.rb
+++ b/test/presenters/coming_soon_presenter_test.rb
@@ -7,7 +7,7 @@ class ComingSoonPresenterTest < PresenterTestCase
 
   test 'presents the basic details required to display a coming soon item' do
     assert_equal schema_item['title'], presented_item.title
-    assert_equal schema_item['format'], presented_item.format
+    assert_equal schema_item['schema_name'], presented_item.format
     assert_equal schema_item['locale'], presented_item.locale
     assert_equal schema_item['details']['publish_time'], presented_item.publish_time
   end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -7,7 +7,7 @@ class DetailedGuidePresenterTest < PresenterTestCase
 
   test 'presents the basic details of a content item' do
     assert_equal schema_item['description'], presented_item.description
-    assert_equal schema_item['format'], presented_item.format
+    assert_equal schema_item['schema_name'], presented_item.format
     assert_equal schema_item['title'], presented_item.title
     assert_equal schema_item['details']['body'], presented_item.body
   end

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -17,7 +17,7 @@ class DocumentCollectionPresenterTest
     end
 
     test 'presents the format' do
-      assert_equal schema_item['format'], presented_item.format
+      assert_equal schema_item['schema_name'], presented_item.format
     end
 
     test 'presents the body' do

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -6,7 +6,7 @@ class HtmlPublicationPresenterTest < PresenterTestCase
   end
 
   test 'presents the basic details of a content item' do
-    assert_equal schema_item("published")['format'], presented_item("published").format
+    assert_equal schema_item("published")['schema_name'], presented_item("published").format
     assert_equal schema_item("published")['links']['parent'][0]['document_type'], presented_item("published").format_sub_type
     assert_equal schema_item("published")['title'], presented_item("published").title
     assert_equal schema_item("published")['details']['body'], presented_item("published").body

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -7,7 +7,7 @@ class PublicationPresenterTest < PresenterTestCase
 
   test 'presents the basic details of a content item' do
     assert_equal schema_item['description'], presented_item.description
-    assert_equal schema_item['format'], presented_item.format
+    assert_equal schema_item['schema_name'], presented_item.format
     assert_equal schema_item['title'], presented_item.title
     assert_equal schema_item['details']['body'], presented_item.details
     assert_equal schema_item['details']['documents'].join(''), presented_item.documents

--- a/test/presenters/statistical_data_set_presenter_test.rb
+++ b/test/presenters/statistical_data_set_presenter_test.rb
@@ -9,7 +9,7 @@ class StatisticalDataSetPresenterTest
 
   class PresentedStatisticalDataSet < StatisticalDataSetTestCase
     test 'presents the format' do
-      assert_equal schema_item['format'], presented_item.format
+      assert_equal schema_item['schema_name'], presented_item.format
     end
 
     test 'presents a list of contents extracted from headings in the body' do

--- a/test/presenters/take_part_presenter_test.rb
+++ b/test/presenters/take_part_presenter_test.rb
@@ -7,7 +7,7 @@ class TakePartPresenterTest < PresenterTestCase
 
   test 'presents the basic details of a content item' do
     assert_equal schema_item['description'], presented_item.description
-    assert_equal schema_item['format'], presented_item.format
+    assert_equal schema_item['schema_name'], presented_item.format
     assert_equal schema_item['locale'], presented_item.locale
     assert_equal schema_item['title'], presented_item.title
     assert_equal schema_item['details']['body'], presented_item.body

--- a/test/presenters/topical_event_about_page_presenter_test.rb
+++ b/test/presenters/topical_event_about_page_presenter_test.rb
@@ -7,7 +7,7 @@ class TopicalEventAboutPagePresenterTest < PresenterTestCase
 
   test 'presents the basic details of a content item' do
     assert_equal schema_item['description'], presented_item.description
-    assert_equal schema_item['format'], presented_item.format
+    assert_equal schema_item['schema_name'], presented_item.format
     assert_equal schema_item['title'], presented_item.title
     assert_equal schema_item['details']['body'], presented_item.body
   end

--- a/test/presenters/unpublishing_presenter_test.rb
+++ b/test/presenters/unpublishing_presenter_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class UnpublishingPresenterTest < ActiveSupport::TestCase
   test 'presents the basic details required to display an unpublishing' do
-    assert_equal unpublishing['format'], presented_unpublishing.format
+    assert_equal unpublishing['schema_name'], presented_unpublishing.format
     assert_equal unpublishing['locale'], presented_unpublishing.locale
     assert_equal unpublishing['details']['explanation'], presented_unpublishing.explanation
     assert_equal unpublishing['details']['alternative_url'], presented_unpublishing.alternative_url


### PR DESCRIPTION
The content item attribute `format` is deprecated.

alphagov/govuk-content-schemas#444 attempts to remove `format` from the frontend, but the tests for this application fail without `format` in the examples. This is because the tests are testing kind of the wrong thing.

For example:

```
assert_equal schema_item['format'], presented_item.format
```

Checks the string in `presented_item.format` which actually points to `schema_item['schema_name']`. Because they're `format` and `schema_name` are identical in the examples this worked. Now that we've removed `format` it doesn't anymore.

https://trello.com/c/C8A9bnuO/344-work-on-making-the-document-type-concept-clearer