### PR TITLE
Track document collections as `finding` pages in Google Analytics

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -42,6 +42,10 @@ class ContentItemPresenter
     @nav_helper.taxonomy_sidebar
   end
 
+  def user_journey_stage
+    nil
+  end
+
 private
 
   def display_date(timestamp, format = "%-d %B %Y")

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -42,6 +42,10 @@ class DocumentCollectionPresenter < ContentItemPresenter
     content_tag :h3, title, class: "group-title", id: group_title_id(title)
   end
 
+  def user_journey_stage
+    "finding"
+  end
+
 private
 
   def group_documents(group)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,9 @@
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
   <meta name="govuk:content-id" content="<%= @content_item.content_id %>" />
+  <% if @content_item.user_journey_stage %>
+    <meta name="govuk:user-journey-stage" content="<%= @content_item.user_journey_stage %>" />
+  <% end %>
   <%= @education_navigation_ab_test.analytics_meta_tag.html_safe if @education_navigation_ab_test.ab_test_applies? %>
   <%= yield :extra_head_content %>
 </head>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -173,6 +173,24 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_unaffected_by_ab_test
   end
 
+  test "document collections are tracked as 'finding' pages" do
+    content_item = content_store_has_schema_example('document_collection', 'document_collection')
+
+    get :show, params: { path: path_for(content_item) }
+
+    assert_select "meta[name='govuk:user-journey-stage'][content='finding']", 1
+  end
+
+  test "content pages are tracked as the default user journey stage" do
+    content_item = content_store_has_schema_example('case_study', 'case_study')
+
+    get :show, params: { path: path_for(content_item) }
+
+    # Assert that the meta tag is missing, which will be interpreted by the
+    # analytics code as the default value
+    assert_select "meta[name='govuk:user-journey-stage']", false
+  end
+
   def path_for(content_item)
     content_item['base_path'].sub(/^\//, '')
   end


### PR DESCRIPTION
Add meta tag which marks document collection pages as being in the `finding` (navigation) stage of a user journey, as opposed to the `thing` (content) stage.

This will enable us to analyse how users navigate the site so that we can work out whether the new navigation pages are helping users find what they need.

Trello: https://trello.com/c/SCsj2A9D/425-add-custom-dimension-to-page-view-tracking-on-new-navigation-pages