### PR TITLE
Enable taxonomy breadcrumb back link on mobile

### DIFF
--- a/app/views/shared/_breadcrumbs.html+new_navigation.erb
+++ b/app/views/shared/_breadcrumbs.html+new_navigation.erb
@@ -15,5 +15,7 @@
       }
     )
   %>
-  <%= render 'govuk_component/breadcrumbs', breadcrumbs: @content_item.taxon_breadcrumbs %>
+  <%= render 'govuk_component/breadcrumbs',
+    breadcrumbs: @content_item.taxon_breadcrumbs,
+    collapse_on_mobile: true %>
 <% end %>


### PR DESCRIPTION
Pass `collapse_on_mobile` parameter to enable the collapse of the taxonomy breadcrumbs to a single back link.

https://trello.com/c/Y7OirowB/472-mobile-version-of-breadcrumbs-should-only-show-previous-link