### PR TITLE
Render corporate information page format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby File.read(".ruby-version").strip
 gem 'airbrake', '~> 5.5'
 gem 'airbrake-ruby', '1.5'
 
-gem 'govuk_frontend_toolkit', '2.0.1'
+gem 'govuk_frontend_toolkit', '5.1.0'
 gem 'logstasher', '0.6.1'
 gem 'plek', '1.11'
 gem 'rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     govuk-lint (1.2.0)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_frontend_toolkit (2.0.1)
+    govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_navigation_helpers (1.0.0)
@@ -253,7 +253,7 @@ DEPENDENCIES
   gds-api-adapters (= 39.1.0)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
-  govuk_frontend_toolkit (= 2.0.1)
+  govuk_frontend_toolkit (= 5.1.0)
   govuk_navigation_helpers (~> 1.0)
   jasmine-rails (~> 0.13.0)
   logstasher (= 0.6.1)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,7 @@
 @import "helpers/share-buttons";
 @import "helpers/national_statistics_logo";
 @import "helpers/notice";
+@import "helpers/organisation-links";
 @import "helpers/history-notice";
 @import "helpers/withdrawal-notice";
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,3 +40,4 @@
 @import "views/speech";
 @import "views/world-location-news-article";
 @import "views/news-article";
+@import "views/corporate-information-page";

--- a/app/assets/stylesheets/helpers/_organisation-links.scss
+++ b/app/assets/stylesheets/helpers/_organisation-links.scss
@@ -1,0 +1,7 @@
+@mixin organisation-links {
+  @each $organisation in $all-organisation-brand-colours {
+    .#{nth($organisation, 1)}-brand-colour a {
+      color: nth($organisation, 3);
+    }
+  }
+}

--- a/app/assets/stylesheets/views/_corporate-information-page.scss
+++ b/app/assets/stylesheets/views/_corporate-information-page.scss
@@ -1,0 +1,3 @@
+.corporate-information-page {
+
+}

--- a/app/assets/stylesheets/views/_corporate-information-page.scss
+++ b/app/assets/stylesheets/views/_corporate-information-page.scss
@@ -1,3 +1,5 @@
 .corporate-information-page {
-
+  @include description;
+  @include sidebar-with-body;
+  @include organisation-links;
 }

--- a/app/assets/stylesheets/views/_corporate-information-page.scss
+++ b/app/assets/stylesheets/views/_corporate-information-page.scss
@@ -2,4 +2,9 @@
   @include description;
   @include sidebar-with-body;
   @include organisation-links;
+
+  .direction-rtl & {
+    direction: rtl;
+    text-align: start;
+  }
 }

--- a/app/presenters/corporate_information_page_presenter.rb
+++ b/app/presenters/corporate_information_page_presenter.rb
@@ -6,6 +6,12 @@ class CorporateInformationPagePresenter < ContentItemPresenter
     content_item["details"]["body"]
   end
 
+  def page_title
+    "#{title} - #{default_organisation['title']}"
+  end
+
+private
+
   def default_organisation
     organisation_content_id = content_item["details"]["organisation"]
     organisation = content_item["links"]["organisations"].detect do |org|

--- a/app/presenters/corporate_information_page_presenter.rb
+++ b/app/presenters/corporate_information_page_presenter.rb
@@ -1,0 +1,2 @@
+class CorporateInformationPagePresenter < ContentItemPresenter
+end

--- a/app/presenters/corporate_information_page_presenter.rb
+++ b/app/presenters/corporate_information_page_presenter.rb
@@ -1,2 +1,8 @@
 class CorporateInformationPagePresenter < ContentItemPresenter
+  include ContentsList
+  include OrganisationBranding
+
+  def body
+    content_item["details"]["body"]
+  end
 end

--- a/app/presenters/corporate_information_page_presenter.rb
+++ b/app/presenters/corporate_information_page_presenter.rb
@@ -5,4 +5,15 @@ class CorporateInformationPagePresenter < ContentItemPresenter
   def body
     content_item["details"]["body"]
   end
+
+  def default_organisation
+    organisation_content_id = content_item["details"]["organisation"]
+    organisation = content_item["links"]["organisations"].detect do |org|
+      org["content_id"] == organisation_content_id
+    end
+
+    raise "No organisation in links that matches the one specified in details: #{organisation_content_id}" unless organisation
+
+    organisation
+  end
 end

