### PR TITLE
Improve layout of contacts content

### DIFF
--- a/app/assets/stylesheets/views/_contact.scss
+++ b/app/assets/stylesheets/views/_contact.scss
@@ -2,4 +2,13 @@
   .add-title-margin {
     @include responsive-top-margin;
   }
+
+  // FIXME: Overrides specific govspeak heading styles while h3s & h4s look similar
+  // Govspeak component renders h3s and h4s at the same font size with different margins
+  // Reduce the visual importance of specific h4s by making them a normal font weight.
+  // This gives content correct visual hierarchy and semantics
+  // `normal-weight` is not a class used by the govspeak component
+  .govuk-govspeak .normal-weight {
+    font-weight: normal;
+  }
 }

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -72,7 +72,7 @@ class ContactPresenter < ContentItemPresenter
   end
 
   def phone_body
-    content_item["details"]["more_info_phone_number"].html_safe
+    content_item.dig("details", "more_info_phone_number").try(:html_safe)
   end
 
   def post
@@ -95,7 +95,7 @@ class ContactPresenter < ContentItemPresenter
   end
 
   def post_body
-    content_item["details"]["more_info_post_address"].html_safe
+    content_item.dig("details", "more_info_post_address").try(:html_safe)
   end
 
   def email
@@ -112,7 +112,7 @@ class ContactPresenter < ContentItemPresenter
   end
 
   def email_body
-    content_item["details"]["more_info_email_address"].html_safe
+    content_item.dig("details", "more_info_email_address").try(:html_safe)
   end
 
   def show_webchat?

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -52,7 +52,7 @@
             <div class="contact">
               <div class="content">
                 <% phone_group[:numbers].each do |number| %>
-                  <p><%= number[:label] %>:<br /><%= number[:number] %></p>
+                  <p><%= number[:label] %>:<br /><strong><%= number[:number] %></strong></p>
                 <% end%>
               </div>
             </div>

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -58,12 +58,12 @@
             </div>
           <% end %>
           <% if phone_group[:opening_times].present? %>
-            <h4>Opening times</h4>
+            <h4 class="normal-weight">Opening times:</h4>
             <%= phone_group[:opening_times] %>
           <% end %>
 
           <% if phone_group[:best_time_to_call].present? %>
-            <h4>Best time to call</h4>
+            <h4 class="normal-weight">Best time to call:</h4>
             <%= phone_group[:best_time_to_call] %>
           <% end %>
         <% end %>

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -47,7 +47,7 @@
           <% if @content_item.phone.size > 1 %>
             <h3><%= phone_group[:title] %></h3>
           <% end %>
-
+          <%= phone_group[:description] %>
           <% if phone_group[:numbers].any? %>
             <div class="contact">
               <div class="content">
@@ -57,9 +57,6 @@
               </div>
             </div>
           <% end %>
-
-          <%= phone_group[:description] %>
-
           <% if phone_group[:opening_times].present? %>
             <h4>Opening times</h4>
             <%= phone_group[:opening_times] %>

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -44,7 +44,9 @@
       <% if @content_item.phone.any? %>
         <h2 id="phone-title">Phone</h2>
         <% @content_item.phone.each do |phone_group| %>
-          <h3><%= phone_group[:title] %></h3>
+          <% if @content_item.phone.size > 1 %>
+            <h3><%= phone_group[:title] %></h3>
+          <% end %>
 
           <% if phone_group[:numbers].any? %>
             <div class="contact">

--- a/test/integration/contact_test.rb
+++ b/test/integration/contact_test.rb
@@ -31,13 +31,24 @@ class ContactTest < ActionDispatch::IntegrationTest
   test "phones are rendered" do
     setup_and_visit_content_item('contact')
     within_component_govspeak do |component_args|
-      content = component_args.fetch("content")
-      first_phone = @content_item["details"]["phone_numbers"].first["number"]
+      first_phone = @content_item["details"]["phone_numbers"].first
+      html = Nokogiri::HTML.parse(component_args.fetch("content"))
 
-      html = Nokogiri::HTML.parse(content)
       assert_not_nil html.at_css("h2#phone-title")
