### PR TITLE
Splits ISBN into print ISBN and web ISBN

### DIFF
--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -17,6 +17,10 @@ class HtmlPublicationPresenter < ContentItemPresenter
     content_item["details"]["isbn"]
   end
 
+  def web_isbn
+    content_item["details"]["web_isbn"]
+  end
+
   def print_meta_data_contact_address
     content_item["details"]["print_meta_data_contact_address"]
   end

--- a/app/views/content_items/html_publication/_print_meta_data.html.erb
+++ b/app/views/content_items/html_publication/_print_meta_data.html.erb
@@ -22,6 +22,12 @@
 
 <% unless @content_item.isbn.blank? %>
     <p>
-      Web ISBN: <%= @content_item.isbn %>
+      Print ISBN: <%= @content_item.isbn %>
+    </p>
+<% end %>
+
+<% unless @content_item.web_isbn.blank? %>
+    <p>
+      Web ISBN: <%= @content_item.web_isbn %>
     </p>
 <% end %>

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -36,7 +36,8 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       assert page.has_no_text?("© Crown copyright #{@content_item['details']['public_timestamp'].to_date.year}")
       assert page.has_no_text?("Any enquiries regarding this publication should be sent to us at:")
       assert page.has_no_text?((@content_item['details']['print_meta_data_contact_address']).to_s)
-      assert page.has_no_text?("Web ISBN: #{@content_item['details']['isbn']}")
+      assert page.has_no_text?("Print ISBN: #{@content_item['details']['isbn']}")
+      assert page.has_no_text?("Web ISBN: #{@content_item['details']['web_isbn']}")
     end
   end
 
@@ -49,7 +50,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       assert page.has_text?("© Crown copyright #{@content_item['details']['public_timestamp'].to_date.year}")
       assert page.has_text?("Any enquiries regarding this publication should be sent to us at:")
       assert page.has_text?((@content_item['details']['print_meta_data_contact_address']).to_s)
-      assert page.has_text?("Web ISBN: #{@content_item['details']['isbn']}")
+      assert page.has_text?("Print ISBN: #{@content_item['details']['isbn']}")
     end
   end
 

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -15,6 +15,7 @@ class HtmlPublicationPresenterTest < PresenterTestCase
 
   test 'presents the meta data info of a content item' do
     assert_equal schema_item("print_with_meta_data")['details']['isbn'], presented_item("print_with_meta_data").isbn
+    assert_equal schema_item("print_with_meta_data")['details']['web_isbn'], presented_item("print_with_meta_data").web_isbn
     assert_equal schema_item("print_with_meta_data")['details']['print_meta_data_contact_address'], presented_item("print_with_meta_data").print_meta_data_contact_address
   end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/OEZIdXTE/135-separate-file-attachment-form-and-html-attachment-form)

Depends on: 
https://github.com/alphagov/whitehall/pull/3170
https://github.com/alphagov/govuk-content-schemas/pull/607

## Background
It was pointed out that the "ISBN (web version)" field is showing up not only in the HTML Attachments form, but also in the File Attachments form. This is becoming confusing to people, as they were entering the Print ISBN in that field. The two forms will now show different content. 

## What this does
This PR will separate the "ISBN (web version)" field into "Print ISBN" and "Web ISBN". 
Both fields are optional and will appear (if present) when an HTML publication is printed.

## UI

<img width="999" alt="screen shot 2017-04-18 at 15 36 30" src="https://cloud.githubusercontent.com/assets/1354439/25136449/e5463ea0-244c-11e7-8015-c776a710abc3.png">