### PR TITLE
Make travel advice more resilient

### DIFF
--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -112,9 +112,17 @@ class TravelAdvicePresenter < ContentItemPresenter
   # Feature included as it _could_ still be used
   # Remove when alert status boxes no longer in travel advice publisher
   def alert_status
+    allowed_statuses = %w{
+      avoid_all_but_essential_travel_to_parts
+      avoid_all_travel_to_parts
+      avoid_all_but_essential_travel_to_whole_country
+      avoid_all_travel_to_whole_country
+    }
     alert_statuses = content_item["details"]["alert_status"] || []
     alert_statuses = alert_statuses.map do |alert|
-      content_tag(:p, I18n.t("travel_advice.alert_status.#{alert}").html_safe)
+      if allowed_statuses.include?(alert)
+        content_tag(:p, I18n.t("travel_advice.alert_status.#{alert}").html_safe)
+      end
     end
 
     alert_statuses.join('').html_safe

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -21,12 +21,15 @@ class TravelAdvicePresenter < ContentItemPresenter
     reviewed_at = content_item['details']['reviewed_at']
     updated_at = content_item['details']['updated_at']
 
+    other = {
+      "Still current at" => I18n.l(Time.now, format: "%-d %B %Y"),
+      "Updated" => display_date(reviewed_at || updated_at),
+    }
+
+    other["Latest update"] = simple_format(latest_update) if latest_update.present?
+
     {
-      other: {
-        "Still current at" => I18n.l(Time.now, format: "%-d %B %Y"),
-        "Updated" => display_date(reviewed_at || updated_at),
-        "Latest update" => simple_format(latest_update)
-      }
+      other: other
     }
   end
 
@@ -196,7 +199,7 @@ private
   # Avoids: "Latest update: Latest update - …"
   def latest_update
     change_description.sub(/^Latest update:?\s-?\s?/i, '').tap do |latest|
-      latest[0] = latest[0].capitalize
+      latest[0] = latest[0].capitalize if latest.present?
     end
   end
 end

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class TravelAdviceTest < ActionDispatch::IntegrationTest
+  test "random but valid items do not error" do
+    setup_and_visit_random_content_item
+  end
+
   test "travel advice header and navigation" do
     setup_and_visit_content_item('full-country')
 

--- a/test/presenters/travel_advice_presenter_test.rb
+++ b/test/presenters/travel_advice_presenter_test.rb
@@ -146,6 +146,7 @@ class TravelAdvicePresenterTest
         { original: "Latest update - changes", presented: "<p>Changes</p>" },
         { original: "Latest update changes", presented: "<p>Changes</p>" },
         { original: "Latest Update: Summary of changes. Next sentence", presented: "<p>Summary of changes. Next sentence</p>" },
+        { original: "", presented: nil },
       ].each do |i|
         assert_equal i[:presented], present_latest(i[:original])
       end


### PR DESCRIPTION
1. Protect against unexpected alert status types. Alert status should be an enum in the schema: alphagov/govuk-content-schemas#568
2. Handle change description being an empty string

* Change description is required, but it could be empty
* Capitalise fails on nil
* Handle an empty latest update a little more cleanly
* Test against randomly generated content