--- a/app/presenters/corporate_information_page_presenter.rb
+++ b/app/presenters/corporate_information_page_presenter.rb
@@ -1,5 +1,6 @@
 class CorporateInformationPagePresenter < ContentItemPresenter
   include ContentsList
+  include TitleAndContext
   include OrganisationBranding
 
   def body
@@ -8,6 +9,13 @@ class CorporateInformationPagePresenter < ContentItemPresenter
 
   def page_title
     "#{title} - #{default_organisation['title']}"
+  end
+
+  def title_and_context
+    super.tap do |t|
+      t.delete(:average_title_length)
+      t.delete(:context)
+    end
   end
 
 private

--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -1,4 +1,6 @@
 class HtmlPublicationPresenter < ContentItemPresenter
+  include OrganisationBranding
+
   def body
     content_item["details"]["body"]
   end
@@ -28,14 +30,5 @@ class HtmlPublicationPresenter < ContentItemPresenter
 
   def organisations
     content_item["links"]["organisations"].sort_by { |o| o["title"] }
-  end
-
-  # HACK: Replaces the organisation_brand for executive office organisations.
-  # Remove this in the future after migrating organisations to the content store API,
-  # and updating them with the correct brand in the actual store.
-  def organisation_brand(organisation)
-    brand = organisation["details"]["brand"]
-    brand = "executive-office" if organisation["details"]["logo"]["crest"] == "eo"
-    brand
   end
 end

--- a/app/presenters/organisation_branding.rb
+++ b/app/presenters/organisation_branding.rb
@@ -1,5 +1,5 @@
 module OrganisationBranding
-  def organisation_logo(organisation = first_organisation)
+  def organisation_logo(organisation = default_organisation)
     {
       organisation: {
         name: organisation["details"]["logo"]["formatted_title"],
@@ -10,13 +10,13 @@ module OrganisationBranding
     }
   end
 
-  def organisation_brand_class(organisation = first_organisation)
+  def organisation_brand_class(organisation = default_organisation)
     "#{organisation_brand(organisation)}-brand-colour"
   end
 
 private
 
-  def first_organisation
+  def default_organisation
     content_item["links"]["organisations"].first
   end
 
@@ -25,7 +25,11 @@ private
   # and updating them with the correct brand in the actual store.
   def organisation_brand(organisation)
     brand = organisation["details"]["brand"]
-    brand = "executive-office" if organisation["details"]["logo"]["crest"] == "eo"
+    brand = "executive-office" if executive_order_crest?(organisation)
     brand
+  end
+
+  def executive_order_crest?(organisation)
+    organisation["details"]["logo"]["crest"] == "eo"
   end
 end

--- a/app/presenters/organisation_branding.rb
+++ b/app/presenters/organisation_branding.rb
@@ -10,6 +10,10 @@ module OrganisationBranding
     }
   end
 
+  def organisation_brand_class(organisation = first_organisation)
+    "#{organisation_brand(organisation)}-brand-colour"
+  end
+
 private
 
   def first_organisation

--- a/app/presenters/organisation_branding.rb
+++ b/app/presenters/organisation_branding.rb
@@ -1,0 +1,27 @@
+module OrganisationBranding
+  def organisation_logo(organisation = first_organisation)
+    {
+      organisation: {
+        name: organisation["details"]["logo"]["formatted_title"],
+        url: organisation["base_path"],
+        brand: organisation_brand(organisation),
+        crest: organisation["details"]["logo"]["crest"]
+      }
+    }
+  end
+
+private
+
+  def first_organisation
+    content_item["links"]["organisations"].first
+  end
+
+  # HACK: Replaces the organisation_brand for executive office organisations.
+  # Remove this in the future after migrating organisations to the content store API,
+  # and updating them with the correct brand in the actual store.
+  def organisation_brand(organisation)
+    brand = organisation["details"]["brand"]
+    brand = "executive-office" if organisation["details"]["logo"]["crest"] == "eo"
+    brand
+  end
+end

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, @content_item.title %>
+<%= content_for :title, @content_item.page_title %>
 
 <div class="<%= @content_item.organisation_brand_class %>">
   <%= render 'govuk_component/organisation_logo', @content_item.organisation_logo %>

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -1,0 +1,11 @@
+<%= content_for :title, @content_item.title %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+        context: t("content_item.format.#{@content_item.document_type}", count: 1),
+        title: @content_item.title %>
+  </div>
+</div>
+
+<%= render 'shared/description', description: @content_item.description %>

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -1,11 +1,20 @@
 <%= content_for :title, @content_item.title %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.document_type}", count: 1),
