### PR TITLE
DRY up views by moving metadata logic into module

### DIFF
--- a/app/presenters/case_study_presenter.rb
+++ b/app/presenters/case_study_presenter.rb
@@ -1,13 +1,8 @@
 class CaseStudyPresenter < ContentItemPresenter
-  include ActionView::Helpers::UrlHelper
-  include Linkable
-  include Updatable
+  include Metadata
 
-  attr_reader :body
-
-  def initialize(content_item)
-    super
-    @body = content_item["details"]["body"]
+  def body
+    content_item['details']['body']
   end
 
   def image

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -1,6 +1,5 @@
 class ConsultationPresenter < ContentItemPresenter
-  include Linkable
-  include Updatable
+  include Metadata
   include NationalApplicability
   include Political
   include Withdrawable

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -2,7 +2,6 @@ class ConsultationPresenter < ContentItemPresenter
   include Metadata
   include NationalApplicability
   include Political
-  include Withdrawable
   include Shareable
 
   def body

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -40,4 +40,8 @@ private
   def sorted_locales(translations)
     translations.sort_by { |t| t["locale"] == I18n.default_locale.to_s ? '' : t["locale"] }
   end
+
+  def text_direction
+    I18n.t("i18n.direction", locale: I18n.locale, default: "ltr")
+  end
 end

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -1,9 +1,8 @@
 class DetailedGuidePresenter < ContentItemPresenter
   include ExtractsHeadings
-  include Linkable
+  include Metadata
   include NationalApplicability
   include Political
-  include Updatable
   include ActionView::Helpers::UrlHelper
 
   def body
@@ -30,5 +29,13 @@ class DetailedGuidePresenter < ContentItemPresenter
 
   def image
     content_item["details"]["image"]["url"] if content_item["details"]["image"]
+  end
+
+  def document_footer
+    super.tap do |m|
+      m[:other] = {
+        I18n.t('detailed_guide.related_guides') => related_guides
+      }
+    end
   end
 end

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -1,7 +1,6 @@
 class DocumentCollectionPresenter < ContentItemPresenter
-  include Linkable
+  include Metadata
   include Political
-  include Updatable
   include ActionView::Helpers::UrlHelper
 
   def body

--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -1,6 +1,5 @@
 class FatalityNoticePresenter < ContentItemPresenter
-  include Linkable
-  include Updatable
+  include Metadata
 
   def field_of_operation
     attributes = content_item["links"]["field_of_operation"].first
@@ -9,6 +8,14 @@ class FatalityNoticePresenter < ContentItemPresenter
 
   def image
     { "url" => ActionController::Base.helpers.asset_url("ministry-of-defence-crest.png"), "alt_text" => "Ministry of Defence crest" }
+  end
+
+  def metadata
+    super.tap do |m|
+      m[:other] = {
+        "Field of operation" => link_to(field_of_operation.title, field_of_operation.path)
+      }
+    end
   end
 
   def body

--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -7,6 +7,10 @@ class FatalityNoticePresenter < ContentItemPresenter
     OpenStruct.new(title: attributes["title"], path: attributes["base_path"])
   end
 
+  def image
+    { "url" => ActionController::Base.helpers.asset_url("ministry-of-defence-crest.png"), "alt_text" => "Ministry of Defence crest" }
+  end
+
   def body
     content_item['details']['body']
   end

--- a/app/presenters/linkable.rb
+++ b/app/presenters/linkable.rb
@@ -42,8 +42,12 @@ private
 
   def organisations_with_emphasised_first
     expanded_links_from_content_item("organisations").sort_by do |organisation|
-      is_emphasised = organisation["content_id"].in?(content_item["details"]["emphasised_organisations"])
+      is_emphasised = organisation["content_id"].in?(emphasised_organisations)
       is_emphasised ? -1 : 1
     end
+  end
+
+  def emphasised_organisations
+    content_item["details"]["emphasised_organisations"] || []
   end
 end

--- a/app/presenters/metadata.rb
+++ b/app/presenters/metadata.rb
@@ -7,7 +7,9 @@ module Metadata
       from: from,
       first_published: published,
       last_updated: updated,
-      see_updates_link: true
+      see_updates_link: true,
+      part_of: part_of,
+      direction: text_direction
     }
   end
 
@@ -16,7 +18,9 @@ module Metadata
       from: from,
       published: published,
       updated: updated,
-      history: history
+      history: history,
+      part_of: part_of,
+      direction: text_direction
     }
   end
 end

--- a/app/presenters/metadata.rb
+++ b/app/presenters/metadata.rb
@@ -1,0 +1,22 @@
+module Metadata
+  include Linkable
+  include Updatable
+
+  def metadata
+    {
+      from: from,
+      first_published: published,
+      last_updated: updated,
+      see_updates_link: true
+    }
+  end
+
+  def document_footer
+    {
+      from: from,
+      published: published,
+      updated: updated,
+      history: history
+    }
+  end
+end

