### PR TITLE
Render custom organisation logos when provided

### DIFF
--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -31,4 +31,12 @@ class HtmlPublicationPresenter < ContentItemPresenter
   def organisations
     content_item["links"]["organisations"].sort_by { |o| o["title"] }
   end
+
+  def organisation_logo(organisation)
+    super.tap do |logo|
+      if organisations.count > 1
+        logo[:organisation].delete(:image)
+      end
+    end
+  end
 end

--- a/app/presenters/organisation_branding.rb
+++ b/app/presenters/organisation_branding.rb
@@ -1,13 +1,24 @@
 module OrganisationBranding
   def organisation_logo(organisation = default_organisation)
-    {
+    logo = organisation["details"]["logo"]
+
+    logo_component_params = {
       organisation: {
-        name: organisation["details"]["logo"]["formatted_title"],
+        name: logo["formatted_title"],
         url: organisation["base_path"],
         brand: organisation_brand(organisation),
-        crest: organisation["details"]["logo"]["crest"]
+        crest: logo["crest"],
       }
     }
+
+    if logo["image"]
+      logo_component_params[:organisation][:image] = {
+        url: logo["image"]["url"],
+        alt_text: logo["image"]["alt_text"],
+      }
+    end
+
+    logo_component_params
   end
 
   def organisation_brand_class(organisation = default_organisation)

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -1,7 +1,11 @@
 <%= content_for :title, @content_item.page_title %>
 
 <div class="<%= @content_item.organisation_brand_class %>">
-  <%= render 'govuk_component/organisation_logo', @content_item.organisation_logo %>
+  <div class="grid-row">
+    <div class="column-quarter">
+      <%= render 'govuk_component/organisation_logo', @content_item.organisation_logo %>
+    </div>
+  </div>
   <%= render 'shared/title_and_translations', content_item: @content_item %>
   <%= render 'shared/description', description: @content_item.description %>
 

--- a/test/integration/corporate_information_page_test.rb
+++ b/test/integration/corporate_information_page_test.rb
@@ -39,4 +39,20 @@ class CorporateInformationPageTest < ActionDispatch::IntegrationTest
       }
     )
   end
+
+  test "renders a custom organisation logo" do
+    setup_and_visit_content_item('corporate_information_page_translated_custom_logo')
+    assert_has_component_organisation_logo(
+      organisation: {
+        name: 'Land Registry',
+        url: '/government/organisations/land-registry',
+        brand: 'department-for-business-innovation-skills',
+        crest: nil,
+        image: {
+          url: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/69/LR_logo_265.png',
+          alt_text: 'Land Registry'
+        }
+      }
+    )
+  end
 end

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -39,4 +39,25 @@ class HtmlPublicationPresenterTest < PresenterTestCase
   test 'has organisation branding' do
     assert presented_item("published").is_a?(OrganisationBranding)
   end
+
+  test 'includes custom organisation logos when a single organisation is listed' do
+    presented = presented_item("updated")
+    organisation = presented.organisations.first
+    example_logo = schema_item("updated")["links"]["organisations"][0]["details"]["logo"]["image"].symbolize_keys
+    presented_logo = presented.organisation_logo(organisation)[:organisation][:image]
+
+    assert presented.organisations.count == 1
+    assert_equal example_logo, presented_logo
+  end
+
+  test 'hides custom organisation logos when multiple organisations listed together' do
+    presented = presented_item("multiple_organisations")
+    organisation = presented.organisations.first
+    organisation["details"]["logo"]["image"] = {
+      "url" => "url"
+    }
+
+    assert presented.organisations.count > 1
+    refute presented.organisation_logo(organisation)[:organisation][:image]
+  end
 end

--- a/test/presenters/organisation_branding_test.rb
+++ b/test/presenters/organisation_branding_test.rb
@@ -36,4 +36,17 @@ class OrganisationBrandingTest < ActiveSupport::TestCase
     refute_equal organisation_brand(organisation), test_organisation["details"]["brand"]
     assert_equal organisation_brand(organisation), "executive-office"
   end
+
+  test "includes an image organisations with a custom logo" do
+    organisation = test_organisation
+    organisation["details"]["logo"]["image"] = {
+      "url" => "url",
+      "alt_text" => "alt_text"
+    }
+
+    logo = organisation_logo(organisation)
+
+    assert_equal logo[:organisation][:image][:url], organisation["details"]["logo"]["image"]["url"]
+    assert_equal logo[:organisation][:image][:alt_text], organisation["details"]["logo"]["image"]["alt_text"]
+  end
 end


### PR DESCRIPTION
Goes with:
* https://github.com/alphagov/govuk-content-schemas/pull/514 (tests will fail until merged and deployed)
* https://github.com/alphagov/static/pull/894

Part of https://trello.com/c/HtSGDoRb/594-add-organisation-logos-that-are-images-to-content-item-2

* Pass custom organisation images to component
* Restrict width of component to 25% to match HTML publication
* Include image only when provided
* Don't show custom logos on HTML pubs with many orgs

## HTML pubs
![screen shot 2017-02-08 at 15 50 52](https://cloud.githubusercontent.com/assets/319055/22744814/7366279e-ee16-11e6-8954-a3eb616898d9.png)

## Corp info pages
![screen shot 2017-02-08 at 15 51 08](https://cloud.githubusercontent.com/assets/319055/22744815/73685582-ee16-11e6-89cc-8aad2bb74fcc.png)
