### PR TITLE
Adds SRI

### DIFF
--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -1,7 +1,7 @@
 <%- if params[:medium] == 'print' %>
-  <%= stylesheet_link_tag "print.css", :media => "screen" %>
+  <%= stylesheet_link_tag "print.css", :media => "screen", integrity: true, crossorigin: "anonymous" %>
 <%- else %>
-  <%= stylesheet_link_tag "print.css", :media => "print" %>
+  <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: "anonymous" %>
 <%- end %>
 
 <%

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title><%= yield :title %> - GOV.UK</title>
-  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application" %><!--<![endif]-->
+  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: true, crossorigin: "anonymous" %><!--<![endif]-->
   <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><script>var ieVersion = 6;</script><![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><script>var ieVersion = 7;</script><![endif]-->
   <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><script>var ieVersion = 8;</script><![endif]-->
-  <%= javascript_include_tag "application" %>
+  <%= javascript_include_tag "application", integrity: true, crossorigin: "anonymous" %>
   <%= csrf_meta_tags %>
   <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item.content_item } %>
   <% if @content_item.description %>

--- a/app/views/shared/_webchat.html.erb
+++ b/app/views/shared/_webchat.html.erb
@@ -16,4 +16,4 @@
   </span>
 </span>
 <% # This is inline in the source however slimmer will optimize this. %>
-<%= javascript_include_tag "webchat" %>
+<%= javascript_include_tag "webchat", integrity: true, crossorigin: "anonymous" %>


### PR DESCRIPTION
[Trello card](https://trello.com/c/oFhtO0Gm/146-enable-subresource-integrity-sri-on-government-frontend-l)

This will add security checks to verify that the content being served on GOV.UK hasn't been modified by third parties:

- adds sprockets-rails so we can use the SRI check feature
- adds `integrity: true` to javascript_include_tag and stylesheet_link_tag

Depends on:

- static: https://github.com/alphagov/static/pull/1008
- govuk_template: https://github.com/alphagov/govuk_template/pull/294

In order to use SRI, the browser expects CORS to be supported. This is why we need to add `crossorigin: true` alongside `integrity: true`. See more [here](https://hacks.mozilla.org/2015/09/subresource-integrity-in-firefox-43/)