### PR TITLE
Upgrade navigation helpers and gds api adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,10 +27,10 @@ gem 'statsd-ruby', '1.3.0', require: 'statsd'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 40.1'
+  gem 'gds-api-adapters', '~> 41.0'
 end
 
-gem 'govuk_navigation_helpers', '~> 4.0'
+gem 'govuk_navigation_helpers', '~> 5.1'
 
 group :development, :test do
   gem 'govuk_schemas'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (40.2.0)
+    gds-api-adapters (41.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -88,8 +88,8 @@ GEM
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (4.0.0)
-      gds-api-adapters (~> 40.1)
+    govuk_navigation_helpers (5.1.0)
+      gds-api-adapters (~> 41.0)
     govuk_schemas (2.1.0)
       json-schema (~> 2.5.0)
     htmlentities (4.3.4)
@@ -263,12 +263,12 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara
-  gds-api-adapters (~> 40.1)
+  gds-api-adapters (~> 41.0)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
   govuk_ab_testing (~> 2.0)
   govuk_frontend_toolkit (= 5.1.0)
-  govuk_navigation_helpers (~> 4.0)
+  govuk_navigation_helpers (~> 5.1)
   govuk_schemas
   htmlentities (= 4.3.4)
   jasmine-rails (~> 0.14.0)


### PR DESCRIPTION
This commit needs to upgrade both gems at the same time due to
dependencies between each other.

Trello: https://trello.com/c/vM6Kaw9B/546-ias-and-content-designers-can-curate-related-links-for-any-content-type