### PR TITLE
Upgrade to govuk_navigation_helpers 6.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,10 +28,10 @@ gem 'statsd-ruby', '1.3.0', require: 'statsd'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 41.0'
+  gem 'gds-api-adapters', '~> 42.0'
 end
 
-gem 'govuk_navigation_helpers', '~> 5.1'
+gem 'govuk_navigation_helpers', '~> 6.0'
 
 group :development, :test do
   gem 'govuk_schemas'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,11 +66,11 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
-    domain_name (0.5.20170223)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (41.0.0)
+    gds-api-adapters (42.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -92,8 +92,8 @@ GEM
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (5.1.0)
-      gds-api-adapters (~> 41.0)
+    govuk_navigation_helpers (6.0.1)
+      gds-api-adapters (~> 42.0)
     govuk_schemas (2.1.0)
       json-schema (~> 2.5.0)
     htmlentities (4.3.4)
@@ -195,7 +195,7 @@ GEM
     raindrops (0.17.0)
     rake (11.2.2)
     request_store (1.3.1)
-    rest-client (2.0.1)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -243,7 +243,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.4)
     unicode-display_width (1.1.3)
     unicorn (4.8.0)
       kgio (~> 2.6)
@@ -267,13 +267,13 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara
-  gds-api-adapters (~> 41.0)
+  gds-api-adapters (~> 42.0)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
   govuk_ab_testing (~> 2.0)
   govuk_elements_rails (= 3.0.1)
   govuk_frontend_toolkit (= 5.1.0)
-  govuk_navigation_helpers (~> 5.1)
+  govuk_navigation_helpers (~> 6.0)
   govuk_schemas
   htmlentities (= 4.3.4)
   jasmine-rails (~> 0.14.0)


### PR DESCRIPTION
This fixes the issue with repeated related links across different
taxons.

Trello: https://trello.com/c/I4rs80n1/80-remove-duplicated-related-links-across-all-parent-taxons