### PR TITLE
Add facet metadata to specialist documents

### DIFF
--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -27,6 +27,21 @@ class SpecialistDocumentPresenter < ContentItemPresenter
     end
   end
 
+  def breadcrumbs
+    return [] unless finder
+
+    [
+      {
+        title: "Home",
+        url: "/",
+      },
+      {
+        title: finder['title'],
+        url: finder['base_path'],
+      }
+    ]
+  end
+
 private
 
   # Maximum of one finder

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -125,4 +125,14 @@ private
     changes = reverse_chronological_change_history
     changes.any? ? changes.last[:timestamp] : nil
   end
+
+  # specialist document change history can have a modified date that is
+  # slightly different to the public_updated_at, eg milliseconds different
+  # this means the direct comparison in updatable gives a false positive
+  # Use change_history as specialist-frontend did
+  #
+  # Can be removed when first_published_at is reliable
+  def any_updates?
+    change_history.size > 1
+  end
 end

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -17,13 +17,19 @@ class SpecialistDocumentPresenter < ContentItemPresenter
 
   def metadata
     super.tap do |m|
-      m[:other] = facet_metadata
+      facets_with_values.each do |facet|
+        m[:other][facet['name']] = facet['values'].join(', ')
+      end
     end
   end
 
   def document_footer
     super.tap do |m|
-      m[:other] = facet_metadata
+      m[:other_dates] = {}
+      facets_with_values.each do |facet|
+        type = facet['type'] == 'date' ? :other_dates : :other
+        m[type][facet['name']] = facet['values'].join(', ')
+      end
     end
   end
 
@@ -107,15 +113,6 @@ private
     key = facet['key']
 
     link_to(allowed_value['label'], "#{finder_base_path}?#{key}%5B%5D=#{allowed_value['value']}")
-  end
-
-  def facet_metadata
-    metadata = {}
-    facets_with_values.each do |facet|
-      metadata[facet['name']] = facet['values'].join(', ')
-    end
-
-    metadata
   end
 
   # first_published_at does not have reliable data

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -15,7 +15,93 @@ class SpecialistDocumentPresenter < ContentItemPresenter
     end
   end
 
+  def metadata
+    super.tap do |m|
+      m[:other] = facet_metadata
+    end
+  end
+
+  def document_footer
+    super.tap do |m|
+      m[:other] = facet_metadata
+    end
+  end
+
 private
+
+  # Maximum of one finder
+  # but finder may be empty
+  def finder
+    content_item.dig("links", "finder", 0)
+    # TODO: Shout loudly if missing parent finder
+  end
+
+  def facets
+    return nil unless finder
+    finder.dig('details', 'facets')
+  end
+
+  def facet_values
+    # Metadata is a required field
+    content_item["details"]["metadata"]
+  end
+
+  def facets_with_values
+    return [] unless facets && facet_values.any?
+    only_facets_with_values = facets.select { |f| facet_values[f['key']] }
+
+    only_facets_with_values.map do |facet|
+      facet_key = facet['key']
+      # Cast all values into an array
+      values = [facet_values[facet_key]].flatten
+
+      facet['values'] = case facet['type']
+                        when 'text'
+                          friendly_facet_text(facet, values)
+                        when 'date'
+                          friendly_facet_date(values)
+                        else
+                          values
+                        end
+
+      facet
+    end
+  end
+
+  def friendly_facet_text(facet, values)
+    if facet['allowed_values'] && facet['allowed_values'].any?
+      friendly_facet_allowed_values(facet, values)
+    else
+      values
+    end
+  end
+
+  def friendly_facet_allowed_values(facet, values)
+    # TODO: Shout loudly if a value isn't one of the allowed ones
+    facet['allowed_values'].select { |v| values.include?(v['value']) }.map do |allowed_value|
+      facet['filterable'] ? filterable_facet_link(facet, allowed_value) : allowed_value['label']
+    end
+  end
+
+  def friendly_facet_date(dates)
+    dates.map { |date| display_date(date) }
+  end
+
+  def filterable_facet_link(facet, allowed_value)
+    finder_base_path = finder['base_path']
+    key = facet['key']
+
+    link_to(allowed_value['label'], "#{finder_base_path}?#{key}%5B%5D=#{allowed_value['value']}")
+  end
+
+  def facet_metadata
+    metadata = {}
+    facets_with_values.each do |facet|
+      metadata[facet['name']] = facet['values'].join(', ')
+    end
+
+    metadata
+  end
 
   # first_published_at does not have reliable data
   # at time of writing dates could be after public_updated_at

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -50,11 +50,18 @@ class SpecialistDocumentPresenter < ContentItemPresenter
 
 private
 
