### PR TITLE
Remove the New Navigation feature flag

### DIFF
--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -12,7 +12,7 @@ class EducationNavigationAbTestRequest
   end
 
   def ab_test_applies?
-    new_navigation_enabled? && content_is_tagged_to_a_taxon? && content_schema_has_new_navigation?
+    content_is_tagged_to_a_taxon? && content_schema_has_new_navigation?
   end
 
   def should_present_new_navigation_view?
@@ -24,10 +24,6 @@ class EducationNavigationAbTestRequest
   end
 
 private
-
-  def new_navigation_enabled?
-    ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
-  end
 
   def content_is_tagged_to_a_taxon?
     @content_item.dig("links", "taxons").present?

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -4,14 +4,6 @@ class ContentItemsControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::ContentStore
   include GovukAbTesting::MinitestHelpers
 
-  setup do
-    ENV['ENABLE_NEW_NAVIGATION'] = 'yes'
-  end
-
-  teardown do
-    ENV['ENABLE_NEW_NAVIGATION'] = nil
-  end
-
   test 'routing handles paths with no format or locale' do
     assert_routing(
       '/government/news/statement-the-status-of-eu-nationals-in-the-uk',


### PR DESCRIPTION
This means we can toggle the A/B variant in production via the chrome
extension.  When we rollout the new navigation with a Fastly
configuration change, the % of users we select will start seeing these
new pages.

Trello: https://trello.com/c/940kowVa/484-remove-enable-new-navigation-check-from-repos-and-from-puppet