--- a/app/presenters/national_applicability.rb
+++ b/app/presenters/national_applicability.rb
@@ -1,4 +1,6 @@
 module NationalApplicability
+  include Metadata
+
   def applies_to
     return nil if !national_applicability
     all_nations = national_applicability.values
@@ -19,6 +21,14 @@ module NationalApplicability
     end
 
     applies_to
+  end
+
+  def metadata
+    super.tap do |m|
+      m[:other] = {
+        'Applies to' => applies_to
+      }
+    end
   end
 
 private

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -1,9 +1,7 @@
 class PublicationPresenter < ContentItemPresenter
-  include Linkable
+  include Metadata
   include NationalApplicability
   include Political
-  include Updatable
-  include ActionView::Helpers::UrlHelper
 
   def details
     content_item["details"]["body"]

--- a/app/presenters/statistical_data_set_presenter.rb
+++ b/app/presenters/statistical_data_set_presenter.rb
@@ -1,8 +1,7 @@
 class StatisticalDataSetPresenter < ContentItemPresenter
   include ExtractsHeadings
   include Political
-  include Linkable
-  include Updatable
+  include Metadata
   include ActionView::Helpers::UrlHelper
 
   def body

--- a/app/presenters/statistical_data_set_presenter.rb
+++ b/app/presenters/statistical_data_set_presenter.rb
@@ -1,7 +1,6 @@
 class StatisticalDataSetPresenter < ContentItemPresenter
   include ExtractsHeadings
   include Political
-  include Withdrawable
   include Linkable
   include Updatable
   include ActionView::Helpers::UrlHelper

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -1,17 +1,5 @@
 class StatisticsAnnouncementPresenter < ContentItemPresenter
-  include ActionView::Helpers::UrlHelper
-
-  def from
-    content_item["links"]["organisations"].map { |org|
-      link_to(org["title"], org["base_path"])
-    }
-  end
-
-  def part_of
-    content_item["links"]["policy_areas"].map { |policy_area|
-      link_to(policy_area["title"], policy_area["base_path"])
-    }
-  end
+  include Metadata
 
   def release_date
     content_item["details"]["display_date"]
@@ -30,14 +18,18 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
     content_item["details"].include?("previous_display_date")
   end
 
-  def other_metadata
-    if cancelled?
-      {
-        "Proposed release" => release_date,
-        "Cancellation date" => cancellation_date,
-      }
-    else
-      { "Release date" => release_date_and_status }
+  def metadata
+    super.tap do |m|
+      m[:other] = if cancelled?
+                    {
+                      "Proposed release" => release_date,
+                      "Cancellation date" => cancellation_date,
+                    }
+                  else
+                    {
+                      "Release date" => release_date_and_status
+                    }
+                  end
     end
   end
 

--- a/app/presenters/updatable.rb
+++ b/app/presenters/updatable.rb
@@ -7,14 +7,6 @@ module Updatable
     display_date(content_item["public_updated_at"]) if any_updates?
   end
 
-  def short_history
-    if any_updates?
-      "#{I18n.t('content_item.metadata.updated')} #{updated}"
-    else
-      "#{I18n.t('content_item.metadata.published')} #{published}"
-    end
-  end
-
   def history
     return [] unless any_updates?
     content_item["details"]["change_history"].map do |item|

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -20,26 +20,7 @@
 </div>
 
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/metadata',
-        from: @content_item.from,
-        history: @content_item.short_history,
-        direction: page_text_direction,
-        part_of: @content_item.part_of
-    %>
-  </div>
-</div>
-
+<%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 <%= render 'shared/sidebar_with_body', content_item: @content_item %>
-
-<%= render 'govuk_component/document_footer',
-        from: @content_item.from,
-        updated: @content_item.updated,
-        history: @content_item.history,
-        published: @content_item.published,
-        direction: page_text_direction,
-        part_of: @content_item.part_of
-%>
+<%= render 'govuk_component/document_footer', @content_item.document_footer %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -11,21 +11,7 @@
 </div>
 
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/metadata',
-        from: @content_item.from,
-        part_of: @content_item.part_of,
-        first_published: @content_item.published,
-        last_updated: @content_item.updated,
-        other: {
-          'Applies to' => @content_item.applies_to
-        },
-        see_updates_link: true
-    %>
-  </div>
-</div>
+<%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 
 <% if @content_item.unopened? %>
@@ -235,11 +221,4 @@
   </div>
 </div>
 
