### PR TITLE
Track clicks on the floating Contents link

### DIFF
--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -47,7 +47,7 @@
         direction: page_text_direction %>
   </div>
   <div data-sticky-element class="sticky-element">
-    <a class="back-to-content" href="#contents"><%= t("content_item.contents") %></a>
+    <%= render 'shared/back_to_content_link' %>
   </div>
 </div>
 

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -55,5 +55,5 @@
     locals: {
       content: @content_item.body,
       direction: page_text_direction,
-      sticky_footer_html: %(<a class="back-to-content" href="#contents">#{ t("content_item.contents") }</a>)
+      sticky_footer_html: (render partial: 'shared/back_to_content_link'),
     } %>

--- a/app/views/shared/_back_to_content_link.html.erb
+++ b/app/views/shared/_back_to_content_link.html.erb
@@ -1,0 +1,11 @@
+<%= link_to(
+  t('content_item.contents'),
+  '#contents',
+  class: 'back-to-content',
+  data: {
+    track_category: 'contentsClicked',
+    track_action: 'backToContentsLinkClicked',
+    track_label: t('content_item.contents'),
+    module: 'track-click',
+  },
+) %>

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -73,4 +73,12 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
 
     assert page.has_css?('.available-languages')
   end
+
+  test 'return to contents link is tracked' do
+    setup_and_visit_content_item('detailed_guide')
+
+    assert page.has_css?("a.back-to-content[data-track-category='contentsClicked']")
+    assert page.has_css?("a.back-to-content[data-track-action='backToContentsLinkClicked']")
+    assert page.has_css?("a.back-to-content[data-track-label='Contents']")
+  end
 end


### PR DESCRIPTION
Track clicks on the floating "Contents" link that appears when scrolling down the page on:

- Detailed guides
- HTML publications

The following event will be tracked:
- category: `contentsClicked`
- action: `backToContentsLinkClicked`
- label: `Contents`

### Trello

https://trello.com/c/DpEK2IwV/518-track-clicks-on-floating-contents-link-on-detailed-guide-pages
