### PR TITLE
Move meta description and page class to base layout

### DIFF
--- a/app/assets/stylesheets/views/_case-studies.scss
+++ b/app/assets/stylesheets/views/_case-studies.scss
@@ -1,4 +1,4 @@
-.case-studies {
+.case-study {
   @include description;
   @include sidebar-with-body;
   @include withdrawal-notice;

--- a/app/assets/stylesheets/views/_unpublishing.scss
+++ b/app/assets/stylesheets/views/_unpublishing.scss
@@ -1,4 +1,5 @@
-.unpublishing {
+.unpublishing,
+.gone {
   margin-bottom: $gutter * 2;
 
   .summary,

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
 
 <%= render "shared/breadcrumbs" %>

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_class, @content_item.format.dasherize.pluralize %>
+<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
 
 <%= render "shared/breadcrumbs" %>

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -1,6 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize.pluralize %>
 <%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
-<%= content_for :meta_description, @content_item.description %>
 
 <%= render "shared/breadcrumbs" %>
 <%= render 'shared/title_and_translations', content_item: @content_item %>

--- a/app/views/content_items/coming_soon.html.erb
+++ b/app/views/content_items/coming_soon.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_class, "coming-soon" %>
+<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, "Coming soon - GOV.UK" %>
 
 <div class="grid-row">

--- a/app/views/content_items/coming_soon.html.erb
+++ b/app/views/content_items/coming_soon.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, "Coming soon - GOV.UK" %>
 
 <div class="grid-row">

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.title %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
 
 <%= render "shared/breadcrumbs" %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,6 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
-<%= content_for :meta_description, @content_item.description %>
 
 <%= render "shared/breadcrumbs" %>
 

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
 
 <%= render "shared/breadcrumbs" %>

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -1,6 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
-<%= content_for :meta_description, @content_item.description %>
 
 <%= render "shared/breadcrumbs" %>
 <%= render 'shared/title_and_translations', content_item: @content_item %>

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -1,6 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
-<%= content_for :meta_description, @content_item.description %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>

--- a/app/views/content_items/gone.html.erb
+++ b/app/views/content_items/gone.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, "No longer available - GOV.UK" %>
 
 <div class="grid-row">

--- a/app/views/content_items/gone.html.erb
+++ b/app/views/content_items/gone.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_class, "unpublishing" %>
+<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, "No longer available - GOV.UK" %>
 
 <div class="grid-row">

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -1,7 +1,6 @@
 <%
   content_for :page_class, @content_item.format.dasherize
   content_for :title, @content_item.title
-  content_for :meta_description, @content_item.description
   content_for :simple_header, true
 
   direction_css_class = ""

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -1,5 +1,4 @@
 <%
-  content_for :page_class, @content_item.format.dasherize
   content_for :title, @content_item.title
   content_for :simple_header, true
 

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
 
 <%= render "shared/breadcrumbs" %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -1,6 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
-<%= content_for :meta_description, @content_item.description %>
 
 <%= render "shared/breadcrumbs" %>
 

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -1,6 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
-<%= content_for :meta_description, @content_item.description %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -1,6 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
-<%= content_for :meta_description, @content_item.description %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -1,6 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, "#{@content_item.title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
-<%= content_for :meta_description, @content_item.description %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, "#{@content_item.title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
 
 <div class="grid-row">

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -1,6 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.title %>
-<%= content_for :meta_description, @content_item.description %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.title %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.title %>
 
 <%= render "shared/breadcrumbs" %>

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -1,6 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.title %>
-<%= content_for :meta_description, @content_item.description %>
 
 <%= render "shared/breadcrumbs" %>
 

--- a/app/views/content_items/unpublishing.html.erb
+++ b/app/views/content_items/unpublishing.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, "No longer available - GOV.UK" %>
 
 <div class="grid-row">

--- a/app/views/content_items/unpublishing.html.erb
+++ b/app/views/content_items/unpublishing.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_class, "unpublishing" %>
+<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, "No longer available - GOV.UK" %>
 
 <div class="grid-row">

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -1,6 +1,5 @@
 <%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.title %>
-<%= content_for :meta_description, @content_item.description %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.title %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
   <% end %>
 
   <div id="wrapper" class="<%= wrapper_class %>">
-    <main role="main" id="content" class="<%= yield(:page_class) %>" lang="<%= I18n.locale %>">
+    <main role="main" id="content" class="<%= @content_item.format.dasherize %>" lang="<%= I18n.locale %>">
       <%= render_phase_label @content_item, content_for(:phase_message) %>
       <%= yield %>
     </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,8 @@
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
   <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item.content_item } %>
-  <% if content_for(:meta_description).present? %>
-    <meta name="description" content="<%= content_for(:meta_description) %>" />
+  <% if @content_item.description %>
+    <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
   <meta name="govuk:content-id" content="<%= @content_item.content_id %>" />
 </head>

--- a/lib/generators/format/templates/format.html.erb
+++ b/lib/generators/format/templates/format.html.erb
@@ -1,4 +1,3 @@
-<%%= content_for :page_class, @content_item.format.dasherize %>
 <%%= content_for :title, @content_item.title %>
 
 <div class="grid-row">


### PR DESCRIPTION
When adding formats it's easy to forget to set the meta description to the content item’s description. This is a sensible default. Description isn't always present (eg html publications), in those cases omit the meta tag.

Almost all formats set the page class consistently to the dasherized version of the format name. Make those that were slightly different consistent and switch responsibility to the base layout, DRYing up the format templates. This reduces the risk of a format being accidentally added with a different page_class behaviour.