-<%= render 'govuk_component/document_footer',
-    from: @content_item.from,
-    updated: @content_item.updated,
-    history: @content_item.history,
-    published: @content_item.published,
-    part_of: @content_item.part_of,
-    direction: page_text_direction
-%>
+<%= render 'govuk_component/document_footer', @content_item.document_footer %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -22,21 +22,7 @@
 </div>
 
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/metadata',
-        from: @content_item.from,
-        part_of: @content_item.part_of,
-        first_published: @content_item.published,
-        last_updated: @content_item.updated,
-        see_updates_link: true,
-        other: {
-          'Applies to' => @content_item.applies_to
-        }
-    %>
-  </div>
-</div>
+<%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 
@@ -70,14 +56,4 @@
   </div>
 </div>
 
-<%= render 'govuk_component/document_footer',
-    from: @content_item.from,
-    updated: @content_item.updated,
-    history: @content_item.history,
-    published: @content_item.published,
-    part_of: @content_item.part_of,
-    direction: page_text_direction,
-    other: {
-      t('detailed_guide.related_guides') => @content_item.related_guides
-    }
-%>
+<%= render 'govuk_component/document_footer', @content_item.document_footer %>

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -14,18 +14,7 @@
 </div>
 
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/metadata',
-        from: @content_item.from,
-        part_of: @content_item.part_of,
-        first_published: @content_item.published,
-        last_updated: @content_item.updated,
-        see_updates_link: true
-    %>
-  </div>
-</div>
+<%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 
@@ -69,11 +58,4 @@
   </div>
 </div>
 
-<%= render 'govuk_component/document_footer',
-    from: @content_item.from,
-    updated: @content_item.updated,
-    history: @content_item.history,
-    published: @content_item.published,
-    part_of: @content_item.part_of,
-    direction: page_text_direction
-%>
+<%= render 'govuk_component/document_footer', @content_item.document_footer %>

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -13,27 +13,7 @@
 </div>
 
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/metadata',
-        from: @content_item.from,
-        first_published: @content_item.published,
-        last_updated: @content_item.updated,
-        see_updates_link: true,
-        other: {
-          "Field of operation" => link_to(@content_item.field_of_operation.title, @content_item.field_of_operation.path)
-        }
-      %>
-  </div>
-</div>
-
+<%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 <%= render 'shared/sidebar_with_body', content_item: @content_item %>
-
-<%= render 'govuk_component/document_footer',
-    from: @content_item.from,
-    published: @content_item.published,
-    updated: @content_item.updated,
-    history: @content_item.history
-%>
+<%= render 'govuk_component/document_footer', @content_item.document_footer %>

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -29,18 +29,7 @@
 </div>
 
 <%= render 'shared/description', description: @content_item.description %>
-
-<div class="grid-row sidebar-with-body">
-  <div class="column-third">
-    <%# The Ministry of Defence crest only has visual value so has an empty alt attribute.
-        See https://davidwalsh.name/accessibility-tip-empty-alt-attributes %>
-    <%= render 'shared/sidebar_image',
-      image: { "url" => image_url("ministry-of-defence-crest.png"), "alt_text" => "" } %>
-  </div>
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/govspeak', content: @content_item.body %>
-  </div>
-</div>
+<%= render 'shared/sidebar_with_body', content_item: @content_item %>
 
 <%= render 'govuk_component/document_footer',
     from: @content_item.from,

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -17,21 +17,7 @@
 </div>
 
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/metadata',
-        from: @content_item.from,
-        part_of: @content_item.part_of,
-        first_published: @content_item.published,
-        last_updated: @content_item.updated,
-        see_updates_link: true,
-        other: {
-          'Applies to' => @content_item.applies_to
-        }
-    %>
-  </div>
-</div>
+<%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 
@@ -61,11 +47,4 @@
   </div>
 </div>
 
-<%= render 'govuk_component/document_footer',
-    from: @content_item.from,
-    updated: @content_item.updated,
-    history: @content_item.history,
-    published: @content_item.published,
-    part_of: @content_item.part_of,
-    direction: page_text_direction
-%>
+<%= render 'govuk_component/document_footer', @content_item.document_footer %>

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -12,20 +12,8 @@
 </div>
 
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/metadata',
-        from: @content_item.from,
-        part_of: @content_item.part_of,
-        first_published: @content_item.published,
-        last_updated: @content_item.updated,
-        see_updates_link: true
-    %>
-  </div>
-</div>
+<%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-
 <%= render 'shared/description', description: @content_item.description %>
 
 <div class="grid-row sidebar-with-body">
@@ -39,11 +27,4 @@
   </div>
 </div>
 
-<%= render 'govuk_component/document_footer',
-    from: @content_item.from,
-    updated: @content_item.updated,
-    history: @content_item.history,
-    published: @content_item.published,
-    part_of: @content_item.part_of,
-    direction: page_text_direction
-%>
+<%= render 'govuk_component/document_footer', @content_item.document_footer %>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -15,14 +15,8 @@
   <% end %>
 </div>
 
