### PR TITLE
Add link tracking to left-hand contents list

### DIFF
--- a/app/presenters/contents_list.rb
+++ b/app/presenters/contents_list.rb
@@ -12,7 +12,14 @@ module ContentsList
   end
 
   def contents_link(text, id)
-    link_to(text, "##{id}")
+    link_to(
+      text,
+      "##{id}",
+      data: {
+        track_category: 'contentsClicked',
+        track_action: 'leftColumnH2',
+        track_label: id
+      })
   end
 
 private

--- a/app/presenters/contents_list.rb
+++ b/app/presenters/contents_list.rb
@@ -1,4 +1,22 @@
-module ExtractsHeadings
+module ContentsList
+  include ActionView::Helpers::UrlHelper
+
+  def contents
+    contents_items.map do |item|
+      contents_link(item[:text], item[:id])
+    end
+  end
+
+  def contents_items
+    extract_headings_with_ids(body)
+  end
+
+  def contents_link(text, id)
+    link_to(text, "##{id}")
+  end
+
+private
+
   def extract_headings_with_ids(html)
     headings = Nokogiri::HTML(html).css('h2').map do |heading|
       id = heading.attribute('id')

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -1,19 +1,12 @@
 class DetailedGuidePresenter < ContentItemPresenter
-  include ExtractsHeadings
+  include ContentsList
   include Metadata
   include NationalApplicability
   include Political
-  include ActionView::Helpers::UrlHelper
   include TitleAndContext
 
   def body
     content_item["details"]["body"]
-  end
-
-  def contents
-    extract_headings_with_ids(body).map do |heading|
-      link_to(heading[:text], "##{heading[:id]}")
-    end
   end
 
   def context

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -2,16 +2,16 @@ class DocumentCollectionPresenter < ContentItemPresenter
   include Metadata
   include Political
   include TitleAndContext
-  include ActionView::Helpers::UrlHelper
+  include ContentsList
 
   def body
     content_item["details"]["body"]
   end
 
-  def contents
+  def contents_items
     groups.map do |group|
       title = group["title"]
-      link_to(title, "##{group_title_id(title)}")
+      { text: title, id: group_title_id(title) }
     end
   end
 

--- a/app/presenters/statistical_data_set_presenter.rb
+++ b/app/presenters/statistical_data_set_presenter.rb
@@ -1,17 +1,10 @@
 class StatisticalDataSetPresenter < ContentItemPresenter
-  include ExtractsHeadings
+  include ContentsList
   include TitleAndContext
   include Political
   include Metadata
-  include ActionView::Helpers::UrlHelper
 
   def body
     content_item["details"]["body"]
-  end
-
-  def contents
-    extract_headings_with_ids(body).map do |heading|
-      link_to(heading[:text], "##{heading[:id]}")
-    end
   end
 end

--- a/app/presenters/topical_event_about_page_presenter.rb
+++ b/app/presenters/topical_event_about_page_presenter.rb
@@ -1,16 +1,9 @@
 class TopicalEventAboutPagePresenter < ContentItemPresenter
-  include ExtractsHeadings
+  include ContentsList
   include TitleAndContext
-  include ActionView::Helpers::UrlHelper
 
   def body
     content_item["details"]["body"]
-  end
-
-  def contents
-    extract_headings_with_ids(body).map do |heading|
-      link_to(heading[:text], "##{heading[:id]}")
-    end
   end
 
   # Old topical event pages have a "archived" string appended to their title

--- a/app/presenters/working_group_presenter.rb
+++ b/app/presenters/working_group_presenter.rb
@@ -1,7 +1,6 @@
 class WorkingGroupPresenter < ContentItemPresenter
-  include ExtractsHeadings
+  include ContentsList
   include TitleAndContext
-  include ActionView::Helpers::UrlHelper
 
   def email
     content_item["details"]["email"]
@@ -11,11 +10,8 @@ class WorkingGroupPresenter < ContentItemPresenter
     content_item["details"]["body"]
   end
 
-  def contents
-    body_headings = extract_headings_with_ids(body)
-    (body_headings + extra_headings).map do |heading|
-      link_to(heading[:text], "##{heading[:id]}")
-    end
+  def contents_items
+    super + extra_headings
   end
 
   def policies

--- a/app/views/shared/_sidebar_contents.html.erb
+++ b/app/views/shared/_sidebar_contents.html.erb
@@ -1,7 +1,7 @@
 <% if contents.any? %>
   <nav role="navigation">
     <h1><%= t("content_item.contents") %></h1>
-    <ol class="dash-list">
+    <ol class="dash-list" data-module="track-click">
       <% contents.each do |heading| %>
         <li>
           <%= heading %>

--- a/test/presenter_test_helper.rb
+++ b/test/presenter_test_helper.rb
@@ -5,6 +5,10 @@ class PresenterTestCase < ActiveSupport::TestCase
     raise NotImplementedError, "Override this method in your test class"
   end
 
+  def contents_link_attributes
+    'data-track-category="contentsClicked" data-track-action="leftColumnH2"'
+  end
+
 private
 
   def presented_item(type = format_name, overrides = {})

