### PR TITLE
Render nested contents for specialist documents

### DIFF
--- a/app/assets/stylesheets/helpers/_dash-list.scss
+++ b/app/assets/stylesheets/helpers/_dash-list.scss
@@ -2,20 +2,20 @@
   margin-bottom: $gutter-two-thirds;
 
   li {
-    list-style-type: disc;
-    margin-left: $gutter-half;
-    padding-right: $gutter-half;
+    margin-left: $gutter-half + 5;
+    padding-right: $gutter-half + 5;
     padding-top: $gutter / 6;
+    list-style-type: disc;
 
-    @media (min-width: 1px) { // target modern browsers
+    @supports (content: "—") {
       list-style-type: none;
 
       &:before {
-        content: "-";
+        content: "— ";
         position: relative;
         float: left;
-        width: $gutter-half;
-        margin-left: $gutter-half * -1;
+        width: $gutter-half + 5;
+        margin-left: -($gutter-half + 5);
       }
     }
   }

--- a/app/assets/stylesheets/helpers/_dash-list.scss
+++ b/app/assets/stylesheets/helpers/_dash-list.scss
@@ -20,6 +20,21 @@
     }
   }
 
+  // When nesting contents lists, the top level items have no
+  // list marker and are styled in bold
+  .nested-contents-item-h2 {
+    margin-left: 0;
+    list-style-type: none;
+
+    &:before {
+      content: '';
+    }
+  }
+
+  .nested-contents-link-h2 {
+    font-weight: bold;
+  }
+
   // Remove underlines from lists of links
   // to improve legibility
   a {

--- a/app/helpers/typography_helper.rb
+++ b/app/helpers/typography_helper.rb
@@ -4,4 +4,8 @@ module TypographyHelper
     escaped_text = html_escape_once(text.strip)
     escaped_text.sub(/\s([\w\.\?\!]+)$/, '&nbsp;\1').html_safe
   end
+
+  def strip_trailing_colons(text)
+    text.gsub(/\:$/, '')
+  end
 end

--- a/app/presenters/contents_list.rb
+++ b/app/presenters/contents_list.rb
@@ -1,5 +1,6 @@
 module ContentsList
   include ActionView::Helpers::UrlHelper
+  include TypographyHelper
 
   def contents
     contents_items.map do |item|
@@ -30,9 +31,5 @@ private
       { text: strip_trailing_colons(heading.text), id: id.value } if id
     end
     headings.compact
-  end
-
-  def strip_trailing_colons(heading)
-    heading.gsub(/\:$/, '')
   end
 end

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -1,12 +1,15 @@
 class SpecialistDocumentPresenter < ContentItemPresenter
   include Updatable
   include Linkable
-  include ContentsList
   include TitleAndContext
   include Metadata
 
   def body
     content_item["details"]["body"]
+  end
+
+  def nested_contents
+    content_item["details"]["headers"] || []
   end
 
   def title_and_context

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -8,12 +8,17 @@
 <%= render 'shared/description', description: @content_item.description %>
 
 <div class="grid-row sidebar-with-body">
-  <% if @content_item.contents.any? %>
+  <% if @content_item.nested_contents.any? %>
     <div class="column-third">
-      <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
+      <nav role="navigation">
+        <h2><%= t("content_item.contents") %></h2>
+        <ol class="dash-list" data-module="track-click">
+          <%= render 'shared/nested_content_item', headings: @content_item.nested_contents %>
+        </ol>
+      </nav>
     </div>
   <% end %>
-  <div class="column-two-thirds <% unless @content_item.contents.any? %>offset-one-third<% end %>">
+  <div class="column-two-thirds <% unless @content_item.nested_contents.any? %>offset-one-third<% end %>">
     <%= render 'govuk_component/govspeak',
         content: @content_item.body,
         direction: page_text_direction %>

--- a/app/views/shared/_nested_content_item.html.erb
+++ b/app/views/shared/_nested_content_item.html.erb
@@ -1,0 +1,18 @@
+<% heading_level ||= 2 %>
+<% headings.each do |heading| %>
+  <li class="nested-contents-item-h<%= heading_level %>">
+    <a
+      class="nested-contents-link-h<%= heading_level %>"
+      href="#<%= heading['id']%>"
+      data-track-category="contentsClicked"
+      data-track-action="leftColumnH<%= heading_level %>"
+      data-track-label="<%= heading['id']%>">
+      <%= strip_trailing_colons(heading['text']) %>
+    </a>
+    <% if heading['headers'].present? && heading_level < 3 %>
+      <ol>
+        <%= render 'shared/nested_content_item', headings: heading['headers'], heading_level: heading_level + 1 %>
+      </ol>
+    <% end %>
+   </li>
+ <% end %>

--- a/app/views/shared/_sidebar_contents.html.erb
+++ b/app/views/shared/_sidebar_contents.html.erb
@@ -1,6 +1,6 @@
 <% if contents.any? %>
   <nav role="navigation">
-    <h1><%= t("content_item.contents") %></h1>
+    <h2><%= t("content_item.contents") %></h2>
     <ol class="dash-list" data-module="track-click">
       <% contents.each do |heading| %>
         <li>

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -22,8 +22,9 @@ class SpecialistDocumentPresenterTest
       assert presented_item('aaib-reports').is_a?(Metadata)
     end
 
-    test 'has contents list' do
-      assert presented_item('aaib-reports').is_a?(ContentsList)
+    test 'presents headers as nested contents' do
+      expected_headers = schema_item('aaib-reports')['details']['headers']
+      assert_equal expected_headers, presented_item('aaib-reports').nested_contents
     end
 
     test 'presents updates based on change history' do


### PR DESCRIPTION
https://trello.com/c/phs722pV/186-1-add-new-contents-list

* Use an em dash for all contents lists
* Include a two level contents list (based on h2s and h3s)
* Style the h2s without a list marker and in bold
* h3s appear like standard contents lists
* h4s and further, although appearing in the `headers` hash are not displayed – at this level the contents list stops being useful
* Markup mostly ported from specialist-frontend
* Move strip_trailing_colons into shared helper

| Nested | Normal |
|--|--|
|![screen shot 2017-04-19 at 11 24 55](https://cloud.githubusercontent.com/assets/319055/25177735/e26b741c-24fa-11e7-947e-89771ee545ea.png)|![screen shot 2017-04-19 at 11 25 00](https://cloud.githubusercontent.com/assets/319055/25177736/e285ba66-24fa-11e7-86e9-c60358e98aa9.png)|

On older browsers that don't support `content: ` or `@supports`:
![screen shot 2017-04-19 at 12 51 12](https://cloud.githubusercontent.com/assets/319055/25178755/1a678d84-24ff-11e7-91c8-ea2c69fb98cc.png)
