### PR TITLE
Render further corporate information at bottom of about pages

### DIFF
--- a/app/presenters/corporate_information_groups.rb
+++ b/app/presenters/corporate_information_groups.rb
@@ -18,10 +18,30 @@ module CorporateInformationGroups
     content_tag(:h2, corporate_information_heading[:text], id: corporate_information_heading[:id])
   end
 
+  def further_information
+    [
+      further_information_about("publication_scheme"),
+      further_information_about("welsh_language_scheme"),
+      further_information_about("personal_information_charter"),
+      further_information_about("social_media_use"),
+      further_information_about("about_our_services")
+    ].join(' ').html_safe
+  end
+
 private
 
+  def further_information_link(type)
+    link = corporate_information_page_links.find { |l| l["document_type"] == type }
+    link_to(link["title"], link["base_path"]) if link
+  end
+
+  def further_information_about(type)
+    link = further_information_link(type)
+    I18n.t("corporate_information_page.#{type}_html", link: link) if link
+  end
+
   def corporate_information_heading
-    heading_text = "Corporate information"
+    heading_text = I18n.t('corporate_information_page.corporate_information')
 
     {
       text: heading_text,

--- a/app/presenters/corporate_information_groups.rb
+++ b/app/presenters/corporate_information_groups.rb
@@ -1,0 +1,58 @@
+module CorporateInformationGroups
+  include Linkable
+
+  def corporate_information?
+    corporate_information_groups.any?
+  end
+
+  def corporate_information
+    corporate_information_groups.map do |group|
+      {
+        heading: content_tag(:h3, group["name"], id: group_title_id(group["name"])),
+        links: normalised_group_links(group)
+      }
+    end
+  end
+
+  def corporate_information_heading_tag
+    content_tag(:h2, corporate_information_heading[:text], id: corporate_information_heading[:id])
+  end
+
+private
+
+  def corporate_information_heading
+    heading_text = "Corporate information"
+
+    {
+      text: heading_text,
+      id: group_title_id(heading_text)
+    }
+  end
+
+  def group_title_id(title)
+    title.tr(' ', '-').downcase
+  end
+
+  def normalised_group_links(group)
+    group["contents"].map do |group_item|
+      normalised_group_item_link(group_item)
+    end
+  end
+
+  def normalised_group_item_link(group_item)
+    if group_item.is_a?(String)
+      group_item_link = corporate_information_page_links.find { |l| l["content_id"] == group_item }
+      link_to(group_item_link["title"], group_item_link["base_path"])
+    else
+      link_to(group_item["title"], group_item["path"] || group_item["url"])
+    end
+  end
+
+  def corporate_information_page_links
+    expanded_links_from_content_item('corporate_information_pages')
+  end
+
+  def corporate_information_groups
+    content_item["details"]["corporate_information_groups"] || []
+  end
+end

--- a/app/presenters/corporate_information_page_presenter.rb
+++ b/app/presenters/corporate_information_page_presenter.rb
@@ -2,6 +2,7 @@ class CorporateInformationPagePresenter < ContentItemPresenter
   include ContentsList
   include TitleAndContext
   include OrganisationBranding
+  include CorporateInformationGroups
 
   def body
     content_item["details"]["body"]
@@ -18,7 +19,17 @@ class CorporateInformationPagePresenter < ContentItemPresenter
     end
   end
 
+  def contents_items
+    super + extra_headings
+  end
+
 private
+
+  def extra_headings
+    extra_headings = []
+    extra_headings << corporate_information_heading if corporate_information?
+    extra_headings
+  end
 
   def default_organisation
     organisation_content_id = content_item["details"]["organisation"]

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -25,6 +25,12 @@
               <% end %>
             </ul>
           <% end %>
+
+          <% if @content_item.further_information.present? %>
+            <p>
+              <%= @content_item.further_information %>
+            </p>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -12,8 +12,24 @@
       </div>
     <% end %>
     <div class="column-two-thirds <% unless @content_item.contents.any? %>offset-one-third<% end %>">
+      <% @additional_body = capture do %>
+        <% if @content_item.corporate_information? %>
+          <%= @content_item.corporate_information_heading_tag %>
+          <% @content_item.corporate_information.each do |group| %>
+            <%= group[:heading] %>
+            <ul>
+              <% group[:links].each do |link| %>
+                <li>
+                  <%= link %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+        <% end %>
+      <% end %>
+
       <%= render 'govuk_component/govspeak',
-          content: "#{@content_item.body}",
+          content: "#{@content_item.body}#{@additional_body}",
           direction: page_text_direction %>
     </div>
   </div>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -335,3 +335,12 @@ ar:
       few:
       many:
       other: "وثائق"
+  corporate_information_page:
+    corporate_information: معلومات عن الوزارة
+    publication_scheme_html: إقرأ عن أنواع المعلومات التي ننشرها بشكل روتيني في موقعنا
+      %{link} الرابط.
+    personal_information_charter_html: "%{link} يشرح كيفية التعامل مع المعلومات الشخصية
+      الخاصة بك"
+    welsh_language_scheme_html: معرفة التزامنا النشر في%{link} الرابط.
+    social_media_use_html: اقرأ عن سياستنا تجاه %{link}
+    about_our_services_html:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -149,3 +149,10 @@ az:
     documents:
       one:
       other:
+  corporate_information_page:
+    corporate_information:
+    publication_scheme_html:
+    personal_information_charter_html:
+    welsh_language_scheme_html:
+    social_media_use_html:
+    about_our_services_html:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -241,3 +241,12 @@ be:
       few:
       many:
       other: "Дакументы"
+  corporate_information_page:
+    corporate_information: Карпаратыўная інфармацыя
+    publication_scheme_html: Чытайце пра тыпы інфармацыі, якую мы рэгулярна публікуем,
+      у нашым %{link}.
+    personal_information_charter_html: Наша %{link}  тлумачыць, як мы ставімся да
+      Вашай асабістай інфармацыі.
+    welsh_language_scheme_html: Даведайцеся аб нашых абавязках да публікацыі ў %{link}.
+    social_media_use_html: Прачытайце пра нашу палітыку датычна %{link}.
+    about_our_services_html:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -149,3 +149,13 @@ bg:
     documents:
       one: "Документ"
       other: "Документи"
+  corporate_information_page:
+    corporate_information: Корпоративна информация
+    publication_scheme_html: Прочетете какви видове информация публикуваме в нашия
+      %{link}.
+    personal_information_charter_html: Нашият %{link} дава информация за начина на
+      ползване на личните Ви данни
+    welsh_language_scheme_html: Разберете повече за нашето задължение да публикуваме
+      в %{link}.
+    social_media_use_html: Вижте политиката ни по %{link}.
+    about_our_services_html:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -149,3 +149,10 @@ bn:
     documents:
       one:
       other:
+  corporate_information_page:
+    corporate_information:
+    publication_scheme_html:
+    personal_information_charter_html:
+    welsh_language_scheme_html:
+    social_media_use_html:
+    about_our_services_html:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -195,3 +195,12 @@ cs:
       one: Dokument
       few:
       other: Dokumenty
+  corporate_information_page:
+    corporate_information: Korporátní informace
+    publication_scheme_html: Více o typech informací, které pravidelně zveřejňujeme
+      na %{link}.
+    personal_information_charter_html: Jak nakládáme s vašimi osobními informacemi
+      %{link}
+    welsh_language_scheme_html: Více o našem závazku zvěřejňovat informace na %{link}.
+    social_media_use_html: Více o naší strategii o %{link}.
+    about_our_services_html:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -334,3 +334,12 @@ cy:
       few:
       many:
       other: Dogfennau
+  corporate_information_page:
+    corporate_information: Gwybodaeth gorfforaethol
+    publication_scheme_html: Darllenwch am y mathau o wybodaeth rydym yn eu cyhoeddi'n
+      rheolaidd yn ein %{link}.
+    personal_information_charter_html: Mae ein %{link} yn egluro sut rydym yn trin
+      eich gwybodaeth bersonol.
+    welsh_language_scheme_html: Dysgwch am ein hymrwymiad i %{link}.
+    social_media_use_html: Darllenwch ein polisi ar %{link}
+    about_our_services_html: Canfod %{link}

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -149,3 +149,13 @@ de:
     documents:
       one: Dokument
       other: Dokumente
+  corporate_information_page:
+    corporate_information: Administrative Informationen
+    publication_scheme_html: Lesen Sie hier %{link}, welche Informationen wir routinemäßig
+      publizieren
+    personal_information_charter_html: Unser %{link} erklärt, wie wir Ihre personenbezogenen
+      Daten schützen.
+    welsh_language_scheme_html: Mehr zu unserer Verpflichtung zur Veröffentlichung
+      in %{link}
+    social_media_use_html: Unsere Politik zu %{link}
+    about_our_services_html:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -149,3 +149,12 @@ dr:
     documents:
       one: "سند"
       other: "اسناد"
+  corporate_information_page:
+    corporate_information: معلومات یکی شده
+    publication_scheme_html: در مورد انواع معلوماتی بخوانید که ما به طور منظم نشر
+      می کنیم.
+    personal_information_charter_html: "  %{link} ما شیوه برخود با معلومات شخصی را
+      تشریح مینماید"
+    welsh_language_scheme_html: در مورد تعهد ما به نشر در %{link} معلومات حاصل نمایید
+    social_media_use_html: پالیسی ما را در %{link} بخوانید
+    about_our_services_html:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -149,3 +149,13 @@ el:
     documents:
       one: "Έγγραφο"
       other: "Έγγραφα"
+  corporate_information_page:
+    corporate_information: Πληροφορίες για τον Οργανισμό
+    publication_scheme_html: Μάθετε περισσότερα για τις πληροφορίας που δημοσιεύουμε
+      συνήθως στο %{link}
+    personal_information_charter_html: Το %{link} εξηγεί πώς χειριζόμαστε τα προσωπικά
+      σας δεδομένα
+    welsh_language_scheme_html: Μάθετε περισσότερα για την δέσμευση μας στη δημοσίευση
+      στο %{link}.
+    social_media_use_html: Μάθετε περισσότερα για την πολιτική μας στο %{link}.
+    about_our_services_html:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -246,3 +246,12 @@ en:
       one: Document
       other: Documents
     details: Details
+  corporate_information_page:
+    corporate_information: Corporate information
+    publication_scheme_html: Read about the types of information we routinely publish
+      in our %{link}.
+    personal_information_charter_html: Our %{link} explains how we treat your personal
+      information.
+    welsh_language_scheme_html: Find out about our commitment to %{link}.
+    social_media_use_html: Read our policy on %{link}.
+    about_our_services_html: Find out %{link}.

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -149,3 +149,13 @@ es-419:
     documents:
       one: Documento
       other: Documentos
+  corporate_information_page:
+    corporate_information: Información institucional
+    publication_scheme_html: Lea sobre los tipos de información que usualmente publicamos
+      en nuestro %{link}
+    personal_information_charter_html: Nuestro %{link} explica cómo manejamos su información
+      personal
+    welsh_language_scheme_html: Descubra sobre nuestro compromiso de publicar en el
+      %{link}
+    social_media_use_html: Lea nuestra política en %{link}
+    about_our_services_html:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -149,3 +149,13 @@ es:
     documents:
       one: Documento
       other: Documentos
+  corporate_information_page:
+    corporate_information: Información corporativa
+    publication_scheme_html: Lea acerca del tipo de información que publicamos en
+      el siguiente enlace %{link}
+    personal_information_charter_html: El siguiente enlace %{link} explica cómo tratamos
+      tu información personal
+    welsh_language_scheme_html: 'Encuentre más sobre nuestro compromiso de publicar
+      en %{link} '
+    social_media_use_html: Lea nuestra política en %{link}
+    about_our_services_html:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -149,3 +149,13 @@ et:
     documents:
       one: Dokument
       other: Dokumendid
+  corporate_information_page:
+    corporate_information: Korporatiivne info
+    publication_scheme_html: 'Lugege lisaks infoliikide kohta, mida me regulaarselt
+      avalikustame: %{link}'
+    personal_information_charter_html: 'Meie %{link} selgitab kuidas me kohtleme Teie
+      eraelulist teavet. '
+    welsh_language_scheme_html: 'Lugege lisaks meie pühandumusest avaldamise osas:
+      %{link}'
+    social_media_use_html: 'Lugege meie poliitika kohta: %{link}'
+    about_our_services_html: 'Uuri lisaks: %{link}'

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -149,3 +149,12 @@ fa:
     documents:
       one: "مدرک"
       other: "مدارک"
+  corporate_information_page:
+    corporate_information: اطلاعات سازمانی
+    publication_scheme_html: 'درباره نوع اطلاعاتی که ما به طور روال در %{link} منتشر
+      می کنیم بخوانید '
+    personal_information_charter_html: "%{link} چگونگی نگهداری از اطلاعات شخصی شما
+      را توضیح می دهد"
+    welsh_language_scheme_html: درباره تعهد ما به انتشار مطالب به %{link} بخوانید
+    social_media_use_html: سیاست ما را درباره  %{link} بخوانید
+    about_our_services_html:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -149,3 +149,13 @@ fr:
     documents:
       one: Document
       other: Documents
+  corporate_information_page:
+    corporate_information: Informations générales
+    publication_scheme_html: En savoir plus sur les types d'informations régulièrement
+      publiés dans notre %{link}.
+    personal_information_charter_html: Notre %{link} explique comment nous traitons
+      vos renseignements personnels.
+    welsh_language_scheme_html: En savoir plus sur notre engagement à l'édition en
+      %{link}.
+    social_media_use_html: Lire notre politique d' %{link}.
+    about_our_services_html:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -241,3 +241,11 @@ he:
       two:
       many:
       other: "מסמכים"
+  corporate_information_page:
+    corporate_information: מידע מסחרי
+    publication_scheme_html: קרא/י אודות סוגי מידע שאנחנו מפרסמים %{link}
+    personal_information_charter_html: ה%{link} מסביר אודות המדיניות שלנו כלפי מידע
+      פרטי
+    welsh_language_scheme_html: מידע נוסף על המחויבות שלנו לפרסום %{link}
+    social_media_use_html: קרא/י אודות המדיניות שלנו %{link}
+    about_our_services_html:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -149,3 +149,13 @@ hi:
     documents:
       one: "दस्तावेज़"
       other: "दस्तावेजों"
+  corporate_information_page:
+    corporate_information: निकाय सूचना
+    publication_scheme_html: सूचना के उन प्रकारों के बारे में पढ़ें, जिन्हें हम अपने
+      %{link} में नियमित रूप से प्रकाशित करते हैं।
+    personal_information_charter_html: हमारे %{link} बताते हैं कि हम कैसे आपकी व्यक्तिगत
+      सूचना का उपयोग करते हैं।
+    welsh_language_scheme_html: हमारी प्रकाशन के प्रति वचनबद्धता के बारे में जानें
+      %(link)।
+    social_media_use_html: इस बारे में हमारी नीतियां पढ़ें %{link}
+    about_our_services_html:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -149,3 +149,13 @@ hu:
     documents:
       one: Dokumentum
       other: Dokumentumok
+  corporate_information_page:
+    corporate_information: Szervezeti információk
+    publication_scheme_html: 'Tekintse meg, hogy milyen jellegű információkat teszünk
+      közzé: %{link}'
+    personal_information_charter_html: 'A következő oldalon olvashat róla, hogy hogyan
+      kezeljük a személyes adatokat: %{link}'
+    welsh_language_scheme_html: 'Tájékozódjon az információk közzétételével kapcsolatos
+      elkötelezettségünkről: %{link}'
+    social_media_use_html: 'Bővebb információk az alábbi témával kapcsolatban: %{link}'
+    about_our_services_html:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -149,3 +149,13 @@ hy:
     documents:
       one: "Փաստաթուղթ"
       other: "Փաստաթղթեր"
+  corporate_information_page:
+    corporate_information: Կորպորատիվ տեղեկատվություն
+    publication_scheme_html: Կարդացեք այն ամնենի մասին ինչ մենք հրապարակում ենք մեր
+      %{link} ում
+    personal_information_charter_html: 'Մեր %{link} ը կպարզաբանի մեր մոտեցումները
+      անձնական տեղեկատվությանը '
+    welsh_language_scheme_html: Գտեք այստեղ %{link} ում հրապարակելու մեր պարտավորության
+      մասին
+    social_media_use_html: Կարդացեք մեր քաղաքականության մասին
+    about_our_services_html:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -149,3 +149,13 @@ id:
     documents:
       one: Dokumen
       other: Dokumen-dokumen
+  corporate_information_page:
+    corporate_information: Informasi korporat
+    publication_scheme_html: Baca jenis-jenis informasi yang secara rutin kami muat
+      di %{link}
+    personal_information_charter_html: "%{link} menjelaskan tentang bagaimana kami
+      memperlakukan informasi pribadi Anda"
+    welsh_language_scheme_html: Informasi lebih lanjut mengenai komitmen kami dalam
+      memuat informasi di %{link}
+    social_media_use_html: Baca kebijakan kami di %{link}
+    about_our_services_html:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -149,3 +149,14 @@ it:
     documents:
       one: Documento
       other: Documenti
+  corporate_information_page:
+    corporate_information: Informazioni aziendali
+    publication_scheme_html: Per maggiori dettagli sul tipo di documenti pubblicati
+      di routine, consulta la pagina %{link}.
+    personal_information_charter_html: Per informazioni sul trattamento dei dati personali,
+      consulta la pagina %{link}.
+    welsh_language_scheme_html: Per maggiori informazioni sul nostro impegno a pubblicare
+      quante più informazioni possibili, consulta la pagina %{link}.
+    social_media_use_html: Per saperne di più sulla nostra politica, consulta la pagina
+      %{link}.
+    about_our_services_html:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -149,3 +149,10 @@ ja:
     documents:
       one: "お知らせ"
       other: "お知らせ"
+  corporate_information_page:
+    corporate_information: 各種情報
+    publication_scheme_html: 情報公開の種類については %{link} をご覧下さい
+    personal_information_charter_html: 個人情報の取り扱いについては %{link} をご覧下さい
+    welsh_language_scheme_html: 情報公開の詳細については %{link} をご覧下さい
+    social_media_use_html: "%{link}に関する政策を読む"
+    about_our_services_html:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -149,3 +149,10 @@ ka:
     documents:
       one:
       other:
+  corporate_information_page:
+    corporate_information:
+    publication_scheme_html:
+    personal_information_charter_html:
+    welsh_language_scheme_html:
+    social_media_use_html:
+    about_our_services_html:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -149,3 +149,10 @@ ko:
     documents:
       one: "문서"
       other: "문서"
+  corporate_information_page:
+    corporate_information: 대사관 정보
+    publication_scheme_html: 정기적으로 공개되는 %{link} 정보에 대한 안내
+    personal_information_charter_html: "%{link} 에서 개인정보 처리에 대한 안내"
+    welsh_language_scheme_html: "%{link} 에서 정보 공개에 대한 내용"
+    social_media_use_html: "%{link} 에서 정책 정보 확인"
+    about_our_services_html:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -195,3 +195,12 @@ lt:
       one: Dokumentas
       few:
       other: Dokumentai
+  corporate_information_page:
+    corporate_information: Korporatyvinė informacija
+    publication_scheme_html: Sužinokite, kokią informaciją mes pastoviai pateikiame
+      puslapyje %{link}.
+    personal_information_charter_html: Čia %{link} rasite paaiškinimą, kaip tvarkoma
+      Jūsų asmeninė informacija
+    welsh_language_scheme_html: Sužinokite apie mūsų įsipareigojimą skelbti %{link}.
+    social_media_use_html: Perskaitykite mūsų strategiją %{link}.
+    about_our_services_html:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -149,3 +149,13 @@ lv:
     documents:
       one: Dokuments
       other: Dokumenti
+  corporate_information_page:
+    corporate_information: Korporatīva informācija
+    publication_scheme_html: Iepazīsties ar informāciju, kāda parasti tiek publicēta
+      mūsu %{link}
+    personal_information_charter_html: Šeit %{link} izskaidrots, kā tiks apstrādāta
+      Jūsu sniegtā personīgā informācija
+    welsh_language_scheme_html: Vairāk par mūsu apņemšanos nodrošināt informācijas
+      pieejamību %{link}
+    social_media_use_html: Iepazīsties ar mūsu nostāju par %{link}.
+    about_our_services_html:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -149,3 +149,10 @@ ms:
     documents:
       one:
       other:
+  corporate_information_page:
+    corporate_information:
+    publication_scheme_html:
+    personal_information_charter_html:
+    welsh_language_scheme_html:
+    social_media_use_html:
+    about_our_services_html:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -241,3 +241,13 @@ pl:
       few:
       many:
       other: Dokumenty
+  corporate_information_page:
+    corporate_information: Informacje korporacyjne
+    publication_scheme_html: Przeczytaj, jakiego rodzaju wiadomości publikujemy zwykle
+      w naszym %{link}
+    personal_information_charter_html: Nasz %{link} pokazuje, w jaki sposób traktujemy
+      Państwa informacje osobiste
+    welsh_language_scheme_html: Poznaj nasze zobowiązania związane z publikowaniem
+      w %{link}
+    social_media_use_html: Przeczytaj naszą politykę dotyczącą %{link}
+    about_our_services_html:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -149,3 +149,13 @@ ps:
     documents:
       one: "سند"
       other: "سندونه"
+  corporate_information_page:
+    corporate_information: متحد معلومات
+    publication_scheme_html: زموږ د هغو معلوماتو په اړه ولولۍ چې هره ورڅ یې موږ خپروو
+      %{link}.
+    personal_information_charter_html: " زموږ تشریح کوی چې موږ د شخصی معلوماتو سره
+      څرنګه چلند کوو"
+    welsh_language_scheme_html: د نشریاتو په اړه  زموږ د ژمنو  معلومات ترلاسه کړۍ
+      %{link}.
+    social_media_use_html: زموږه پالسی ولولی %{link}.
+    about_our_services_html:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -149,3 +149,13 @@ pt:
     documents:
       one: Documento
       other: Documentos
+  corporate_information_page:
+    corporate_information: Informações administrativas
+    publication_scheme_html: Leia sobre os tipos de informações que publicamos rotineiramente
+      em nosso %{link}.
+    personal_information_charter_html: Nosso %{link} explica como nós tratamos suas
+      informações pessoais
+    welsh_language_scheme_html: Saiba mais sobre nosso comprometimento em publicar
+      em %{link}
+    social_media_use_html: Leia nossa política sobre %{link}
+    about_our_services_html:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -195,3 +195,13 @@ ro:
       one: Document
       few:
       other: Documente
+  corporate_information_page:
+    corporate_information: Informaţii despre ambasadă
+    publication_scheme_html: Citește mai multe despre informațiile pe care le publigăm
+      în mod regulat pe  %{link}.
+    personal_information_charter_html: Mai multe despre cum folosim informațiile cu
+      caracter personal pe %{link}
+    welsh_language_scheme_html: Află mai multe despre angajamentul nostru față de
+      accesul la informații publice pe %{link}.
+    social_media_use_html: 'Citește mai multe despre strategia noastră pe '
+    about_our_services_html:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -241,3 +241,13 @@ ru:
       few:
       many:
       other: "Документы"
+  corporate_information_page:
+    corporate_information: Корпоративная информация
+    publication_scheme_html: Прочитать информацию, которая обычно публикуется,  по
+      указанной %{link}.
+    personal_information_charter_html: По %{link} объяснение о том, как мы обращаемся
+      с вашей личной информацией
+    welsh_language_scheme_html: Выяснить о наших обязательствах по публикации можно
+      по %{link}.
+    social_media_use_html: Ознакомиться с нашей политикой по %{link}.
+    about_our_services_html:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -151,3 +151,11 @@ si:
     documents:
       one: "ලේඛණය"
       other: "ලේඛණ"
+  corporate_information_page:
+    corporate_information: සංවිධානයේ තොරතුරු
+    publication_scheme_html: අප නිතර අපේ %{link} පල කරන තොරතුරු වර්ගයන් ගැන කියවන්න
+    personal_information_charter_html: ඔබගේ පුද්ගලික තොරතුරු භාවිතා කිරීම ගැන අපේ
+      %{link} පැහැදිලි කිරීම
+    welsh_language_scheme_html: " %{link} හි පල කිරීමට අපේ ඇති කැපවීම ගැන කියවන්න"
+    social_media_use_html: " %{link}හිදී අපේ ප්‍රතිපත්ති කියවන්න"
+    about_our_services_html:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -195,3 +195,10 @@ sk:
       one:
       few:
       other:
+  corporate_information_page:
+    corporate_information:
+    publication_scheme_html:
+    personal_information_charter_html:
+    welsh_language_scheme_html:
+    social_media_use_html:
+    about_our_services_html:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -151,3 +151,13 @@ so:
     documents:
       one: Dokumenti
       other: Dokumentiyo
+  corporate_information_page:
+    corporate_information: Macluumaad ku saabsan hay'ad
+    publication_scheme_html: Akhri noocyada macluumaadka aan caadi ahaan ku daabacno/nashrinno
+      %{link} aan soo saarno.
+    personal_information_charter_html: "%{link} ayaa sharxaya sida aan ula tacaamulno
+      macluumaadkaaga shakhsiga ah"
+    welsh_language_scheme_html: Wax ka ogow sida aan ugu dadaalno ku daabacadda/nashrinta
+      %{link}.
+    social_media_use_html: Akhri siyaasaddeenna ku saabsan %{link}.
+    about_our_services_html:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -149,3 +149,12 @@ sq:
     documents:
       one: Dokument
       other: Dokumente
+  corporate_information_page:
+    corporate_information: Informacion korporate
+    publication_scheme_html: Lexo mbi llojet e informacionit qe ne publikojme rregullisht
+      ne %{link}.
+    personal_information_charter_html: "%{link} shpjegon si trajtohet informacioni
+      juaj personal"
+    welsh_language_scheme_html: Meso mbi angazhimin tone ndaj publikimit ne %{link}
+    social_media_use_html: Lexo politikat tona ne %{link}
+    about_our_services_html:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -243,3 +243,12 @@ sr:
       few:
       many:
       other: Dokumenti
+  corporate_information_page:
+    corporate_information: Informacije o organizaciji
+    publication_scheme_html: Čitajte o tipovima informacija koje redovno objavljujemo
+      u  %{link}.
+    personal_information_charter_html: "%{link} daje informacije o tome kako obrađujemo
+      vaše lične podatke. "
+    welsh_language_scheme_html: Saznajte naš stav o objavljivanju u %{link}.
+    social_media_use_html: Pročitajte o našoj politici prema  %{link}.
+    about_our_services_html:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -149,3 +149,10 @@ sw:
     documents:
       one:
       other:
+  corporate_information_page:
+    corporate_information:
+    publication_scheme_html:
+    personal_information_charter_html:
+    welsh_language_scheme_html:
+    social_media_use_html:
+    about_our_services_html:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -151,3 +151,12 @@ ta:
     documents:
       one: " ஆவணம்"
       other: "ஆவணங்கள்"
+  corporate_information_page:
+    corporate_information: கூட்டாண்மைத் தகவல்
+    publication_scheme_html: எங்களது %{link} நாங்கள் வழமையாக வெளியிடும் தகவல்களின்  வகைகள்
+      பற்றி வாசிக்கவும்
+    personal_information_charter_html: உங்களது தனிப்பட்ட தகவல்களை எப்படி நாங்கள் கையாள்கிறோம்
+      என்பதை எங்களது %{link} விளக்கும்
+    welsh_language_scheme_html: "%{link} இல் பிரசுரிப்பதற்கான எங்களது பற்றுறுதி பற்றி
+      கண்டறியவும்"
+    social_media_use_html: எங்களது  கொள்கையை %{link} இல் வாசிக்கவும்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -149,3 +149,11 @@ th:
     documents:
       one: "เอกสาร"
       other: "เอกสารต่างๆ"
+  corporate_information_page:
+    corporate_information: ข้อมูลบริษัท
+    publication_scheme_html: อ่านประเภทข้อมูลซึ่งเราเผยแพร่เป็นประจำได้ที่ %{link}
+    personal_information_charter_html: ลิงค์นี้อธิบายถึงวิธีการที่เราปฏิบัติต่อข้อมูลส่วนบุคคลของคุณ
+    welsh_language_scheme_html: ค้นหาข้อมูลเกี่ยวกับพันธสัญญาในการตีพิมพ์ของเราได้ที่
+      %{link}.
+    social_media_use_html: อ่านนโยบายของเราได้ที่ %{link}
+    about_our_services_html:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -151,3 +151,10 @@ tk:
     documents:
       one:
       other:
+  corporate_information_page:
+    corporate_information:
+    publication_scheme_html:
+    personal_information_charter_html:
+    welsh_language_scheme_html:
+    social_media_use_html:
+    about_our_services_html:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -149,3 +149,14 @@ tr:
     documents:
       one: Belge
       other: Belgeler
+  corporate_information_page:
+    corporate_information: Kurumsal bilgi
+    publication_scheme_html: Rutin olarak yayınladığımız bilgiler için bu %{link}
+      'e bakınız
+    personal_information_charter_html: Bu %{link} bilgilerinizi nasıl sakladığımız
+      açıklamaktadır
+    welsh_language_scheme_html: Yayın hedefimiz ile ilgili bilgilere bu  %{link}ten
+      ulaşabilirsiniz.
+    social_media_use_html: Konuyla ilgili politikamız hakkında daha fazla bilgi için
+      %{link}
+    about_our_services_html:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -243,3 +243,13 @@ uk:
       few:
       many:
       other: "Документи"
+  corporate_information_page:
+    corporate_information: Корпоративна інформація
+    publication_scheme_html: Прочитайти, яку інформацію ми регулярно публікуємо у
+      %{link}.
+    personal_information_charter_html: 'Це %{link} пояснює наші принципи роботи з
+      персональними даними. '
+    welsh_language_scheme_html: 'Дізнайтеся про наші зобов''язання щодо публікації
+      інформації у %{link}. '
+    social_media_use_html: Прочитайне про наші принципи роботи щодо %{link}.
+    about_our_services_html:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -151,3 +151,13 @@ ur:
     documents:
       one: "دستاویز"
       other: "دستاویزات"
+  corporate_information_page:
+    corporate_information: کارپوریٹ معلومات
+    publication_scheme_html: 'ہماری معمول کے مطابق  شائع کردہ معلومات کی نوعیت  %{link}
+      پرملاحظہ کیجئیے '
+    personal_information_charter_html: ہمارے %{link} واضح کرتے ہیں کہ ہم آپکی ذاتی
+      معلومات کو کیسے استعمال کرتے ہیں
+    welsh_language_scheme_html: اشاعت کے باب میں ہمارے کمٹ منٹ %{link} میں ملاحظہ
+      کیجئیے
+    social_media_use_html: ہماری پالیسی  %{link} پر ملاحظہ کیجئیے
+    about_our_services_html:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -151,3 +151,13 @@ uz:
     documents:
       one: Hujjat
       other: Hujjatlar
+  corporate_information_page:
+    corporate_information: Korporativ ma'lumot
+    publication_scheme_html: "%{link} Biz doimiy tarzda nashr etayotgan ma'lumot haqida
+      o'qing"
+    personal_information_charter_html: Bizning %{link} qanday qilib shaxsiy ma'lumot
+      bilan ishlashimiz haqida sizga ma'lumot beradi 
+    welsh_language_scheme_html: "%{link} Nashr etish uchun biz olib borayotgan faoliyatimiz
+      haqida o'qing"
+    social_media_use_html: "%{link} Bizning dasturimiz haqida batafsil ma'lumot"
+    about_our_services_html:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -149,3 +149,13 @@ vi:
     documents:
       one: Tài liệu
       other: Tài liệu
+  corporate_information_page:
+    corporate_information: Thông tin về phòng tổng hợp
+    publication_scheme_html: Xem các loại thông tin mà chúng tôi cập nhật thường xuyên
+      tại %{link}
+    personal_information_charter_html: "%{link} của chúng tôi giải thích cách chúng
+      tôi xử lý thông tin cá nhân của bạn"
+    welsh_language_scheme_html: Tìm hiểu các cam kết của chúng tôi trong việc công
+      bố thông tin tại %{link}
+    social_media_use_html: Đọc chính sách của chúng tôi tại %{link}
+    about_our_services_html:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -151,3 +151,10 @@ zh-hk:
     documents:
       one: "文件"
       other: "其他文件"
+  corporate_information_page:
+    corporate_information: 政府資訊
+    publication_scheme_html: 查閱我們在%{link}定期發布的資訊。
+    personal_information_charter_html: 我們的%{link}解釋我們如何處理你的個人資料。
+    welsh_language_scheme_html: 查閱我們在%{link}的發布承諾。
+    social_media_use_html: 查閱我們在%{link}的政策。
+    about_our_services_html:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -149,3 +149,10 @@ zh-tw:
     documents:
       one: "文件"
       other: "其他文件"
+  corporate_information_page:
+    corporate_information: 政府資訊
+    publication_scheme_html: 查閱我們在%{link}定期發布的資訊。
+    personal_information_charter_html: 我們的%{link}解釋我們如何處理你的個人資料。
+    welsh_language_scheme_html: 查閱我們在%{link}的發佈承諾。
+    social_media_use_html: 查閱我們在%{link}的政策。
+    about_our_services_html:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -153,3 +153,10 @@ zh:
     documents:
       one: "文件"
       other: "文件"
+  corporate_information_page:
+    corporate_information: 政府信息
+    publication_scheme_html: 阅读我们在%{link}定期发布的信息。
+    personal_information_charter_html: 我们的%{link}解释了我们如何对待您的个人信息。
+    welsh_language_scheme_html: 查阅我们在%{link}发布的信息。
+    social_media_use_html: 阅读我们在%{link}的政策
+    about_our_services_html:

--- a/test/integration/corporate_information_page_test.rb
+++ b/test/integration/corporate_information_page_test.rb
@@ -2,15 +2,37 @@ require 'test_helper'
 
 class CorporateInformationPageTest < ActionDispatch::IntegrationTest
   test "renders title, description and body" do
-    setup_and_visit_content_item('corporate_information_page')
+    setup_and_visit_content_item('corporate_information_page_translated_custom_logo')
 
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
     assert_has_component_govspeak(@content_item["details"]["body"])
+  end
 
+  test "renders with contents list" do
+    setup_and_visit_content_item('corporate_information_page')
     assert_has_contents_list([
       { text: "Our responsibilities", id: "our-responsibilities" },
+      { text: "Corporate information", id: "corporate-information" },
     ])
+  end
+
+  test "renders corporate information with body when present" do
+    setup_and_visit_content_item('corporate_information_page')
+
+    within_component_govspeak do |component_args|
+      content = component_args.fetch("content")
+      assert content.gsub(/\s+/, ' ').include? @content_item["details"]["body"].gsub(/\s+/, ' ')
+
+      html = Nokogiri::HTML.parse(content)
+      assert_not_nil html.at_css("h2#corporate-information")
+      assert_not_nil html.at_css("h3#access-our-information")
+      assert_not_nil html.at_css("h3#jobs-and-contracts")
+
+      assert_not_nil html.at_css("ul li a[href='/government/organisations/department-of-health/about/complaints-procedure']")
+      assert_not_nil html.at_css("ul li a[href*='/government/publications']")
+      assert_not_nil html.at_css("ul li a[href='https://www.civilservicejobs.service.gov.uk/csr']")
+    end
   end
 
   test "renders with organisation branding" do

--- a/test/integration/corporate_information_page_test.rb
+++ b/test/integration/corporate_information_page_test.rb
@@ -35,6 +35,15 @@ class CorporateInformationPageTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "renders further information with body when present" do
+    setup_and_visit_content_item('corporate_information_page')
+
+    within_component_govspeak do |component_args|
+      content = component_args.fetch("content")
+      assert content.gsub(/\s+/, ' ').include? "Read about the types of information we routinely"
+    end
+  end
+
   test "renders with organisation branding" do
     setup_and_visit_content_item('corporate_information_page')
     assert page.has_css?('.department-of-health-brand-colour')

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -56,5 +56,15 @@ class CorporateInformationPagePresenterTest
       presented_groups = presented_item.corporate_information
       assert_equal '<h3 id="access-our-information">Access our information</h3>', presented_groups.first[:heading]
     end
+
+    test 'presents further information based on corporate information page links' do
+      publication_scheme = schema_item['links']['corporate_information_pages'].find { |l| l['document_type'] == 'publication_scheme' }
+      information_charter = schema_item['links']['corporate_information_pages'].find { |l| l['document_type'] == 'personal_information_charter' }
+
+      assert presented_item.further_information.include?(publication_scheme['base_path'])
+      assert presented_item.further_information.include?(publication_scheme['title'])
+      assert presented_item.further_information.include?(information_charter['base_path'])
+      assert presented_item.further_information.include?(information_charter['title'])
+    end
   end
 end

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -28,5 +28,33 @@ class CorporateInformationPagePresenterTest
     test 'has organisation branding' do
       assert presented_item.is_a?(OrganisationBranding)
     end
+
+    test 'presents corporate information groups on about pages' do
+      assert presented_item.is_a?(CorporateInformationGroups)
+
+      assert_equal '<a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="corporate-information" href="#corporate-information">Corporate information</a>', presented_item.contents.last
+
+      assert presented_item.corporate_information?
+    end
+
+    test 'presents group links that are guids' do
+      presented_groups = presented_item.corporate_information
+      assert_equal '<a href="/government/organisations/department-of-health/about/complaints-procedure">Complaints procedure</a>', presented_groups.first[:links].first
+    end
+
+    test 'presents group links that are internal links with paths and no GUID' do
+      presented_groups = presented_item.corporate_information
+      assert_equal '<a href="/government/publications?departments%5B%5D=department-of-health&amp;publication_type=corporate-reports">Corporate reports</a>', presented_groups.first[:links].last
+    end
+
+    test 'presents group links that are external' do
+      presented_groups = presented_item.corporate_information
+      assert_equal '<a href="https://www.civilservicejobs.service.gov.uk/csr">Jobs</a>', presented_groups.last[:links].last
+    end
+
+    test 'presents group headings' do
+      presented_groups = presented_item.corporate_information
+      assert_equal '<h3 id="access-our-information">Access our information</h3>', presented_groups.first[:heading]
+    end
   end
 end


### PR DESCRIPTION
Goes with:
https://github.com/alphagov/govuk-content-schemas/pull/522

Part of:
https://trello.com/c/8syU3iNh/593-add-corporate-information-block-to-about-pages-corporate-information-pages-2

When corporate information groups are provided (about pages only), append the list of links with headings to the body and render as content without any special rules.

* Add Corporate information heading
* Include heading in contents list
* Links in groups can be GUIDs, internal or external
* Port translations for strings needing translation from Whitehall

| Before | After |
|--|--|
|![screen shot 2017-02-16 at 15 39 01](https://cloud.githubusercontent.com/assets/319055/23028041/162382ae-f45e-11e6-8904-fed9e4d7897e.png) | ![screen shot 2017-02-16 at 15 38 51](https://cloud.githubusercontent.com/assets/319055/23028037/1424c094-f45e-11e6-81b2-88b188ccad80.png) |
