### PR TITLE
Move Access-Control-Allow-Origin header into parent controller

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -11,6 +11,7 @@ class ContentItemsController < ApplicationController
     load_content_item
     set_up_education_navigation_ab_testing
     set_expiry
+    set_access_control_allow_origin_header if request.format.atom?
     render_template
   end
 
@@ -39,6 +40,10 @@ private
     with_locale do
       render content_item_template
     end
+  end
+
+  def set_access_control_allow_origin_header
+    response.headers["Access-Control-Allow-Origin"] = "*"
   end
 
   def set_expiry

--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -1,6 +1,4 @@
 class TravelAdviceController < ContentItemsController
-  after_action :set_access_control_allow_origin_header,
-    only: :show, if: ->(controller) { controller.request.format.atom? }
 
 private
 
@@ -18,9 +16,5 @@ private
 
   def content_item_path
     "/foreign-travel-advice/#{URI.encode(params[:country])}"
-  end
-
-  def set_access_control_allow_origin_header
-    response.headers["Access-Control-Allow-Origin"] = "*"
   end
 end

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -234,6 +234,13 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_response_not_modified_for_ab_test('EducationNavigation')
   end
 
+  test "sets the Access-Control-Allow-Origin header for atom pages" do
+    content_store_has_schema_example('travel_advice', 'full-country')
+    get :show, params: { path: 'foreign-travel-advice/albania', format: 'atom' }
+
+    assert_equal response.headers["Access-Control-Allow-Origin"], "*"
+  end
+
   def path_for(content_item, locale = nil)
     base_path = content_item['base_path'].sub(/^\//, '')
     base_path.gsub!(/\.#{locale}$/, '') if locale

--- a/test/controllers/travel_advice_controller_test.rb
+++ b/test/controllers/travel_advice_controller_test.rb
@@ -35,6 +35,8 @@ class TravelAdviceControllerTest < ActionController::TestCase
     assert_equal part_slug, assigns[:content_item].part_slug
   end
 
+  # This is a duplicate test to one in content_items_controller_test.rb to
+  # cover the additional route GET /foreign-travel-advice/:country/:part(.:format) travel_advice#show
   test "sets the Access-Control-Allow-Origin header to atom feed" do
     content_item = content_store_has_schema_example('travel_advice', 'full-country')
     part_slug = content_item['details']['parts'][0]['slug']


### PR DESCRIPTION
An update to https://github.com/alphagov/government-frontend/pull/326
We should add this header for all atom pages served by government-frontend
so move the logic into the parent ContentItemsController.