### PR TITLE
Add max-width to give more readable line-length to description

### DIFF
--- a/app/assets/stylesheets/helpers/_description.scss
+++ b/app/assets/stylesheets/helpers/_description.scss
@@ -2,5 +2,7 @@
   .description {
     @include core-24;
     @include responsive-bottom-margin;
+    // Ensure the text has a line-length of around 60 characters
+    max-width: 30em;
   }
 }


### PR DESCRIPTION
A max width of 30em gives us around 60-70 characters based on the current font-size
which is regarded as a decent line-length for reading.

Change recommended by Mia Allers

Before

![screen shot 2017-04-12 at 13 14 39](https://cloud.githubusercontent.com/assets/2445413/24957046/3b8c6278-1f82-11e7-83a5-5a98c4c9e2c2.png)

After

![screen shot 2017-04-12 at 13 14 45](https://cloud.githubusercontent.com/assets/2445413/24957045/3b8b14ea-1f82-11e7-864b-7cd16a83e454.png)

---

Before

![screen shot 2017-04-12 at 13 15 26](https://cloud.githubusercontent.com/assets/2445413/24957047/3b8e29be-1f82-11e7-8807-eeebfa8ecca6.png)

After

![screen shot 2017-04-12 at 13 15 44](https://cloud.githubusercontent.com/assets/2445413/24957048/3b96c98e-1f82-11e7-9e1b-727d69de4922.png)
