### PR TITLE
Allow speeches to be translated

### DIFF
--- a/app/assets/stylesheets/views/_speech.scss
+++ b/app/assets/stylesheets/views/_speech.scss
@@ -3,4 +3,9 @@
   @include description;
   @include history-notice;
   @include withdrawal-notice;
+
+  .direction-rtl & {
+    direction: rtl;
+    text-align: start;
+  }
 }

--- a/app/presenters/speech_presenter.rb
+++ b/app/presenters/speech_presenter.rb
@@ -3,6 +3,7 @@ class SpeechPresenter < ContentItemPresenter
   include Political
   include Updatable
   include TitleAndContext
+  include Metadata
 
   def body
     content_item["details"]["body"]
@@ -24,17 +25,26 @@ class SpeechPresenter < ContentItemPresenter
     "#{delivered_on}#{speech_type_explanation}"
   end
 
-  def location
-    content_item["details"]["location"]
-  end
-
   def from
     super.tap do |f|
       f.push(speaker_without_profile) if speaker_without_profile
     end
   end
 
+  def metadata
+    super.tap do |m|
+      m[:other] = {
+        "Location" => location,
+        delivery_type => delivered_on_metadata
+      }
+    end
+  end
+
 private
+
+  def location
+    content_item["details"]["location"]
+  end
 
   def delivered_on
     delivered_on_date = content_item["details"]["delivered_on"]

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -4,31 +4,8 @@
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/metadata',
-        from: @content_item.from,
-        first_published: @content_item.published,
-        last_updated: @content_item.updated,
-        part_of: @content_item.part_of,
-        see_updates_link: true,
-        other: {
-          @content_item.delivery_type => @content_item.delivered_on_metadata,
-          "Location" => @content_item.location
-        }
-      %>
-  </div>
-</div>
-
+<%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 <%= render 'shared/sidebar_with_body', content_item: @content_item %>
-
-<%= render 'govuk_component/document_footer',
-    from: @content_item.from,
-    published: @content_item.published,
-    updated: @content_item.updated,
-    history: @content_item.history,
-    part_of: @content_item.part_of
-%>
+<%= render 'govuk_component/document_footer', @content_item.document_footer %>

--- a/test/integration/speech_test.rb
+++ b/test/integration/speech_test.rb
@@ -9,6 +9,14 @@ class SpeechTest < ActionDispatch::IntegrationTest
     assert_has_component_govspeak(@content_item["details"]["body"])
   end
 
+  test "translated speech" do
+    setup_and_visit_content_item('speech-translated')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+    assert page.has_css?('.available-languages')
+  end
+
   test "renders metadata and document footer, including speaker" do
     setup_and_visit_content_item('speech')
 

--- a/test/presenters/speech_presenter_test.rb
+++ b/test/presenters/speech_presenter_test.rb
@@ -21,7 +21,7 @@ class SpeechPresenterTest
     end
 
     test 'presents a speech location' do
-      assert_equal schema_item['details']['location'], presented_item.location
+      assert_equal schema_item['details']['location'], presented_item.metadata[:other]["Location"]
     end
 
     test 'presents how speech was delivered' do


### PR DESCRIPTION
* Add language switcher
* Switch to using the new Metadata module which adds right-to-left support
* Add right to left styling for speeches (matches case-studies approach)

Tests depend on https://github.com/alphagov/govuk-content-schemas/pull/472

Note that in both old and new the helper text for the format (eg Transcript of the speech, exactly as it was delivered) is not translated. We ought to fix this when migrating the format.

| Old | New |
| --- | --- |
| ![translated-speech-old](https://cloud.githubusercontent.com/assets/319055/21614795/eafb94f2-d1d2-11e6-896b-cd9ce9382149.png) | ![translated-speech-new](https://cloud.githubusercontent.com/assets/319055/21614799/f022eed0-d1d2-11e6-8b36-1740c20e77ec.png) |

Part of https://trello.com/c/TWsLTRzc/547-speech-migration-1-mvp-content-schema-examples-and-front-end-work