### PR TITLE
Remove Whitehall header navigation from new navigation pages

### DIFF
--- a/app/views/content_items/detailed_guide.html+new_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+new_navigation.erb
@@ -1,4 +1,5 @@
 <%= content_for :title, @content_item.page_title %>
+<%= content_for :simple_header, true %>
 
 <div class="grid-row" data-module="sticky-element-container">
   <div class="column-two-thirds">

--- a/app/views/content_items/document_collection.html+new_navigation.erb
+++ b/app/views/content_items/document_collection.html+new_navigation.erb
@@ -1,4 +1,5 @@
 <%= content_for :title, @content_item.page_title %>
+<%= content_for :simple_header, true %>
 
 <div class="grid-row" data-module="sticky-element-container">
   <div class="column-two-thirds">

--- a/app/views/content_items/publication.html+new_navigation.erb
+++ b/app/views/content_items/publication.html+new_navigation.erb
@@ -1,4 +1,5 @@
 <%= content_for :title, @content_item.page_title %>
+<%= content_for :simple_header, true %>
 
 <div class="grid-row">
   <div class="column-two-thirds">


### PR DESCRIPTION
The Whitehall navigation in the header is not compatible with the new Education navigation being A/B tested.

This change removes that navigation for all "B" variants of the education navigation pages.

### Trello

https://trello.com/c/PkN40aGb/479-don-t-show-whitehall-navigation-in-government-frontend-a-b-test
