### PR TITLE
Don't render description when there isn't one

### DIFF
--- a/app/views/shared/_description.html.erb
+++ b/app/views/shared/_description.html.erb
@@ -1,3 +1,5 @@
-<p class="description">
-  <%= nbsp_between_last_two_words(description) %>
-</p>
+<% if description.present? %>
+  <p class="description">
+    <%= nbsp_between_last_two_words(description) %>
+  </p>
+<% end %>


### PR DESCRIPTION
Avoid printing an empty paragraph when there is no description.
* Some specialist documents have no description
* Description is required, but it can be an empty string

Live example:
https://www.gov.uk/aaib-reports/vans-rv-9a-g-cdmf-2-september-2007

## Before
![screen shot 2017-04-24 at 16 51 16](https://cloud.githubusercontent.com/assets/319055/25345998/527df6c8-290e-11e7-96a9-4bad201a182a.png)

## After
![screen shot 2017-04-24 at 16 51 24](https://cloud.githubusercontent.com/assets/319055/25345999/5286b02e-290e-11e7-9124-bacf50f2699c.png)
