### PR TITLE
Bump slimmer gem to fix memory leak

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'sass-rails', '~> 5.0.4'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '9.6.0'
+  gem 'slimmer', '~> 10.1.3'
 end
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
       phantomjs (>= 1.9)
       railties (>= 3.2.0)
       sprockets-rails
-    json (2.0.2)
+    json (2.0.3)
     json-schema (2.5.2)
       addressable (~> 2.3.8)
     kgio (2.10.0)
@@ -202,7 +202,7 @@ GEM
     scss_lint (0.52.0)
       rake (>= 0.9, < 13)
       sass (~> 3.4.20)
-    slimmer (9.6.0)
+    slimmer (10.1.3)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -267,7 +267,7 @@ DEPENDENCIES
   rails-i18n (>= 4.0.4)
   rails_translation_manager (~> 0.0.2)
   sass-rails (~> 5.0.4)
-  slimmer (= 9.6.0)
+  slimmer (~> 10.1.3)
   uglifier (>= 1.3.0)
   unicorn (= 4.8)
   webmock (~> 1.18.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  include Slimmer::SharedTemplates
+  include Slimmer::GovukComponents
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,6 @@ Rails.application.configure do
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.action_controller.asset_host = Plek.current.asset_root
-  config.slimmer.use_cache = true
   config.slimmer.asset_host = Plek.current.find('static')
 
   # Specifies the header that your server uses for sending files.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,12 +7,12 @@ require 'rails/test_help'
 require 'webmock/minitest'
 require 'support/govuk_content_schema_examples'
 require 'capybara/rails'
-require 'slimmer/test_helpers/shared_templates'
+require 'slimmer/test_helpers/govuk_components'
 require 'mocha/mini_test'
 
 class ActiveSupport::TestCase
   include GovukContentSchemaExamples
-  include Slimmer::TestHelpers::SharedTemplates
+  include Slimmer::TestHelpers::GovukComponents
 
   def setup
     stub_shared_component_locales
@@ -30,7 +30,7 @@ end
 class ActionDispatch::IntegrationTest
   # Make the Capybara DSL available in all integration tests
   include Capybara::DSL
-  include Slimmer::TestHelpers::SharedTemplates
+  include Slimmer::TestHelpers::GovukComponents
 
   def setup
     stub_shared_component_locales


### PR DESCRIPTION
Most important: https://github.com/alphagov/slimmer/pull/191, which maybe fixes a memory leak in the components.

Changelog:

# 10.1.3

* Fix memory leak in components

# 10.1.2

* Bugfix for request URI's encoded as ASCII

# 10.1.1

* Bugfix for caching behaviour

# 10.1.0

* Use `Rails.cache` as the cache for templates, locales and components.
You can
remove `config.slimmer.use_cache` for your application, as you can no
longer
opt-out of caching.
* Add a `User-Agent` header to all outgoing API requests

# 10.0.0

* Removes the need_id meta tag, which is no longer used.
* Removes the functionality for breadcrumbs, related links and
artefact-powered
metatags.
* Drop support for old Rails & Ruby versions. This gem now supports
Rails 4.2 and 5.X
on Ruby 2.1 and 2.2.
* Renames `Slimmer::SharedTemplates` to `Slimmer::GovukComponents`

https://trello.com/c/TYpcs2W1