### PR TITLE
Make official stats announcements translation key singular

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,7 +77,7 @@ en:
   content_item:
     format:
       # `national` & `official` are old document types for
-      # `national_statistics_announcement` and `official_statistics_announcements`.
+      # `national_statistics_announcement` and `official_statistics_announcement`.
       # They can be removed once https://github.com/alphagov/whitehall/pull/2783 is
       # deployed and all statistics announcements have been republished.
       national:
@@ -213,7 +213,7 @@ en:
       official_statistics:
         one: Official Statistics
         other: Official Statistics
-      official_statistics_announcements:
+      official_statistics_announcement:
         one: Official statistics announcement
         other: Official statistics announcements
       take_part:


### PR DESCRIPTION
The format is singular:
https://github.com/alphagov/whitehall/pull/2783/files

Fixes:
`translation missing: en.content_item.format.official_statistics_announcement`

@tijmenb Do you know if it's ok to remove `national` and `official` keys now?