### PR TITLE
Education navigation ab testing

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -41,8 +41,8 @@ private
   end
 
   def set_up_education_navigation_ab_testing
-    @education_navigation_ab_test = EducationNavigationAbTestRequest.new(request)
-    return unless @education_navigation_ab_test.content_schema_has_new_navigation?(@content_item.content_item)
+    @education_navigation_ab_test = EducationNavigationAbTestRequest.new(request, @content_item.content_item)
+    return unless @education_navigation_ab_test.ab_test_applies?
 
     @education_navigation_ab_test.set_response_vary_header response
 
@@ -52,7 +52,7 @@ private
     # will attempt to load _breadcrumbs.html+new_navigation.erb instead. If such a file does not exist, then it falls
     # back to _breadcrumbs.html.erb.
     # See: http://edgeguides.rubyonrails.org/4_1_release_notes.html#action-pack-variants
-    request.variant = :new_navigation if @education_navigation_ab_test.should_present_new_navigation_view?(@content_item.content_item)
+    request.variant = :new_navigation if @education_navigation_ab_test.should_present_new_navigation_view?
   end
 
   def with_locale

--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -1,5 +1,5 @@
 class EducationNavigationAbTestRequest
-  NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS = %w{detailed_guide publication}.freeze
+  NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS = %w{detailed_guide document_collection publication}.freeze
 
   attr_accessor :requested_variant
 

--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -5,17 +5,18 @@ class EducationNavigationAbTestRequest
 
   delegate :analytics_meta_tag, to: :requested_variant
 
-  def initialize(request)
+  def initialize(request, content_item)
+    @content_item = content_item
     @ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: 41)
     @requested_variant = @ab_test.requested_variant request
   end
 
-  def content_schema_has_new_navigation?(content_item)
-    NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS.include? content_item["schema_name"]
+  def ab_test_applies?
+    new_navigation_enabled? && content_is_tagged_to_a_taxon? && content_schema_has_new_navigation?
   end
 
-  def should_present_new_navigation_view?(content_item)
-    @requested_variant.variant_b? && new_navigation_enabled? && content_is_tagged_to_a_taxon?(content_item)
+  def should_present_new_navigation_view?
+    ab_test_applies? && @requested_variant.variant_b?
   end
 
   def set_response_vary_header(response)
@@ -28,7 +29,11 @@ private
     ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
   end
 
-  def content_is_tagged_to_a_taxon?(content_item)
-    content_item.dig("links", "taxons").present?
+  def content_is_tagged_to_a_taxon?
+    @content_item.dig("links", "taxons").present?
+  end
+
+  def content_schema_has_new_navigation?
+    NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS.include? @content_item["schema_name"]
   end
 end

--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -1,5 +1,5 @@
 class EducationNavigationAbTestRequest
-  NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS = %w{detailed_guide}.freeze
+  NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS = %w{detailed_guide publication}.freeze
 
   attr_accessor :requested_variant
 

--- a/app/views/content_items/detailed_guide.html+new_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+new_navigation.erb
@@ -1,7 +1,4 @@
 <%= content_for :title, @content_item.page_title %>
-<%= content_for :extra_head_content do %>
-  <%= @education_navigation_ab_test.analytics_meta_tag.html_safe %>
-<% end %>
 
 <div class="grid-row" data-module="sticky-element-container">
   <div class="column-two-thirds">

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,9 +1,6 @@
 <% # THIS IS PART OF EDUCATION NAVIGATION A/B TESTING - PLEASE KEEP IN SYNC WITH +new_navigation.erb %>
 
 <%= content_for :title, @content_item.page_title %>
