### PR TITLE
Update jasmine-rails to 0.14.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'govuk_navigation_helpers', '~> 2.3.1'
 group :development, :test do
   gem 'govuk-lint'
   gem 'pry-byebug'
-  gem 'jasmine-rails', '~> 0.13.0'
+  gem 'jasmine-rails', '~> 0.14.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,8 +91,8 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
-    jasmine-core (2.5.0)
-    jasmine-rails (0.13.0)
+    jasmine-core (2.5.2)
+    jasmine-rails (0.14.1)
       jasmine-core (>= 1.3, < 3.0)
       phantomjs (>= 1.9)
       railties (>= 3.2.0)
@@ -257,7 +257,7 @@ DEPENDENCIES
   govuk_ab_testing (= 0.1.4)
   govuk_frontend_toolkit (= 5.1.0)
   govuk_navigation_helpers (~> 2.3.1)
-  jasmine-rails (~> 0.13.0)
+  jasmine-rails (~> 0.14.0)
   logstasher (= 0.6.1)
   mocha
   plek (= 1.11)
@@ -273,4 +273,4 @@ DEPENDENCIES
   webmock (~> 1.18.0)
 
 BUNDLED WITH
-   1.12.5
+   1.14.4


### PR DESCRIPTION
Removes deprecation warnings when running the jasmine tests