### PR TITLE
Ignore facets that are set to empty strings

### DIFF
--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -114,7 +114,7 @@ private
     return [] unless facets && facet_values.any?
 
     facets
-      .select { |f| facet_values[f['key']] }
+      .select { |f| facet_values[f['key']] && facet_values[f['key']].present? }
       .reject { |f| f['key'] == first_published_at_facet_key }
       .sort_by { |f| f['type'] }
   end

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -194,6 +194,26 @@ class SpecialistDocumentPresenterTest
       assert_empty presented.document_footer[:other]
     end
 
+    test 'ignores facets if valid key but set to an empty string' do
+      example = example_with_finder_facets([
+                                              {
+                                                "name" => "Facet name",
+                                                "key" => "facet-key",
+                                                "type" => "text",
+                                              },
+                                              {
+                                                "name" => "Date facet",
+                                                "key" => "date-facet",
+                                                "type" => "date",
+                                              }
+                                            ],
+                                            "facet-key" => "",
+                                            "date-facet" => ""
+                                          )
+
+      assert_empty present_example(example).metadata[:other]
+    end
+
     test 'passes array of multiple values to metadata and document_footer components' do
       overrides = {
         "allowed_values" => [


### PR DESCRIPTION
If a facet has no value, ignore it.

Fixes:

Seen on staging, a CMA case has a date facet set to an empty string:
https://www.gov.uk/api/content/cma-cases/midcounties-co-operative-harry-tuffin-investments
`"opened_date": “”`
__Object must be a Date, DateTime or Time object. nil given.__

See also:
https://www.gov.uk/api/content/cma-cases/higher-education-sector-call-for-information
`"outcome_type": "",`
Gives:
```ruby
{
  "error_message" => "Facet value '' not an allowed value for facet 'Outcome' on /cma-cases/higher-education-sector-call-for-information content item"
}
```