### PR TITLE
Don't print share links

### DIFF
--- a/app/views/shared/_share_buttons.html.erb
+++ b/app/views/shared/_share_buttons.html.erb
@@ -1,4 +1,4 @@
-<div class="grid-row sidebar-with-body">
+<div class="grid-row sidebar-with-body dont-print">
   <div class="column-two-thirds offset-one-third">
     <h2>Share this page</h2>
     <div class="share-buttons" data-module="track-share-button-clicks">


### PR DESCRIPTION
* The links aren’t useful when printed
* The long dynamic URLs don’t read well

(This also highlights that when printing there is no clear "end of content" point)

## Before

![screen shot 2017-02-27 at 14 39 35](https://cloud.githubusercontent.com/assets/319055/23365331/988ead64-fcfa-11e6-807b-819d8f1b639d.png)

## After

![screen shot 2017-02-27 at 14 40 52](https://cloud.githubusercontent.com/assets/319055/23365363/c310af92-fcfa-11e6-850f-aac3b5dbdc15.png)
