### PR TITLE
Add space beneath HTML publication contents

### DIFF
--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -71,6 +71,11 @@
 
     background: $light-blue;
     padding: $gutter $gutter $gutter / 3;
+    margin-bottom: $gutter;
+
+    @include media(tablet) {
+      margin-bottom: $gutter * 2;
+    }
 
     &.direction-rtl {
       direction: rtl;


### PR DESCRIPTION
Include a default margin beneath the blue block of contents.
Coincides with a component change in static: https://github.com/alphagov/static/pull/870

## Before
![screen shot 2017-01-04 at 16 29 23](https://cloud.githubusercontent.com/assets/319055/21649846/fe9b18e8-d29a-11e6-992c-b907a86c8b57.png)

## After
![screen shot 2017-01-04 at 16 28 54](https://cloud.githubusercontent.com/assets/319055/21649845/fe95aae8-d29a-11e6-8d59-a6677f88457d.png)