### PR TITLE
Bump gds-api-adapters to 37.5.1.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'rails-controller-testing', '~> 0.1'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem "gds-api-adapters", "37.5.1"
+  gem "gds-api-adapters", "39.1.0"
 end
 
 gem 'govuk_navigation_helpers', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (37.5.1)
+    gds-api-adapters (39.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -250,7 +250,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara
-  gds-api-adapters (= 37.5.1)
+  gds-api-adapters (= 39.1.0)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
   govuk_frontend_toolkit (= 2.0.1)


### PR DESCRIPTION
This ensures the GOVUK_FACT_CHECK_ID header is passed through on
upstream requests.