-        title: @content_item.title %>
+<div class="<%= @content_item.organisation_brand_class %>">
+  <%= render 'govuk_component/organisation_logo', @content_item.organisation_logo %>
+  <%= render 'govuk_component/title', title: @content_item.title %>
+  <%= render 'shared/description', description: @content_item.description %>
+
+  <div class="grid-row sidebar-with-body">
+    <% if @content_item.contents.any? %>
+      <div class="column-third">
+        <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
+      </div>
+    <% end %>
+    <div class="column-two-thirds <% unless @content_item.contents.any? %>offset-one-third<% end %>">
+      <%= render 'govuk_component/govspeak',
+          content: "#{@content_item.body}",
+          direction: page_text_direction %>
+    </div>
   </div>
 </div>
-
-<%= render 'shared/description', description: @content_item.description %>

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -2,7 +2,7 @@
 
 <div class="<%= @content_item.organisation_brand_class %>">
   <%= render 'govuk_component/organisation_logo', @content_item.organisation_logo %>
-  <%= render 'govuk_component/title', title: @content_item.title %>
+  <%= render 'shared/title_and_translations', content_item: @content_item %>
   <%= render 'shared/description', description: @content_item.description %>
 
   <div class="grid-row sidebar-with-body">

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -10,14 +10,7 @@
   <ol class="organisation-logos">
     <% @content_item.organisations.each do |organisation| %>
       <li class="organisation-logo">
-        <%= render partial: 'govuk_component/organisation_logo', locals: {
-          organisation: {
-            name: organisation["details"]["logo"]["formatted_title"],
-            url: organisation["base_path"],
-            brand: @content_item.organisation_brand(organisation),
-            crest: organisation["details"]["logo"]["crest"]
-          }
-        } %>
+        <%= render 'govuk_component/organisation_logo', @content_item.organisation_logo(organisation) %>
       </li>
     <% end %>
   </ol>

--- a/test/integration/corporate_information_page_test.rb
+++ b/test/integration/corporate_information_page_test.rb
@@ -1,4 +1,32 @@
 require 'test_helper'
 
 class CorporateInformationPageTest < ActionDispatch::IntegrationTest
+  test "renders title, description and body" do
+    setup_and_visit_content_item('corporate_information_page')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+    assert_has_component_govspeak(@content_item["details"]["body"])
+
+    assert_has_contents_list([
+      { text: "Our responsibilities", id: "our-responsibilities" },
+    ])
+  end
+
+  test "renders with organisation branding" do
+    setup_and_visit_content_item('corporate_information_page')
+    assert page.has_css?('.department-of-health-brand-colour')
+  end
+
+  test "renders an organisation logo" do
+    setup_and_visit_content_item('corporate_information_page')
+    assert_has_component_organisation_logo(
+      organisation: {
+        name: 'Department<br/>of Health',
+        url: '/government/organisations/department-of-health',
+        brand: 'department-of-health',
+        crest: 'single-identity'
+      }
+    )
+  end
 end

--- a/test/integration/corporate_information_page_test.rb
+++ b/test/integration/corporate_information_page_test.rb
@@ -23,6 +23,11 @@ class CorporateInformationPageTest < ActionDispatch::IntegrationTest
     assert page.has_css?('title', text: 'About us - Department of Health - GOV.UK', visible: false)
   end
 