-<div class="grid-row primary-metadata">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/metadata',
-        other: @content_item.other_metadata,
-        from: @content_item.from,
-        part_of: @content_item.part_of
-    %>
-  </div>
+<div class="primary-metadata">
+  <%= render 'shared/metadata', content_item: @content_item %>
 </div>
 <% if @content_item.cancelled? %>
   <div class="cancellation-notice">

--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -1,0 +1,5 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/metadata', @content_item.metadata %>
+  </div>
+</div>

--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -49,8 +49,8 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
     end
 
     assert(
-      page.has_css?("img[src*=ministry-of-defence-crest][alt='']"),
-      'should have image with ministry-of-defence source and empty alt text'
+      page.has_css?("img[src*=ministry-of-defence-crest][alt='Ministry of Defence crest']"),
+      'should have image with ministry-of-defence source with alt text'
     )
 
     assert_has_component_govspeak "<div class=\"govspeak\"><h2 id=\"sir-george-pomeroy-colley\">Sir George Pomeroy Colley</h2><figure class=\"image embedded\"> <div class=\"img\"><img alt=\"Photograph of Sir George Pomeroy Colley posed standing\" src=\"https://assets-origin.integration.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/56271/colley.jpg\"></div> <figcaption>Sir George Pomeroy Colley (All rights reserved.)</figcaption></figure><p>Colley served nearly all of his military and administrative career in British South Africa, but he played a significant part in the Second Anglo-Afghan War as military secretary and then private secretary to the governor-general of India, Lord Lytton. The war began in November 1878 and ended in May 1879 with the Treaty of Gandamak.</p><p>After the war Colley returned to South Africa, became high commissioner for South Eastern Africa in 1880… and died a year later at the Battle of Majuba Hill during the First Boer War.</p><p>A british officer had the following to say</p><blockquote> <p class=\"last-child\">Major General Colley was an exceptional talent, and it is with great sadness that we have learned about this loss. His contribution to Britain through his efforts in the Boer War will not be forgotten.</p></blockquote></div>"

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -27,14 +27,6 @@ class CaseStudyPresenterTest < PresenterTestCase
     assert_equal '21 March 2013', presented_case_study_with_updates.updated
   end
 
-  test '#short_history returns the published day of a non-updated content item' do
-    assert_equal 'Published 17 December 2012', presented_item.short_history
-  end
-
-  test '#short_history returns the last update day for a content item that has updates' do
-    assert_equal 'Updated 21 March 2013', presented_case_study_with_updates.short_history
-  end
-
   test '#from returns links to lead organisations, supporting organisations and worldwide organisations' do
     with_organisations = {
       "details" => {

--- a/test/presenters/statistics_announcement_presenter_test.rb
+++ b/test/presenters/statistics_announcement_presenter_test.rb
@@ -14,13 +14,6 @@ class StatisticsAnnouncementPresenterTest < PresenterTestCase
     assert_equal links, statistics_announcement.from
   end
 
-  test 'presents part_of as links to a topic' do
-    links = [
-      link_to('National Health Service', '/government/topics/national-health-service')
-    ]
-    assert_equal links, statistics_announcement.part_of
-  end
-
   test 'presents release_date' do
     assert_equal '20 January 2016 9:30am', statistics_announcement.release_date
   end
@@ -45,7 +38,7 @@ class StatisticsAnnouncementPresenterTest < PresenterTestCase
     other = {
       "Release date" => "20 January 2016 9:30am (confirmed)"
     }
-    assert_equal other, statistics_announcement.other_metadata
+    assert_equal other, statistics_announcement.metadata[:other]
   end
 
   test "present other metadata when cancelled" do
@@ -53,7 +46,7 @@ class StatisticsAnnouncementPresenterTest < PresenterTestCase
       "Proposed release" => "20 January 2016 9:30am",
       "Cancellation date" => "17 January 2016 2:19pm"
     }
-    assert_equal other, statistics_announcement_cancelled.other_metadata
+    assert_equal other, statistics_announcement_cancelled.metadata[:other]
   end
 
   test "shows the cancellation reason when cancelled" do


### PR DESCRIPTION
* Create a metadata module that provides all the parameters to be passed to the metadata and document footer metadata components
  * Module makes it hard to miss out an aspect of the metadata
  * Makes it easy to iterate across formats
  * Abstracts away the text direction, so it can't be forgotten
* Update case studies to behave in the same was as other formats
  * Use full history rather than short history like other formats
* Simplify fatality notices by moving image into presenter
* Remove 'withdrawable' from format presenters, it's redundant
* Stop rendering links to policy_areas on stat announcements, they are being deprecated, no
other format links to them