### PR TITLE
Show breadcrumbs consistently

### DIFF
--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -1,6 +1,5 @@
 <%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
 
-<%= render "shared/breadcrumbs" %>
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,7 +1,5 @@
 <%= content_for :title, @content_item.page_title %>
 
-<%= render "shared/breadcrumbs" %>
-
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -1,6 +1,5 @@
 <%= content_for :title, @content_item.page_title %>
 
-<%= render "shared/breadcrumbs" %>
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -1,7 +1,5 @@
 <%= content_for :title, @content_item.page_title %>
 
-<%= render "shared/breadcrumbs" %>
-
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -1,7 +1,5 @@
 <%= content_for :title, @content_item.title %>
 
-<%= render "shared/breadcrumbs" %>
-
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/description', description: @content_item.description %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,7 @@
   <div id="wrapper" class="<%= wrapper_class %>">
     <main role="main" id="content" class="<%= @content_item.format.dasherize %>" lang="<%= I18n.locale %>">
       <%= render_phase_label @content_item, content_for(:phase_message) %>
+      <%= render 'shared/breadcrumbs' %>
       <%= yield %>
     </main>
   </div>


### PR DESCRIPTION
Currently we don't show the breadcrumbs if the format traditionally doesn't have them.

On other pages on GOV.UK we've introduced the breadcrumbs, whether or not they're set. For example, https://www.gov.uk/aaib-reports just has a "Home" breadcrumb, because
https://www.gov.uk/aaib-reports/aaib-investigation-to-airbus-a319-111-g-ezfj has a breadcrumb to that page.

This adds consistent breadcrumbs to all pages. This means that we'll show empty "Home" breadcrumbs for fatality notices, statistics announcements, statistical data sets, "take part" pages and groups. Note that it's super easy to set the breadcrumb for these pages, by adding a `parent` link to the presenter in Whitehall. 

This should make https://github.com/alphagov/government-frontend/pull/237 a little easier.

@nickcolley @fofr thoughts?

## Examples

| before | after |
|--|--|
| ![screen shot 2017-01-25 at 12 41 11](https://cloud.githubusercontent.com/assets/233676/22291145/b8f20776-e2fc-11e6-9688-dbb53a0d6c2b.png) | ![screen shot 2017-01-25 at 12 41 23](https://cloud.githubusercontent.com/assets/233676/22291146/b8f28192-e2fc-11e6-9272-411cf1573c59.png) |
| ![screen shot 2017-01-25 at 12 41 27](https://cloud.githubusercontent.com/assets/233676/22291154/bf1e0ae6-e2fc-11e6-99cf-a6744421b316.png) | ![screen shot 2017-01-25 at 12 41 40](https://cloud.githubusercontent.com/assets/233676/22291155/bf221a96-e2fc-11e6-8e0c-55bed95704b3.png) |

