### PR TITLE
Refactor title and context into module

### DIFF
--- a/app/presenters/case_study_presenter.rb
+++ b/app/presenters/case_study_presenter.rb
@@ -1,5 +1,6 @@
 class CaseStudyPresenter < ContentItemPresenter
   include Metadata
+  include TitleAndContext
 
   def body
     content_item['details']['body']

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -3,6 +3,7 @@ class ConsultationPresenter < ContentItemPresenter
   include NationalApplicability
   include Political
   include Shareable
+  include TitleAndContext
 
   def body
     content_item["details"]["body"]

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -34,9 +34,13 @@ class DetailedGuidePresenter < ContentItemPresenter
 
   def document_footer
     super.tap do |m|
-      m[:other] = {
-        I18n.t('detailed_guide.related_guides') => related_guides
-      }
+      m[:other][related_guides_title] = related_guides
     end
+  end
+
+private
+
+  def related_guides_title
+    I18n.t('detailed_guide.related_guides')
   end
 end

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -4,6 +4,7 @@ class DetailedGuidePresenter < ContentItemPresenter
   include NationalApplicability
   include Political
   include ActionView::Helpers::UrlHelper
+  include TitleAndContext
 
   def body
     content_item["details"]["body"]

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -1,6 +1,7 @@
 class DocumentCollectionPresenter < ContentItemPresenter
   include Metadata
   include Political
+  include TitleAndContext
   include ActionView::Helpers::UrlHelper
 
   def body

--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -17,9 +17,7 @@ class FatalityNoticePresenter < ContentItemPresenter
   def metadata
     super.tap do |m|
       if field_of_operation
-        m[:other] = {
-          "Field of operation" => link_to(field_of_operation.title, field_of_operation.path)
-        }
+        m[:other]['Field of operation'] = link_to(field_of_operation.title, field_of_operation.path)
       end
     end
   end

--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -1,4 +1,5 @@
 class FatalityNoticePresenter < ContentItemPresenter
+  include TitleAndContext
   include Metadata
 
   def field_of_operation
@@ -19,6 +20,14 @@ class FatalityNoticePresenter < ContentItemPresenter
         m[:other] = {
           "Field of operation" => link_to(field_of_operation.title, field_of_operation.path)
         }
+      end
+    end
+  end
+
+  def title_and_context
+    super.tap do |t|
+      if field_of_operation
+        t[:context] = "Operations in #{field_of_operation.try(:title)}"
       end
     end
   end

--- a/app/presenters/metadata.rb
+++ b/app/presenters/metadata.rb
@@ -9,7 +9,8 @@ module Metadata
       last_updated: updated,
       see_updates_link: true,
       part_of: part_of,
-      direction: text_direction
+      direction: text_direction,
+      other: {}
     }
   end
 
@@ -20,7 +21,8 @@ module Metadata
       updated: updated,
       history: history,
       part_of: part_of,
-      direction: text_direction
+      direction: text_direction,
+      other: {}
     }
   end
 end

--- a/app/presenters/national_applicability.rb
+++ b/app/presenters/national_applicability.rb
@@ -25,9 +25,7 @@ module NationalApplicability
 
   def metadata
     super.tap do |m|
-      m[:other] = {
-        'Applies to' => applies_to
-      }
+      m[:other]['Applies to'] = applies_to
     end
   end
 

--- a/app/presenters/speech_presenter.rb
+++ b/app/presenters/speech_presenter.rb
@@ -2,6 +2,7 @@ class SpeechPresenter < ContentItemPresenter
   include Linkable
   include Political
   include Updatable
+  include TitleAndContext
 
   def body
     content_item["details"]["body"]

--- a/app/presenters/statistical_data_set_presenter.rb
+++ b/app/presenters/statistical_data_set_presenter.rb
@@ -1,5 +1,6 @@
 class StatisticalDataSetPresenter < ContentItemPresenter
   include ExtractsHeadings
