### PR TITLE
Make breadcrumbs nice for HTML publications

### DIFF
--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -1,8 +1,6 @@
 @import "grid_layout";
 
 .html-publication {
-  @include responsive-top-margin;
-
   .publication-external {
     @extend %grid-row;
     margin-bottom: $gutter-two-thirds;
@@ -14,37 +12,6 @@
 
       .organisation-logo {
         padding-bottom: $gutter-one-third;
-      }
-    }
-
-    .see-more-about-container {
-      @include grid-column(3 / 4);
-
-      .see-more-about {
-        @include core-19;
-        padding-top: $gutter-one-third;
-        position: static;
-
-        @include media(tablet) {
-          bottom: 0;
-          position: absolute;
-          right: $gutter-half;
-        }
-      }
-
-      &.direction-rtl {
-        direction: rtl;
-        text-align: start;
-
-        // Chrome (and probably other browsers) does a weird thing where it changes
-        // the font kerning ever so slightly when RTL rendering latin characters,
-        // which will cause the glyphs to become slightly wider, which will cause
-        // them to collapse over multiple rows even though they do have enough space to fit.
-        // It's reproducible only for specific character strings, such as "See More".
-        // This is a sheepish fix, by giving the element much more space than it needs.
-        .see-more-about {
-          width: 100%;
-        }
       }
     }
   }

--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -26,10 +26,6 @@ class HtmlPublicationPresenter < ContentItemPresenter
     end
   end
 
-  def parent_base_path
-    parent["base_path"]
-  end
-
   def organisations
     content_item["links"]["organisations"].sort_by { |o| o["title"] }
   end

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -21,12 +21,6 @@
       </li>
     <% end %>
   </ol>
-
-  <div class="see-more-about-container<%= direction_css_class %>">
-    <p class="see-more-about">
-      <%= link_to t('html_publication.see_more', document_type: t("content_item.format.#{@content_item.format_sub_type}", count: 1)), @content_item.parent_base_path %>
-    </p>
-  </div>
 </div>
 
 <header class="publication-header<%= direction_css_class %>" id="contents">

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -320,8 +320,6 @@ ar:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       zero:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -142,8 +142,6 @@ az:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -230,8 +230,6 @@ be:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "Дакумент"

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -142,8 +142,6 @@ bg:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "Документ"

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -142,8 +142,6 @@ bn:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -186,8 +186,6 @@ cs:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Dokument

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -319,8 +319,6 @@ cy:
     related_mainstream_content: Gormod o fanylion?<br/>Edrychwch ar y canllawiau cyflym
       hyn
     related_guides: Arweiniad manwl perthnasol
-  html_publication:
-    see_more:
   publication:
     documents:
       zero:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -142,8 +142,6 @@ de:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Dokument

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -142,8 +142,6 @@ dr:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "سند"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -142,8 +142,6 @@ el:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "Έγγραφο"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,8 +235,6 @@ en:
       published: Published
       updated: Updated
     contents: Contents
-  html_publication:
-    see_more: See more information about this %{document_type}
   detailed_guide:
     related_guides: "Related guides"
     related_mainstream_content: Too much detail?<br/>See these quick guides

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -142,8 +142,6 @@ es-419:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Documento

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -142,8 +142,6 @@ es:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Documento

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -139,8 +139,6 @@ et:
       published: avaldatud
       updated: Täiendatud
     contents: Sisukord
