### PR TITLE
Add print view for travel advice

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -34,6 +34,8 @@ private
   end
 
   def render_template
+    request.variant = :print if params[:variant] == "print"
+
     with_locale do
       render content_item_template
     end

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -59,6 +59,10 @@ class TravelAdvicePresenter < ContentItemPresenter
     }
   end
 
+  def parts
+    content_item["details"]["parts"] || []
+  end
+
   def parts_navigation
     part_links.each_slice(part_navigation_group_size).to_a
   end
@@ -143,10 +147,6 @@ private
     else
       parts.find { |part| part["slug"] == @part_slug }
     end
-  end
-
-  def parts
-    content_item["details"]["parts"] || []
   end
 
   def part_links

--- a/app/views/content_items/travel_advice.html+print.erb
+++ b/app/views/content_items/travel_advice.html+print.erb
@@ -1,0 +1,34 @@
+<%
+  content_for :title, "Print #{@content_item.page_title}"
+  content_for :simple_header, true
+  content_for :extra_head_content do %>
+  <meta name="robots" content="noindex, nofollow">
+  <script>window.onload = function() { window.print(); }</script>
+<% end %>
+
+<div class="grid-row travel-advice-print">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title', @content_item.title_and_context %>
+
+    <section>
+      <h1 class="part-title">
+        <%= @content_item.current_part_title %>
+      </h1>
+      <%= render 'shared/travel_advice_summary', content_item: @content_item %>
+      <%= render 'govuk_component/govspeak',
+          content: @content_item.current_part_body,
+          direction: page_text_direction %>
+    </section>
+
+    <% @content_item.parts.each do |part| %>
+      <section>
+        <h1 class="part-title">
+          <%= part['title'] %>
+        </h1>
+        <%= render 'govuk_component/govspeak',
+            content: part['body'],
+            direction: page_text_direction %>
+      </section>
+    <% end %>
+  </div>
+</div>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -39,28 +39,7 @@
     </h1>
 
     <% if @content_item.is_summary? %>
-      <% if @content_item.alert_status.present? %>
-        <% alert_body = capture do %>
-          <div class="help-notice">
-            <%= @content_item.alert_status %>
-          </div>
-        <% end %>
-        <%= render 'govuk_component/govspeak',
-            content: alert_body,
-            direction: page_text_direction %>
-      <% end %>
-
-      <%= render 'govuk_component/metadata', @content_item.metadata %>
-      <% if @content_item.map %>
-        <figure class="map">
-          <img src="<%= @content_item.map["url"] %>" alt="<%= @content_item.map["alt_text"] %>">
-          <% if @content_item.map_download_url %>
-            <figcaption class="map-download">
-              <a href="<%= @content_item.map_download_url %>">Download map (PDF)</a>
-            </figcaption>
-          <% end %>
-        </figure>
-      <% end %>
+      <%= render 'shared/travel_advice_summary', content_item: @content_item %>
     <% end %>
 
     <%= render 'govuk_component/govspeak',

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -47,7 +47,7 @@
         direction: page_text_direction %>
 
     <div class="print-link">
-      <%= link_to "Print entire guide", @content_item.print_link %>
+      <%= link_to "Print entire guide", @content_item.print_link, rel: 'alternate' %>
     </div>
   </div>
   <div class="column-one-third add-title-margin">

--- a/app/views/shared/_travel_advice_summary.html.erb
+++ b/app/views/shared/_travel_advice_summary.html.erb
@@ -1,0 +1,22 @@
+<% if content_item.alert_status.present? %>
+  <% alert_body = capture do %>
+    <div class="help-notice">
+      <%= content_item.alert_status %>
+    </div>
+  <% end %>
+  <%= render 'govuk_component/govspeak',
+      content: alert_body,
+      direction: page_text_direction %>
+<% end %>
+
+<%= render 'govuk_component/metadata', content_item.metadata %>
+<% if content_item.map %>
+  <figure class="map">
+    <img src="<%= content_item.map["url"] %>" alt="<%= content_item.map["alt_text"] %>">
+    <% if content_item.map_download_url %>
+      <figcaption class="map-download">
+        <a href="<%= content_item.map_download_url %>">Download map (PDF)</a>
+      </figcaption>
+    <% end %>
+  </figure>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,9 @@ Rails.application.routes.draw do
   mount JasmineRails::Engine => "/specs" if defined?(JasmineRails)
 
   get 'healthcheck', to: proc { [200, {}, ['']] }
-  get '*path/:format' => 'content_items#show',
+  get '*path/:variant' => 'content_items#show',
       constraints: {
-        format: /print/
+        variant: /print/
       }
 
   # FIXME: Update when https://trello.com/c/w8HN3M4A/ is ready

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
   mount JasmineRails::Engine => "/specs" if defined?(JasmineRails)
 
   get 'healthcheck', to: proc { [200, {}, ['']] }
+  get '*path/:format' => 'content_items#show',
+      constraints: {
+        format: /print/
+      }
 
   # FIXME: Update when https://trello.com/c/w8HN3M4A/ is ready
   get 'foreign-travel-advice/:country/:part' => 'travel_advice#show'

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -54,13 +54,13 @@ class ContentItemsControllerTest < ActionController::TestCase
     )
   end
 
