### PR TITLE
Tweak specialist documents to match specialist-frontend rendering

### DIFF
--- a/app/assets/stylesheets/views/_specialist-document.scss
+++ b/app/assets/stylesheets/views/_specialist-document.scss
@@ -1,4 +1,11 @@
 .specialist-document {
   @include description;
   @include sidebar-with-body;
+
+  // FIXME: Remove when metadata component design is improved
+  // https://trello.com/c/2pik3I0j/
+  // Metadata hack ported from specialist-frontend
+  .govuk-metadata dt {
+    min-width: 134px;
+  }
 }

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -21,7 +21,7 @@ class SpecialistDocumentPresenter < ContentItemPresenter
   def metadata
     super.tap do |m|
       facets_with_values.each do |facet|
-        m[:other][facet['name']] = join_facets(facet)
+        m[:other][facet['name']] = value_or_array_of_values(facet['values'])
       end
     end
   end
@@ -31,7 +31,7 @@ class SpecialistDocumentPresenter < ContentItemPresenter
       m[:other_dates] = {}
       facets_with_values.each do |facet|
         type = facet['type'] == 'date' ? :other_dates : :other
-        m[type][facet['name']] = join_facets(facet)
+        m[type][facet['name']] = value_or_array_of_values(facet['values'])
       end
     end
   end
@@ -67,8 +67,8 @@ class SpecialistDocumentPresenter < ContentItemPresenter
 
 private
 
-  def join_facets(facet)
-    facet['values'].join(', ')
+  def value_or_array_of_values(values)
+    values.length == 1 ? values.first : values
   end
 
   # Finder is a required link that must have 1 item

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -95,7 +95,7 @@ private
     return [] unless facets && facet_values.any?
     only_facets_with_values = facets.select { |f| facet_values[f['key']] }
 
-    only_facets_with_values.map do |facet|
+    only_facets_with_values.sort_by { |facet| facet['type'] }.map do |facet|
       facet_key = facet['key']
       # Cast all values into an array
       values = [facet_values[facet_key]].flatten

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -50,21 +50,23 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('countryside-stewardship-grants')
 
     def test_meta(component)
+      tiers = [
+        "<a href=\"/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=higher-tier\">Higher Tier</a>",
+        "<a href=\"/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=mid-tier\">Mid Tier</a>"
+      ]
+
+      land_use = [
+        "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=arable-land\">Arable land</a>",
+        "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=wildlife-package\">Wildlife package</a>",
+        "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=water-quality\">Water quality</a>",
+        "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=wildlife-package\">Wildlife package</a>"
+      ]
+
       within shared_component_selector(component) do
         component_args = JSON.parse(page.text)
         assert_equal component_args["other"]["Grant type"], "<a href=\"/countryside-stewardship-grants?grant_type%5B%5D=option\">Option</a>"
-        assert_equal component_args["other"]["Tiers or standalone items"],
-        [
-          "<a href=\"/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=higher-tier\">Higher Tier</a>",
-          "<a href=\"/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=mid-tier\">Mid Tier</a>"
-        ].join(", ")
-        assert_equal component_args["other"]["Land use"],
-        [
-          "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=arable-land\">Arable land</a>",
-          "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=wildlife-package\">Wildlife package</a>",
-          "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=water-quality\">Water quality</a>",
-          "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=wildlife-package\">Wildlife package</a>"
-        ].join(", ")
+        assert_equal component_args["other"]["Tiers or standalone items"], tiers
+        assert_equal component_args["other"]["Land use"], land_use
         assert_equal component_args["other"]["Funding (per unit per year)"],
         "<a href=\"/countryside-stewardship-grants?funding_amount%5B%5D=more-than-500\">More than £500</a>"
       end

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -254,6 +254,39 @@ class SpecialistDocumentPresenterTest
       assert_equal "1 January 2010", presented_metadata["Facet name"]
     end
 
