### PR TITLE
Don't show empty contents lists on HTML publications

### DIFF
--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -78,8 +78,11 @@
     }
   }
 
+  .headings {
+    margin-bottom: $gutter;
+  }
+
   .in-page-navigation {
-    margin-top: $gutter;
     margin-bottom: $gutter;
 
     @include media(tablet) {

--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -3,6 +3,10 @@ class HtmlPublicationPresenter < ContentItemPresenter
     content_item["details"]["body"]
   end
 
+  def contents?
+    contents && contents != '<ol></ol>'
+  end
+
   def contents
     content_item["details"]["headings"].html_safe
   end

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -39,12 +39,14 @@
     </div>
     <%= @content_item.last_changed %>
   </div>
-  <nav class="in-page-navigation">
-    <h2>
-      <%= t("content_item.contents") %>
-    </h2>
-    <%= @content_item.contents %>
-  </nav>
+  <% if @content_item.contents? %>
+    <nav class="in-page-navigation">
+      <h2>
+        <%= t("content_item.contents") %>
+      </h2>
+      <%= @content_item.contents %>
+    </nav>
+  <% end %>
 </header>
 
 <%= render partial: 'govuk_component/govspeak_html_publication',

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -27,6 +27,14 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
     assert_has_component_organisation_logo_with_brand("executive-office", 4)
   end
 
+  test "no contents are shown when headings are an empty list" do
+    setup_and_visit_content_item("prime_ministers_office")
+
+    within ".publication-header" do
+      refute page.has_text?("Contents")
+    end
+  end
+
   test "html publication with rtl text direction" do
     setup_and_visit_content_item("arabic_translation")
     assert page.has_css?(".publication-header.direction-rtl"), "has .direction-rtl class on .publication-header element"

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -10,6 +10,12 @@ class HtmlPublicationPresenterTest < PresenterTestCase
     assert_equal schema_item("published")['links']['parent'][0]['document_type'], presented_item("published").format_sub_type
     assert_equal schema_item("published")['title'], presented_item("published").title
     assert_equal schema_item("published")['details']['body'], presented_item("published").body
+    assert_equal schema_item("published")['details']['headings'], presented_item("published").contents
+  end
+
+  test 'presents no contents when headings is an empty list' do
+    assert_equal schema_item("prime_ministers_office")['details']['headings'], '<ol></ol>'
+    refute presented_item("prime_ministers_office").contents?
   end
 
   test 'presents the last change date' do


### PR DESCRIPTION
Not all HTML publications have a list of headings. When there are none, don’t include the empty list or its associated heading.

@gpeng Can you confirm how we publish headings for HTML publications without any headings? Is it passed through as an empty ordered list as in the example? This exists as a bug on live, and I've presumed the logic hasn't been fixed: https://www.gov.uk/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration

## Before
![screen shot 2017-01-04 at 17 00 51](https://cloud.githubusercontent.com/assets/319055/21651143/6fad601e-d29f-11e6-8217-e823bcdb8171.png)

## After
![screen shot 2017-01-04 at 17 00 16](https://cloud.githubusercontent.com/assets/319055/21651144/6fb06e1c-d29f-11e6-9af3-bd16f4b88068.png)