### PR TITLE
Add buttons rendering to specialist documents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'airbrake', '~> 5.5'
 gem 'airbrake-ruby', '1.5'
 
 gem 'govuk_frontend_toolkit', '5.1.0'
+gem 'govuk_elements_rails', '3.0.1'
 gem 'logstasher', '0.6.1'
 gem 'plek', '1.11'
 gem 'rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,10 @@ GEM
       rubocop (~> 0.39.0)
       scss_lint
     govuk_ab_testing (2.0.0)
+    govuk_elements_rails (3.0.1)
+      govuk_frontend_toolkit (>= 5.0.2)
+      rails (>= 4.1.0)
+      sass (>= 3.2.0)
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -267,6 +271,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
   govuk_ab_testing (~> 2.0)
+  govuk_elements_rails (= 3.0.1)
   govuk_frontend_toolkit (= 5.1.0)
   govuk_navigation_helpers (~> 5.1)
   govuk_schemas

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,7 @@
 @import 'helpers/history-notice';
 @import 'helpers/withdrawal-notice';
 @import 'helpers/taxonomy-sidebar';
+@import 'helpers/button';
 
 // pages specific view imports
 @import 'views/case-studies';

--- a/app/assets/stylesheets/helpers/_button.scss
+++ b/app/assets/stylesheets/helpers/_button.scss
@@ -1,0 +1,15 @@
+// TODO: We can move this into GOV.UK Publishing Components if it makes sense to do so.
+
+@import "design-patterns/buttons"; // Elements Button import globally depends on mixins defined in here.
+@import "elements/helpers"; // Elements Button import globally depends on mixins defined in here.
+// DEBT/RISK: Includes a .example-highlight-grid global CSS helper
+// https://github.com/alphagov/govuk_elements/blob/874e287/public/sass/elements/_helpers.scss#L12
+// and a reimplementation of .visually-hidden
+// https://github.com/alphagov/govuk_elements/blob/874e287/public/sass/elements/_helpers.scss#L36
+@import "elements/buttons";
+
+.button-info {
+  display: block;
+  margin-top: .5em;
+  max-width: 14em;
+}

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -1,5 +1,4 @@
 class TravelAdviceController < ContentItemsController
-
 private
 
   def present(content_item)

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -48,6 +48,20 @@ class SpecialistDocumentPresenter < ContentItemPresenter
     ]
   end
 
+  def continuation_link
+    content_item
+      .dig("details", "metadata", "continuation_link")
+      .try(:strip)
+      .try(:html_safe)
+  end
+
+  def will_continue_on
+    content_item
+      .dig("details", "metadata", "will_continue_on")
+      .try(:strip)
+      .try(:html_safe)
+  end
+
 private
 
   def join_facets(facet)

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -17,6 +17,17 @@
     <%= render 'govuk_component/govspeak',
         content: @content_item.body,
         direction: page_text_direction %>
+
+    <% if @content_item.continuation_link %>
+      <%= render(
+          'shared/button',
+          start: true,
+          href: @content_item.continuation_link,
+          info: @content_item.will_continue_on
+      ) do %>
+        Find out more
+      <% end %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/shared/_button.html.erb
+++ b/app/views/shared/_button.html.erb
@@ -1,0 +1,19 @@
+<a
+  class="
+    button
+    <% if local_assigns.include?(:start) && start == true %>
+      button-start
+    <% end %>
+  "
+  <% if local_assigns.include?(:href) %>
+    href="<%= href.try(:html_safe) %>"
+  <% end %>
+  role="button"
+>
+  <%= yield %>
+</a>
+<% if local_assigns.include?(:info) %>
+  <span class="button-info">
+    <%= info.try(:html_safe) %>
+  </span>
+<% end %>

--- a/app/views/shared/_button.html.erb
+++ b/app/views/shared/_button.html.erb
@@ -1,18 +1,23 @@
+<%
+  start ||= false
+  href ||= false
+  info ||= false
+%>
 <a
   class="
     button
-    <% if local_assigns.include?(:start) && start == true %>
+    <% if start == true %>
       button-start
     <% end %>
   "
-  <% if local_assigns.include?(:href) %>
+  <% if href %>
     href="<%= href.try(:html_safe) %>"
   <% end %>
   role="button"
 >
   <%= yield %>
 </a>
-<% if local_assigns.include?(:info) %>
+<% if info %>
   <span class="button-info">
     <%= info.try(:html_safe) %>
   </span>

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -109,4 +109,34 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
       { text: "Summary", id: "summary" },
     ])
   end
+
+  test 'renders no start button when not set' do
+    setup_and_visit_content_item('aaib-reports')
+
+    assert page.has_no_css?('.button')
+  end
+
+  test 'renders start button' do
+    setup_and_visit_content_item('business-finance-support-scheme')
+
+    button_base_selector = '.button.button-start'
+    correct_role_selector = '[role=button]'
+    correct_href_selector = '[href="http://www.bigissueinvest.com"]'
+
+    expected_button_selector =
+      button_base_selector +
+      correct_role_selector +
+      correct_href_selector
+
+    assert page.has_css?(expected_button_selector)
+    within expected_button_selector do
+      assert_text('Find out more')
+    end
+
+    button_info_selector = '.button-info'
+    assert page.has_css?(button_info_selector)
+    within button_info_selector do
+      assert_text('on the Big Issue Invest website')
+    end
+  end
 end

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -82,6 +82,28 @@ class SpecialistDocumentPresenterTest
 
       assert_equal title_component_params, presented_item('aaib-reports').title_and_context
     end
+
+    test 'should not present continuation_link' do
+      assert_equal(presented_item('aaib-reports').continuation_link, nil)
+    end
+
+    test 'should not present will_continue_on' do
+      assert_equal(presented_item('aaib-reports').will_continue_on, nil)
+    end
+
+    test 'should present continuation_link' do
+      assert_equal(
+        presented_item('business-finance-support-scheme').continuation_link,
+        'http://www.bigissueinvest.com'
+      )
+    end
+
+    test 'should present will_continue_on' do
+      assert_equal(
+        presented_item('business-finance-support-scheme').will_continue_on,
+        'on the Big Issue Invest website'
+      )
+    end
   end
 
   class PresentedSpecialistDocumentWithFinderFacets < SpecialistDocumentTestCase


### PR DESCRIPTION
I've added the button in a way that it should be easy to move to be a [GOV.UK Publishing Component](http://govuk-component-guide.herokuapp.com/)

cc @rubenarakelyan I've ended up using the same approach you started with using GOV.UK Elements but I've tried to reduce the amount of global conflict by only adding what's needed with some added comments. Apologies for making you change it the first time!