+    test 'puts date facets together and before text facets' do
+      example = example_with_finder_facets([
+                                            {
+                                              "name" => "Facet name",
+                                              "key" => "facet-key",
+                                              "type" => "text",
+                                            },
+                                            {
+                                              "name" => "First date facet",
+                                              "key" => "first-date-facet",
+                                              "type" => "date",
+                                            },
+                                            {
+                                              "name" => "Second date facet",
+                                              "key" => "second-date-facet",
+                                              "type" => "date",
+                                            },
+                                            {
+                                              "name" => "More text",
+                                              "key" => "more-text",
+                                              "type" => "text",
+                                            }
+                                          ],
+                                            "facet-key" => "Text",
+                                            "first-date-facet" => "2010-01-01",
+                                            "second-date-facet" => "2010-02-03",
+                                            "more-text" => "More text"
+                                        )
+
+      expected_order = ["First date facet", "Second date facet", "Facet name", "More text"]
+      assert_equal expected_order, present_example(example).metadata[:other].keys
+    end
+
     test 'breadcrumbs' do
       assert_equal [
         {

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -194,7 +194,7 @@ class SpecialistDocumentPresenterTest
       assert_empty presented.document_footer[:other]
     end
 
-    test 'handles multiple values for facets' do
+    test 'passes array of multiple values to metadata and document_footer components' do
       overrides = {
         "allowed_values" => [
           {
@@ -212,8 +212,8 @@ class SpecialistDocumentPresenterTest
       example = example_with_finder_facets([example_facet(overrides)], values)
 
       presented = present_example(example)
-      assert_equal "One, Two", presented.metadata[:other]["Facet name"]
-      assert_equal "One, Two", presented.document_footer[:other]["Facet name"]
+      assert_equal %w{One Two}, presented.metadata[:other]["Facet name"]
+      assert_equal %w{One Two}, presented.document_footer[:other]["Facet name"]
     end
 
     test 'creates links for filterable friendly values' do

--- a/test/wraith/config.yaml
+++ b/test/wraith/config.yaml
@@ -33,22 +33,23 @@ domains:
 
 # (required) The paths to capture.
 paths:
-  # Most visited Answers (19th April 2017)
-  answers0: '/national-minimum-wage-rates'
-  answers1: '/apply-uk-visa'
-  answers2: '/when-is-your-next-tax-credits-payment'
-  answers3: '/benefits-calculators'
-  answers4: '/apply-apprenticeship'
-  answers5: '/contact-hmrc'
-  answers6: '/dvla-change-address'
-  answers7: '/passport-fees'
-  answers8: '/vehicle-tax-refund'
-  answers9: '/car-tax-disc-without-v11-reminder'
+  # Most visited Answers (19 April 2017)
+  answers_0: '/national-minimum-wage-rates'
+  answers_1: '/apply-uk-visa'
+  answers_2: '/when-is-your-next-tax-credits-payment'
+  answers_3: '/benefits-calculators'
+  answers_4: '/apply-apprenticeship'
+  answers_5: '/contact-hmrc'
+  answers_6: '/dvla-change-address'
+  answers_7: '/passport-fees'
+  answers_8: '/vehicle-tax-refund'
+  answers_9: '/car-tax-disc-without-v11-reminder'
 
   case_study: '/government/case-studies/get-britain-building-carlisle-park'
   case_study_translated: '/government/case-studies/doing-business-in-spain.es'
   case_study_withdrawn: '/government/case-studies/terence-age-33-stoke-on-trent'
-  # Most visited case_study pages (2nd September 2016)
+
+  # Most visited case_study pages (2 September 2016)
   case_study_1: '/government/case-studies/ww1-canadian-vc-recipient-charles-smith-rutherford'
   case_study_2: '/government/case-studies/the-expert-patients-programme'
   case_study_3: '/government/case-studies/case-study-darwin-initiative-main-round-project'
@@ -73,18 +74,63 @@ paths:
   contact_10: /government/organisations/hm-revenue-customs/contact/welsh-language-helpline-for-debt-management
 
   # Most popular from https://docs.publishing.service.gov.uk/document-types/help+page.html (19 april 2017)
-  help_pages0: '/help/cookies'
-  help_pages1: '/help/accessibility'
-  help_pages2: '/help/browsers'
-  help_pages3: '/help/terms-conditions'
-  help_pages4: '/help/beta'
-  help_pages5: '/help/privacy-policy'
-  help_pages6: '/help/about-govuk'
-  help_pages7: '/help/update-email-notifications'
+  help_page_0: '/help/cookies'
+  help_page_1: '/help/accessibility'
+  help_page_2: '/help/browsers'
+  help_page_3: '/help/terms-conditions'
+  help_page_4: '/help/beta'
+  help_page_5: '/help/privacy-policy'
+  help_page_6: '/help/about-govuk'
+  help_page_7: '/help/update-email-notifications'
+
+  # Most popular specialist docs (25 April 2017)
+  specialist_document_1: /business-finance-support/start-up-loans-uk
+  specialist_document_2: /drug-device-alerts/class-2-medicines-recall-diclo-sr-75-tablets-diclofenac-sodium
+  specialist_document_3: /drug-device-alerts/field-safety-notice-27-march-to-31-march-2017
+  specialist_document_4: /drug-device-alerts/field-safety-notice-03-april-to-07-april-2017
+  specialist_document_5: /drug-device-alerts/field-safety-notices-20-march-24-march-2017
+  specialist_document_6: /maib-reports/accidents-on-board-yacht-cv21-resulting-in-loss-of-2-lives
+  specialist_document_7: /drug-safety-update/sglt2-inhibitors-updated-advice-on-increased-risk-of-lower-limb-amputation-mainly-toes
+  specialist_document_8: /drug-device-alerts/field-safety-notice-10-april-to-14-april-2017
+  specialist_document_9: /cma-cases/digital-comparison-tools-market-study
+  specialist_document_10: /cma-cases/review-of-banking-for-small-and-medium-sized-businesses-smes-in-the-uk
+
+  # Top 2 specialist docs for each specialist document type, excluding those above (25 April 2017)
+  specialist_document_11: /drug-safety-update/paracetamol-updated-dosing-for-children-to-be-introduced
+  specialist_document_12: /drug-safety-update/hyoscine-butylbromide-buscopan-injection-risk-of-serious-adverse-effects-in-patients-with-underlying-cardiac-disease
+  specialist_document_13: /international-development-funding/uk-aid-match
+  specialist_document_14: /international-development-funding/uk-aid-direct
+  specialist_document_15: /aaib-reports/aircraft-accident-report-aar-1-2017-g-bxfi-22-august-2015
+  specialist_document_16: /aaib-reports/aaib-investigation-to-piper-l18c-super-cub-g-axlz
+  specialist_document_17: /raib-reports/fatal-accident-near-david-lane-tram-stop
+  specialist_document_18: /raib-reports/track-workers-class-investigation
+  specialist_document_19: /maib-reports/contact-made-by-passenger-ferry-uriah-heep-with-hythe-pier
+  specialist_document_20: /maib-reports/collision-between-ro-ro-freight-ferry-petunia-seaways-and-historic-motor-launch-peggotty
+  specialist_document_21: /countryside-stewardship-grants/permanent-grassland-with-very-low-inputs-outside-sdas-gs2
+  specialist_document_22: /countryside-stewardship-grants/management-of-hedgerows-be3
+  specialist_document_23: /business-finance-support/childcare-business-grants-england
+  specialist_document_24: /business-finance-support/business-solutions-south-west-england
+  specialist_document_25: /dfid-research-outputs/fair-society-healthy-lives-the-marmot-review-strategic-review-of-health-inequalities-in-england-post-2010
+  specialist_document_26: /dfid-research-outputs/girl-landscaping-studies-pakistan-nepal-and-bangladesh
+  specialist_document_27: /tax-and-chancery-tribunal-decisions/seven-individuals-v-the-commissioners-for-hm-revenue-and-customs-2017-ukut-0132-tcc
+  specialist_document_28: /tax-and-chancery-tribunal-decisions/tayo-bailey-others-and-trusteees-of-manchester-new-moston-v-the-charity-commission-for-england-and-wales-2017-ukut-0134-tcc
+  specialist_document_29: /employment-tribunal-decisions/mr-d-kinnear-v-marley-eternit-ltd-t-a-marley-contract-services-4105271-2016
+  specialist_document_30: /employment-tribunal-decisions/mr-d-templeton-and-others-v-the-rangers-football-club-ltd-4105211-2016
+  specialist_document_31: /employment-appeal-tribunal-decisions/london-borough-of-haringey-v-mrs-c-a-o-brien-ukeat-0004-16-la
+  specialist_document_32: /employment-appeal-tribunal-decisions/kingsmoor-packaging-ltd-v-mr-t-fytch-ukeat-0011-16-joj
+  specialist_document_33: /administrative-appeals-tribunal-decisions/rj-gmcl-and-cs-v-secretary-of-state-for-work-and-pensions-v-rj-pip-2017-ukut-105-aac
+  specialist_document_34: /administrative-appeals-tribunal-decisions/mr-v-secretary-of-state-for-work-and-pensions-pip-2017-ukut-46-aac
+  specialist_document_35: /service-standard-reports/apply-for-a-budgeting-loan-alpha-assessment
+  specialist_document_36: /service-standard-reports/apply-for-a-budgeting-loan
+  specialist_document_37: /european-structural-investment-funds/business-development
+  specialist_document_38: /european-structural-investment-funds/learning-and-skills-project-call-in-sheffield-city-region-lep-oc28s17p0733
+  specialist_document_39: /asylum-support-tribunal-decisions/cs-v-secretary-of-state-for-the-home-department-as-12-12-29244
+  specialist_document_40: /asylum-support-tribunal-decisions/am-v-secretary-of-state-for-the-home-department-as-14-11-32141
 
   statistics_announcement_national: '/government/statistics/announcements/uk-armed-forces-quarterly-personnel-report-october-2015'
   statistics_announcement_cancelled: '/government/statistics/announcements/diagnostic-imaging-dataset-for-september-2015'
-  # Most visited statistics_announcement pages (2nd September 2016)
+
+  # Most visited statistics_announcement pages (2 September 2016)
   statistics_announcement_1: '/government/statistics/announcements/national-curriculum-assessments-at-key-stage-2-2015-to-2016'
   statistics_announcement_2: '/government/statistics/announcements/national-diet-and-nutrition-survey-results-from-years-5-and-6-combined-of-the-rolling-programme-for-2012-to-2013-and-2013-to-2014'
   statistics_announcement_3: '/government/statistics/announcements/provisional-gcse-and-equivalent-results-in-england-2015-to-2016'
@@ -97,7 +143,8 @@ paths:
   statistics_announcement_10: '/government/statistics/announcements/independent-schools-inspection-outcomes-official-statistics-as-at-31-march-2016'
 
   take_part: '/government/get-involved/take-part/become-a-councillor'
-  # Most visited take_part pages (2nd September 2016)
+
+  # Most visited take_part pages (2 September 2016)
   take_part_1: '/government/get-involved/take-part/volunteer'
   take_part_2: '/government/get-involved/take-part/national-citizen-service'
   take_part_3: '/government/get-involved/take-part/set-up-a-new-school'
@@ -110,7 +157,8 @@ paths:
 
   topical_event_about_page_slim: '/government/topical-events/battle-of-the-somme-centenary-commemorations/about'
   topical_event_about_page: '/government/topical-events/ebola-virus-government-response/about'
-  # Most visited topical_event_about_page pages (2nd September 2016)
+
+  # Most visited topical_event_about_page pages (2 September 2016)
   topical_event_about_page_1: '/government/topical-events/eu-referendum/about'
   topical_event_about_page_2: '/government/topical-events/daesh/about'
   topical_event_about_page_3: '/government/topical-events/anti-corruption-summit-london-2016/about'
@@ -121,7 +169,7 @@ paths:
   topical_event_about_page_8: '/government/topical-events/farming/about'
   topical_event_about_page_9: '/government/topical-events/girl-summit-2014/about'
 
-  # Most visited travel advice (2nd March 2017)
+  # Most visited travel advice (2 March 2017)
   travel_advice_1: '/foreign-travel-advice/usa/entry-requirements'
   travel_advice_2: '/foreign-travel-advice/turkey'
   travel_advice_3: '/foreign-travel-advice/usa'
@@ -141,7 +189,8 @@ paths:
   working_group_long: '/government/groups/benefits-credits-consultation-group-bccg'
   working_group_short: '/government/groups/aviation-statistics-team'
   working_group_with_policies: '/government/groups/better-regulation-executive'
-  # Most visited working_group pages (2nd September 2016)
+
+  # Most visited working_group pages (2 September 2016)
   working_group_1: '/government/groups/claims-management-regulator'
   working_group_2: '/government/groups/disposal-services-authority'
   working_group_3: '/government/groups/public-services-network'
@@ -152,7 +201,7 @@ paths:
   working_group_8: '/government/groups/uk-national-screening-committee-uk-nsc'
   working_group_9: '/government/groups/uk-council-for-child-internet-safety-ukccis'
 
-  # Most visited WLNA (2nd March 2017)
+  # Most visited WLNA (2 March 2017)
   world_location_news_article_1: /government/world-location-news/youth-mobility-scheme-2017-for-japanese-nationals.ja
   world_location_news_article_2: /government/world-location-news/youth-mobility-scheme-2017-for-taiwanese-youth--2.zh-tw
   world_location_news_article_3: /government/world-location-news/rear-admiral-simon-ancona-uk-acdsde-visit-to-thailand-13-14-october


### PR DESCRIPTION
* Add most popular specialist docs to wraith - example output: shy-coil.surge.sh/gallery.html
* Pass array of facet values to components to match specialist-frontend
   * When multiple values are passed to the document footer it render each of them on a new line.
   * When multiple values are passed to metadata it joins them and puts 'and' between the last two values
* Group date facets together. Makes dates more comparable and matches specialist-frontend ordering.
* Give specialist metadata more room using same CSS hack as specialist-frontend
* Use first_published_at in facets as canonical value

## first_published_at value

Some specialist document types (drug safety updates, DFID research outcomes) include a “first_published_at” facet.

These documents have been published earlier, in a publication elsewhere. eg Time research published is before the link to the research was published on GOV.UK.

* When provided, use this value as canonical first published date
* Avoids duplicate publish dates from showing

More context here: https://github.com/alphagov/specialist-publisher/issues/1030

## Passing arrays to components
![screen shot 2017-04-26 at 16 18 47](https://cloud.githubusercontent.com/assets/319055/25442121/161f2d48-2a9c-11e7-9032-095735b41ffd.png)
![screen shot 2017-04-26 at 16 18 35](https://cloud.githubusercontent.com/assets/319055/25442122/1620416a-2a9c-11e7-826f-f2d2b1d3f35b.png)

## Grouping dates
![screen shot 2017-04-26 at 16 20 49](https://cloud.githubusercontent.com/assets/319055/25442209/56f059d2-2a9c-11e7-8b1b-f56ef7198606.png)

