### PR TITLE
Update Foreign Travel Advice title to Summary

### DIFF
--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -136,7 +136,7 @@ private
 
   def summary_part
     {
-      "title" => "Current travel advice",
+      "title" => "Summary",
       "body" => content_item["details"]["summary"]
     }
   end
@@ -150,7 +150,7 @@ private
   end
 
   def part_links
-    summary_link_title = 'Current travel advice'
+    summary_link_title = 'Summary'
     summary_part_link = is_summary? ? summary_link_title : link_to(summary_link_title, @base_path)
 
     [summary_part_link] + parts.map do |part|

--- a/test/integration/travel_advice_print_test.rb
+++ b/test/integration/travel_advice_print_test.rb
@@ -26,7 +26,7 @@ class TravelAdvicePrint < ActionDispatch::IntegrationTest
       assert latest_update.include?(@content_item['details']['change_description'].gsub('Latest update: ', ''))
     end
 
-    assert page.has_css?("h1", text: 'Current travel advice')
+    assert page.has_css?("h1", text: 'Summary')
     parts.each do |part|
       assert page.has_css?("h1", text: part['title'])
     end

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -12,8 +12,8 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
 
     assert page.has_css?('.part-navigation ol', count: 2)
     assert page.has_css?('.part-navigation li', count: @content_item['details']['parts'].size + 1)
-    assert page.has_css?('.part-navigation li', text: 'Current travel advice')
-    refute page.has_css?('.part-navigation li a', text: 'Current travel advice')
+    assert page.has_css?('.part-navigation li', text: 'Summary')
+    refute page.has_css?('.part-navigation li a', text: 'Summary')
 
     @content_item['details']['parts'].each do |part|
       assert page.has_css?(".part-navigation li a[href*=\"#{part['slug']}\"]", text: part['name'])
@@ -25,7 +25,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
   test "travel advice summary has latest updates and map" do
     setup_and_visit_content_item('full-country')
 
-    assert page.has_css?("h1", text: "Current travel advice")
+    assert page.has_css?("h1", text: "Summary")
     assert_has_component_govspeak(@content_item["details"]["summary"])
 
     assert_has_component_metadata_pair("Still current at", Date.today.strftime("%-d %B %Y"))

--- a/test/presenters/travel_advice_presenter_test.rb
+++ b/test/presenters/travel_advice_presenter_test.rb
@@ -22,7 +22,7 @@ class TravelAdvicePresenterTest
 
       assert presented.is_summary?
       assert presented.has_valid_part?
-      assert_equal 'Current travel advice', presented.current_part_title
+      assert_equal 'Summary', presented.current_part_title
       assert_equal example['details']['summary'], presented.current_part_body
     end
 
@@ -47,7 +47,7 @@ class TravelAdvicePresenterTest
 
     test "the summary is included as the first navigation item" do
       first_nav_item = presented_item("full-country").parts_navigation.first.first
-      assert_equal 'Current travel advice', first_nav_item
+      assert_equal 'Summary', first_nav_item
     end
 
     test "navigation items are presented as links unless they are the current part" do
@@ -63,7 +63,7 @@ class TravelAdvicePresenterTest
       current_part_nav_item = navigation_items[0][1]
       another_part_nav_item = navigation_items[0][2]
 
-      assert_equal summary_nav_item, "<a href=\"#{base_path}\">Current travel advice</a>"
+      assert_equal summary_nav_item, "<a href=\"#{base_path}\">Summary</a>"
       assert_equal current_part_nav_item, current_part['title']
       assert_equal another_part_nav_item, "<a href=\"#{base_path}/#{another_part['slug']}\">#{another_part['title']}</a>"
     end


### PR DESCRIPTION
The FCO Content team have decided we can simplify the two titles currently on live
to just 'Summary'

Live

![screen shot 2017-03-10 at 14 12 24](https://cloud.githubusercontent.com/assets/2445413/23798252/a9b3c198-059b-11e7-8a24-d5a6be180279.png)

---

Proposed

![screen shot 2017-03-10 at 14 12 28](https://cloud.githubusercontent.com/assets/2445413/23798251/a997dc12-059b-11e7-9e88-dbb635069ac4.png)

