### PR TITLE
Update navigation helpers gem to pick up the latest taxonomy sidebar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ else
   gem 'gds-api-adapters', '~> 40.1'
 end
 
-gem 'govuk_navigation_helpers', '~> 3.1'
+gem 'govuk_navigation_helpers', '~> 3.1.1'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.1.0)
+    govuk_navigation_helpers (3.1.1)
       gds-api-adapters (~> 40.1)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
@@ -261,7 +261,7 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing (= 1.0.1)
   govuk_frontend_toolkit (= 5.1.0)
-  govuk_navigation_helpers (~> 3.1)
+  govuk_navigation_helpers (~> 3.1.1)
   htmlentities (= 4.3.4)
   jasmine-rails (~> 0.14.0)
   logstasher (= 0.6.1)


### PR DESCRIPTION
The list of document types which appear in the sidebar has changed. This gem upgrade picks up the latest version.

https://trello.com/c/RhEocgyj/42-remove-notices-from-guidance-list