### PR TITLE
Fix #181: Highlight nav correctly for news articles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,6 +10,18 @@ module ApplicationHelper
   def active_proposition
     # Which of the government sections is the page part of?
     # Derive this from the request path, eg: /government/consultations => consultations
-    request.original_fullpath.split('/')[2]
+    active = request.original_fullpath.split('/')[2]
+    active_proposition_mapping.fetch(active, active)
+  end
+
+private
+
+  def active_proposition_mapping
+    # Some paths don't map directly to the position nav
+    # eg /government/news sits under 'announcements'
+    {
+      'news' => 'announcements',
+      'fatalities' => 'announcements'
+    }
   end
 end

--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -4,6 +4,8 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
   test "typical fatality notice" do
     setup_and_visit_content_item('fatality_notice')
 
+    assert_has_component_government_navigation_active("announcements")
+
     assert page.has_title?(
       "Sir George Pomeroy Colley killed in Boer War - Fatality notice - GOV.UK"
     )

--- a/test/integration/news_article_test.rb
+++ b/test/integration/news_article_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class NewsArticleTest < ActionDispatch::IntegrationTest
   test "news article renders title, description and body" do
     setup_and_visit_content_item("news_article")
+    assert_has_component_government_navigation_active("announcements")
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
     assert_has_component_govspeak(@content_item["details"]["body"])

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -4,6 +4,8 @@ class PublicationTest < ActionDispatch::IntegrationTest
   test "publication" do
     setup_and_visit_content_item('publication')
 
+    assert_has_component_government_navigation_active("publications")
+
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -85,6 +85,10 @@ class ActionDispatch::IntegrationTest
     end
   end
 
+  def assert_has_component_government_navigation_active(active)
+    assert_component_parameter("government_navigation", "active", active)
+  end
+
   def assert_has_contents_list(contents)
     assert page.has_css?(".dash-list"), "Failed to find an element with a class of dash-list"
     within ".dash-list" do


### PR DESCRIPTION
Hiya 👋 
![](http://vignette3.wikia.nocookie.net/plantsvszombies/images/5/55/Wall-nut-hd.png/revision/latest?cb=20120430000724)

I spotted the broken active nav when someone on Twitter linked to a news article. There was an issue already. This fixes it.

---

Current nav is based on part of the path, which works for common cases like 'publications', but some don't follow the convention, like news articles (with 'government/news/slug') that sit under 'announcements'.

Add a hash to map paths that don't follow the convention.

Add tests to for news articles getting the right active nav, and another to a format that does follow the convention, to ensure that still works.

I'm not sure if there are formats other than news articles that need a mapping, but they'd be easy to add now.

---

**Cyber Screenshot:**

![screen shot 2017-02-27 at 22 44 46](https://cloud.githubusercontent.com/assets/63201/23383463/69f998ee-fd3e-11e6-86b9-aafeb8bd91e6.png)

🎉 