### PR TITLE
Fix nil organisations for HtmlPublicationPresenter

### DIFF
--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -27,7 +27,7 @@ class HtmlPublicationPresenter < ContentItemPresenter
   end
 
   def organisations
-    content_item["links"]["organisations"].sort_by { |o| o["title"] }
+    (content_item["links"]["organisations"] || {}).sort_by { |o| o["title"] }
   end
 
   # HACK: Replaces the organisation_brand for executive office organisations.


### PR DESCRIPTION
Trello: https://trello.com/c/dMbLwfHJ/585-fix-bug-with-html-pub-having-no-organisation-2

Avoid these lines raise an exception if `content_item["links”][“organisations”]` is `nil`