### PR TITLE
Add Access-Control-Allow-Origin header to TA country pages

### DIFF
--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -1,4 +1,7 @@
 class TravelAdviceController < ContentItemsController
+  after_action :set_access_control_allow_origin_header,
+    only: :show, if: ->(controller) { controller.request.format.atom? }
+
 private
 
   def present(content_item)
@@ -15,5 +18,9 @@ private
 
   def content_item_path
     "/foreign-travel-advice/#{URI.encode(params[:country])}"
+  end
+
+  def set_access_control_allow_origin_header
+    response.headers["Access-Control-Allow-Origin"] = "*"
   end
 end

--- a/test/controllers/travel_advice_controller_test.rb
+++ b/test/controllers/travel_advice_controller_test.rb
@@ -34,4 +34,12 @@ class TravelAdviceControllerTest < ActionController::TestCase
 
     assert_equal part_slug, assigns[:content_item].part_slug
   end
+
+  test "sets the Access-Control-Allow-Origin header to atom feed" do
+    content_item = content_store_has_schema_example('travel_advice', 'full-country')
+    part_slug = content_item['details']['parts'][0]['slug']
+    get :show, params: { country: 'albania', part: part_slug, format: 'atom' }
+
+    assert_equal response.headers["Access-Control-Allow-Origin"], "*"
+  end
 end


### PR DESCRIPTION
https://trello.com/c/SEGfmX1v/912-1935680-enable-access-control-allow-origin-header-in-rss-feeds

Allow users to call the data in the Travel Advice atom feed via an AJAX request.
See https://govuk.zendesk.com/agent/tickets/1935680
and https://github.com/alphagov/frontend/pull/1210