### PR TITLE
Add rtl styles to publications

### DIFF
--- a/app/assets/stylesheets/views/_publication.scss
+++ b/app/assets/stylesheets/views/_publication.scss
@@ -16,4 +16,9 @@
       margin-bottom: $gutter;
     }
   }
+
+  .direction-rtl & {
+    direction: rtl;
+    text-align: start;
+  }
 }


### PR DESCRIPTION
* Render right to left languages correctly on publications
* Matches pattern used by other formats, but ought to be updated as
it’s easily omitted
* Fixes https://govuk.zendesk.com/agent/tickets/1968274 (https://www.gov.uk/government/publications/midlands-engine-investment-portfolio.ar)

## Before
![screen shot 2017-04-06 at 10 15 47](https://cloud.githubusercontent.com/assets/319055/24746752/25430f28-1ab2-11e7-91ac-618ae3092369.png)

## After
![screen shot 2017-04-06 at 10 16 22](https://cloud.githubusercontent.com/assets/319055/24746753/2544c75a-1ab2-11e7-82ca-6c4b4f532acb.png)

cc @36degrees @nickcolley 