+  test "includes translations" do
+    setup_and_visit_content_item('corporate_information_page_translated_custom_logo')
+    assert page.has_css?('.available-languages')
+  end
+
   test "renders an organisation logo" do
     setup_and_visit_content_item('corporate_information_page')
     assert_has_component_organisation_logo(

--- a/test/integration/corporate_information_page_test.rb
+++ b/test/integration/corporate_information_page_test.rb
@@ -18,6 +18,11 @@ class CorporateInformationPageTest < ActionDispatch::IntegrationTest
     assert page.has_css?('.department-of-health-brand-colour')
   end
 
+  test "includes organisation in title" do
+    setup_and_visit_content_item('corporate_information_page')
+    assert page.has_css?('title', text: 'About us - Department of Health - GOV.UK', visible: false)
+  end
+
   test "renders an organisation logo" do
     setup_and_visit_content_item('corporate_information_page')
     assert_has_component_organisation_logo(

--- a/test/integration/corporate_information_page_test.rb
+++ b/test/integration/corporate_information_page_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class CorporateInformationPageTest < ActionDispatch::IntegrationTest
+end

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -6,6 +6,10 @@ class CorporateInformationPagePresenterTest
       "corporate_information_page"
     end
 
+    test 'presents the body' do
+      assert_equal schema_item['details']['body'], presented_item.body
+    end
+
     test 'has contents list' do
       assert presented_item.is_a?(ContentsList)
     end

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -10,6 +10,10 @@ class CorporateInformationPagePresenterTest
       assert_equal schema_item['details']['body'], presented_item.body
     end
 
+    test 'presents the organisation in the title' do
+      assert_equal "About us - Department of Health", presented_item.page_title
+    end
+
     test 'has contents list' do
       assert presented_item.is_a?(ContentsList)
     end

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -1,0 +1,13 @@
+require 'presenter_test_helper'
+
+class CorporateInformationPagePresenterTest
+  class PresentedCorporateInformationPage < PresenterTestCase
+    def format_name
+      "corporate_information_page"
+    end
+
+    test 'presents the format' do
+      assert_equal schema_item['format'], presented_item.format
+    end
+  end
+end

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -5,9 +5,5 @@ class CorporateInformationPagePresenterTest
     def format_name
       "corporate_information_page"
     end
-
-    test 'presents the format' do
-      assert_equal schema_item['format'], presented_item.format
-    end
   end
 end

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -18,6 +18,13 @@ class CorporateInformationPagePresenterTest
       assert presented_item.is_a?(ContentsList)
     end
 
+    test 'has title without context' do
+      assert presented_item.is_a?(TitleAndContext)
+      title_component_params = { title: "About us" }
+
+      assert_equal title_component_params, presented_item.title_and_context
+    end
+
     test 'has organisation branding' do
       assert presented_item.is_a?(OrganisationBranding)
     end

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -5,5 +5,13 @@ class CorporateInformationPagePresenterTest
     def format_name
       "corporate_information_page"
     end
+
+    test 'has contents list' do
+      assert presented_item.is_a?(ContentsList)
+    end
+
+    test 'has organisation branding' do
+      assert presented_item.is_a?(OrganisationBranding)
+    end
   end
 end

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -36,14 +36,15 @@ class HtmlPublicationPresenterTest < PresenterTestCase
     assert_equal organisation_titles, presented_organisations
   end
 
-  test "presents the branding for organisations" do
+  test "presents the logo for organisations" do
     mo_presented_item = presented_item("multiple_organisations")
     mo_presented_item.organisations.each do |organisation|
-      assert_equal mo_presented_item.organisation_brand(organisation), organisation["details"]["brand"]
+      logo = mo_presented_item.organisation_logo(organisation)
+      assert_equal logo[:organisation][:brand], organisation["details"]["brand"]
     end
   end
 
-  test "alters the branding for executive office organisations" do
+  test "alters the logo for executive office organisations" do
     organisation = {
       "details" => {
         "brand" => "cabinet-office",
@@ -53,6 +54,9 @@ class HtmlPublicationPresenterTest < PresenterTestCase
         }
       }
     }
-    assert_equal presented_item("prime_ministers_office").organisation_brand(organisation), "executive-office"
+
+    logo = presented_item("prime_ministers_office").organisation_logo(organisation)
+
+    assert_equal logo[:organisation][:brand], "executive-office"
   end
 end

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -36,27 +36,7 @@ class HtmlPublicationPresenterTest < PresenterTestCase
     assert_equal organisation_titles, presented_organisations
   end
 
-  test "presents the logo for organisations" do
-    mo_presented_item = presented_item("multiple_organisations")
-    mo_presented_item.organisations.each do |organisation|
-      logo = mo_presented_item.organisation_logo(organisation)
-      assert_equal logo[:organisation][:brand], organisation["details"]["brand"]
-    end
-  end
-
-  test "alters the logo for executive office organisations" do
-    organisation = {
-      "details" => {
-        "brand" => "cabinet-office",
-        "logo" => {
-          "formatted_title" => "Prime Minister's Office, 10 Downing Street",
-          "crest" => "eo"
-        }
-      }
-    }
-
-    logo = presented_item("prime_ministers_office").organisation_logo(organisation)
-
-    assert_equal logo[:organisation][:brand], "executive-office"
+  test 'has organisation branding' do
+    assert presented_item("published").is_a?(OrganisationBranding)
   end
 end

--- a/test/presenters/organisation_branding_test.rb
+++ b/test/presenters/organisation_branding_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class OrganisationBrandingTest < ActiveSupport::TestCase
+  include OrganisationBranding
+
+  def test_organisation
+    {
+      "base_path" => "/base-path",
+      "details" => {
+        "brand" => "department-of-health",
+        "logo" => {
+          "formatted_title" => "Department<br/>of Health",
+          "crest" => "single-identity"
+        }
+      }
+    }
+  end
+
+  test "presents the logo for organisations" do
+    logo = organisation_logo(test_organisation)
+
+    assert_equal logo[:organisation][:brand], test_organisation["details"]["brand"]
+    assert_equal logo[:organisation][:url], test_organisation["base_path"]
+    assert_equal logo[:organisation][:crest], test_organisation["details"]["logo"]["crest"]
+    assert_equal logo[:organisation][:name], test_organisation["details"]["logo"]["formatted_title"]
+  end
+
+  test "presents the brand colour class for organisations" do
+    assert_equal "department-of-health-brand-colour", organisation_brand_class(test_organisation)
+  end
+
+  test "alters the brand for organisations with an executive order crest" do
+    organisation = test_organisation
+    organisation["details"]["logo"]["crest"] = "eo"
+
+    refute_equal organisation_brand(organisation), test_organisation["details"]["brand"]
+    assert_equal organisation_brand(organisation), "executive-office"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,7 +62,7 @@ class ActionDispatch::IntegrationTest
 
   def assert_has_component_govspeak(content, index: 1)
     within_component_govspeak(index: index) do
-      assert_equal content.gsub('  ', ' '), JSON.parse(page.text).fetch("content")
+      assert_equal content.gsub(/\s+/, ' '), JSON.parse(page.text).fetch("content").gsub(/\s+/, ' ')
     end
   end
 
@@ -76,6 +76,12 @@ class ActionDispatch::IntegrationTest
   def assert_has_component_breadcrumbs(breadcrumbs)
     within shared_component_selector("breadcrumbs") do
       assert_equal breadcrumbs, JSON.parse(page.text).deep_symbolize_keys.fetch(:breadcrumbs)
+    end
+  end
+
+  def assert_has_component_organisation_logo(logo, index = 1)
+    within(shared_component_selector("organisation_logo") + ":nth-of-type(#{index})") do
+      assert_equal logo, JSON.parse(page.text).deep_symbolize_keys
     end
   end
 


### PR DESCRIPTION
Goes with https://github.com/alphagov/govuk-content-schemas/pull/501 (tests will fail until this is merged and deployed)
Part of https://trello.com/c/8ySlDVSs/578-corp-info-migration-1-mvp-content-schema-examples-and-front-end-work

* Minimum viable corporate information page format and rendering, handling of larger organisation logos and complex logic at the foot of About pages has been moved into separate cards:
  * https://trello.com/c/HtSGDoRb/835-add-organsation-logos-that-are-images-to-content-item
  * https://trello.com/c/8syU3iNh/836-add-corporate-information-block-to-about-pages-corporate-information-pages
* Upgrades frontend toolkit to version 5 to pick up organisation colours, used for branding
* Org logo logic moved into shareable module

## Design notes

* Design updated to match other formats, with description above two columns of content
* Body content switched to use component, makes copy look consistent
* Replace "homepage" link with a breadcrumb
* Bigger logos and custom org logo images coming soon

## Screenshots

| Feature | Old | New |
|--|--|--|
| Complaints | ![cip_complaints_old](https://cloud.githubusercontent.com/assets/319055/22418848/af318e80-e6d2-11e6-9332-8674247c085d.png) | ![cip_complaints_new](https://cloud.githubusercontent.com/assets/319055/22418847/af25ed3c-e6d2-11e6-98ea-2c13c5b46c57.png) |
| Translated with custom logo | ![cip_custom_logo_translated_old](https://cloud.githubusercontent.com/assets/319055/22418859/be68f730-e6d2-11e6-83d7-0995ed547af0.png) | ![cip_custom_logo_translated_new](https://cloud.githubusercontent.com/assets/319055/22418860/be6a5ce2-e6d2-11e6-830a-9610d5655e4f.png) |
| About pages | ![cip_about_old](https://cloud.githubusercontent.com/assets/319055/22418837/9cde1fb4-e6d2-11e6-8624-4e2b19018937.png) | ![cip_about_new](https://cloud.githubusercontent.com/assets/319055/22418838/9ce0c976-e6d2-11e6-9935-be32e3e8ecce.png) |






