### PR TITLE
Remove redundant stylesheet link

### DIFF
--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -1,7 +1,6 @@
 <%- if params[:medium] == 'print' %>
   <%= stylesheet_link_tag "print.css", :media => "screen" %>
 <%- else %>
-  <%= stylesheet_link_tag "screen", :media => "screen" %>
   <%= stylesheet_link_tag "print.css", :media => "print" %>
 <%- end %>
 


### PR DESCRIPTION
A snippet of code was used from this website:
https://makandracards.com/makandra/11133-how-to-test-print-stylesheets-with-cucumber-and-capybara
However, this snippet referenced a stylesheet called screen.css that was
never implemented on our end.

Since we never created the stylesheet, but we referenced it, all HTML
publications have been trying and failing to fetch this stylesheet,
resulting in a 404.

We don’t actually need screen.css, so this Pull Request removes the
reference to it.