### PR TITLE
Don't display Document Collection withdrawn documents

### DIFF
--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -16,9 +16,14 @@ class DocumentCollectionPresenter < ContentItemPresenter
   end
 
   def groups
-    content_item["details"]["collection_groups"].reject do |group|
+    groups = content_item["details"]["collection_groups"].reject { |group|
       group_document_links(group).empty?
-    end
+    }
+
+    groups.map { |group|
+      group["documents"] = reject_withdrawn_documents(group)
+      group
+    }
   end
 
   def group_document_links(group)
@@ -49,5 +54,11 @@ private
 
   def documents_hash
     @documents_hash ||= Array(content_item["links"]["documents"]).map { |d| [d["content_id"], d] }.to_h
+  end
+
+  def reject_withdrawn_documents(group)
+    group_documents(group)
+      .reject { |document| document["withdrawn"] }
+      .map { |document| document["content_id"] }
   end
 end

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -124,4 +124,21 @@ class DocumentCollectionPresenterTest
       assert_empty group_with_missing_documents
     end
   end
+
+  class GroupWithDocumentsWhenThereAreWithdrawnDocuments < TestCase
+    test "does not present withdrawn documents" do
+      presenter = presented_item(
+        "document_collection_with_withdrawn_links_documents"
+      )
+
+      presented_documents = presenter.groups.first["documents"]
+
+      expected_number_of_presented_documents = 2
+
+      assert_equal(
+        presented_documents.size,
+        expected_number_of_presented_documents
+      )
+    end
+  end
 end


### PR DESCRIPTION
This brings government-frontend in line with Whitehall, which doesn't show withdrawn documents.

Trello:
https://trello.com/c/IFfWVlb6/533-filter-out-withdrawn-documents-in-document-collections-medium

Follow-up to:

- https://github.com/alphagov/govuk-content-schemas/pull/454
- https://github.com/alphagov/publishing-api/pull/627

Depends on:

- https://github.com/alphagov/govuk-content-schemas/pull/459

# Before

Below screenshots use the fictional `/government/collections/with-withdrawn-links-documents` example I created that has `Financial sanctions, Somalia` marked as withdrawn.

![screen shot 2016-12-13 at 16 00 32](https://cloud.githubusercontent.com/assets/1650875/21147693/becd5216-c14d-11e6-9e24-00c9842ef8a3.png)

# After

![screen shot 2016-12-13 at 16 00 38](https://cloud.githubusercontent.com/assets/1650875/21147737/edaa370c-c14d-11e6-87ea-be5e94925cc3.png)
