### PR TITLE
Add `:meta_description` to Statistical Data Set

### DIFF
--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
+<%= content_for :meta_description, @content_item.description %>
 
 <div class="grid-row">
   <div class="column-two-thirds">


### PR DESCRIPTION
Statistical Data Sets should render the `meta name="description"` tag.

Screenshots show a before and after of the source from a rendered example.  

<table>
  <tr><th>Before</td><th>After</th></tr>
  <tr><td valign="top"><img width="260" alt="screen shot 2016-12-21 at 14 26 40" src="https://cloud.githubusercontent.com/assets/647311/21393238/808a1de2-c78b-11e6-8d6c-787c8d99642d.png"></td><td valign="top"><img width="260" alt="screen shot 2016-12-21 at 14 27 57" src="https://cloud.githubusercontent.com/assets/647311/21392963/3e60ac70-c78a-11e6-8081-07bd2f3db6cc.png"></td></tr>
</table>