-<%= content_for :extra_head_content do %>
-  <%= @education_navigation_ab_test.analytics_meta_tag.html_safe %>
-<% end %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/content_items/document_collection.html+new_navigation.erb
+++ b/app/views/content_items/document_collection.html+new_navigation.erb
@@ -1,0 +1,53 @@
+<%= content_for :title, @content_item.page_title %>
+
+<div class="grid-row" data-module="sticky-element-container">
+  <div class="column-two-thirds">
+    <%= render 'shared/title_and_translations', content_item: @content_item %>
+    <%= render 'shared/withdrawal_notice', content_item: @content_item %>
+    <%= render 'shared/metadata', content_item: @content_item %>
+    <%= render 'shared/history_notice', content_item: @content_item %>
+    <%= render 'shared/description', description: @content_item.description %>
+    <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
+
+    <% if @content_item.body.present? %>
+      <%= render 'govuk_component/govspeak',
+                 content: @content_item.body,
+                 direction: page_text_direction %>
+    <% end %>
+    <% @content_item.groups.each do |group| %>
+      <%= @content_item.group_heading(group) %>
+      <% if group["body"].present? %>
+        <%= render 'govuk_component/govspeak',
+                   content: group["body"],
+                   direction: page_text_direction %>
+      <% end %>
+      <ol class="group-document-list">
+        <% @content_item.group_document_links(group).each do |link| %>
+          <li class="group-document-list-item">
+            <h3 class="group-document-list-item-title">
+              <%= link_to(link[:title], link[:base_path]) %>
+            </h3>
+            <ul class="group-document-list-item-attributes">
+              <li>
+                <time datetime="<%= link[:public_updated_at].iso8601 %>">
+                  <%= l(link[:public_updated_at], format: :short_ordinal) %>
+                </time>
+              </li>
+              <li><%= t("content_item.format.#{link[:document_type]}", count: 1) %></li>
+            </ul>
+          </li>
+        <% end %>
+      </ol>
+    <% end %>
+  </div>
+
+  <div class="column-third">
+    <% if @content_item.contents.any? %>
+      <div data-sticky-element class="sticky-element">
+        <a class="back-to-content" href="#contents"><%= t("content_item.contents") %></a>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/publication.html+new_navigation.erb
+++ b/app/views/content_items/publication.html+new_navigation.erb
@@ -1,0 +1,41 @@
+<%= content_for :title, @content_item.page_title %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+               context: t("content_item.format.#{@content_item.document_type}", count: 1),
+               title: @content_item.title,
+               average_title_length: "long" %>
+
+    <%= render 'shared/translations' %>
+    <% if @content_item.national_statistics? %>
+      <%= render 'shared/national_statistics_logo' %>
+    <% end %>
+
+    <%= render 'shared/withdrawal_notice', content_item: @content_item %>
+    <%= render 'shared/metadata', content_item: @content_item %>
+    <%= render 'shared/history_notice', content_item: @content_item %>
+    <%= render 'shared/description', description: @content_item.description %>
+
+    <h1 class="section-title" id="documents-title">
+      <%= t("publications.documents", count: @content_item.documents_count) %>
+    </h1>
+    <div aria-labelledby="documents-title">
+      <%= render 'govuk_component/govspeak',
+                 content: @content_item.documents,
+                 direction: page_text_direction %>
+    </div>
+
+    <h1 class="section-title" id="details-title">
+      <%= t("publications.details") %>
+    </h1>
+
+    <div aria-labelledby="details-title">
+      <%= render 'govuk_component/govspeak',
+                 content: @content_item.details,
+                 direction: page_text_direction %>
+    </div>
+  </div>
+</div>
+
+<%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
   <meta name="govuk:content-id" content="<%= @content_item.content_id %>" />
+  <%= @education_navigation_ab_test.analytics_meta_tag.html_safe if @education_navigation_ab_test.ab_test_applies? %>
   <%= yield :extra_head_content %>
 </head>
 <body>

--- a/app/views/shared/_national_statistics_logo.html+new_navigation.erb
+++ b/app/views/shared/_national_statistics_logo.html+new_navigation.erb
@@ -1,0 +1,3 @@
+<div class="national-statistics-logo">
+  <%= image_tag 'national-statistics.png', alt: 'National Statistics' %>
+</div>

--- a/app/views/shared/_translations.html+new_navigation.erb
+++ b/app/views/shared/_translations.html+new_navigation.erb
@@ -1,0 +1,5 @@
+<% if @content_item.available_translations.any? %>
+  <%= render 'shared/available_languages',
+    translations: @content_item.available_translations
+  %>
+<% end %>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -137,15 +137,15 @@ class ContentItemsControllerTest < ActionController::TestCase
 
     content_store_has_item(content_item['base_path'], content_item)
 
-    with_variant EducationNavigation: "A" do
-      get :show, params: { path: path_for(content_item) }
-      assert_equal [], @request.variant
-    end
+    setup_ab_variant('EducationNavigation', 'A')
+    get :show, params: { path: path_for(content_item) }
+    assert_equal [], @request.variant
+    assert_unaffected_by_ab_test
 
-    with_variant EducationNavigation: "B" do
-      get :show, params: { path: path_for(content_item) }
-      assert_equal [], @request.variant
-    end
+    setup_ab_variant('EducationNavigation', 'B')
+    get :show, params: { path: path_for(content_item) }
+    assert_equal [], @request.variant
+    assert_unaffected_by_ab_test
   end
 
   test "Case Studies are not included in the AB Test" do


### PR DESCRIPTION
This extends the styling changes made in https://github.com/alphagov/government-frontend/pull/237 to also encompass the following content item schemas:

- `document_collection`
- `publication`

The changes are to:

- Add a `meta` tag to these documents to indicate that they are in an A/B test (when their content is tagged to a taxon)
- Set the `Vary` header on responses from these documents
- Move the content for these documents into the left two thirds of the page (when the user is in the "B" group)

### Trello

https://trello.com/c/jd56fcgd/338-changes-to-education-related-content-pages-as-part-of-the-new-navigation-in-government-frontend-part-2