### PR TITLE
[discussion only] alternative to plek env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 /tmp
 
 /public/government-frontend
+
+# Don't check in credentials 
+config/env.yml

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'airbrake-ruby', '1.5'
 
 gem 'govuk_frontend_toolkit', '5.1.0'
 gem 'logstasher', '0.6.1'
-gem 'plek', '1.11'
 gem 'rails', '~> 5.0'
 gem 'sass-rails', '~> 5.0.4'
 if ENV['SLIMMER_DEV'] == "true"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 ruby File.read(".ruby-version").strip
-
+gem 'envyable', require: 'envyable/rails-now'
 gem 'airbrake', '~> 5.5'
 gem 'airbrake-ruby', '1.5'
 
@@ -10,7 +10,7 @@ gem 'logstasher', '0.6.1'
 gem 'plek', '1.11'
 gem 'rails', '~> 5.0'
 gem 'sass-rails', '~> 5.0.4'
-if ENV['SLIMMER_DEV']
+if ENV['SLIMMER_DEV'] == "true"
   gem 'slimmer', path: '../slimmer'
 else
   gem 'slimmer', '9.6.0'
@@ -21,7 +21,7 @@ gem 'rails-i18n', '>= 4.0.4'
 gem 'rails_translation_manager', '~> 0.0.2'
 gem 'rails-controller-testing', '~> 0.1'
 
-if ENV['API_DEV']
+if ENV['API_DEV'] == "true"
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
   gem "gds-api-adapters", "39.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,7 +261,6 @@ DEPENDENCIES
   jasmine-rails (~> 0.13.0)
   logstasher (= 0.6.1)
   mocha