+  include TitleAndContext
   include Political
   include Metadata
   include ActionView::Helpers::UrlHelper

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -1,5 +1,6 @@
 class StatisticsAnnouncementPresenter < ContentItemPresenter
   include Metadata
+  include TitleAndContext
 
   def release_date
     content_item["details"]["display_date"]

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -21,16 +21,12 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
 
   def metadata
     super.tap do |m|
-      m[:other] = if cancelled?
-                    {
-                      "Proposed release" => release_date,
-                      "Cancellation date" => cancellation_date,
-                    }
-                  else
-                    {
-                      "Release date" => release_date_and_status
-                    }
-                  end
+      if cancelled?
+        m[:other]["Proposed release"] = release_date
+        m[:other]["Cancellation date"] = cancellation_date
+      else
+        m[:other]["Release date"] = release_date_and_status
+      end
     end
   end
 

--- a/app/presenters/take_part_presenter.rb
+++ b/app/presenters/take_part_presenter.rb
@@ -1,9 +1,17 @@
 class TakePartPresenter < ContentItemPresenter
+  include TitleAndContext
+
   def body
     content_item["details"]["body"]
   end
 
   def image
     content_item["details"]["image"]
+  end
+
+  def title_and_context
+    super.tap do |t|
+      t.delete(:average_title_length)
+    end
   end
 end

--- a/app/presenters/title_and_context.rb
+++ b/app/presenters/title_and_context.rb
@@ -1,0 +1,9 @@
+module TitleAndContext
+  def title_and_context
+    {
+      title: title,
+      context: I18n.t("content_item.format.#{document_type}", count: 1),
+      average_title_length: "long"
+    }
+  end
+end

--- a/app/presenters/topical_event_about_page_presenter.rb
+++ b/app/presenters/topical_event_about_page_presenter.rb
@@ -1,5 +1,6 @@
 class TopicalEventAboutPagePresenter < ContentItemPresenter
   include ExtractsHeadings
+  include TitleAndContext
   include ActionView::Helpers::UrlHelper
 
   def body
@@ -19,6 +20,13 @@ class TopicalEventAboutPagePresenter < ContentItemPresenter
     result = super
     result.last[:title] = parent['title']
     result
+  end
+
+  def title_and_context
+    super.tap do |t|
+      t.delete(:average_title_length)
+      t.delete(:context)
+    end
   end
 
 private

--- a/app/presenters/working_group_presenter.rb
+++ b/app/presenters/working_group_presenter.rb
@@ -1,5 +1,6 @@
 class WorkingGroupPresenter < ContentItemPresenter
   include ExtractsHeadings
+  include TitleAndContext
   include ActionView::Helpers::UrlHelper
 
   def email
@@ -22,6 +23,13 @@ class WorkingGroupPresenter < ContentItemPresenter
     # http://ruby-doc.org/core-2.3.0/Hash.html#method-i-dig
     return [] unless content_item["links"] && content_item["links"]["policies"]
     content_item["links"]["policies"]
+  end
+
+  def title_and_context
+    super.tap do |t|
+      t.delete(:average_title_length)
+      t.delete(:context)
+    end
   end
 
 private

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -3,22 +3,7 @@
 <%= content_for :meta_description, @content_item.description %>
 
 <%= render "shared/breadcrumbs" %>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.document_type}", count: 1),
-        title: @content_item.title,
-        average_title_length: 'long' %>
-  </div>
-
-  <div class="column-third">
-  <%= render 'shared/available_languages',
-    translations: @content_item.available_translations
-  %>
-  </div>
-</div>
-
+<%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -1,15 +1,7 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.title %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.document_type}", count: 1),
-        title: @content_item.title,
-        average_title_length: 'long' %>
-  </div>
-</div>
-
+<%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -6,10 +6,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.document_type}", count: 1),
-        title: @content_item.title,
-        average_title_length: "long" %>
+    <%= render 'govuk_component/title', @content_item.title_and_context %>
   </div>
   <div class="column-third">
     <%= render 'shared/available_languages',

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -3,16 +3,7 @@
 <%= content_for :meta_description, @content_item.description %>
 
 <%= render "shared/breadcrumbs" %>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.document_type}", count: 1),