-  html_publication:
-    see_more: 'Loe lähemalt: %{document_type}'
   detailed_guide:
     related_mainstream_content: 'Liiga detailne?<br/>Vt. neid kokkuvõtlikke juhendeid? '
     related_guides: Seotud detailne juhend

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -142,8 +142,6 @@ fa:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "مدرک"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -142,8 +142,6 @@ fr:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Document

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -230,8 +230,6 @@ he:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "מסמך"

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -142,8 +142,6 @@ hi:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "दस्तावेज़"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -142,8 +142,6 @@ hu:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Dokumentum

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -142,8 +142,6 @@ hy:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "Փաստաթուղթ"

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -142,8 +142,6 @@ id:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Dokumen

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -142,8 +142,6 @@ it:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Documento

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -142,8 +142,6 @@ ja:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "お知らせ"

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -142,8 +142,6 @@ ka:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -142,8 +142,6 @@ ko:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "문서"

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -186,8 +186,6 @@ lt:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Dokumentas

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -142,8 +142,6 @@ lv:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Dokuments

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -142,8 +142,6 @@ ms:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -230,8 +230,6 @@ pl:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Dokument

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -142,8 +142,6 @@ ps:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "سند"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -142,8 +142,6 @@ pt:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Documento

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -186,8 +186,6 @@ ro:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Document

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -230,8 +230,6 @@ ru:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "Документ"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -186,8 +186,6 @@ sk:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -142,8 +142,6 @@ sq:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Dokument

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -142,8 +142,6 @@ sw:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -142,8 +142,6 @@ th:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "เอกสาร"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -142,8 +142,6 @@ tr:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Belge

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -144,8 +144,6 @@ ur:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "دستاویز"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -142,8 +142,6 @@ vi:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Tài liệu

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -142,8 +142,6 @@ zh-tw:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "文件"

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -3,7 +3,6 @@ require 'test_helper'
 class HtmlPublicationTest < ActionDispatch::IntegrationTest
   test "html publications" do
     setup_and_visit_content_item('published')
-    assert page.has_text?("See more information about this Notice")
 
     within ".publication-header" do
       assert page.has_text?(@content_item["details"]["format_sub_type"])
@@ -38,7 +37,6 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   test "html publication with rtl text direction" do
     setup_and_visit_content_item("arabic_translation")
     assert page.has_css?(".publication-header.direction-rtl"), "has .direction-rtl class on .publication-header element"
-    assert page.has_css?(".see-more-about-container.direction-rtl"), "has .direction-rtl class on .see-more-about-container element"
   end
 
   def assert_has_component_govspeak_html_publication(content)

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -26,10 +26,6 @@ class HtmlPublicationPresenterTest < PresenterTestCase
     assert_equal "Updated 2 February 2016", updated.last_changed
   end
 
-  test 'presents the path to its parent' do
-    assert_equal schema_item("published")["links"]["parent"][0]["base_path"], presented_item("published").parent_base_path
-  end
-
   test 'presents the list of organisations' do
     multiple_organisations_html_publication = schema_item('multiple_organisations')
     organisation_titles = multiple_organisations_html_publication["links"]["organisations"].map { |o| o["title"] }


### PR DESCRIPTION
https://github.com/alphagov/government-frontend/pull/238 introduced breadcrumbs on all pages. Because HTML publications weren't in the list of migrated formats in the readme (fixed in https://github.com/alphagov/government-frontend/pull/239) I didn't notice the changes in this format. @fofr helpfully pointed me to it.

Because HTML publications have its publication in the links as `parent`, the breadcrumb magically shows the parent publication. This means we can remove the link on the right. Because the breadcrumb takes care of its own height, we no longer need to include the responsive-top-margin mixin.

## Before (currently live)

![screen shot 2017-01-25 at 17 58 38](https://cloud.githubusercontent.com/assets/233676/22302726/00950ec2-e328-11e6-9f83-36342a3fae81.png)
![screen shot 2017-01-25 at 17 59 02](https://cloud.githubusercontent.com/assets/233676/22302727/009ae1d0-e328-11e6-8fa7-3f7a2ed701c2.png)

## Before (currently on integration)

![screen shot 2017-01-25 at 17 58 43](https://cloud.githubusercontent.com/assets/233676/22302743/0fb07cf2-e328-11e6-9064-6141264ea9c2.png)
![screen shot 2017-01-25 at 17 59 06](https://cloud.githubusercontent.com/assets/233676/22302744/0fb20c66-e328-11e6-8de6-beb68a3742de.png)

## After

![screen shot 2017-01-25 at 17 58 50](https://cloud.githubusercontent.com/assets/233676/22302753/1c32fcac-e328-11e6-97b2-61331782fc86.png)
![screen shot 2017-01-25 at 17 59 09](https://cloud.githubusercontent.com/assets/233676/22302754/1c33e40a-e328-11e6-848d-65ac1883f976.png)