--- a/test/presenters/contents_list_test.rb
+++ b/test/presenters/contents_list_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
-class ExtractsHeadingsTest < ActiveSupport::TestCase
-  include ExtractsHeadings
+class ContentsListTest < ActiveSupport::TestCase
+  include ContentsList
 
   test "extracts a single h2" do
     html = '<h2 id="custom">A heading</h2>'

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -13,7 +13,7 @@ class DetailedGuidePresenterTest < PresenterTestCase
   end
 
   test 'presents a list of contents extracted from headings in the body' do
-    assert_equal '<a href="#the-basics">The basics</a>', presented_item.contents[0]
+    assert_equal "<a #{contents_link_attributes} data-track-label=\"the-basics\" href=\"#the-basics\">The basics</a>", presented_item.contents[0]
   end
 
   test '#published returns a formatted date of the day the content item became public' do

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -30,12 +30,12 @@ class DocumentCollectionPresenterTest
 
     test 'presents a contents list based on collection groups' do
       contents = [
-        "<a href=\"#car-and-light-van\">Car and light van</a>",
-        "<a href=\"#moped-and-motorcycle\">Moped and motorcycle</a>",
-        "<a href=\"#lorry\">Lorry</a>",
-        "<a href=\"#bus-and-coach\">Bus and coach</a>",
-        "<a href=\"#driver-and-rider-trainer\">Driver and rider trainer</a>",
-        "<a href=\"#developed-driving-competence\">Developed driving competence</a>"
+        "<a #{contents_link_attributes} data-track-label=\"car-and-light-van\" href=\"#car-and-light-van\">Car and light van</a>",
+        "<a #{contents_link_attributes} data-track-label=\"moped-and-motorcycle\" href=\"#moped-and-motorcycle\">Moped and motorcycle</a>",
+        "<a #{contents_link_attributes} data-track-label=\"lorry\" href=\"#lorry\">Lorry</a>",
+        "<a #{contents_link_attributes} data-track-label=\"bus-and-coach\" href=\"#bus-and-coach\">Bus and coach</a>",
+        "<a #{contents_link_attributes} data-track-label=\"driver-and-rider-trainer\" href=\"#driver-and-rider-trainer\">Driver and rider trainer</a>",
+        "<a #{contents_link_attributes} data-track-label=\"developed-driving-competence\" href=\"#developed-driving-competence\">Developed driving competence</a>"
       ]
 
       assert_equal contents, presented_item.contents

--- a/test/presenters/statistical_data_set_presenter_test.rb
+++ b/test/presenters/statistical_data_set_presenter_test.rb
@@ -13,7 +13,7 @@ class StatisticalDataSetPresenterTest
     end
 
     test 'presents a list of contents extracted from headings in the body' do
-      assert_equal '<a href="#olympics">Olympics</a>', presented_item.contents[0]
+      assert_equal "<a #{contents_link_attributes} data-track-label=\"olympics\" href=\"#olympics\">Olympics</a>", presented_item.contents[0]
     end
 
     test '#published returns a formatted date of the day the content item became public' do

--- a/test/presenters/topical_event_about_page_presenter_test.rb
+++ b/test/presenters/topical_event_about_page_presenter_test.rb
@@ -13,13 +13,14 @@ class TopicalEventAboutPagePresenterTest < PresenterTestCase
   end
 
   test 'presents a list of contents extracted from headings in the body' do
-    assert_equal ['<a href="#response-in-the-uk">Response in the UK</a>',
-                  '<a href="#response-in-africa">Response in Africa</a>',
-                  '<a href="#advice-for-travellers">Advice for travellers</a>',
-                  '<a href="#advice-for-medics">Advice for medics</a>',
-                  '<a href="#advice-for-aid-workers">Advice for aid workers</a>',
-                  '<a href="#how-you-can-help">How you can help</a>'
-                 ], presented_item.contents
+    assert_equal [
+        "<a #{contents_link_attributes} data-track-label=\"response-in-the-uk\" href=\"#response-in-the-uk\">Response in the UK</a>",
+        "<a #{contents_link_attributes} data-track-label=\"response-in-africa\" href=\"#response-in-africa\">Response in Africa</a>",
+        "<a #{contents_link_attributes} data-track-label=\"advice-for-travellers\" href=\"#advice-for-travellers\">Advice for travellers</a>",
+        "<a #{contents_link_attributes} data-track-label=\"advice-for-medics\" href=\"#advice-for-medics\">Advice for medics</a>",
+        "<a #{contents_link_attributes} data-track-label=\"advice-for-aid-workers\" href=\"#advice-for-aid-workers\">Advice for aid workers</a>",
+        "<a #{contents_link_attributes} data-track-label=\"how-you-can-help\" href=\"#how-you-can-help\">How you can help</a>"
+      ], presented_item.contents
   end
 
   test 'presents no contents when no headings in the body' do


### PR DESCRIPTION
* Move contents logic into extracts headings module
  * Provide new helper methods for contents_items and contents_link allowing presenters to override them if needed
  * Override content_items method in collections to use a list of groups
  * Add extra headings to working groups when appropriate

* Add link tracking module and attributes to all contents links

Category: contentsClicked
Action: leftColumnH2
Label: ID of the heading

Depends on https://github.com/alphagov/static/pull/883

https://trello.com/c/62Gy8pyj/77-track-interactions-with-contents-lists-1-s

cc @nickcolley 