### PR TITLE
Show closing date on unopened consultations

### DIFF
--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -117,18 +117,27 @@
 <div class="consultation-banner">
   <div class="grid-row">
     <div class="column-third consultation-dates">
-      <p>
+
         <% if @content_item.closed? %>
-          This consultation ran from<br /><span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time> to
-          <time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
+          <p>
+            This consultation ran from<br /><span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time> to
+            <time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
+          </p>
         <% elsif @content_item.open? %>
-          This consultation closes at<br />
-          <span class="consultation-date"><time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
+          <p>
+            This consultation closes at<br />
+            <span class="consultation-date"><time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
+          </p>
         <% elsif @content_item.unopened? %>
-          This consultation opens <% if @content_item.opening_date_midnight? %>on<% else %>at<% end %><br />
-          <span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time></span>
+          <p>
+            This consultation opens <% if @content_item.opening_date_midnight? %>on<% else %>at<% end %><br />
+            <span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time></span>
+          </p>
+          <p>
+            It closes at<br />
+            <span class="consultation-date"><time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
+          </p>
         <% end %>
-      </p>
     </div>
     <div class="column-two-thirds consultation-summary">
       <h2>Summary</h2>

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -49,6 +49,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
 
     assert page.has_text?("Consultation")
     assert page.has_css?('.consultation-notice', text: "This consultation opens at 2pm on 5 October 2200")
+    assert page.has_text?("It closes at 5pm on 31 October 2210")
   end
 
   test "closed consultation pending outcome" do


### PR DESCRIPTION
The date that the consultation closes is useful information for users.

![screen shot 2016-12-02 at 11 42 56](https://cloud.githubusercontent.com/assets/319055/20832996/3a17b320-b885-11e6-9c63-fc06020bab6e.png)

@andrewgarner
