### PR TITLE
Add missing Node.js dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.3.1
 RUN apt-get update -qq && apt-get upgrade -y
 
-RUN apt-get install -y build-essential && apt-get clean
+RUN apt-get install -y build-essential nodejs && apt-get clean
 
 ENV GOVUK_APP_NAME government-frontend
 ENV GOVUK_ASSET_ROOT http://assets-origin.dev.gov.uk


### PR DESCRIPTION
This was missed when the Dockerfile was added.