### PR TITLE
Make more formats resilient

### DIFF
--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -10,11 +10,11 @@ class HtmlPublicationPresenter < ContentItemPresenter
   end
 
   def contents
-    content_item["details"]["headings"].html_safe
+    content_item["details"]["headings"].try(:html_safe)
   end
 
   def format_sub_type
-    parent["document_type"]
+    parent["document_type"] if parent && parent["document_type"].present?
   end
 
   def last_changed
@@ -29,12 +29,13 @@ class HtmlPublicationPresenter < ContentItemPresenter
   end
 
   def organisations
-    content_item["links"]["organisations"].sort_by { |o| o["title"] }
+    orgs = content_item["links"]["organisations"] || []
+    orgs.sort_by { |o| o["title"] }
   end
 
   def organisation_logo(organisation)
     super.tap do |logo|
-      if organisations.count > 1
+      if logo && organisations.count > 1
         logo[:organisation].delete(:image)
       end
     end

--- a/app/presenters/organisation_branding.rb
+++ b/app/presenters/organisation_branding.rb
@@ -1,7 +1,8 @@
 module OrganisationBranding
   def organisation_logo(organisation = default_organisation)
-    logo = organisation["details"]["logo"]
+    return nil unless organisation && organisation.dig("details", "logo")
 
+    logo = organisation["details"]["logo"]
     logo_component_params = {
       organisation: {
         name: logo["formatted_title"],
@@ -28,7 +29,8 @@ module OrganisationBranding
 private
 
   def default_organisation
-    content_item["links"]["organisations"].first
+    orgs = content_item["links"]["organisations"] || []
+    orgs.first
   end
 
   # HACK: Replaces the organisation_brand for executive office organisations.

--- a/app/presenters/topical_event_about_page_presenter.rb
+++ b/app/presenters/topical_event_about_page_presenter.rb
@@ -11,7 +11,7 @@ class TopicalEventAboutPagePresenter < ContentItemPresenter
   # for example: https://www.gov.uk/government/topical-events/ebola-virus-government-response/about
   def breadcrumbs
     result = super
-    result.last[:title] = parent['title']
+    result.last[:title] = parent['title'] if parent
     result
   end
 
@@ -25,7 +25,8 @@ class TopicalEventAboutPagePresenter < ContentItemPresenter
 private
 
   def parent
-    topical_event_end_date = super["details"]["end_date"]
+    return nil unless super
+    topical_event_end_date = super.dig("details", "end_date")
 
     if topical_event_end_date && DateTime.parse(topical_event_end_date) <= Date.today
       super.merge("title" => "#{super['title']} (Archived)")

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -19,7 +19,9 @@
 <header class="publication-header<%= direction_css_class %>" id="contents">
   <div class="headings">
     <div class="html-publication-title">
-      <p class="context"><%= I18n.t("content_item.format.#{@content_item.format_sub_type}", count: 1) %></p>
+      <% if @content_item.format_sub_type %>
+        <p class="context"><%= I18n.t("content_item.format.#{@content_item.format_sub_type}", count: 1) %></p>
+      <% end %>
       <h1><%= @content_item.title %></h1>
     </div>
     <%= @content_item.last_changed %>

--- a/test/integration/case_study_test.rb
+++ b/test/integration/case_study_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class CaseStudyTest < ActionDispatch::IntegrationTest
+  test "random but valid items do not error" do
+    setup_and_visit_random_content_item
+  end
+
   test "translated case study" do
     setup_and_visit_content_item('translated')
 

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -1,6 +1,12 @@
 require 'test_helper'
 
 class HtmlPublicationTest < ActionDispatch::IntegrationTest
+  test "random but valid items do not error" do
+    10.times do
+      setup_and_visit_random_content_item
+    end
+  end
+
   test "html publications" do
     setup_and_visit_content_item('published')
 

--- a/test/integration/topical_event_about_page_test.rb
+++ b/test/integration/topical_event_about_page_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class TopicalEventAboutPageTest < ActionDispatch::IntegrationTest
+  test "random but valid items do not error" do
+    setup_and_visit_random_content_item
+  end
+
   test "topical event about pages" do
     setup_and_visit_content_item('topical_event_about_page')
     assert_has_component_title(@content_item["title"])

--- a/test/integration/working_group_test.rb
+++ b/test/integration/working_group_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class WorkingGroupTest < ActionDispatch::IntegrationTest
+  test "random but valid items do not error" do
+    setup_and_visit_random_content_item
+  end
+
   test "working groups" do
     setup_and_visit_content_item('long')
     assert_has_component_title(@content_item["title"])


### PR DESCRIPTION
This tests 4 further formats against random content.

## How should we report bad content?

Frontend principles:
1. Attempt to give the users what they need by rendering anything that's provided by the content-store
2. Report back to us when crucial data is missing so it can be fixed (ie not masking errors)

This PR only does part 1, ie the frontend will not fall over and users will see content, but we won't know that it's broken. When this happens how should we be reporting it? Send to Errbit while still rendering content? This mostly applies to HTML publications and their relationship with other content (organisations, parent).

---

1. HTML Publications
* Protect against parent document type not existing
* Protect against no organisations
* Protect against organisations with no logo

2. Topical event about pages
* Protect against parent in breadcrumb not existing
* Protect against missing end date

Also adds tests against random content for working groups and case studies