-  # Maximum of one finder
-  # but finder may be empty
+  def join_facets(facet)
+    facet['values'].join(', ')
+  end
+
+  # Finder is a required link that must have 1 item
   def finder
-    content_item.dig("links", "finder", 0)
-    # TODO: Shout loudly if missing parent finder
+    parent_finder = content_item.dig("links", "finder", 0)
+    Airbrake.notify("Finder not found",
+      error_message: "Finder not found in #{base_path} content item"
+    ) if parent_finder.nil?
+
+    parent_finder
   end
 
   def facets
@@ -77,10 +84,10 @@ private
       values = [facet_values[facet_key]].flatten
 
       facet['values'] = case facet['type']
-                        when 'text'
-                          friendly_facet_text(facet, values)
                         when 'date'
                           friendly_facet_date(values)
+                        when 'text'
+                          friendly_facet_text(facet, values)
                         else
                           values
                         end
@@ -89,30 +96,49 @@ private
     end
   end
 
+  def friendly_facet_date(dates)
+    dates.map { |date| display_date(date) }
+  end
+
   def friendly_facet_text(facet, values)
     if facet['allowed_values'] && facet['allowed_values'].any?
-      friendly_facet_allowed_values(facet, values)
+      check_allowed_values(facet, values)
+      facet_blocks(facet, values)
     else
       values
     end
   end
 
-  def friendly_facet_allowed_values(facet, values)
-    # TODO: Shout loudly if a value isn't one of the allowed ones
-    facet['allowed_values'].select { |v| values.include?(v['value']) }.map do |allowed_value|
-      facet['filterable'] ? filterable_facet_link(facet, allowed_value) : allowed_value['label']
+  def check_allowed_values(facet, values)
+    allowed_values = facet['allowed_values'].map { |av| av["value"] }
+    values.each do |v|
+      Airbrake.notify("Facet value not in list of allowed values",
+        error_message: "Facet value '#{v}' not found in allowed values for #{base_path} content item"
+      ) unless allowed_values.include?(v)
     end
   end
 
-  def friendly_facet_date(dates)
-    dates.map { |date| display_date(date) }
+  # the facet value comes back bare, and without a label
+  # so we use the value in the url, and cross reference
+  # the allowed_values to get the label ##funky
+  def facet_blocks(facet, values)
+    values.map do |value|
+      values_with_label = facet["allowed_values"]
+      with_label = values_with_label.select { |av|
+        av["value"] == value
+      }.first
+      facet_block(facet, with_label)
+    end
   end
 
-  def filterable_facet_link(facet, allowed_value)
-    finder_base_path = finder['base_path']
-    key = facet['key']
+  def facet_block(facet, allowed_value)
+    return allowed_value['label'] unless facet['filterable']
+    facet_link(allowed_value['label'], allowed_value['value'], facet['key'])
+  end
 
-    link_to(allowed_value['label'], "#{finder_base_path}?#{key}%5B%5D=#{allowed_value['value']}")
+  def facet_link(label, value, key)
+    finder_base_path = finder['base_path']
+    link_to(label, "#{finder_base_path}?#{key}%5B%5D=#{value}")
   end
 
   # first_published_at does not have reliable data

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -18,7 +18,7 @@ class SpecialistDocumentPresenter < ContentItemPresenter
   def metadata
     super.tap do |m|
       facets_with_values.each do |facet|
-        m[:other][facet['name']] = facet['values'].join(', ')
+        m[:other][facet['name']] = join_facets(facet)
       end
     end
   end
@@ -28,7 +28,7 @@ class SpecialistDocumentPresenter < ContentItemPresenter
       m[:other_dates] = {}
       facets_with_values.each do |facet|
         type = facet['type'] == 'date' ? :other_dates : :other
