### PR TITLE
Extend the schema list for Education Navigation

### DIFF
--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -1,5 +1,6 @@
 class EducationNavigationAbTestRequest
-  NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS = %w{detailed_guide document_collection publication}.freeze
+  NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS =
+    %w{answer contact detailed_guide document_collection publication}.freeze
 
   attr_accessor :requested_variant
 


### PR DESCRIPTION
More details on what guidance is in here:
https://github.com/alphagov/govuk_document_types/blob/master/data/supertypes.yml#L6-L27

We should be showing the new navigation elements for all those document
types. This PR extends the list to the ones that have education content
and were missing from this repository.