### PR TITLE
Navigation AB Test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'unicorn', '4.8'
 gem 'rails-i18n', '>= 4.0.4'
 gem 'rails_translation_manager', '~> 0.0.2'
 gem 'rails-controller-testing', '~> 0.1'
+gem 'govuk_ab_testing', '0.1.4'
 
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
@@ -27,7 +28,7 @@ else
   gem "gds-api-adapters", "39.1.0"
 end
 
-gem 'govuk_navigation_helpers', '~> 2.1.0'
+gem 'govuk_navigation_helpers', '~> 2.2.0'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ else
   gem "gds-api-adapters", "39.1.0"
 end
 
-gem 'govuk_navigation_helpers', '~> 1.0'
+gem 'govuk_navigation_helpers', '~> 2.1.0'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (1.0.0)
+    govuk_navigation_helpers (2.1.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -254,7 +254,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
   govuk_frontend_toolkit (= 5.1.0)
-  govuk_navigation_helpers (~> 1.0)
+  govuk_navigation_helpers (~> 2.1.0)
   jasmine-rails (~> 0.13.0)
   logstasher (= 0.6.1)
   mocha

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,10 +83,11 @@ GEM
     govuk-lint (1.2.0)
       rubocop (~> 0.39.0)
       scss_lint
+    govuk_ab_testing (0.1.4)
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (2.1.0)
+    govuk_navigation_helpers (2.2.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -253,8 +254,9 @@ DEPENDENCIES
   gds-api-adapters (= 39.1.0)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
+  govuk_ab_testing (= 0.1.4)
   govuk_frontend_toolkit (= 5.1.0)
-  govuk_navigation_helpers (~> 2.1.0)
+  govuk_navigation_helpers (~> 2.2.0)
   jasmine-rails (~> 0.13.0)
   logstasher (= 0.6.1)
   mocha

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,23 +1,18 @@
 require 'gds_api/content_store'
 
 class ContentItemsController < ApplicationController
-  include ABTestable
-
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from GdsApi::HTTPNotFound, with: :error_notfound
 
+  attr_accessor :content_item
+
   def show
     load_content_item
+    set_up_education_navigation_ab_testing
     set_expiry
-    set_page_variant
     with_locale do
       render content_item_template
     end
-  end
-
-  # Visible for testing
-  def should_present_new_navigation_view?
-    (education_navigation_ab_testing_group == "B") && new_navigation_enabled? && content_is_tagged_to_a_taxon?
   end
 
 private
@@ -45,6 +40,21 @@ private
     expires_in(max_age, public: !cache_private)
   end
 
+  def set_up_education_navigation_ab_testing
+    @education_navigation_ab_test = EducationNavigationAbTestRequest.new(request)
+    return unless @education_navigation_ab_test.content_schema_has_new_navigation?(@content_item.content_item)
+
+    @education_navigation_ab_test.set_response_vary_header response
+
+    # Setting a variant on a request is a type of Rails Dark Magic that will use a convention to automagically load
+    # an alternative partial/view/layout.
+    # For example, if I set a variant of :new_navigation and we render a partial called _breadcrumbs.html.erb then Rails
+    # will attempt to load _breadcrumbs.html+new_navigation.erb instead. If such a file does not exist, then it falls
+    # back to _breadcrumbs.html.erb.
+    # See: http://edgeguides.rubyonrails.org/4_1_release_notes.html#action-pack-variants
+    request.variant = :new_navigation if @education_navigation_ab_test.should_present_new_navigation_view?(@content_item.content_item)
+  end
+
   def with_locale
     I18n.with_locale(@content_item.locale || I18n.default_locale) { yield }
   end
@@ -63,23 +73,5 @@ private
 
   def error_notfound
     render plain: 'Not found', status: :not_found
-  end
-
-  # Setting a variant on a request is a type of Rails Dark Magic that will use a convention to automagically load
-  # an alternative partial/view/layout.
-  # For example, if I set a variant of :new_navigation and we render a partial called _breadcrumbs.html.erb then Rails
-  # will attempt to load _breadcrumbs.html+new_navigation.erb instead. If such a file does not exist, then it falls
-  # back to _breadcrumbs.html.erb.
-  # See: http://edgeguides.rubyonrails.org/4_1_release_notes.html#action-pack-variants
-  def set_page_variant
-    request.variant = :new_navigation if should_present_new_navigation_view?
-  end
-
-  def new_navigation_enabled?
-    ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
-  end
-
-  def content_is_tagged_to_a_taxon?
-    @content_item.taxons.any?
   end
 end

--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -1,0 +1,34 @@
+class EducationNavigationAbTestRequest
+  NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS = %w{detailed_guide}.freeze
+
+  attr_accessor :requested_variant
+
+  delegate :analytics_meta_tag, to: :requested_variant
+
+  def initialize(request)
+    @ab_test = GovukAbTesting::AbTest.new("educationnavigation", dimension: 41)
+    @requested_variant = @ab_test.requested_variant request
+  end
+
+  def content_schema_has_new_navigation?(content_item)
+    NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS.include? content_item["schema_name"]
+  end
+
+  def should_present_new_navigation_view?(content_item)
+    @requested_variant.variant_b? && new_navigation_enabled? && content_is_tagged_to_a_taxon?(content_item)
+  end
+
+  def set_response_vary_header(response)
+    @requested_variant.configure_response response
+  end
+
+private
+
+  def new_navigation_enabled?
+    ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
+  end
+
+  def content_is_tagged_to_a_taxon?(content_item)
+    content_item.dig("links", "taxons").present?
+  end
+end

--- a/app/presenters/ab_testable.rb
+++ b/app/presenters/ab_testable.rb
@@ -1,5 +1,0 @@
-module ABTestable
-  def education_navigation_ab_testing_group
-    request.headers["HTTP_GOVUK_ABTEST_EDUCATIONNAVIGATION"] == "B" ? "B" : "A"
-  end
-end

--- a/app/presenters/ab_testable.rb
+++ b/app/presenters/ab_testable.rb
@@ -1,0 +1,5 @@
+module ABTestable
+  def education_navigation_ab_testing_group
+    request.headers["HTTP_GOVUK_ABTEST_EDUCATIONNAVIGATION"] == "B" ? "B" : "A"
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -3,8 +3,6 @@ class ContentItemPresenter
 
   attr_reader :content_item, :title, :description, :format, :locale, :phase, :document_type
 
-  delegate :breadcrumbs, to: :@nav_helper
-
   def initialize(content_item)
     @content_item = content_item
     @title = content_item["title"]
@@ -29,6 +27,22 @@ class ContentItemPresenter
 
   def content_id
     content_item.parsed_content["content_id"]
+  end
+
+  def taxons
+    if content_item["links"].include?("taxons")
+      content_item["links"]["taxons"]
+    else
+      []
+    end
+  end
+
+  def breadcrumbs
+    @nav_helper.breadcrumbs[:breadcrumbs]
+  end
+
+  def taxon_breadcrumbs
+    @nav_helper.taxon_breadcrumbs[:breadcrumbs]
   end
 
 private

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -29,14 +29,6 @@ class ContentItemPresenter
     content_item.parsed_content["content_id"]
   end
 
-  def taxons
-    if content_item["links"].include?("taxons")
-      content_item["links"]["taxons"]
-    else
-      []
-    end
-  end
-
   def breadcrumbs
     @nav_helper.breadcrumbs[:breadcrumbs]
   end

--- a/app/presenters/metadata.rb
+++ b/app/presenters/metadata.rb
@@ -14,6 +14,12 @@ module Metadata
     }
   end
 
+  def metadata_for_new_navigation
+    data = metadata
+    data.delete(:part_of)
+    data
+  end
+
   def document_footer
     {
       from: from,
@@ -24,5 +30,11 @@ module Metadata
       direction: text_direction,
       other: {}
     }
+  end
+
+  def document_footer_for_new_navigation
+    data = document_footer
+    data.delete(:part_of)
+    data
   end
 end

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -5,4 +5,4 @@
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 <%= render 'shared/sidebar_with_body', content_item: @content_item %>
-<%= render 'govuk_component/document_footer', @content_item.document_footer %>
+<%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -207,4 +207,4 @@
 <% end %>
 
 <%= render 'shared/share_buttons', share_urls: @content_item.share_urls %>
-<%= render 'govuk_component/document_footer', @content_item.document_footer %>
+<%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/detailed_guide.html+new_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+new_navigation.erb
@@ -1,0 +1,44 @@
+<%= content_for :title, @content_item.page_title %>
+
+<div class="grid-row" data-module="sticky-element-container">
+  <div class="column-two-thirds">
+    <%= render 'shared/title_and_translations', content_item: @content_item %>
+
+    <% if @content_item.image.present? %>
+      <%= image_tag @content_item.image, class: "logo-image" %>
+    <% end %>
+
+    <%= render 'shared/withdrawal_notice', content_item: @content_item %>
+    <%= render 'shared/metadata', content_item: @content_item %>
+    <%= render 'shared/history_notice', content_item: @content_item %>
+    <%= render 'shared/description', description: @content_item.description %>
+
+    <div class="sidebar-with-body" id="contents">
+      <% if @content_item.contents.any? %>
+        <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
+      <% end %>
+      <% if @content_item.related_mainstream_content.any? %>
+        <aside class="related-mainstream-content" role="complementary">
+          <h4>
+            <%= raw(t('detailed_guide.related_mainstream_content')) %>
+          </h4>
+          <% @content_item.related_mainstream_content.each do |link| %>
+            <%= link %><br/>
+          <% end %>
+        </aside>
+      <% end %>
+      <%= render 'govuk_component/govspeak',
+                 content: @content_item.body,
+                 direction: page_text_direction %>
+    </div>
+    <%= render 'shared/footer', @content_item.document_footer %>
+  </div>
+
+  <div class="column-third">
+    <% if @content_item.contents.any? %>
+      <div data-sticky-element class="sticky-element">
+        <a class="back-to-content" href="#contents"><%= t("content_item.contents") %></a>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/content_items/detailed_guide.html+new_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+new_navigation.erb
@@ -1,4 +1,7 @@
 <%= content_for :title, @content_item.page_title %>
+<%= content_for :extra_head_content do %>
+  <%= @education_navigation_ab_test.analytics_meta_tag.html_safe %>
+<% end %>
 
 <div class="grid-row" data-module="sticky-element-container">
   <div class="column-two-thirds">

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,6 +1,9 @@
 <% # THIS IS PART OF EDUCATION NAVIGATION A/B TESTING - PLEASE KEEP IN SYNC WITH +new_navigation.erb %>
 
 <%= content_for :title, @content_item.page_title %>
+<%= content_for :extra_head_content do %>
+  <%= @education_navigation_ab_test.analytics_meta_tag.html_safe %>
+<% end %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,3 +1,5 @@
+<% # THIS IS PART OF EDUCATION NAVIGATION A/B TESTING - PLEASE KEEP IN SYNC WITH +new_navigation.erb %>
+
 <%= content_for :title, @content_item.page_title %>
 
 <div class="grid-row">
@@ -49,4 +51,4 @@
   </div>
 </div>
 
-<%= render 'govuk_component/document_footer', @content_item.document_footer %>
+<%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -46,4 +46,4 @@
   </div>
 </div>
 
-<%= render 'govuk_component/document_footer', @content_item.document_footer %>
+<%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -5,4 +5,4 @@
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 <%= render 'shared/sidebar_with_body', content_item: @content_item %>
-<%= render 'govuk_component/document_footer', @content_item.document_footer %>
+<%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -44,4 +44,4 @@
   </div>
 </div>
 
-<%= render 'govuk_component/document_footer', @content_item.document_footer %>
+<%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -6,4 +6,4 @@
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 <%= render 'shared/sidebar_with_body', content_item: @content_item %>
-<%= render 'govuk_component/document_footer', @content_item.document_footer %>
+<%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -17,4 +17,4 @@
   </div>
 </div>
 
-<%= render 'govuk_component/document_footer', @content_item.document_footer %>
+<%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -7,4 +7,4 @@
 <%= render 'shared/description', description: @content_item.description %>
 <%= render 'shared/sidebar_with_body', content_item: @content_item %>
 <%= render 'shared/share_buttons', share_urls: @content_item.share_urls %>
-<%= render 'govuk_component/document_footer', @content_item.document_footer %>
+<%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
   <meta name="govuk:content-id" content="<%= @content_item.content_id %>" />
+  <%= yield :extra_head_content %>
 </head>
 <body>
   <% unless content_for(:simple_header) %>

--- a/app/views/shared/_breadcrumbs.html+new_navigation.erb
+++ b/app/views/shared/_breadcrumbs.html+new_navigation.erb
@@ -1,3 +1,4 @@
 <% if @content_item.taxon_breadcrumbs.any? %>
+  <%= render 'govuk_component/beta_label' %>
   <%= render 'govuk_component/breadcrumbs', breadcrumbs: @content_item.taxon_breadcrumbs %>
 <% end %>

--- a/app/views/shared/_breadcrumbs.html+new_navigation.erb
+++ b/app/views/shared/_breadcrumbs.html+new_navigation.erb
@@ -1,0 +1,3 @@
+<% if @content_item.taxon_breadcrumbs.any? %>
+  <%= render 'govuk_component/breadcrumbs', breadcrumbs: @content_item.taxon_breadcrumbs %>
+<% end %>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,3 +1,5 @@
+<% # THIS IS PART OF EDUCATION NAVIGATION A/B TESTING - PLEASE KEEP IN SYNC WITH +new_navigation.erb %>
+
 <% if @content_item.breadcrumbs.any? %>
   <%= render 'govuk_component/breadcrumbs', breadcrumbs: @content_item.breadcrumbs %>
 <% end %>

--- a/app/views/shared/_footer.html+new_navigation.erb
+++ b/app/views/shared/_footer.html+new_navigation.erb
@@ -1,0 +1,1 @@
+<%= render 'govuk_component/document_footer', @content_item.document_footer_for_new_navigation %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,3 @@
+<% # THIS IS PART OF EDUCATION NAVIGATION A/B TESTING - PLEASE KEEP IN SYNC WITH +new_navigation.erb %>
+
+<%= render 'govuk_component/document_footer', @content_item.document_footer %>

--- a/app/views/shared/_metadata.html+new_navigation.erb
+++ b/app/views/shared/_metadata.html+new_navigation.erb
@@ -1,0 +1,1 @@
+<%= render 'govuk_component/metadata', @content_item.metadata_for_new_navigation %>

--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -1,3 +1,5 @@
+<% # THIS IS PART OF EDUCATION NAVIGATION A/B TESTING - PLEASE KEEP IN SYNC WITH +new_navigation.erb %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/metadata', @content_item.metadata %>

--- a/app/views/shared/_title_and_translations.html+new_navigation.erb
+++ b/app/views/shared/_title_and_translations.html+new_navigation.erb
@@ -1,0 +1,2 @@
+<%= render 'govuk_component/title', @content_item.title_and_context %>
+<%= render 'shared/translations', translations: @content_item.available_translations %>

--- a/app/views/shared/_title_and_translations.html.erb
+++ b/app/views/shared/_title_and_translations.html.erb
@@ -1,3 +1,5 @@
+<% # THIS IS PART OF EDUCATION NAVIGATION A/B TESTING - PLEASE KEEP IN SYNC WITH +new_navigation.erb %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>


### PR DESCRIPTION
Add functionality to check for A/B Testing, and display content according to which "bucket" the user has been added to.

This WIP PR adds a helper method to the controller to check for A/B bucket (with associated tests).

As a proof-of-concept, it also updates two of the `content_item` views to show either an A or B view. Currently the only difference between the two is the display of "normal" breadcrumbs (view A) or "taxon" breadcrumbs (view B).

If we continue in this style, we should add A/B views for _all_ Content Items. Is this the best approach? If so, should we be grouping them in subfolders under `content_items` to reduce clutter? Is there any scope for commonising, or is that a waste of time, given that - if testing is successful - we'd just want to delete all the "A" views anyway in the long run.