### PR TITLE
Revert "Remove jenkins.sh"

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -x
+
+REPO_NAME=${REPO_NAME:-"alphagov/government-frontend"}
+CONTEXT_MESSAGE=${CONTEXT_MESSAGE:-"default"}
+GH_STATUS_GIT_COMMIT=${SCHEMA_GIT_COMMIT:-${GIT_COMMIT}}
+env
+
+function github_status {
+  REPO_NAME="$1"
+  STATUS="$2"
+  MESSAGE="$3"
+  gh-status "$REPO_NAME" "$GH_STATUS_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
+}
+
+function error_handler {
+  trap - ERR # disable error trap to avoid recursion
+  local parent_lineno="$1"
+  local message="$2"
+  local code="${3:-1}"
+  if [[ -n "$message" ]] ; then
+    echo "Error on or near line ${parent_lineno}: ${message}; exiting with status ${code}"
+  else
+    echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
+  fi
+  github_status "$REPO_NAME" error "errored on Jenkins"
+  exit "${code}"
+}
+
+trap 'error_handler ${LINENO}' ERR
+github_status "$REPO_NAME" pending "is running on Jenkins"
+
+# Cleanup anything left from previous test runs
+git clean -fdx
+
+# Try to merge master into the current branch, and abort if it doesn't exit
+# cleanly (ie there are conflicts). This will be a noop if the current branch
+# is master.
+git merge --no-commit origin/master || git merge --abort
+
+# Clone govuk-content-schemas depedency for contract tests
+rm -rf tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+(
+  cd tmp/govuk-content-schemas
+  git checkout ${SCHEMA_GIT_COMMIT:-"deployed-to-production"}
+)
+export GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas
+
+export RAILS_ENV=test
+bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
+bundle exec rake assets:precompile
+
+if bundle exec rake ${TEST_TASK:-"default"}; then
+  github_status "$REPO_NAME" success "succeeded on Jenkins"
+else
+  github_status "$REPO_NAME" failure "failed on Jenkins"
+  exit 1
+fi


### PR DESCRIPTION
This reverts commit b029b9d2fd1e4133becdc2fc972b6d53da1db8b1.

`jenkins.sh` [was removed as part of moving to the new Jenkins](https://github.com/alphagov/government-frontend/pull/206/commits/b029b9d2fd1e4133becdc2fc972b6d53da1db8b1) but it is needed for content schemas (see `jenkins-schemas.sh`)