-  plek (= 1.11)
   pry-byebug
   rails (~> 5.0)
   rails-controller-testing (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,8 @@ GEM
     debug_inspector (0.0.2)
     domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
+    envyable (1.2.0)
+      thor (>= 0.18.1, < 2.0)
     erubis (2.7.0)
     execjs (2.7.0)
     gds-api-adapters (39.1.0)
@@ -250,6 +252,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara
+  envyable
   gds-api-adapters (= 39.1.0)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
@@ -270,5 +273,8 @@ DEPENDENCIES
   unicorn (= 4.8)
   webmock (~> 1.18.0)
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.12.5
+   1.14.3

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ This is a Ruby on Rails application that fetches documents from
 - [content-store](https://github.com/alphagov/content-store) - provides documents
 - [static](https://github.com/alphagov/static) - provides shared GOV.UK assets and templates.
 
+
+### enviroment variables
+
+environment is handled in development by (envyable)[https://github.com/philnash/envyable]
+
+```
+cp config/env.yml.example config/env.yml
+
+```
+
 ### Running the application
 
 ```

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -46,7 +46,7 @@ private
   end
 
   def content_store
-    @content_store ||= GdsApi::ContentStore.new(Plek.current.find("content-store"))
+    @content_store ||= GdsApi::ContentStore.new(ENV['PLEK_SERVICE_CONTENT_STORE_URI'])
   end
 
   def error_403(exception)

--- a/app/presenters/shareable.rb
+++ b/app/presenters/shareable.rb
@@ -19,6 +19,6 @@ private
   end
 
   def share_url
-    url_encode(Plek.current.website_root + content_item["base_path"])
+    url_encode(ENV['WEBSITE_ROOT'] + content_item["base_path"])
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,7 +41,7 @@ module GovernmentFrontend
     config.action_dispatch.rack_cache = nil
 
     # Path within public/ where assets are compiled to
-    config.assets.prefix = '/government-frontend'
+    config.assets.prefix = ENV['ASSET_PREFIX']
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true

--- a/config/env.yml.example
+++ b/config/env.yml.example
@@ -1,0 +1,13 @@
+development:
+  SLIMMER_DEV: "false"
+  API_DEV: "false"
+  GOVUK_ASSET_ROOT: ""
+  RAILS_SERVE_STATIC_FILES: ""
+  ERRBIT_API_KEY: ""
+  ERRBIT_ENVIRONMENT_NAME: ""
+  JENKINS: "false"
+
+test:
+  GOVUK_APP_DOMAIN: "test.gov.uk"
+  GOVUK_ASSET_ROOT: "http://static.test.gov.uk"
+  USE_SLIMMER: "false"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  if ENV['GOVUK_ASSET_ROOT'].present?
+  unless ENV['GOVUK_ASSET_ROOT'].blank?
     config.asset_host = ENV['GOVUK_ASSET_ROOT']
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if ENV['CACHING'] == "true"
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,9 +28,10 @@ Rails.application.configure do
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = Plek.current.asset_root
+  # NOT TOO SURE WHAT THIS WOUlD COME OUT AS
+  config.action_controller.asset_host = "HTTP://foo"
   config.slimmer.use_cache = true
-  config.slimmer.asset_host = Plek.current.find('static')
+  config.slimmer.asset_host = ENV['PLEK_SERVICE_STATIC_URI']
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,4 +1,4 @@
-if ENV['ERRBIT_API_KEY'].present?
+unless ENV['ERRBIT_API_KEY'].blank?
   errbit_uri = Plek.find('errbit')
 
   Airbrake.configure do |config|

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,5 +1,5 @@
 unless ENV['ERRBIT_API_KEY'].blank?
-  errbit_uri = Plek.find('errbit')
+  errbit_uri = ENV['ERRBIT_HOST']
 
   Airbrake.configure do |config|
     config.project_key = ENV['ERRBIT_API_KEY']

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -3,4 +3,5 @@
   .rbenv-vars
   tmp/restart.txt
   tmp/caching-dev.txt
+  config/env.yml
 ).each { |path| Spring.watch(path) }

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,6 +1,6 @@
 desc "run ruby and sass linters"
 task :lint do
-  if ENV["JENKINS"]
+  if ENV["JENKINS"] == "true"
     sh "govuk-lint-ruby --format html --out rubocop-${GIT_COMMIT}.html --format clang Gemfile app test config"
   else
     sh "govuk-lint-ruby --format clang Gemfile app test config"

--- a/startup.sh
+++ b/startup.sh
@@ -1,13 +1,4 @@
 #!/bin/bash
 
 bundle install
-
-if [[ $1 == "--live" ]] ; then
-  GOVUK_APP_DOMAIN=www.gov.uk \
-  GOVUK_WEBSITE_ROOT=https://www.gov.uk \
-  PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api \
-  PLEK_SERVICE_STATIC_URI=assets.publishing.service.gov.uk \
-  bundle exec rails s -p 3090
-else
-  bundle exec rails s -p 3090
-fi
+bundle exec rails s -p 3090

--- a/test/presenters/shareable_presenter_test.rb
+++ b/test/presenters/shareable_presenter_test.rb
@@ -14,7 +14,7 @@ end
 
 class ShareablePresenterTest < ActiveSupport::TestCase
   def expected_path
-    url_encode(Plek.current.website_root + "/a/base/path")
+    url_encode(env['WEBSITE_ROOT'] + "/a/base/path")
   end
 
   test 'presents the twitter share url' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 ENV['RAILS_ENV'] ||= 'test'
-ENV['GOVUK_APP_DOMAIN'] = 'test.gov.uk'
-ENV['GOVUK_ASSET_ROOT'] = 'http://static.test.gov.uk'
+
+require 'envyable'
 
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
@@ -23,7 +23,7 @@ end
 # content from static (i.e. core_layout.html.erb).
 class ActionController::Base
   before_action proc {
-    response.headers[Slimmer::Headers::SKIP_HEADER] = "true" unless ENV["USE_SLIMMER"]
+    response.headers[Slimmer::Headers::SKIP_HEADER] = "true" unless ENV["USE_SLIMMER"] == "true"
   }
 end
 


### PR DESCRIPTION
this pull is only for discussion, and definitely not saying this is the correct way, just illustrating how we used to do it at @mintdigial 

so everything is contained in an env yml file, all the app config variables, and then can be done by standard env variables in a production environment.

for me this provides the following advantages
1. one central way to handle app config
2. urls are obvious and explicit
3. dependencies are recorded in code in one central place as opposed to littered around all working in various different ways
4. makes sure keys are not accidentally checked in due to the process being defined and easy
5. multiple configs can easily live in the same place, just comment/out/in
6. works exactly the same as env variables, so easy for production environments and heroku

the weaknesses as far as i can see with this implementation that i can see are as follows, please add more :D

1. across app config
  this could be solved by [loading a common file](https://github.com/philnash/envyable#other-applications) from one of the govuk gems

2. could be said convention over configuration is preferrable
personally i think, in the case of config, it is good to be explicit

3. the gem needs work on truthy falsy values imo

The motivation for this comes out having problems setting up projects on your local machine, and it's somewhat inconsistent
