### PR TITLE
Remove IE specific stylesheets

### DIFF
--- a/app/assets/stylesheets/application-ie6.scss
+++ b/app/assets/stylesheets/application-ie6.scss
@@ -1,7 +1,0 @@
-// BASE STYLESHEET FOR IE 6 COMPILER
-
-$is-ie: true;
-$ie-version: 6;
-$mobile-ie6: false;
-
-@import "application";

--- a/app/assets/stylesheets/application-ie7.scss
+++ b/app/assets/stylesheets/application-ie7.scss
@@ -1,6 +1,0 @@
-// BASE STYLESHEET FOR IE 7 COMPILER
-
-$is-ie: true;
-$ie-version: 7;
-
-@import "application";

--- a/app/assets/stylesheets/application-ie8.scss
+++ b/app/assets/stylesheets/application-ie8.scss
@@ -1,6 +1,0 @@
-// BASE STYLESHEET FOR IE 8 COMPILER
-
-$is-ie: true;
-$ie-version: 8;
-
-@import "application";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,10 +2,7 @@
 <html>
 <head>
   <title><%= yield :title %> - GOV.UK</title>
-  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application" %><!--<![endif]-->
-  <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><script>var ieVersion = 6;</script><![endif]-->
-  <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><script>var ieVersion = 7;</script><![endif]-->
-  <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><script>var ieVersion = 8;</script><![endif]-->
+  <%= stylesheet_link_tag "application" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
   <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item.content_item } %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,8 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w(
-  application-ie6.css
-  application-ie7.css
-  application-ie8.css
-)
+# Rails.application.config.assets.precompile += %w()


### PR DESCRIPTION
There are no IE specific styles in this application.

The govuk_frontend_toolkit defines some IE helpers here: https://github.com/alphagov/govuk_frontend_toolkit/blob/2011e77436fccd31f32a0a975a2bf4cc3b961495/stylesheets/_conditionals.scss#L67-L81

These rely on the IE6-8 specific stylesheets. We've ported almost all the formats now and we haven't had to override styles for these older browsers.