### PR TITLE
Add noopener and noreferrer to new window links

### DIFF
--- a/app/views/shared/_share_buttons.html.erb
+++ b/app/views/shared/_share_buttons.html.erb
@@ -2,11 +2,13 @@
 <div class="share-buttons" data-module="track-share-button-clicks">
   <%= link_to share_urls[:facebook],
     target: "_blank",
+    rel: "noopener noreferrer",
     class: "share-button-link js-share-facebook" do %>
     <span class="share-button share-button-facebook"></span><span class="visually-hidden">Share on </span>Facebook<% end %>
 
   <%= link_to share_urls[:twitter],
     target: "_blank",
+    rel: "noopener noreferrer",
     class: "share-button-link js-share-twitter" do %>
     <span class="share-button share-button-twitter"></span><span class="visually-hidden">Share on </span>Twitter<% end %>
 </div>


### PR DESCRIPTION
Fixes #217

We're using `[target=_blank]` which has a vulnerability
https://mathiasbynens.github.io/rel-noopener/

“To prevent pages from abusing window.opener, use rel=noopener. This
ensures window.opener is null in Chrome 49 and Opera 36.”

“For older browsers, you could use rel=noreferrer which also disables
the Referer HTTP header”

@nickcolley 