### PR TITLE
Render news article format

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,3 +39,4 @@
 @import "views/consultation";
 @import "views/speech";
 @import "views/world-location-news-article";
+@import "views/news-article";

--- a/app/assets/stylesheets/helpers/_share-buttons.scss
+++ b/app/assets/stylesheets/helpers/_share-buttons.scss
@@ -6,6 +6,24 @@
     @include core-16;
     margin-top: $gutter-one-third;
 
+    .direction-rtl & {
+      .share-button-link {
+        // By changing the link to inline-block the browser
+        // calculates the icon and the text as a single run of text
+        // rather than two. When they are considered to be two runs
+        // the browser splits the first link, putting the text before
+        // the second link, and the icon after the second link.
+        display: inline-block;
+        margin-right: 0;
+        margin-left: $gutter;
+
+        .share-button {
+          margin-right: 0;
+          margin-left: $gutter-one-third;
+        }
+      }
+    }
+
     .share-button-link {
       margin-right: $gutter;
 

--- a/app/assets/stylesheets/views/_news-article.scss
+++ b/app/assets/stylesheets/views/_news-article.scss
@@ -1,3 +1,7 @@
 .news-article {
-
+  @include description;
+  @include sidebar-with-body;
+  @include history-notice;
+  @include withdrawal-notice;
+  @include share-buttons;
 }

--- a/app/assets/stylesheets/views/_news-article.scss
+++ b/app/assets/stylesheets/views/_news-article.scss
@@ -4,4 +4,9 @@
   @include history-notice;
   @include withdrawal-notice;
   @include share-buttons;
+
+  .direction-rtl & {
+    direction: rtl;
+    text-align: start;
+  }
 }

--- a/app/assets/stylesheets/views/_news-article.scss
+++ b/app/assets/stylesheets/views/_news-article.scss
@@ -1,0 +1,3 @@
+.news-article {
+
+}

--- a/app/assets/stylesheets/views/_world-location-news-article.scss
+++ b/app/assets/stylesheets/views/_world-location-news-article.scss
@@ -4,4 +4,9 @@
   @include history-notice;
   @include withdrawal-notice;
   @include share-buttons;
+
+  .direction-rtl & {
+    direction: rtl;
+    text-align: start;
+  }
 }

--- a/app/presenters/news_article_presenter.rb
+++ b/app/presenters/news_article_presenter.rb
@@ -1,0 +1,2 @@
+class NewsArticlePresenter < ContentItemPresenter
+end

--- a/app/presenters/news_article_presenter.rb
+++ b/app/presenters/news_article_presenter.rb
@@ -1,2 +1,16 @@
 class NewsArticlePresenter < ContentItemPresenter
+  include Political
+  include Linkable
+  include Updatable
+  include Shareable
+  include TitleAndContext
+  include Metadata
+
+  def body
+    content_item["details"]["body"]
+  end
+
+  def image
+    content_item["details"]["image"]
+  end
 end

--- a/app/presenters/world_location_news_article_presenter.rb
+++ b/app/presenters/world_location_news_article_presenter.rb
@@ -1,7 +1,5 @@
 class WorldLocationNewsArticlePresenter < ContentItemPresenter
-  include ExtractsHeadings
   include Political
-  include Withdrawable
   include Linkable
   include Updatable
   include Shareable
@@ -10,12 +8,6 @@ class WorldLocationNewsArticlePresenter < ContentItemPresenter
 
   def body
     content_item["details"]["body"]
