### PR TITLE
Fix casing of A/B test name

### DIFF
--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -6,7 +6,7 @@ class EducationNavigationAbTestRequest
   delegate :analytics_meta_tag, to: :requested_variant
 
   def initialize(request)
-    @ab_test = GovukAbTesting::AbTest.new("educationnavigation", dimension: 41)
+    @ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: 41)
     @requested_variant = @ab_test.requested_variant request
   end
 

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -118,12 +118,12 @@ class ContentItemsControllerTest < ActionController::TestCase
 
     content_store_has_item(content_item['base_path'], content_item)
 
-    with_variant educationnavigation: "A" do
+    with_variant EducationNavigation: "A" do
       get :show, params: { path: path_for(content_item) }
       assert_equal [], @request.variant
     end
 
-    with_variant educationnavigation: "B" do
+    with_variant EducationNavigation: "B" do
       get :show, params: { path: path_for(content_item) }
       assert_equal [:new_navigation], @request.variant
     end
@@ -137,12 +137,12 @@ class ContentItemsControllerTest < ActionController::TestCase
 
     content_store_has_item(content_item['base_path'], content_item)
 
-    with_variant educationnavigation: "A" do
+    with_variant EducationNavigation: "A" do
       get :show, params: { path: path_for(content_item) }
       assert_equal [], @request.variant
     end
 
-    with_variant educationnavigation: "B" do
+    with_variant EducationNavigation: "B" do
       get :show, params: { path: path_for(content_item) }
       assert_equal [], @request.variant
     end


### PR DESCRIPTION
The name of the A/B test must match the cookie name exactly. The name of this test is defined as EducationNavigation in alphagov/govuk-cdn-config#17.