### PR TITLE
[Do not merge] Bump navigation helper version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ else
   gem "gds-api-adapters", "39.1.0"
 end
 
-gem 'govuk_navigation_helpers', '~> 2.2.0'
+gem 'govuk_navigation_helpers', '~> 2.3.1'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (2.2.0)
+    govuk_navigation_helpers (2.3.1)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -256,7 +256,7 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing (= 0.1.4)
   govuk_frontend_toolkit (= 5.1.0)
-  govuk_navigation_helpers (~> 2.2.0)
+  govuk_navigation_helpers (~> 2.3.1)
   jasmine-rails (~> 0.13.0)
   logstasher (= 0.6.1)
   mocha


### PR DESCRIPTION
The new version of navigation helpers will display the current page in the breadcrumbs.

Dependent on:
- [x] Deployment of `static` [`release_2466`](https://github.com/alphagov/static/commit/07c2bcfb04e87efc9f9bd0c75ecc33573bfd5fc2) to Production

Trello: https://trello.com/c/MVM5bueS/386-add-current-page-to-taxonomy-breadcrumbs