### PR TITLE
Upgrade govuk_ab_testing to 1.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'unicorn', '4.8'
 gem 'rails-i18n', '>= 4.0.4'
 gem 'rails_translation_manager', '~> 0.0.2'
 gem 'rails-controller-testing', '~> 0.1'
-gem 'govuk_ab_testing', '0.1.4'
+gem 'govuk_ab_testing', '1.0.1'
 
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_ab_testing (0.1.4)
+    govuk_ab_testing (1.0.1)
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -254,7 +254,7 @@ DEPENDENCIES
   gds-api-adapters (= 39.1.0)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
-  govuk_ab_testing (= 0.1.4)
+  govuk_ab_testing (= 1.0.1)
   govuk_frontend_toolkit (= 5.1.0)
   govuk_navigation_helpers (~> 2.4.0)
   jasmine-rails (~> 0.14.0)

--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -8,7 +8,7 @@ class EducationNavigationAbTestRequest
   def initialize(request, content_item)
     @content_item = content_item
     @ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: 41)
-    @requested_variant = @ab_test.requested_variant request
+    @requested_variant = @ab_test.requested_variant(request.headers)
   end
 
   def ab_test_applies?

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -121,12 +121,11 @@ class ContentItemsControllerTest < ActionController::TestCase
 
     with_variant EducationNavigation: "A" do
       get :show, params: { path: path_for(content_item) }
-      assert_equal [], @request.variant
+      refute_match(/A Taxon/, taxonomy_sidebar)
     end
 
     with_variant EducationNavigation: "B" do
       get :show, params: { path: path_for(content_item) }
-      assert_equal [:new_navigation], @request.variant
       assert_match(/A Taxon/, taxonomy_sidebar)
     end
   end
@@ -143,13 +142,13 @@ class ContentItemsControllerTest < ActionController::TestCase
     get :show, params: { path: path_for(content_item) }
     assert_equal [], @request.variant
     refute_match(/A Taxon/, taxonomy_sidebar)
-    assert_unaffected_by_ab_test
+    assert_response_not_modified_for_ab_test
 
     setup_ab_variant('EducationNavigation', 'B')
     get :show, params: { path: path_for(content_item) }
     assert_equal [], @request.variant
     refute_match(/A Taxon/, taxonomy_sidebar)
-    assert_unaffected_by_ab_test
+    assert_response_not_modified_for_ab_test
   end
 
   test "Case Studies are not included in the AB Test" do
@@ -170,7 +169,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     get :show, params: { path: path_for(content_item) }
     assert_equal [], @request.variant
     refute_match(/A Taxon/, taxonomy_sidebar)
-    assert_unaffected_by_ab_test
+    assert_response_not_modified_for_ab_test
   end
 
   def path_for(content_item)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,10 @@ require 'capybara/rails'
 require 'slimmer/test_helpers/govuk_components'
 require 'mocha/mini_test'
 
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :active_support
+end
+
 class ActiveSupport::TestCase
   include GovukContentSchemaExamples
   include Slimmer::TestHelpers::GovukComponents


### PR DESCRIPTION
Main changes are:
- passing in the request headers to the variant checker;
- setting the acceptance testing framework in the configuration of the
  gem.

Gem changes: https://github.com/alphagov/govuk_ab_testing/pull/20

Trello: https://trello.com/c/t4n8kPpx/434-make-sure-collections-can-be-toggled-with-the-a-b-test-and-react-to-it