-  end
-
-  def contents
-    extract_headings_with_ids(body).map do |heading|
-      link_to(heading[:text], "##{heading[:id]}")
-    end
   end
 
   def image

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -1,0 +1,11 @@
+<%= content_for :title, @content_item.title %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+        context: t("content_item.format.#{@content_item.document_type}", count: 1),
+        title: @content_item.title %>
+  </div>
+</div>
+
+<%= render 'shared/description', description: @content_item.description %>

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -1,11 +1,10 @@
-<%= content_for :title, @content_item.title %>
+<%= content_for :title, @content_item.page_title %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.document_type}", count: 1),
-        title: @content_item.title %>
-  </div>
-</div>
-
+<%= render 'shared/title_and_translations', content_item: @content_item %>
+<%= render 'shared/withdrawal_notice', content_item: @content_item %>
+<%= render 'shared/metadata', content_item: @content_item %>
+<%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
+<%= render 'shared/sidebar_with_body', content_item: @content_item %>
+<%= render 'shared/share_buttons', share_urls: @content_item.share_urls %>
+<%= render 'govuk_component/document_footer', @content_item.document_footer %>

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -1,6 +1,4 @@
-<%= content_for :page_class, @content_item.format.dasherize %>
 <%= content_for :title, @content_item.page_title %>
-<%= content_for :meta_description, @content_item.description %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>

--- a/test/integration/news_article_test.rb
+++ b/test/integration/news_article_test.rb
@@ -1,4 +1,53 @@
 require 'test_helper'
 
 class NewsArticleTest < ActionDispatch::IntegrationTest
+  test "news article renders title, description and body" do
+    setup_and_visit_content_item("news_article")
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+    assert_has_component_govspeak(@content_item["details"]["body"])
+  end
+
+  test "renders first published and from in metadata and document footer" do
+    setup_and_visit_content_item("news_article")
+    from = [
+      "<a href=\"/government/organisations/prime-ministers-office-10-downing-street\">Prime Minister&#39;s Office, 10 Downing Street</a>",
+      "<a href=\"/government/people/theresa-may\">The Rt Hon Theresa May MP</a>"
+    ]
+
+    assert_has_component_metadata_pair("first_published", "25 December 2016")
+    assert_has_component_document_footer_pair("published", "25 December 2016")
+
+    assert_has_component_metadata_pair("from", from)
+    assert_has_component_document_footer_pair("from", from)
+  end
+
+  test "renders 'part of' in metadata and document footer" do
+    setup_and_visit_content_item('news_article_government_response')
+
+    part_of = "<a href=\"/government/policies/marine-environment\">Marine environment</a>"
+    assert_has_component_metadata_pair("part_of", [part_of])
+    assert_has_component_document_footer_pair("part_of", [part_of])
+  end
+
+  test "renders translation links when there is more than one translation" do
+    setup_and_visit_content_item("news_article")
+
+    assert page.has_css?("div[class='available-languages']")
+    assert page.has_css?("li[class='translation']")
+    assert page.has_link?("ردو", href: "/government/news/christmas-2016-prime-ministers-message.ur")
+  end
+
+  test "renders the lead image" do
+    setup_and_visit_content_item("news_article")
+    assert page.has_css?("img[src*='s465_Christmas'][alt='Christmas']")
+  end
+
+  test "renders history notice" do
+    setup_and_visit_content_item("news_article_history_mode")
+
+    within ".history-notice" do
+      assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
+    end
+  end
 end

--- a/test/integration/news_article_test.rb
+++ b/test/integration/news_article_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class NewsArticleTest < ActionDispatch::IntegrationTest
+end

--- a/test/integration/world_location_news_article_test.rb
+++ b/test/integration/world_location_news_article_test.rb
@@ -50,7 +50,7 @@ class WorldLocationNewsArticleTest < ActionDispatch::IntegrationTest
   test "renders the lead image" do
     setup_and_visit_content_item("world_location_news_article")
 
-    assert page.has_css?("img[src*=placeholder-a6e35fc15d4bfcc9d0781f3888dc548b39288f0fe10a65a4b51fef603540b0c5][alt='placeholder']")
+    assert page.has_css?("img[src*='placeholder-a6e35fc15d4bfcc9d0781f3888dc548b39288f0fe10a65a4b51fef603540b0c5'][alt='placeholder']")
   end
 
   test "renders history notice" do

--- a/test/presenters/news_article_presenter_test.rb
+++ b/test/presenters/news_article_presenter_test.rb
@@ -1,13 +1,69 @@
 require 'presenter_test_helper'
 
 class NewsArticlePresenterTest