-      assert_not_nil html.at("p:contains(\"#{first_phone}\")")
+      assert_not_nil html.at("h3:contains(\"#{first_phone['title']}\")")
+      assert_not_nil html.at("p:contains(\"#{first_phone['number']}\")")
       assert_not_nil html.at("p:contains(\"24 hours a day, 7 days a week\")")
+    end
+  end
+
+  test "phone number heading is not rendered when only one number" do
+    setup_and_visit_content_item('contact_with_welsh')
+    within_component_govspeak do |component_args|
+      first_phone = @content_item["details"]["phone_numbers"].first
+      html = Nokogiri::HTML.parse(component_args.fetch("content"))
+
+      assert_equal 1, @content_item["details"]["phone_numbers"].size
+      refute html.at("h3:contains(\"#{first_phone['title']}\")")
     end
   end
 

--- a/test/presenters/contact_presenter_test.rb
+++ b/test/presenters/contact_presenter_test.rb
@@ -77,5 +77,27 @@ class ContactPresenterTest
     test 'email_body' do
       assert_equal schema_item['details']['more_info_email_address'], presented_item.email_body
     end
+
+    test 'handles more info when set to nil' do
+      example = schema_item
+      example['details']['more_info_phone_number'] = nil
+      example['details']['more_info_email_address'] = nil
+      example['details']['more_info_post_address'] = nil
+
+      assert_equal nil, present_example(example).phone_body
+      assert_equal nil, present_example(example).email_body
+      assert_equal nil, present_example(example).post_body
+    end
+
+    test 'handles more info when not set' do
+      example = schema_item
+      example['details'].delete('more_info_phone_number')
+      example['details'].delete('more_info_email_address')
+      example['details'].delete('more_info_post_address')
+
+      assert_equal nil, present_example(example).phone_body
+      assert_equal nil, present_example(example).email_body
+      assert_equal nil, present_example(example).post_body
+    end
   end
 end


### PR DESCRIPTION
Make contacts more like contacts frontend:
* Only render phone headings when there are multiple numbers
* Render telephone numbers in bold so they can be found easily

General improvements:
* Move description of phone number above the number, this is consistent with postal addresses and works well with existing content. eg Description says when you should use number and what things you'll need when you make the call

On contacts, when many phone numbers are listed, these are presented using h3 titles (h2: Phone, h3: Type of number). Within this “Opening times” and “Best time to call” are presented as h4s.
In a list of numbers the distinction between phone numbers and these h4 headings was being lost, making the list hard to scan.

* Reduce the visual importance of  specific h4s by making them a normal
font weight. This corrects the visual hierarchy of the content while
preserving semantics.
* Add colons to headings to make them more clearly headings, this
matches contacts-frontend

## Screenshots

| Live | Old frontend | New frontend |
|--|--|--|
|![contact-1-old](https://cloud.githubusercontent.com/assets/319055/23706469/37dc5ab2-0406-11e7-8737-d06f1f7adc9d.png)|![contact-1-old-gov](https://cloud.githubusercontent.com/assets/319055/23706472/37f5db86-0406-11e7-97a6-4468f76b3b97.png)|![contact-1-new](https://cloud.githubusercontent.com/assets/319055/23706467/37db1c9c-0406-11e7-9755-606fa19cc3ce.png)|
|![contact-2-old](https://cloud.githubusercontent.com/assets/319055/23706471/37df4ba0-0406-11e7-9eae-d8e3fb2b03d0.png)|No screenshot – errors|![contact-2-new](https://cloud.githubusercontent.com/assets/319055/23706468/37dc008a-0406-11e7-8c38-a62b0f97dc79.png)
|![contact-3-old](https://cloud.githubusercontent.com/assets/319055/23706466/37da94f2-0406-11e7-9403-4858cd64cc86.png)|![contact-3-old-gov](https://cloud.githubusercontent.com/assets/319055/23706470/37de223e-0406-11e7-9727-25463960cf2a.png)|![contact-3-new](https://cloud.githubusercontent.com/assets/319055/23706473/37f9f734-0406-11e7-9b42-618daca708de.png)|
