### PR TITLE
Fix CorporateInformationPage Preview bug

### DIFF
--- a/app/presenters/corporate_information_page_presenter.rb
+++ b/app/presenters/corporate_information_page_presenter.rb
@@ -9,7 +9,9 @@ class CorporateInformationPagePresenter < ContentItemPresenter
   end
 
   def page_title
-    "#{title} - #{default_organisation['title']}"
+    page_title = title.to_s
+    page_title += " - #{default_organisation['title']}" if default_organisation
+    page_title
   end
 
   def title_and_context
@@ -33,12 +35,16 @@ private
 
   def default_organisation
     organisation_content_id = content_item["details"]["organisation"]
-    organisation = content_item["links"]["organisations"].detect do |org|
-      org["content_id"] == organisation_content_id
+    organisation = nil
+    if organisations.present?
+      organisation = organisations.detect { |org| org["content_id"] == organisation_content_id }
+      raise "No organisation in links that matches the one specified in details: #{organisation_content_id}" unless organisation
     end
 
-    raise "No organisation in links that matches the one specified in details: #{organisation_content_id}" unless organisation
-
     organisation
+  end
+
+  def organisations
+    content_item["links"]["organisations"] || []
   end
 end

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -14,6 +14,11 @@ class CorporateInformationPagePresenterTest
       assert_equal "About us - Department of Health", presented_item.page_title
     end
 
+    test 'does not present an organisation in the title when it is not present in links' do
+      presented_item = presented_item(format_name, "links" => {})
+      assert_equal "About us", presented_item.page_title
+    end
+
     test 'has contents list' do
       assert presented_item.is_a?(ContentsList)
     end


### PR DESCRIPTION
When previewing a Corporate Information page in Whitehall, a bug was found
where the content didn't display. This is because Corporate Information pages
don't currently use edition links, and so the CorporateInformationPagePresenter
couldn't find `organisations` in the `links` hash.  This fix allows
CorporateInformationPagePresenter to handle this more gracefully.