### PR TITLE
Upgrade govuk_navigation_helpers to 3.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.0.0)
+    govuk_navigation_helpers (3.0.2)
       gds-api-adapters (~> 40.1)
     htmlentities (4.3.4)
     http-cookie (1.0.3)


### PR DESCRIPTION
This makes sure parent taxons in the breadrumbs are selected from a list
of ordered parent taxons.

Trello: Trello: https://trello.com/c/RLWfiG6N/481-make-breadcrumb-use-1st-alphabetic-topic