-        title: @content_item.title,
-        average_title_length: "long" %>
-  </div>
-</div>
-
+<%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -2,16 +2,7 @@
 <%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
 <%= content_for :meta_description, @content_item.description %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/title',
-        context: "Operations in #{@content_item.field_of_operation.try(:title)}",
-        title: @content_item.title,
-        average_title_length: "long"
-      %>
-  </div>
-</div>
-
+<%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -2,15 +2,7 @@
 <%= content_for :title, @content_item.page_title %>
 <%= content_for :meta_description, @content_item.description %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.document_type}", count: 1),
-        title: @content_item.title,
-        average_title_length: 'long' %>
-  </div>
-</div>
-
+<%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 
 <div class="grid-row">

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -2,15 +2,7 @@
 <%= content_for :title, @content_item.page_title %>
 <%= content_for :meta_description, @content_item.description %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.document_type}", count: 1),
-        title: @content_item.title,
-        average_title_length: "long" %>
-  </div>
-</div>
-
+<%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -4,12 +4,8 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.document_type}", count: 1),
-        title: @content_item.title,
-        average_title_length: "long" %>
+    <%= render 'govuk_component/title', @content_item.title_and_context %>
   </div>
-
   <% if @content_item.national_statistics? %>
     <%= render 'shared/national_statistics_logo' %>
   <% end %>

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -2,13 +2,6 @@
 <%= content_for :title, @content_item.title %>
 <%= content_for :meta_description, @content_item.description %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.document_type}", count: 1),
-        title: @content_item.title %>
-  </div>
-</div>
-
+<%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 <%= render 'shared/sidebar_with_body', content_item: @content_item %>

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -4,12 +4,7 @@
 
 <%= render "shared/breadcrumbs" %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/title', title: @content_item.title %>
-  </div>
-</div>
-
+<%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 
 <div class="grid-row sidebar-with-body">

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -2,16 +2,8 @@
 <%= content_for :title, @content_item.title %>
 <%= content_for :meta_description, @content_item.description %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/title',
-        title: @content_item.title %>
-  </div>
-</div>
-
-<% unless @content_item.description.blank? %>
-  <%= render 'shared/description', description: @content_item.description %>
-<% end %>
+<%= render 'shared/title_and_translations', content_item: @content_item %>
+<%= render 'shared/description', description: @content_item.description %>
 
 <div class="grid-row sidebar-with-body">
   <% if @content_item.contents.any? %>

--- a/app/views/shared/_title_and_translations.html.erb
+++ b/app/views/shared/_title_and_translations.html.erb
@@ -1,0 +1,12 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title', @content_item.title_and_context %>
+  </div>
+  <% if @content_item.available_translations.any? %>
+    <div class="column-third">
+      <%= render 'shared/available_languages',
+        translations: @content_item.available_translations
+      %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
Clean up each format’s template by moving format specific logic into module, with overrides in format presenters.

Default:
* Content item title
* Context based on document type
* Long title length

This makes it difficult to include titles with the wrong attributes.
It also makes it easy to link to translations to any format – if a format has translations, then the links will display – protecting against accidental omission as with the speeches format.

One further commit:
* Protect against overwriting properties on the `other` hash provided to metadata and document footer components

A template for a standard format is now as simple as:
```
<%= content_for :page_class, @content_item.format.dasherize %>
<%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
<%= content_for :meta_description, @content_item.description %>

<%= render 'shared/title_and_translations', content_item: @content_item %>
<%= render 'shared/withdrawal_notice', content_item: @content_item %>
<%= render 'shared/metadata', content_item: @content_item %>
<%= render 'shared/description', description: @content_item.description %>
<%= render 'shared/sidebar_with_body', content_item: @content_item %>
<%= render 'govuk_component/document_footer', @content_item.document_footer %>
```