### PR TITLE
Add lang attribute to page translation links

### DIFF
--- a/app/views/shared/_available_languages.html.erb
+++ b/app/views/shared/_available_languages.html.erb
@@ -6,7 +6,7 @@
           <% if translation["locale"] == I18n.locale.to_s %>
             <%= native_language_name_for(translation["locale"]) %>
           <% else %>
-            <%= link_to native_language_name_for(translation["locale"]), translation["base_path"] %>
+            <%= link_to native_language_name_for(translation["locale"]), translation["base_path"], lang: translation["locale"] %>
           <% end %>
         </li>
       <% end %>


### PR DESCRIPTION
This commit adds the HTML lang attribute to links to translated content. This ensures that the language name is understood correctly by screen readers and browsers, and therefore read correctly. Fixes https://github.com/alphagov/whitehall/issues/2873.