### PR TITLE
[Do not merge] Add schema name analytics meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ the government-frontend repository then run the tests with:
 
 `bundle exec rake`
 
+To test a specific file you can run (for example content_item_test):
+
+`bundle exec rake test TEST=test/integration/content_item_test.rb`
+
 Or to specify the location explicitly:
 
 `GOVUK_CONTENT_SCHEMAS_PATH=/some/dir/govuk-content-schemas bundle exec rake`

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,7 +1,7 @@
 class ContentItemPresenter
   include Withdrawable
 
-  attr_reader :content_item, :base_path, :title, :description, :format, :locale, :phase, :document_type
+  attr_reader :content_item, :base_path, :title, :description, :format, :locale, :phase, :document_type, :schema_name
 
   def initialize(content_item)
     @content_item = content_item
@@ -9,6 +9,7 @@ class ContentItemPresenter
     @title = content_item["title"]
     @description = content_item["description"]
     @format = content_item["schema_name"]
+    @schema_name = content_item["schema_name"]
     @locale = content_item["locale"] || "en"
     @phase = content_item["phase"]
     @document_type = content_item["document_type"]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
   <% if @content_item.description %>
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
+  <meta name="govuk:schema-name" content="<%= @content_item.schema_name %>" />
   <meta name="govuk:content-id" content="<%= @content_item.content_id %>" />
   <%= @education_navigation_ab_test.analytics_meta_tag.html_safe if @education_navigation_ab_test.ab_test_applies? %>
   <%= yield :extra_head_content %>

--- a/test/integration/content_item_test.rb
+++ b/test/integration/content_item_test.rb
@@ -16,13 +16,12 @@ class ContentItemTest < ActionDispatch::IntegrationTest
     result
   end
 
-  test "content id" do
+  test "meta tags include content-id" do
     test_examples.each do |format, example|
       define_singleton_method("schema_format") { format }
 
       setup_and_visit_content_item(example)
-      has_component_metadata("name", "govuk:content-id")
-      has_component_metadata("content", @content_item["content_id"])
+      has_component_meta_tag("name", "govuk:content-id", @content_item["content_id"])
     end
   end
 end

--- a/test/integration/content_item_test.rb
+++ b/test/integration/content_item_test.rb
@@ -24,4 +24,13 @@ class ContentItemTest < ActionDispatch::IntegrationTest
       has_component_meta_tag("name", "govuk:content-id", @content_item["content_id"])
     end
   end
+
+  test "meta tags include schema-name" do
+    test_examples.each do |format, example|
+      define_singleton_method("schema_format") { format }
+
+      setup_and_visit_content_item(example)
+      has_component_meta_tag("name", "govuk:schema-name", @content_item["schema_name"])
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -111,8 +111,8 @@ class ActionDispatch::IntegrationTest
     end
   end
 
-  def has_component_metadata(key, value)
-    assert page.has_css? "meta[#{key}=\"#{value}\"]", visible: false
+  def has_component_meta_tag(key, value, content)
+    assert page.has_css? "meta[#{key}=\"#{value}\"][content=\"#{content}\"]", visible: false
   end
 
   def setup_and_visit_content_item(name, print = false)


### PR DESCRIPTION
At the moment, we track the format but the way government-frontend chooses
to render a page is based on the schema_name, this means using the format will
result in duplication of testing, and when testing is slow with visual
regression testing we want to test quickly as possible.

This relies on some upstream changes in Static so that we can add this meta tag against a dimension.