### PR TITLE
Render specialist documents

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,3 +45,4 @@
 @import 'views/corporate-information-page';
 @import 'views/travel-advice';
 @import "views/contact";
+@import 'views/specialist-document';

--- a/app/assets/stylesheets/views/_specialist-document.scss
+++ b/app/assets/stylesheets/views/_specialist-document.scss
@@ -1,0 +1,4 @@
+.specialist-document {
+  @include description;
+  @include sidebar-with-body;
+}

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -14,4 +14,17 @@ class SpecialistDocumentPresenter < ContentItemPresenter
       t.delete(:context)
     end
   end
+
+private
+
+  # first_published_at does not have reliable data
+  # at time of writing dates could be after public_updated_at
+  # details.first_public_at is not provided
+  # https://trello.com/c/xCJ3RN6W/
+  #
+  # Instead use first date in change history
+  def first_public_at
+    changes = reverse_chronological_change_history
+    changes.any? ? changes.last[:timestamp] : nil
+  end
 end

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -1,0 +1,17 @@
+class SpecialistDocumentPresenter < ContentItemPresenter
+  include Updatable
+  include Linkable
+  include ContentsList
+  include TitleAndContext
+  include Metadata
+
+  def body
+    content_item["details"]["body"]
+  end
+
+  def title_and_context
+    super.tap do |t|
+      t.delete(:context)
+    end
+  end
+end

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -1,0 +1,23 @@
+<%
+  content_for :simple_header, true
+  content_for :title, @content_item.page_title
+%>
+
+<%= render 'shared/title_and_translations', content_item: @content_item %>
+<%= render 'shared/metadata', content_item: @content_item %>
+<%= render 'shared/description', description: @content_item.description %>
+
+<div class="grid-row sidebar-with-body">
+  <% if @content_item.contents.any? %>
+    <div class="column-third">
+      <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
+    </div>
+  <% end %>
+  <div class="column-two-thirds <% unless @content_item.contents.any? %>offset-one-third<% end %>">
+    <%= render 'govuk_component/govspeak',
+        content: @content_item.body,
+        direction: page_text_direction %>
+  </div>
+</div>
+
+<%= render 'shared/footer', @content_item.document_footer %>

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -17,6 +17,29 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
     assert_has_component_document_footer_pair("from", [aaib])
   end
 
+  test "renders published and updated in metadata and document footer" do
+    setup_and_visit_content_item('countryside-stewardship-grants')
+
+    assert_has_component_metadata_pair("first_published", "2 April 2015")
+    assert_has_component_metadata_pair("last_updated", "29 March 2016")
+
+    assert_has_component_document_footer_pair("published", "2 April 2015")
+    assert_has_component_document_footer_pair("updated", "29 March 2016")
+  end
+
+  test "renders change history in reverse chronological order" do
+    setup_and_visit_content_item('countryside-stewardship-grants')
+
+    within shared_component_selector("document_footer") do
+      component_args = JSON.parse(page.text)
+      history = component_args.fetch("history")
+
+      assert_equal history.first["note"], @content_item["details"]["change_history"].last["note"]
+      assert_equal history.last["note"], @content_item["details"]["change_history"].first["note"]
+      assert_equal history.size, @content_item["details"]["change_history"].size
+    end
+  end
+
   test "renders a contents list" do
     setup_and_visit_content_item('aaib-reports')
 

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class SpecialistDocumentTest < ActionDispatch::IntegrationTest
+  test "renders title, description and body" do
+    setup_and_visit_content_item('aaib-reports')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+    assert_has_component_govspeak(@content_item["details"]["body"])
+  end
+
+  test "renders from in metadata and document footer" do
+    setup_and_visit_content_item('aaib-reports')
+
+    aaib = "<a href=\"/government/organisations/air-accidents-investigation-branch\">Air Accidents Investigation Branch</a>"
+    assert_has_component_metadata_pair("from", [aaib])
+    assert_has_component_document_footer_pair("from", [aaib])
+  end
+
+  test "renders a contents list" do
+    setup_and_visit_content_item('aaib-reports')
+
+    assert_has_contents_list([
+      { text: "Summary", id: "summary" },
+    ])
+  end
+end

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -26,6 +26,28 @@ class SpecialistDocumentPresenterTest
       assert presented_item('aaib-reports').is_a?(ContentsList)
     end
 
