### PR TITLE
Update govuk_navigation_helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ else
   gem 'gds-api-adapters', '~> 40.1'
 end
 
-gem 'govuk_navigation_helpers', '~> 3.2'
+gem 'govuk_navigation_helpers', '~> 4.0'
 
 group :development, :test do
   gem 'govuk_schemas'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.2.1)
+    govuk_navigation_helpers (4.0.0)
       gds-api-adapters (~> 40.1)
     govuk_schemas (2.1.0)
       json-schema (~> 2.5.0)
@@ -263,7 +263,7 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing (= 1.0.1)
   govuk_frontend_toolkit (= 5.1.0)
-  govuk_navigation_helpers (~> 3.2)
+  govuk_navigation_helpers (~> 4.0)
   govuk_schemas
   htmlentities (= 4.3.4)
   jasmine-rails (~> 0.14.0)


### PR DESCRIPTION
This picks up the latest version of the taxonomy sidebar. There should not be any user-visible changes - the library has just switched from a hard-coded list of guidance content to filtering it in search.

https://trello.com/c/PtQXkimK/520-switch-from-using-hardcoded-guidance-document-types-into-using-document-supertypes