-  test 'routing handles paths with print format' do
+  test 'routing handles paths with print variant' do
     assert_routing(
       '/government/news/statement-the-status-of-eu-nationals-in-the-uk/print',
       controller: 'content_items',
       action: 'show',
       path: 'government/news/statement-the-status-of-eu-nationals-in-the-uk',
-      format: 'print'
+      variant: 'print'
     )
   end
 
@@ -107,6 +107,15 @@ class ContentItemsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_select "feed title", 'Travel Advice Summary'
+  end
+
+  test "renders print variants" do
+    content_item = content_store_has_schema_example('travel_advice', 'full-country')
+    get :show, params: { path: path_for(content_item), variant: 'print' }
+
+    assert_response :success
+    assert_equal request.variant, [:print]
+    assert_select ".travel-advice-print"
   end
 
   test "gets item from content store even when url contains multi-byte UTF8 character" do

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -54,6 +54,16 @@ class ContentItemsControllerTest < ActionController::TestCase
     )
   end
 
+  test 'routing handles paths with print format' do
+    assert_routing(
+      '/government/news/statement-the-status-of-eu-nationals-in-the-uk/print',
+      controller: 'content_items',
+      action: 'show',
+      path: 'government/news/statement-the-status-of-eu-nationals-in-the-uk',
+      format: 'print'
+    )
+  end
+
   test "gets item from content store" do
     content_item = content_store_has_schema_example('case_study', 'case_study')
 

--- a/test/integration/travel_advice_print_test.rb
+++ b/test/integration/travel_advice_print_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class TravelAdvicePrint < ActionDispatch::IntegrationTest
+  test "it renders the print view" do
+    setup_and_visit_travel_advice_print('full-country')
+    assert page.has_css?(".travel-advice-print")
+  end
+
+  test "it is not indexable by search engines" do
+    setup_and_visit_travel_advice_print('full-country')
+    assert page.has_css?("meta[name='robots'][content='noindex, nofollow']", visible: false)
+  end
+
+  test "it renders the summary and all parts in the print view" do
+    setup_and_visit_travel_advice_print('full-country')
+    parts = @content_item['details']['parts']
+
+    assert_has_component_metadata_pair("Still current at", Date.today.strftime("%-d %B %Y"))
+    assert_has_component_metadata_pair("Updated", Date.parse(@content_item["details"]["reviewed_at"]).strftime("%-d %B %Y"))
+
+    within shared_component_selector("metadata") do
+      component_args = JSON.parse(page.text)
+      latest_update = component_args["other"].fetch("Latest update")
+
+      assert latest_update.include?('<p>')
+      assert latest_update.include?(@content_item['details']['change_description'].gsub('Latest update: ', ''))
+    end
+
+    assert page.has_css?("h1", text: 'Current travel advice')
+    parts.each do |part|
+      assert page.has_css?("h1", text: part['title'])
+    end
+
+    page.all(shared_component_selector("govspeak")).each_with_index do |govspeak_component, i|
+      within(govspeak_component) do
+        content_passed_to_component = JSON.parse(page.text).fetch("content").gsub(/\s+/, ' ')
+        if i == 0
+          assert_equal @content_item["details"]["summary"].gsub(/\s+/, ' '), content_passed_to_component
+        else
+          assert_equal parts[i - 1]['body'].gsub(/\s+/, ' '), content_passed_to_component
+        end
+      end
+    end
+  end
+
+  def setup_and_visit_travel_advice_print(name)
+    example = get_content_example_by_format_and_name('travel_advice', name)
+    @content_item = JSON.parse(example).tap do |item|
+      content_store_has_item(item["base_path"], item.to_json)
+      visit "#{item['base_path']}/print"
+    end
+  end
+end

--- a/test/presenters/travel_advice_presenter_test.rb
+++ b/test/presenters/travel_advice_presenter_test.rb
@@ -181,6 +181,13 @@ class TravelAdvicePresenterTest
       assert_equal "<p>Test&lt;br&gt;XML</p>", present_example(example).atom_change_description
     end
 
+    test "presents all parts for the print view" do
+      example_parts = schema_item("full-country")["details"]["parts"]
+      presented = presented_item("full-country")
+
+      assert_equal example_parts, presented.parts
+    end
+
   private
 
     def present_latest(latest)


### PR DESCRIPTION
https://trello.com/c/MluRcP1W/138-2-render-travel-advice-print-page-in-government-frontend-m

* Add route for handling print requests
* Render a print view showing all parts
* Use variants to indicate which template to render
* Render summary and all parts using standard template rather than slimmer’s print version – this applies the print styles we use across GOV.UK rather than the broken bespoke slimmer ones
* Indicate that the link to the print page is an alternate version
* Don’t index the print version
* Add “Print” to title element for unique title

Note that we opted against general line-length improvements to print: https://github.com/alphagov/static/pull/913

When reviewing I recommend comparing the PDF versions. (ProTip: You can drag and drop PDFs to PRs)

| Old | New |
|--|--|
|[Old print view (PDF)](https://github.com/alphagov/government-frontend/files/816749/old-print.pdf)|[New print view (PDF)](https://github.com/alphagov/government-frontend/files/816748/new-print.pdf)|
|![old-print-view](https://cloud.githubusercontent.com/assets/319055/23551440/80077a66-000e-11e7-83a4-8a9107982b39.png)|![new-print-view](https://cloud.githubusercontent.com/assets/319055/23551392/38c85562-000e-11e7-9c36-64470111a11d.png)|



