### PR TITLE
Add taxonomy sidebar to pages displaying the new navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ else
   gem "gds-api-adapters", "39.1.0"
 end
 
-gem 'govuk_navigation_helpers', '~> 2.3.1'
+gem 'govuk_navigation_helpers', '~> 2.4.0'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (2.3.1)
+    govuk_navigation_helpers (2.4.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -256,7 +256,7 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing (= 0.1.4)
   govuk_frontend_toolkit (= 5.1.0)
-  govuk_navigation_helpers (~> 2.3.1)
+  govuk_navigation_helpers (~> 2.4.0)
   jasmine-rails (~> 0.14.0)
   logstasher (= 0.6.1)
   mocha
@@ -272,5 +272,8 @@ DEPENDENCIES
   unicorn (= 4.8)
   webmock (~> 1.18.0)
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.14.4
+   1.14.5

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,40 +7,40 @@
 @import 'typography';
 
 // government-frontend mixins
-@import "mixins/margins";
-@import "mixins/white-links";
+@import 'mixins/margins';
+@import 'mixins/white-links';
 
 // helpers for common page elements
-@import "helpers/available-languages";
-@import "helpers/back-to-content";
-@import "helpers/dash-list";
-@import "helpers/description";
-@import "helpers/sidebar-with-body";
-@import "helpers/share-buttons";
-@import "helpers/national_statistics_logo";
-@import "helpers/notice";
-@import "helpers/organisation-links";
-@import "helpers/history-notice";
-@import "helpers/withdrawal-notice";
-@import "helpers/taxonomy-sidebar";
+@import 'helpers/available-languages';
+@import 'helpers/back-to-content';
+@import 'helpers/dash-list';
+@import 'helpers/description';
+@import 'helpers/sidebar-with-body';
+@import 'helpers/share-buttons';
+@import 'helpers/national_statistics_logo';
+@import 'helpers/notice';
+@import 'helpers/organisation-links';
+@import 'helpers/history-notice';
+@import 'helpers/withdrawal-notice';
+@import 'helpers/taxonomy-sidebar';
 
 // pages specific view imports
-@import "views/case-studies";
-@import "views/coming-soon";
-@import "views/html-publication";
-@import "views/statistics_announcement";
-@import "views/take-part";
-@import "views/topical-event-about-page";
-@import "views/unpublishing";
-@import "views/working-group";
-@import "views/detailed-guide";
-@import "views/publication";
-@import "views/document-collection";
-@import "views/fatality-notice";
-@import "views/statistical-data-set";
-@import "views/consultation";
-@import "views/speech";
-@import "views/world-location-news-article";
-@import "views/news-article";
-@import "views/corporate-information-page";
-@import "views/travel-advice";
+@import 'views/case-studies';
+@import 'views/coming-soon';
+@import 'views/html-publication';
+@import 'views/statistics_announcement';
+@import 'views/take-part';
+@import 'views/topical-event-about-page';
+@import 'views/unpublishing';
+@import 'views/working-group';
+@import 'views/detailed-guide';
+@import 'views/publication';
+@import 'views/document-collection';
+@import 'views/fatality-notice';
+@import 'views/statistical-data-set';
+@import 'views/consultation';
+@import 'views/speech';
+@import 'views/world-location-news-article';
+@import 'views/news-article';
+@import 'views/corporate-information-page';
+@import 'views/travel-advice';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,7 @@
 @import "helpers/organisation-links";
 @import "helpers/history-notice";
 @import "helpers/withdrawal-notice";
+@import "helpers/taxonomy-sidebar";
 
 // pages specific view imports
 @import "views/case-studies";

--- a/app/assets/stylesheets/helpers/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/helpers/_taxonomy-sidebar.scss
@@ -1,0 +1,5 @@
+@mixin taxonomy-sidebar {
+  .govuk-taxonomy-sidebar {
+    margin-top: 50px;
+  }
+}

--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -3,6 +3,7 @@
   @include sidebar-with-body;
   @include history-notice;
   @include withdrawal-notice;
+  @include taxonomy-sidebar;
 
   .related-mainstream-content {
     background: $panel-colour;

--- a/app/assets/stylesheets/views/_document-collection.scss
+++ b/app/assets/stylesheets/views/_document-collection.scss
@@ -3,6 +3,7 @@
   @include sidebar-with-body;
   @include history-notice;
   @include withdrawal-notice;
+  @include taxonomy-sidebar;
 
   .group-title {
     @include bold-27;

--- a/app/assets/stylesheets/views/_publication.scss
+++ b/app/assets/stylesheets/views/_publication.scss
@@ -4,6 +4,7 @@
   @include history-notice;
   @include withdrawal-notice;
   @include national-statistics-logo;
+  @include taxonomy-sidebar;
 
   .section-title {
     @include bold-27;

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -45,18 +45,23 @@ private
   end
 
   def set_up_education_navigation_ab_testing
-    @education_navigation_ab_test = EducationNavigationAbTestRequest.new(request, @content_item.content_item)
+    @education_navigation_ab_test = EducationNavigationAbTestRequest.new(
+      request, @content_item.content_item
+    )
     return unless @education_navigation_ab_test.ab_test_applies?
 
     @education_navigation_ab_test.set_response_vary_header response
 
-    # Setting a variant on a request is a type of Rails Dark Magic that will use a convention to automagically load
-    # an alternative partial/view/layout.
-    # For example, if I set a variant of :new_navigation and we render a partial called _breadcrumbs.html.erb then Rails
-    # will attempt to load _breadcrumbs.html+new_navigation.erb instead. If such a file does not exist, then it falls
-    # back to _breadcrumbs.html.erb.
-    # See: http://edgeguides.rubyonrails.org/4_1_release_notes.html#action-pack-variants
-    request.variant = :new_navigation if @education_navigation_ab_test.should_present_new_navigation_view?
+    # Setting a variant on a request is a type of Rails Dark Magic that will
+    # use a convention to automagically load an alternative partial, view or
+    # layout.  For example, if I set a variant of :new_navigation and we render
+    # a partial called _breadcrumbs.html.erb then Rails will attempt to load
+    # _breadcrumbs.html+new_navigation.erb instead. If this file doesn't exist,
+    # then it falls back to _breadcrumbs.html.erb.  See:
+    # http://edgeguides.rubyonrails.org/4_1_release_notes.html#action-pack-variants
+    if @education_navigation_ab_test.should_present_new_navigation_view?
+      request.variant = :new_navigation
+    end
   end
 
   def with_locale

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -38,6 +38,10 @@ class ContentItemPresenter
     @nav_helper.taxon_breadcrumbs[:breadcrumbs]
   end
 
+  def taxonomy_sidebar
+    @nav_helper.taxonomy_sidebar
+  end
+
 private
 
   def display_date(timestamp, format = "%-d %B %Y")

--- a/app/views/content_items/detailed_guide.html+new_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+new_navigation.erb
@@ -40,5 +40,7 @@
         <a class="back-to-content" href="#contents"><%= t("content_item.contents") %></a>
       </div>
     <% end %>
+
+    <%= render partial: 'govuk_component/taxonomy_sidebar', locals: @content_item.taxonomy_sidebar %>
   </div>
 </div>

--- a/app/views/content_items/document_collection.html+new_navigation.erb
+++ b/app/views/content_items/document_collection.html+new_navigation.erb
@@ -47,6 +47,8 @@
         <a class="back-to-content" href="#contents"><%= t("content_item.contents") %></a>
       </div>
     <% end %>
+
+    <%= render partial: 'govuk_component/taxonomy_sidebar', locals: @content_item.taxonomy_sidebar %>
   </div>
 </div>
 

--- a/app/views/content_items/publication.html+new_navigation.erb
+++ b/app/views/content_items/publication.html+new_navigation.erb
@@ -36,6 +36,10 @@
                  direction: page_text_direction %>
     </div>
   </div>
+
+  <div class="column-third">
+    <%= render partial: 'govuk_component/taxonomy_sidebar', locals: @content_item.taxonomy_sidebar %>
+  </div>
 </div>
 
 <%= render 'shared/footer', @content_item.document_footer %>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -89,18 +89,19 @@ class ContentItemsControllerTest < ActionController::TestCase
     path = 'government/abtest/detailed-guide'
     content_item['base_path'] = "/#{path}"
     content_item['links'] = {
-        'taxons' => [
-            {
-                'title' => 'A Taxon',
-                'base_path' => '/a-taxon',
-            }
-        ]
+      'taxons' => [
+        {
+          'title' => 'A Taxon',
+          'base_path' => '/a-taxon',
+        }
+      ]
     }
 
     content_store_has_item(content_item['base_path'], content_item)
 
     get :show, params: { path: path_for(content_item) }
     assert_equal [], @request.variant
+    refute_match(/A Taxon/, taxonomy_sidebar)
   end
 
   test "honours Education Navigation AB Testing cookie for Detailed Guides" do
@@ -108,12 +109,12 @@ class ContentItemsControllerTest < ActionController::TestCase
     path = 'government/abtest/detailed-guide'
     content_item['base_path'] = "/#{path}"
     content_item['links'] = {
-        'taxons' => [
-            {
-                'title' => 'A Taxon',
-                'base_path' => '/a-taxon',
-            }
-        ]
+      'taxons' => [
+        {
+          'title' => 'A Taxon',
+          'base_path' => '/a-taxon',
+        }
+      ]
     }
 
     content_store_has_item(content_item['base_path'], content_item)
@@ -126,6 +127,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     with_variant EducationNavigation: "B" do
       get :show, params: { path: path_for(content_item) }
       assert_equal [:new_navigation], @request.variant
+      assert_match(/A Taxon/, taxonomy_sidebar)
     end
   end
 
@@ -140,11 +142,13 @@ class ContentItemsControllerTest < ActionController::TestCase
     setup_ab_variant('EducationNavigation', 'A')
     get :show, params: { path: path_for(content_item) }
     assert_equal [], @request.variant
+    refute_match(/A Taxon/, taxonomy_sidebar)
     assert_unaffected_by_ab_test
 
     setup_ab_variant('EducationNavigation', 'B')
     get :show, params: { path: path_for(content_item) }
     assert_equal [], @request.variant
+    refute_match(/A Taxon/, taxonomy_sidebar)
     assert_unaffected_by_ab_test
   end
 
@@ -165,10 +169,15 @@ class ContentItemsControllerTest < ActionController::TestCase
 
     get :show, params: { path: path_for(content_item) }
     assert_equal [], @request.variant
+    refute_match(/A Taxon/, taxonomy_sidebar)
     assert_unaffected_by_ab_test
   end
 
   def path_for(content_item)
     content_item['base_path'].sub(/^\//, '')
+  end
+
+  def taxonomy_sidebar
+    Nokogiri::HTML.parse(response.body).at_css(".column-third")
   end
 end


### PR DESCRIPTION
Use the taxonomy sidebar component in static and rework the tests to
assert for the presence of the sidebar where appropriate.

Along with the taxon breadcrumbs this change is part of the education nav AB test.

## Old nav ('A' version)

![window](https://cloud.githubusercontent.com/assets/519250/23404315/33867e9e-fdac-11e6-9785-2c7bcea1c145.png)


## New nav ('B' version)

Note that this PR adds the sidebar only - the breadcrumbs are already implemented in this repo.

![window](https://cloud.githubusercontent.com/assets/519250/23404451/fe166624-fdac-11e6-84fc-9d1fa1e9fd33.png)


https://trello.com/c/0BD3POzu/403-show-parent-taxons-in-the-side-navigation-on-all-education-content-pages