-        m[type][facet['name']] = facet['values'].join(', ')
+        m[type][facet['name']] = join_facets(facet)
       end
     end
   end
@@ -124,10 +124,10 @@ private
   def facet_blocks(facet, values)
     values.map do |value|
       values_with_label = facet["allowed_values"]
-      with_label = values_with_label.select { |av|
+      allowed_value = values_with_label.select { |av|
         av["value"] == value
       }.first
-      facet_block(facet, with_label)
+      facet_block(facet, allowed_value)
     end
   end
 

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -40,7 +40,18 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
     within shared_component_selector("document_footer") do
       component_args = JSON.parse(page.text)
       history = component_args.fetch("history")
+      assert_equal history.first["note"], @content_item["details"]["change_history"].last["note"]
+      assert_equal history.last["note"], @content_item["details"]["change_history"].first["note"]
+      assert_equal history.size, @content_item["details"]["change_history"].size
+    end
+  end
 
+  test "renders facets correctly" do
+    setup_and_visit_content_item('countryside-stewardship-grants')
+
+    within shared_component_selector("document_footer") do
+      component_args = JSON.parse(page.text)
+      history = component_args.fetch("history")
       assert_equal history.first["note"], @content_item["details"]["change_history"].last["note"]
       assert_equal history.last["note"], @content_item["details"]["change_history"].first["note"]
       assert_equal history.size, @content_item["details"]["change_history"].size

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class SpecialistDocumentTest < ActionDispatch::IntegrationTest
+  test "random but valid items do not error" do
+    setup_and_visit_random_content_item(document_type: 'aaib_report')
+    setup_and_visit_random_content_item(document_type: 'raib_report')
+    setup_and_visit_random_content_item(document_type: 'tax_tribunal_decision')
+    setup_and_visit_random_content_item(document_type: 'cma_case')
+  end
+
   test "renders title, description and body" do
     setup_and_visit_content_item('aaib-reports')
 

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -46,15 +46,59 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders facets correctly" do
+  test "renders text facets correctly" do
     setup_and_visit_content_item('countryside-stewardship-grants')
+
+    def test_meta(component)
+      within shared_component_selector(component) do
+        component_args = JSON.parse(page.text)
+        assert_equal component_args["other"]["Grant type"], "<a href=\"/countryside-stewardship-grants?grant_type%5B%5D=option\">Option</a>"
+        assert_equal component_args["other"]["Tiers or standalone items"],
+        [
+          "<a href=\"/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=higher-tier\">Higher Tier</a>",
+          "<a href=\"/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=mid-tier\">Mid Tier</a>"
+        ].join(", ")
+        assert_equal component_args["other"]["Land use"],
+        [
+          "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=arable-land\">Arable land</a>",
+          "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=wildlife-package\">Wildlife package</a>",
+          "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=water-quality\">Water quality</a>",
+          "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=wildlife-package\">Wildlife package</a>"
+        ].join(", ")
+        assert_equal component_args["other"]["Funding (per unit per year)"],
+        "<a href=\"/countryside-stewardship-grants?funding_amount%5B%5D=more-than-500\">More than £500</a>"
+      end
+    end
+    test_meta("document_footer")
+    test_meta("metadata")
+  end
+
+  test "renders date facets correctly" do
+    setup_and_visit_content_item('drug-device-alerts')
 
     within shared_component_selector("document_footer") do
       component_args = JSON.parse(page.text)
-      history = component_args.fetch("history")
-      assert_equal history.first["note"], @content_item["details"]["change_history"].last["note"]
-      assert_equal history.last["note"], @content_item["details"]["change_history"].first["note"]
-      assert_equal history.size, @content_item["details"]["change_history"].size
+      assert_equal component_args["other_dates"]["Issued"], "6 July 2015"
+    end
+
+    within shared_component_selector("metadata") do
+      component_args = JSON.parse(page.text)
+      assert_equal component_args["other"]["Issued"], "6 July 2015"
+    end
+  end
+
+  test "renders when no facet or finder" do
+    setup_and_visit_content_item('business-finance-support-scheme')
+    assert_has_component_metadata_pair("first_published", "9 July 2015")
+
+    within shared_component_selector("document_footer") do
+      component_args = JSON.parse(page.text)
+      assert_equal component_args["other_dates"], {}
+    end
+
+    within shared_component_selector("metadata") do
+      component_args = JSON.parse(page.text)
+      assert_equal component_args["other"], {}
     end
   end
 

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -214,6 +214,16 @@ class SpecialistDocumentPresenterTest
       ], present_example(example_with_finder_facets).breadcrumbs
     end
 
