### PR TITLE
Use London timezone

### DIFF
--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -22,7 +22,7 @@ class ConsultationPresenter < ContentItemPresenter
   end
 
   def opening_date_midnight?
-    Time.parse(opening_date_time).strftime("%l:%M%P") == "12:00am"
+    Time.zone.parse(opening_date_time).strftime("%l:%M%P") == "12:00am"
   end
 
   def closing_date
@@ -116,7 +116,7 @@ class ConsultationPresenter < ContentItemPresenter
 private
 
   def display_date_and_time(date, rollback_midnight = false)
-    time = Time.parse(date)
+    time = Time.zone.parse(date)
     date_format = "%-e %B %Y"
     time_format = "%l:%M%P"
 

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -45,7 +45,7 @@ class ContentItemPresenter
 private
 
   def display_date(timestamp, format = "%-d %B %Y")
-    I18n.l(Time.parse(timestamp), format: format) if timestamp
+    I18n.l(Time.zone.parse(timestamp), format: format) if timestamp
   end
 
   def sorted_locales(translations)

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -29,7 +29,7 @@ class DocumentCollectionPresenter < ContentItemPresenter
   def group_document_links(group)
     group_documents(group).map do |link|
       {
-        public_updated_at: Time.parse(link["public_updated_at"]),
+        public_updated_at: Time.zone.parse(link["public_updated_at"]),
         document_type: link["document_type"],
         title: link["title"],
         base_path: link["base_path"]

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -36,7 +36,7 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
 
   def cancellation_date
     cancelled_at = content_item["details"]["cancelled_at"]
-    DateTime.parse(cancelled_at).strftime("%e %B %Y %-l:%M%P")
+    Time.zone.parse(cancelled_at).strftime("%e %B %Y %-l:%M%P")
   end
 
   def cancelled?

--- a/app/presenters/topical_event_about_page_presenter.rb
+++ b/app/presenters/topical_event_about_page_presenter.rb
@@ -28,7 +28,7 @@ private
     return nil unless super
     topical_event_end_date = super.dig("details", "end_date")
 
-    if topical_event_end_date && DateTime.parse(topical_event_end_date) <= Date.today
+    if topical_event_end_date && Time.zone.parse(topical_event_end_date) <= Time.zone.today
       super.merge("title" => "#{super['title']} (Archived)")
     else
       super

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -22,7 +22,7 @@ class TravelAdvicePresenter < ContentItemPresenter
     updated_at = content_item['details']['updated_at']
 
     other = {
-      "Still current at" => I18n.l(Time.now, format: "%-d %B %Y"),
+      "Still current at" => I18n.l(Time.zone.now, format: "%-d %B %Y"),
       "Updated" => display_date(reviewed_at || updated_at),
     }
 

--- a/app/presenters/updatable.rb
+++ b/app/presenters/updatable.rb
@@ -33,7 +33,7 @@ private
 
   def any_updates?
     if public_updated_at && first_public_at
-      DateTime.parse(public_updated_at) != DateTime.parse(first_public_at)
+      Time.zone.parse(public_updated_at) != Time.zone.parse(first_public_at)
     else
       false
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ module GovernmentFrontend
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'London'
 
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += %W(#{config.root}/lib)

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -41,15 +41,18 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('open_consultation')
 
     assert page.has_text?("Open consultation")
-    assert page.has_text?("closes at 4pm on 16 December 2216")
+    assert page.has_text?("closes at 3pm on 16 December 2216")
   end
 
   test "unopened consultation" do
     setup_and_visit_content_item('unopened_consultation')
 
     assert page.has_text?("Consultation")
-    assert page.has_css?('.consultation-notice', text: "This consultation opens at 2pm on 5 October 2200")
-    assert page.has_text?("It closes at 5pm on 31 October 2210")
+
+    # There’s no daylight savings after 2037
+    # http://timezonesjl.readthedocs.io/en/stable/faq/#far-future-zoneddatetime-with-variabletimezone
+    assert page.has_css?('.consultation-notice', text: "This consultation opens at 1pm on 5 October 2200")
+    assert page.has_text?("It closes at 4pm on 31 October 2210")
   end
 
   test "closed consultation pending outcome" do
@@ -59,7 +62,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     assert page.has_css?('.consultation-notice', text: "We are analysing your feedback")
 
     assert page.has_text?("ran from")
-    assert page.has_text?("2pm on 5 September 2016 to 5pm on 31 October 2016")
+    assert page.has_text?("2pm on 5 September 2016 to 4pm on 31 October 2016")
   end
 
   test "consultation outcome" do

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -12,14 +12,19 @@ class ConsultationPresenterTest
     end
 
     test 'presents friendly dates for opening and closing dates, including time' do
-      assert_equal "10am on 4 November 2016", presented_item("open_consultation").opening_date
-      assert_equal "4pm on 16 December 2216", presented_item("open_consultation").closing_date
+      schema = schema_item("open_consultation")
+      schema['details']['opening_date'] = "2016-11-04T10:00:00+00:00"
+      schema['details']['closing_date'] = "2216-12-16T16:00:00+00:00"
+      presented = presented_item("open_consultation", schema)
+
+      assert_equal "10am on 4 November 2016", presented.opening_date
+      assert_equal "4pm on 16 December 2216", presented.closing_date
     end
 
     test 'presents closing dates at 12am as 11:59pm on the day before' do
       schema = schema_item("open_consultation")
-      schema['details']['opening_date'] = "2016-11-03T00:01:00+01:00"
-      schema['details']['closing_date'] = "2016-11-04T00:00:00+01:00"
+      schema['details']['opening_date'] = "2016-11-03T00:01:00+00:00"
+      schema['details']['closing_date'] = "2016-11-04T00:00:00+00:00"
       presented = presented_item("open_consultation", schema)
 
       assert_equal "12:01am on 3 November 2016", presented.opening_date
@@ -28,8 +33,8 @@ class ConsultationPresenterTest
 
     test 'presents opening dates at 12am as the date without a time' do
       schema = schema_item("open_consultation")
-      schema['details']['opening_date'] = "2016-11-03T00:00:00+01:00"
-      schema['details']['closing_date'] = "2016-11-04T00:00:00+01:00"
+      schema['details']['opening_date'] = "2016-11-03T00:00:00+00:00"
+      schema['details']['closing_date'] = "2016-11-04T00:00:00+00:00"
       presented = presented_item("open_consultation", schema)
 
       assert_equal "3 November 2016", presented.opening_date
@@ -37,7 +42,7 @@ class ConsultationPresenterTest
 
     test 'presents 12pm as midday' do
       schema = schema_item("open_consultation")
-      schema['details']['opening_date'] = "2016-11-04T12:00:00+01:00"
+      schema['details']['opening_date'] = "2016-11-04T12:00:00+00:00"
       presented = presented_item("open_consultation", schema)
 
       assert_equal "midday on 4 November 2016", presented.opening_date

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -50,7 +50,7 @@ class DocumentCollectionPresenterTest
     test 'presents an ordered list of group documents' do
       documents = [
         {
-          public_updated_at: Time.parse("2007-03-16 15:00:02 +0000"),
+          public_updated_at: Time.zone.parse("2007-03-16 15:00:02 +0000"),
           document_type: "guidance",
           title: "National standard for driving cars and light vans",
           base_path: "/government/publications/national-standard-for-driving-cars-and-light-vans"


### PR DESCRIPTION
Most dates in content items are UTC, occasionally some are BST. Any UTC dates during daylight savings time would render an hour out – when the time is around midnight, then the date will also be wrong.

## How bug appeared
via https://govuk.zendesk.com/agent/tickets/2044273
On: https://www.gov.uk/government/publications/your-new-state-pension-explained
```json
"public_updated_at": "2017-04-09T23:15:05.000+00:00",
"public_timestamp": "2017-04-10T00:15:05.000+01:00",
```
Those two dates are the same when taking into account time zone. But they rendered as:
![screen shot 2017-04-10 at 13 52 44](https://cloud.githubusercontent.com/assets/319055/24862582/09b20570-1df5-11e7-9cd1-4a1b48453233.png)

## Fix
* Use London timezone
* Update all uses of Time.parse to Time.zone.parse
* Replace most uses of DateTime.parse with Time.zone.parse
* Fix tests now they correctly handle the daylight savings time (DST)
* Include comment about far future dates having no DST
* Update tests to use times in November in GMT, not BST (this has
highlighted an [odd usage of daylight savings timezones](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/consultation/frontend/examples/open_consultation.json#L14) during a non DST
time period in the content schema examples – e.g. 4 Nov is in BST, but
that’s not in a DST period)