+    test 'presents the published date using the oldest date in the change history' do
+      example = schema_item('aaib-reports')
+      example["first_published_at"] = "2001-01-01"
+      example["details"]["change_history"] = [
+        {
+          "note" => "Newer",
+          "public_timestamp" => "2003-03-03"
+        },
+        {
+          "note" => "Oldest",
+          "public_timestamp" => "2002-02-02"
+        },
+        {
+          "note" => "More recent",
+          "public_timestamp" => "2013-03-03"
+        },
+      ]
+
+      presented = present_example(example)
+      assert DateTime.parse(presented.published) == DateTime.parse("2002-02-02")
+    end
+
     test 'has title without context' do
       assert presented_item('aaib-reports').is_a?(TitleAndContext)
       title_component_params = {

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -1,0 +1,39 @@
+require 'presenter_test_helper'
+
+class SpecialistDocumentPresenterTest
+  class SpecialistDocumentTestCase < PresenterTestCase
+    def format_name
+      "specialist_document"
+    end
+  end
+
+  class PresentedSpecialistDocument < SpecialistDocumentTestCase
+    test 'presents the format' do
+      assert_equal schema_item('aaib-reports')['schema_name'], presented_item('aaib-reports').format
+    end
+
+    test 'presents the body' do
+      expected_body = schema_item('aaib-reports')['details']['body']
+
+      assert_equal expected_body, presented_item('aaib-reports').body
+    end
+
+    test 'has metadata' do
+      assert presented_item('aaib-reports').is_a?(Metadata)
+    end
+
+    test 'has contents list' do
+      assert presented_item('aaib-reports').is_a?(ContentsList)
+    end
+
+    test 'has title without context' do
+      assert presented_item('aaib-reports').is_a?(TitleAndContext)
+      title_component_params = {
+                                  title: schema_item('aaib-reports')['title'],
+                                  average_title_length: 'long'
+                               }
+
+      assert_equal title_component_params, presented_item('aaib-reports').title_and_context
+    end
+  end
+end

--- a/test/presenters/updatable_test.rb
+++ b/test/presenters/updatable_test.rb
@@ -20,6 +20,54 @@ class UpdatableTest < ActiveSupport::TestCase
     assert_empty @updatable.history
   end
 
+  test '#history returns updates when first_public_at does not match public_updated_at' do
+    class << @updatable
+      def content_item
+        {
+          'public_updated_at' => '2002-02-02',
+          'details' => {
+            'first_public_at' => '2001-01-01',
+            'change_history' => [
+              {
+                'note' => 'note',
+                'public_timestamp' => '2002-02-02'
+              }
+            ]
+          }
+        }
+      end
+
+      def display_date(date)
+        date
+      end
+    end
+
+    assert @updatable.history.any?
+    assert_equal @updatable.updated, '2002-02-02'
+  end
+
+  test '#history returns no updates when first_public_at matches public_updated_at' do
+    class << @updatable
+      def content_item
+        {
+          'public_updated_at' => '2002-02-02',
+          'details' => {
+            'first_public_at' => '2002-02-02',
+            'change_history' => [
+              {
+                'note' => 'note',
+                'public_timestamp' => '2002-02-02'
+              }
+            ]
+          }
+        }
+      end
+    end
+
+    assert @updatable.history.empty?
+    refute @updatable.updated
+  end
+
   test '#history returns an array of hashes when there is change history' do
     class << @updatable
       def any_updates?

--- a/test/presenters/updatable_test.rb
+++ b/test/presenters/updatable_test.rb
@@ -36,7 +36,7 @@ class UpdatableTest < ActiveSupport::TestCase
             'change_history' => [
               {
                 'note' => 'notes',
-                'public_timestamp' => 'timestamp',
+                'public_timestamp' => '2016-02-29T09:24:10.000+00:00',
               }
             ]
           }
@@ -47,9 +47,44 @@ class UpdatableTest < ActiveSupport::TestCase
     assert_equal @updatable.history,
                  [
                    {
-                     display_time: 'timestamp',
+                     display_time: '2016-02-29T09:24:10.000+00:00',
                      note: 'notes',
-                     timestamp: 'timestamp' }
+                     timestamp: '2016-02-29T09:24:10.000+00:00' }
                  ]
+  end
+
+  test '#history returns a reverse chronologically sorted array of hashes when there is change history' do
+    class << @updatable
+      def any_updates?
+        true
+      end
+
+      def display_date(date)
+        date
+      end
+
+      def content_item
+        {
+          'details' => {
+            'change_history' => [
+              {
+                'note' => 'first',
+                'public_timestamp' => '2001-01-01',
+              },
+              {
+                'note' => 'third',
+                'public_timestamp' => '2003-03-03',
+              },
+              {
+                'note' => 'second',
+                'public_timestamp' => '2002-02-02',
+              }
+            ]
+          }
+        }
+      end
+    end
+
+    assert_equal @updatable.history.map { |i| i[:timestamp] }, ['2003-03-03', '2002-02-02', '2001-01-01']
   end
 end


### PR DESCRIPTION
https://trello.com/c/h9hITGPy/158-render-specialist-content-in-government-frontend
Tests depend on merge and deploy of https://github.com/alphagov/govuk-content-schemas/pull/548

This is the first part of switching specialist content to government-frontend

* Renders with an incomplete metadata and footer
  * Metadata is pending https://trello.com/c/6CBttvZL/ and is covered by a later story: https://trello.com/c/al2fPH5p/
* Renders with existing contents list rather than the nested version currently on specialist frontend
* Use the oldest entry in the change history to determine first published date – this matches specialist frontend but should be updated when https://trello.com/c/xCJ3RN6W/ is ready
* Display change history in reverse chronological order, matching all other formats

Note: This doesn't include recently added button support: https://github.com/alphagov/specialist-frontend/pull/138

## Screenshots

| Old | New |
|--|--|
|![cma-cases-old](https://cloud.githubusercontent.com/assets/319055/23465312/c76e594a-fe8f-11e6-881f-df3b8c244029.png)|![cma-cases-new](https://cloud.githubusercontent.com/assets/319055/23465313/c770d990-fe8f-11e6-839e-41271582085b.png)|
|![aaib-old](https://cloud.githubusercontent.com/assets/319055/23465310/c76d5702-fe8f-11e6-8c56-4edb4997c501.png)|![aaib-new](https://cloud.githubusercontent.com/assets/319055/23465311/c76d8ea2-fe8f-11e6-8bed-e5811e5a5d73.png)|



