### PR TITLE
Fix wraith when running against prod/staging from within VM

### DIFF
--- a/test/wraith/config-staging-vs-production.yaml
+++ b/test/wraith/config-staging-vs-production.yaml
@@ -17,6 +17,15 @@
 # (required) The engine to run Wraith with. Examples: 'phantomjs', 'casperjs', 'slimerjs'
 browser: "phantomjs"
 
+# Use TLS v1 when requesting https://www.gov.uk/… from within the VM
+# Ignore SSL errors when accessing staging
+# Stops "Error with page" problems
+#
+# PhantomJS depends on the system OpenSSL library.
+# http://phantomjs.org/api/command-line.html
+# Default is SSLv3
+phantomjs_options: --ignore-ssl-errors=true --ssl-protocol=tlsv1
+
 # (required) The domain to take screenshots of.
 domains:
   production: "https://www.gov.uk"

--- a/test/wraith/config.yaml
+++ b/test/wraith/config.yaml
@@ -17,6 +17,15 @@
 # (required) The engine to run Wraith with. Examples: 'phantomjs', 'casperjs', 'slimerjs'
 browser: "phantomjs"
 
+# Use TLS v1 when requesting https://www.gov.uk/… from within the VM
+# Ignore SSL errors when accessing staging
+# Stops "Error with page" problems
+#
+# PhantomJS depends on the system OpenSSL library.
+# http://phantomjs.org/api/command-line.html
+# Default is SSLv3
+phantomjs_options: --ignore-ssl-errors=true --ssl-protocol=tlsv1
+
 # (required) The domain to take screenshots of.
 domains:
   production: "https://www.gov.uk"


### PR DESCRIPTION
I'm not sure why this works.

We were seeing errors when trying to run the wraith tests from the VM:
```
Error with page https://www.gov.uk/government/case-studies/doing-business-in-spain.es
```

Add phantomjs option:
```yaml
phantomjs_options: --ignore-ssl-errors=true --ssl-protocol=tlsv1
```

* Use TLS v1 when requesting https://www.gov.uk/… from within the VM (all other versions reported errors)
* Ignore SSL errors when accessing staging (production works fine with just TLS, but staging would fail)

PhantomJS depends on the system OpenSSL library.
http://phantomjs.org/api/command-line.html
Default is SSLv3