### PR TITLE
Avoid use of `map!` on travel advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Not all formats that this app can handle are rendered by it in production.
 | Speech | | Rendered by Whitehall |
 | Take part | [View on GOV.UK](https://www.gov.uk/government/get-involved/take-part/become-a-councillor) | Migrated |
 | Topical event about page | [View on GOV.UK](https://www.gov.uk/government/topical-events/2014-overseas-territories-joint-ministerial-council/about) | Migrated |
+| Travel advice | [View on GOV.UK](https://www.gov.uk/foreign-travel-advice/nepal) | Rendered by multipage-frontend |
 | Unpublishing | | Rendered by Whitehall, might not be migrated |
 | Working group | [View on GOV.UK](https://www.gov.uk/government/groups/2gether-nhs-foundation-trust) | Migrated |
 

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -105,7 +105,7 @@ class TravelAdvicePresenter < ContentItemPresenter
   # Remove when alert status boxes no longer in travel advice publisher
   def alert_status
     alert_statuses = content_item["details"]["alert_status"] || []
-    alert_statuses.map! do |alert|
+    alert_statuses = alert_statuses.map do |alert|
       content_tag(:p, I18n.t("travel_advice.alert_status.#{alert}").html_safe)
     end
 


### PR DESCRIPTION
`map!` was directly manipulating `content_item["details"]["alert_status”]`
We should protect content_item from being manipulated

Also adds travel advice to the supported formats table in README.