### PR TITLE
[DO NOT MERGE] Proof of concept for rendering help pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,3 +39,4 @@
 @import "views/consultation";
 @import "views/speech";
 @import "views/world-location-news-article";
+@import "views/help-page";

--- a/app/assets/stylesheets/views/_help-page.scss
+++ b/app/assets/stylesheets/views/_help-page.scss
@@ -1,0 +1,3 @@
+.help-page {
+  @include description;
+}

--- a/app/presenters/help_page_presenter.rb
+++ b/app/presenters/help_page_presenter.rb
@@ -1,0 +1,16 @@
+class HelpPagePresenter < ContentItemPresenter
+  include Linkable
+
+  def body
+    content_item["details"]["body"]
+  end
+
+  def related_items
+    content_item["links"]["ordered_related_items"].map do |link|
+      {
+        title: link["title"],
+        url:  link["base_path"]
+      }
+    end
+  end
+end

--- a/app/views/content_items/help_page.html.erb
+++ b/app/views/content_items/help_page.html.erb
@@ -1,0 +1,30 @@
+<% content_for :simple_header, true %>
+<%= content_for :title, @content_item.title %>
+
+<%= render "shared/breadcrumbs" %>
+
+<div class="grid-row sidebar-with-body">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+        context: 'Help',
+        title: @content_item.title %>
+
+    <%= render 'shared/description', description: @content_item.description %>
+
+    <%= render 'govuk_component/govspeak',
+        content: @content_item.body,
+        direction: page_text_direction %>
+  </div>
+  <div class="column-third">
+    <div style="margin-top: 45px">
+    <%= render partial: 'govuk_component/related_items', locals: {
+      sections: [
+        {
+          title: "Elsewhere on GOV.UK",
+          items: @content_item.related_items
+        }
+      ]
+    } %>
+    </div>
+  </div>
+</div>

--- a/test/integration/help_page_test.rb
+++ b/test/integration/help_page_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class HelpPageTest < ActionDispatch::IntegrationTest
+end

--- a/test/presenters/help_page_presenter_test.rb
+++ b/test/presenters/help_page_presenter_test.rb
@@ -1,0 +1,13 @@
+require 'presenter_test_helper'
+
+class HelpPagePresenterTest
+  class PresentedHelpPage < PresenterTestCase
+    def format_name
+      "help_page"
+    end
+
+    test 'presents the format' do
+      assert_equal schema_item['format'], presented_item.format
+    end
+  end
+end


### PR DESCRIPTION
Renders help page example from:
https://github.com/alphagov/govuk-content-schemas/pull/495

| Old | New |
| -- | -- |
|<img width="1200" alt="help_old" src="https://cloud.githubusercontent.com/assets/319055/22214915/6b8c7992-e191-11e6-8ccd-a41b062fd104.png">|<img width="1200" alt="help_new" src="https://cloud.githubusercontent.com/assets/319055/22214916/6ba98dfc-e191-11e6-9191-7677df89bab7.png">|

