### PR TITLE
Add translations to publications

### DIFF
--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -7,6 +7,7 @@
         title: @content_item.title,
         average_title_length: "long" %>
   </div>
+  <%= render 'shared/translations' %>
   <% if @content_item.national_statistics? %>
     <%= render 'shared/national_statistics_logo' %>
   <% end %>

--- a/app/views/shared/_title_and_translations.html.erb
+++ b/app/views/shared/_title_and_translations.html.erb
@@ -2,11 +2,5 @@
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>
   </div>
-  <% if @content_item.available_translations.any? %>
-    <div class="column-third">
-      <%= render 'shared/available_languages',
-        translations: @content_item.available_translations
-      %>
-    </div>
-  <% end %>
+  <%= render 'shared/translations' %>
 </div>

--- a/app/views/shared/_translations.html.erb
+++ b/app/views/shared/_translations.html.erb
@@ -1,0 +1,7 @@
+<% if @content_item.available_translations.any? %>
+  <div class="column-third">
+    <%= render 'shared/available_languages',
+      translations: @content_item.available_translations
+    %>
+  </div>
+<% end %>


### PR DESCRIPTION
Publications can be translated but we have neglected to add the necessary code to render the locale choice UI in the publication view.

This PR remedies that along with a small refactor to avoid duplication.

There could be an issue if National Statistics type publications are translated as this might break the grid but a) there are none in the Whitehall database, b) it seems unlikely that that sub-type would be translated and c) the quick test one that I knocked up appears to be OK. So... I think we can proceed without worrying about that for now to unblock deploying [Whitehall](https://github.com/alphagov/whitehall/pull/2986)

Before:
<img width="1002" alt="screen shot 2017-02-09 at 18 22 29" src="https://cloud.githubusercontent.com/assets/5216/22797064/e27094ce-eef4-11e6-8472-396d00a41885.png">

After:
<img width="985" alt="screen shot 2017-02-09 at 18 22 48" src="https://cloud.githubusercontent.com/assets/5216/22797069/eafd2526-eef4-11e6-9c54-e109230d9670.png">

Test with national statistics logo and translations:
<img width="994" alt="screen shot 2017-02-09 at 18 23 05" src="https://cloud.githubusercontent.com/assets/5216/22797074/f21eb540-eef4-11e6-884d-2d8922deea8a.png">
