### PR TITLE
Mouse tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'unicorn', '4.8'
 gem 'rails-i18n', '>= 4.0.4'
 gem 'rails_translation_manager', '~> 0.0.2'
 gem 'rails-controller-testing', '~> 0.1'
-gem 'govuk_ab_testing', '1.0.1'
+gem 'govuk_ab_testing', '~> 2.0'
 gem 'htmlentities', '4.3.4'
 gem 'statsd-ruby', '1.3.0', require: 'statsd'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_ab_testing (1.0.1)
+    govuk_ab_testing (2.0.0)
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -266,7 +266,7 @@ DEPENDENCIES
   gds-api-adapters (~> 40.1)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
-  govuk_ab_testing (= 1.0.1)
+  govuk_ab_testing (~> 2.0)
   govuk_frontend_toolkit (= 5.1.0)
   govuk_navigation_helpers (~> 4.0)
   govuk_schemas

--- a/app/assets/javascripts/mouseflow.js
+++ b/app/assets/javascripts/mouseflow.js
@@ -1,0 +1,9 @@
+var _mfq = _mfq || [];
+
+(function() {
+  var mf = document.createElement("script");
+  mf.type = "text/javascript";
+  mf.async = true;
+  mf.src = "//cdn.mouseflow.com/projects/807ab5b2-3fe4-4b3b-b4d7-e83b8f6e71fe.js";
+  document.getElementsByTagName("head")[0].appendChild(mf);
+})();

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,19 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  helper_method :benchmarking_ab_test
+  helper_method :should_track_mouse_movements?
+
+  def benchmarking_ab_test
+    @benchmarking_ab_test ||= begin
+      benchmarking_test = BenchmarkingAbTestRequest.new(request)
+      benchmarking_test.set_response_vary_header(response)
+      benchmarking_test
+    end
+  end
+
+  def should_track_mouse_movements?
+    benchmarking_ab_test.in_benchmarking?
+  end
 end

--- a/app/models/benchmarking_ab_test_request.rb
+++ b/app/models/benchmarking_ab_test_request.rb
@@ -1,0 +1,22 @@
+class BenchmarkingAbTestRequest
+  attr_accessor :requested_variant
+
+  delegate :analytics_meta_tag, to: :requested_variant
+
+  def initialize(request)
+    dimension = Rails.application.config.benchmarking_ab_test_dimension
+    ab_test = GovukAbTesting::AbTest.new(
+        "Benchmarking",
+        dimension: dimension
+    )
+    @requested_variant = ab_test.requested_variant(request.headers)
+  end
+
+  def in_benchmarking?
+    requested_variant.variant_b?
+  end
+
+  def set_response_vary_header(response)
+    requested_variant.configure_response(response)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
   <% end %>
   <meta name="govuk:content-id" content="<%= @content_item.content_id %>" />
   <%= @education_navigation_ab_test.analytics_meta_tag.html_safe if @education_navigation_ab_test.ab_test_applies? %>
+  <%= benchmarking_ab_test.requested_variant.analytics_meta_tag.html_safe %>
   <%= yield :extra_head_content %>
 </head>
 <body>
@@ -28,5 +29,9 @@
       <%= yield %>
     </main>
   </div>
+
+  <% if should_track_mouse_movements? %>
+    <%= javascript_include_tag 'mouseflow' %>
+  <% end %>
 </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,9 @@ module GovernmentFrontend
     # Path within public/ where assets are compiled to
     config.assets.prefix = '/government-frontend'
 
+    # Google Analytics dimension assigned to the benchmarking A/B test
+    config.benchmarking_ab_test_dimension = 49
+
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true
   end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,4 +14,5 @@ Rails.application.config.assets.precompile += %w(
   application-ie8.css
   webchat.js
   print.css
+  mouseflow.js
 )

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -234,6 +234,24 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_response_not_modified_for_ab_test('EducationNavigation')
   end
 
+  test "shows the mouseflow tag when in the benchmarking test" do
+    with_variant Benchmarking: "B" do
+      content_item = content_store_has_schema_example('case_study', 'case_study')
+      get :show, params: { path: path_for(content_item) }
+
+      assert_select("script[src*=mouseflow-]", 1, "Expected to find one script tag with the mouseflow js code on the page")
+    end
+  end
+
+  test "does not show the mouseflow tag when not in the benchmarking test" do
+    with_variant Benchmarking: "A" do
+      content_item = content_store_has_schema_example('case_study', 'case_study')
+      get :show, params: { path: path_for(content_item) }
+
+      assert_select("script[src*=mouseflow-]", 0, "Did not expect to find a script tag with the mouseflow js code on the page")
+    end
+  end
+
   def path_for(content_item, locale = nil)
     base_path = content_item['base_path'].sub(/^\//, '')
     base_path.gsub!(/\.#{locale}$/, '') if locale

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -204,13 +204,13 @@ class ContentItemsControllerTest < ActionController::TestCase
     get :show, params: { path: path_for(content_item) }
     assert_equal [], @request.variant
     refute_match(/A Taxon/, taxonomy_sidebar)
-    assert_response_not_modified_for_ab_test
+    assert_response_not_modified_for_ab_test('EducationNavigation')
 
     setup_ab_variant('EducationNavigation', 'B')
     get :show, params: { path: path_for(content_item) }
     assert_equal [], @request.variant
     refute_match(/A Taxon/, taxonomy_sidebar)
-    assert_response_not_modified_for_ab_test
+    assert_response_not_modified_for_ab_test('EducationNavigation')
   end
 
   test "Case Studies are not included in the AB Test" do
@@ -231,7 +231,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     get :show, params: { path: path_for(content_item) }
     assert_equal [], @request.variant
     refute_match(/A Taxon/, taxonomy_sidebar)
-    assert_response_not_modified_for_ab_test
+    assert_response_not_modified_for_ab_test('EducationNavigation')
   end
 
   def path_for(content_item, locale = nil)


### PR DESCRIPTION
### Background

We are going to conduct a 2nd round of Benchmarking in GOV.UK. The idea is that we will try it with the new Education Navigation enabled across GOV.UK and see how it performs against the current navigation patterns (mainstream browse pages, topics, etc).

Besides checking if people actually complete the tasks, we would also like to know more details about how they use the new navigation pages and also about the new orientation in content pages. In order to do that, we will track mouse movements and gather the results in a heatmap. We are using a software called mouseflow to do this.

The tracking code will only be present for the people doing the benchmarking test (around 60 people). It will be behind a new A/B test so the tracking doesn't run for other GOV.UK users. These 60 users will be presented with a consent form where this will be explained.

### What this PR does

This PR adds the Mouseflow tracking code behind a new A/B test (`GOVUK-ABTest-Benchmarking`). With this new A/B test, we will be able to enable Mouseflow for all 60 users in the benchmarking round. This will allow us to collect data on how the navigation pages are used and generate a heatmap in the end in order to help us understand what areas of the site will be improved.

Trello: https://trello.com/c/NJ6O76BR/281-heatmap-tracking