### PR TITLE
Strip trailing colons from contents list

### DIFF
--- a/app/presenters/extracts_headings.rb
+++ b/app/presenters/extracts_headings.rb
@@ -2,8 +2,12 @@ module ExtractsHeadings
   def extract_headings_with_ids(html)
     headings = Nokogiri::HTML(html).css('h2').map do |heading|
       id = heading.attribute('id')
-      { text: heading.text, id: id.value } if id
+      { text: strip_trailing_colons(heading.text), id: id.value } if id
     end
     headings.compact
+  end
+
+  def strip_trailing_colons(heading)
+    heading.gsub(/\:$/, '')
   end
 end

--- a/test/presenters/extracts_headings_test.rb
+++ b/test/presenters/extracts_headings_test.rb
@@ -8,6 +8,16 @@ class ExtractsHeadingsTest < ActiveSupport::TestCase
     assert_equal [{ text: "A heading", id: 'custom' }], extract_headings_with_ids(html)
   end
 
+  test "removes trailing colons from headings" do
+    html = '<h2 id="custom">List:</h2>'
+    assert_equal [{ text: "List", id: 'custom' }], extract_headings_with_ids(html)
+  end
+
+  test "removes only trailing colons from headings" do
+    html = '<h2 id="custom">Part 2: List:</h2>'
+    assert_equal [{ text: "Part 2: List", id: 'custom' }], extract_headings_with_ids(html)
+  end
+
   test "ignores headings without an id" do
     html = '<h2>John Doe</h2>'
     assert_empty extract_headings_with_ids(html)


### PR DESCRIPTION
When extracting headings from content, discard trailing colons. The colon may make sense in the body of content, but it’s incorrect in a list of contents.

## Before

![screen shot 2017-01-05 at 14 17 21](https://cloud.githubusercontent.com/assets/319055/21683557/b97205b2-d351-11e6-99ab-9273be44f0e5.png)


## After

![screen shot 2017-01-05 at 14 14 02](https://cloud.githubusercontent.com/assets/319055/21683525/a2b99920-d351-11e6-81ef-fafc64bcd803.png)
