### PR TITLE
Handle nil field of operation in fatality notice view

### DIFF
--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -5,7 +5,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
-        context: "Operations in #{@content_item.field_of_operation.title}",
+        context: "Operations in #{@content_item.field_of_operation.try(:title)}",
         title: @content_item.title,
         average_title_length: "long"
       %>


### PR DESCRIPTION
Part of previous temp fix to allow publication of a pending fatality notice. More complete fix will follow.