### PR TITLE
Add breadcrumbs to contacts page

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -134,6 +134,31 @@ class ContactPresenter < ContentItemPresenter
     whitelisted_paths.include?(content_item["base_path"])
   end
 
+  def breadcrumbs
+    orgs = content_item["links"]['organisations']
+    return [] if orgs.length != 1
+
+    org         = orgs.first
+    title       = org['title']
+    base        = org['base_path']
+    contact_url = "#{base}/contact"
+
+    [
+      {
+        title: "Home",
+        url: "/",
+      },
+      {
+        title: title,
+        url: base,
+      },
+      {
+        title: "Contact #{title}",
+        url: contact_url,
+      }
+    ]
+  end
+
 private
 
   def v_card_part(v_card_class, value)

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -135,10 +135,7 @@ class ContactPresenter < ContentItemPresenter
   end
 
   def breadcrumbs
-    orgs = content_item["links"]['organisations']
-    return [] if orgs.length != 1
-
-    org         = orgs.first
+    org         = content_item["links"]['organisations'].first
     title       = org['title']
     base        = org['base_path']
     contact_url = "#{base}/contact"

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -135,6 +135,8 @@ class ContactPresenter < ContentItemPresenter
   end
 
   def breadcrumbs
+    return [] if content_item["links"]['organisations'].try(:length) != 1
+
     org         = content_item["links"]['organisations'].first
     title       = org['title']
     base        = org['base_path']

--- a/test/presenters/contact_presenter_test.rb
+++ b/test/presenters/contact_presenter_test.rb
@@ -99,5 +99,22 @@ class ContactPresenterTest
       assert_equal nil, present_example(example).email_body
       assert_equal nil, present_example(example).post_body
     end
+
+    test 'breadcrumbs' do
+      assert_equal [
+        {
+          title: "Home",
+          url: "/"
+        },
+        {
+          title: "HM Revenue & Customs",
+          url: "/government/organisations/hm-revenue-customs"
+        },
+        {
+          title: "Contact HM Revenue & Customs",
+          url: "/government/organisations/hm-revenue-customs/contact"
+        }
+      ], presented_item.breadcrumbs
+    end
   end
 end

--- a/test/presenters/contact_presenter_test.rb
+++ b/test/presenters/contact_presenter_test.rb
@@ -116,5 +116,29 @@ class ContactPresenterTest
         }
       ], presented_item.breadcrumbs
     end
+
+    test 'no breadcrumbs render with no organisations' do
+      schema = schema_item('contact')
+      schema["links"]["organisations"] = []
+
+      assert_equal [], present_example(schema).breadcrumbs
+    end
+
+    test 'no breadcrumbs render with no organisations set' do
+      schema = schema_item('contact')
+      schema["links"].delete("organisations")
+      assert_equal [], present_example(schema).breadcrumbs
+    end
+
+    test 'no breadcrumbs render with two organisations' do
+      schema = schema_item('contact')
+      two_orgs = [
+        schema["links"]["organisations"],
+        schema["links"]["organisations"]
+      ].flatten
+
+      schema["links"]["organisations"] = two_orgs
+      assert_equal [], present_example(schema).breadcrumbs
+    end
   end
 end


### PR DESCRIPTION
Ideally this would be coming from the parents links in the content api, but
this is blocked until the publishing platform has completed
https://trello.com/c/0OvN0dtQ/

we wish to get the page out before the code rots, so we copied over
the way contacts-frontend was doing it initially

is dependent on 
https://github.com/alphagov/govuk-content-schemas/pull/556