+    test 'sends an Airbrake notification when there is no finder' do
+      example = schema_item('aaib-reports')
+      example['links']['finder'] = []
+
+      Airbrake.expects(:notify).with('Finder not found',
+        error_message: 'Finder not found in /aaib-reports/aaib-investigation-to-rotorsport-uk-calidus-g-pcpc content item')
+
+      present_example(example).metadata
+    end
+
     test 'no breadcrumbs render with no finder' do
       example = schema_item('aaib-reports')
       example['links']['finder'] = []

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -89,15 +89,16 @@ class SpecialistDocumentPresenterTest
       }.merge(overrides)
     end
 
-    test 'includes non-filterable facet as text in metadata' do
+    test 'includes non-filterable facet as text in metadata and document footer' do
       values = { "facet-key" => "document-value" }
       example = example_with_finder_facets([example_facet], values)
 
-      presented_metadata = present_example(example).metadata[:other]
-      assert_equal "document-value", presented_metadata["Facet name"]
+      presented = present_example(example)
+      assert_equal "document-value", presented.metadata[:other]["Facet name"]
+      assert_equal "document-value", presented.document_footer[:other]["Facet name"]
     end
 
-    test 'includes friendly label for facet value in metadata' do
+    test 'includes friendly label for facet value in metadata and document footer' do
       overrides = {
         "allowed_values" => [
           {
@@ -110,8 +111,9 @@ class SpecialistDocumentPresenterTest
       values = { "facet-key" => "document-value" }
       example = example_with_finder_facets([example_facet(overrides)], values)
 
-      presented_metadata = present_example(example).metadata[:other]
-      assert_equal "Document value from label", presented_metadata["Facet name"]
+      presented = present_example(example)
+      assert_equal "Document value from label", presented.metadata[:other]["Facet name"]
+      assert_equal "Document value from label", presented.document_footer[:other]["Facet name"]
     end
 
     test 'handles multiple values for facets' do
@@ -131,8 +133,9 @@ class SpecialistDocumentPresenterTest
       values = { "facet-key" => %w{one two} }
       example = example_with_finder_facets([example_facet(overrides)], values)
 
-      presented_metadata = present_example(example).metadata[:other]
-      assert_equal "One, Two", presented_metadata["Facet name"]
+      presented = present_example(example)
+      assert_equal "One, Two", presented.metadata[:other]["Facet name"]
+      assert_equal "One, Two", presented.document_footer[:other]["Facet name"]
     end
 
     test 'creates links for filterable friendly values' do
@@ -149,8 +152,10 @@ class SpecialistDocumentPresenterTest
       values = { "facet-key" => "something" }
       example = example_with_finder_facets([example_facet(overrides)], values)
 
-      presented_metadata = present_example(example).metadata[:other]
-      assert_equal "<a href=\"/finder-base-path?facet-key%5B%5D=something\">Something</a>", presented_metadata["Facet name"]
+      presented = present_example(example)
+      expected_link = "<a href=\"/finder-base-path?facet-key%5B%5D=something\">Something</a>"
+      assert_equal expected_link, presented.metadata[:other]["Facet name"]
+      assert_equal expected_link, presented.document_footer[:other]["Facet name"]
     end
 
     test 'includes friendly dates for date facets in metadata' do
@@ -159,6 +164,15 @@ class SpecialistDocumentPresenterTest
       example = example_with_finder_facets([example_facet(overrides)], values)
 
       presented_metadata = present_example(example).metadata[:other]
+      assert_equal "1 January 2010", presented_metadata["Facet name"]
+    end
+
+    test 'includes friendly dates in other_dates for date facets in document footer' do
+      overrides = { "type" => "date" }
+      values = { "facet-key" => "2010-01-01" }
+      example = example_with_finder_facets([example_facet(overrides)], values)
+
+      presented_metadata = present_example(example).document_footer[:other_dates]
       assert_equal "1 January 2010", presented_metadata["Facet name"]
     end
 

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -26,6 +26,31 @@ class SpecialistDocumentPresenterTest
       assert presented_item('aaib-reports').is_a?(ContentsList)
     end
 
+    test 'presents updates based on change history' do
+      example = schema_item('aaib-reports')
+      example["details"]["change_history"] = [
+        {
+          "note" => "First published",
+          "public_timestamp" => "2003-03-03"
+        }
+      ]
+
+      refute present_example(example).updated
+
+      example["details"]["change_history"] = [
+        {
+          "note" => "First published",
+          "public_timestamp" => "2003-03-03"
+        },
+        {
+          "note" => "Modified since first published",
+          "public_timestamp" => "2013-04-05"
+        }
+      ]
+
+      assert present_example(example).updated
+    end
+
     test 'presents the published date using the oldest date in the change history' do
       example = schema_item('aaib-reports')
       example["first_published_at"] = "2001-01-01"

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -141,6 +141,27 @@ class SpecialistDocumentPresenterTest
       assert_equal "Document value from label", presented.document_footer[:other]["Facet name"]
     end
 
+    test 'falls back to provided value if value not found in allowed list' do
+      overrides = {
+        "allowed_values" => [
+          {
+            "label" => "Document value from label",
+            "value" => "document-value"
+          }
+        ]
+      }
+
+      values = { "facet-key" => "not-an-allowed-value" }
+      example = example_with_finder_facets([example_facet(overrides)], values)
+
+      Airbrake.expects(:notify).twice.with('Facet value not in list of allowed values',
+        error_message: "Facet value 'not-an-allowed-value' not an allowed value for facet 'Facet name' on /aaib-reports/aaib-investigation-to-rotorsport-uk-calidus-g-pcpc content item")
+
+      presented = present_example(example)
+      assert_equal "not-an-allowed-value", presented.metadata[:other]["Facet name"]
+      assert_equal "not-an-allowed-value", presented.document_footer[:other]["Facet name"]
+    end
+
     test 'handles multiple values for facets' do
       overrides = {
         "allowed_values" => [

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -58,4 +58,108 @@ class SpecialistDocumentPresenterTest
       assert_equal title_component_params, presented_item('aaib-reports').title_and_context
     end
   end
+
+  class PresentedSpecialistDocumentWithFinderFacets < SpecialistDocumentTestCase
+    def example_with_finder_facets(facets = [], values = {})
+      example = schema_item('aaib-reports')
+      example_finder = {
+        "base_path" => "/finder-base-path",
+        "title" => "Finder title",
+        "details" => {
+          "document_noun" => "case",
+          "filter" => {
+            "document_type" => "cma_case"
+          },
+          "format_name" => "Competition and Markets Authority case",
+          "facets" => facets,
+        },
+      }
+
+      example['details']['metadata'] = values
+      example['links']['finder'] = [example_finder]
+      example
+    end
+
+    def example_facet(overrides = {})
+      {
+        "name" => "Facet name",
+        "key" => "facet-key",
+        "type" => "text",
+        "filterable" => false
+      }.merge(overrides)
+    end
+
+    test 'includes non-filterable facet as text in metadata' do
+      values = { "facet-key" => "document-value" }
+      example = example_with_finder_facets([example_facet], values)
+
+      presented_metadata = present_example(example).metadata[:other]
+      assert_equal "document-value", presented_metadata["Facet name"]
+    end
+
+    test 'includes friendly label for facet value in metadata' do
+      overrides = {
+        "allowed_values" => [
+          {
+            "label" => "Document value from label",
+            "value" => "document-value"
+          }
+        ]
+      }
+
+      values = { "facet-key" => "document-value" }
+      example = example_with_finder_facets([example_facet(overrides)], values)
+
+      presented_metadata = present_example(example).metadata[:other]
+      assert_equal "Document value from label", presented_metadata["Facet name"]
+    end
+
+    test 'handles multiple values for facets' do
+      overrides = {
+        "allowed_values" => [
+          {
+            "label" => "One",
+            "value" => "one"
+          },
+          {
+            "label" => "Two",
+            "value" => "two"
+          }
+        ]
+      }
+
+      values = { "facet-key" => %w{one two} }
+      example = example_with_finder_facets([example_facet(overrides)], values)
+
+      presented_metadata = present_example(example).metadata[:other]
+      assert_equal "One, Two", presented_metadata["Facet name"]
+    end
+
+    test 'creates links for filterable friendly values' do
+      overrides = {
+        "filterable" => true,
+        "allowed_values" => [
+          {
+            "label" => "Something",
+            "value" => "something"
+          }
+        ]
+      }
+
+      values = { "facet-key" => "something" }
+      example = example_with_finder_facets([example_facet(overrides)], values)
+
+      presented_metadata = present_example(example).metadata[:other]
+      assert_equal "<a href=\"/finder-base-path?facet-key%5B%5D=something\">Something</a>", presented_metadata["Facet name"]
+    end
+
+    test 'includes friendly dates for date facets in metadata' do
+      overrides = { "type" => "date" }
+      values = { "facet-key" => "2010-01-01" }
+      example = example_with_finder_facets([example_facet(overrides)], values)
+
+      presented_metadata = present_example(example).metadata[:other]
+      assert_equal "1 January 2010", presented_metadata["Facet name"]
+    end
+  end
 end

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -162,6 +162,15 @@ class SpecialistDocumentPresenterTest
       assert_equal "not-an-allowed-value", presented.document_footer[:other]["Facet name"]
     end
 
+    test 'ignores facets in metadata if not a valid finder facet' do
+      values = { "random-invalid-facet" => "something-odd" }
+      example = example_with_finder_facets([example_facet], values)
+
+      presented = present_example(example)
+      assert_empty presented.metadata[:other]
+      assert_empty presented.document_footer[:other]
+    end
+
     test 'handles multiple values for facets' do
       overrides = {
         "allowed_values" => [

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -161,5 +161,27 @@ class SpecialistDocumentPresenterTest
       presented_metadata = present_example(example).metadata[:other]
       assert_equal "1 January 2010", presented_metadata["Facet name"]
     end
+
+    test 'breadcrumbs' do
+      assert_equal [
+        {
+          title: "Home",
+          url: "/"
+        },
+        {
+          title: "Finder title",
+          url: "/finder-base-path"
+        }
+      ], present_example(example_with_finder_facets).breadcrumbs
+    end
+
+    test 'no breadcrumbs render with no finder' do
+      example = schema_item('aaib-reports')
+      example['links']['finder'] = []
+      assert_equal [], present_example(example).breadcrumbs
+
+      example['links'].delete('finder')
+      assert_equal [], present_example(example).breadcrumbs
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/al2fPH5p/192-1-render-missing-finder-metadata-in-government-frontend

* Add facet values to metadata and document footer now they're provided by the finder in the links hash. Assumes that all possible facet values could be multiple and so normalizes values as an array before working with them. Multiple values get joined with a comma.
* Add custom breadcrumb based on finder
* Fix logic for display of `updated` field in metadata and footer
* Sends Airbrake notifications when missing finder or forbidden facet value found
* The random content generator doesn't create random facets and values

### How facets display in metadata
| Facet type | Allowed values | Filterable | Displays |
|--|--|--|--|
| Text | True | True | Shows the allowed value labels with links to the filtered results
| Text | True | False | Shows the allowed value labels, no links
| Text | False | - | Shows the provided text directly, never linked
| Date | - | - | Shows a friendly date, never linked

## Screenshots
| Feature | Old | New |
|--|--|--|
| Metadata | ![screen shot 2017-04-13 at 12 30 38](https://cloud.githubusercontent.com/assets/319055/25002995/2656350a-2045-11e7-8cfa-eb745008efd9.png) | ![screen shot 2017-04-13 at 12 30 23](https://cloud.githubusercontent.com/assets/319055/25002999/2acb3cca-2045-11e7-94af-8663c9eb522f.png) |
| Document footer | ![screen shot 2017-04-13 at 12 30 52](https://cloud.githubusercontent.com/assets/319055/25003009/33b04074-2045-11e7-806f-1f86460a4eba.png) | ![screen shot 2017-04-13 at 12 30 45](https://cloud.githubusercontent.com/assets/319055/25003015/386d200a-2045-11e7-9224-bb33ae312d22.png) |



