### PR TITLE
Remove the phantom gem, the only thing this does is download a binary

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,5 +50,4 @@ group :test do
   gem 'govuk-content-schema-test-helpers', '1.1.0'
   gem 'mocha'
   gem 'poltergeist', require: false
-  gem 'phantomjs'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,6 @@ DEPENDENCIES
   jasmine-rails (~> 0.14.0)
   logstasher (= 0.6.1)
   mocha
-  phantomjs
   plek (= 1.11)
   poltergeist
   pry-byebug
@@ -293,4 +292,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This is a Ruby on Rails application that fetches documents from
 
 - [content-store](https://github.com/alphagov/content-store) - provides documents
 - [static](https://github.com/alphagov/static) - provides shared GOV.UK assets and templates.
+- [phantomjs](http://phantomjs.org/) Used by poltergeist for integration testing
 
 ### Running the application
 


### PR DESCRIPTION
this gem is not official as far as i can tell,
and only downloads a binary, instead list as a
dependency in the readme, and leave it as an excercise
to the reader/vm to have phantomjs