-  class PresentedNewsArticle < PresenterTestCase
+  class NewsArticlePresenterTestCase < PresenterTestCase
+    attr_accessor :example_schema_name
+
     def format_name
       "news_article"
     end
+  end
 
-    test 'presents the format' do
-      assert_equal schema_item['format'], presented_item.format
+  class PresentedNewsArticleTest < NewsArticlePresenterTestCase
+    test 'is linkable' do
+      assert presented_item.is_a?(Linkable)
+    end
+
+    test 'is updatable' do
+      assert presented_item.is_a?(Updatable)
+    end
+
+    test 'is withdrawable' do
+      assert presented_item.is_a?(Withdrawable)
+    end
+
+    test 'is shareable' do
+      assert presented_item.is_a?(Shareable)
+    end
+
+    test 'includes political' do
+      assert presented_item.is_a?(Political)
+    end
+
+    test 'presents a description' do
+      assert_equal schema_item['description'], presented_item.description
+    end
+
+    test 'presents a body' do
+      assert_equal schema_item['details']['body'], presented_item.body
+    end
+
+    test 'presents a readable first published date' do
+      assert_equal '25 December 2016', presented_item.published
+    end
+
+    test 'presents the locale' do
+      assert_equal schema_item['locale'], presented_item.locale
+    end
+  end
+
+  class HistoryModePresentedNewsArticle < NewsArticlePresenterTestCase
+    def example_schema_name
+      "news_article_history_mode"
+    end
+
+    test 'presents historically political' do
+      assert presented_item(example_schema_name).historically_political?
+    end
+  end
+
+  class TranslatedPresentedNewsArticle < NewsArticlePresenterTestCase
+    def example_schema_name
+      "news_article_news_story_translated_arabic"
+    end
+
+    test 'presents the locale as the translated item locale' do
+      assert_equal 'ur', presented_item(example_schema_name).locale
     end
   end
 end

--- a/test/presenters/news_article_presenter_test.rb
+++ b/test/presenters/news_article_presenter_test.rb
@@ -1,0 +1,13 @@
+require 'presenter_test_helper'
+
+class NewsArticlePresenterTest
+  class PresentedNewsArticle < PresenterTestCase
+    def format_name
+      "news_article"
+    end
+
+    test 'presents the format' do
+      assert_equal schema_item['format'], presented_item.format
+    end
+  end
+end


### PR DESCRIPTION
Tests will fail until the schema and examples have been merged and deployed: https://github.com/alphagov/govuk-content-schemas/pull/488

* Render the news article format, with each of its sub-types: news_story, press_release and government_response (identical except for the title context provided by `document_type`)
* Includes a couple of fixes for world location news article
* Allow news and world location news to be translated rtl
* Fix rtl rendering of share buttons

| Type | Old | New |
| ----- | --- | ----- |
| News story | ![news_story_old](https://cloud.githubusercontent.com/assets/319055/22061499/190a9690-dd6d-11e6-8e2a-507949e3b19c.png) | ![news_story_new](https://cloud.githubusercontent.com/assets/319055/22061503/1dc00b3e-dd6d-11e6-9ccc-ea4ade37096b.png)
| Translated | ![news_story_translated_old](https://cloud.githubusercontent.com/assets/319055/22061520/34a52c1c-dd6d-11e6-81ca-1432e88b1b74.png) | ![news_story_translated_new](https://cloud.githubusercontent.com/assets/319055/22061532/392dbc9a-dd6d-11e6-917f-6fecc112c329.png)
| History mode | ![news_story_history_mode_old](https://cloud.githubusercontent.com/assets/319055/22061550/4907dfc4-dd6d-11e6-8cb9-18d61a8055b9.png) | ![news_story_history_mode_new](https://cloud.githubusercontent.com/assets/319055/22061549/4719a026-dd6d-11e6-9087-eb5c6c804bdc.png)

https://trello.com/c/Jse0oAvr/575-news-article-migration-1-mvp-content-schema-examples-and-front-end-work