### PR TITLE
Tweaks to Guides to match live

### DIFF
--- a/app/assets/stylesheets/views/_guide.scss
+++ b/app/assets/stylesheets/views/_guide.scss
@@ -18,7 +18,8 @@
   // Distinguish between part titles (27px) and h2s
   // within content of part by reducing font-size
   //
-  // Override h2 sizes to match frontend typography
+  // Override h2 sizes to match layout used by alphagov/frontend
+  // https://github.com/alphagov/static/blob/f44470edc4e4159ea37481985c641034741623ac/app/assets/stylesheets/helpers/_text.scss#L38
   .govuk-govspeak {
     h2 {
       @include bold-24;

--- a/app/assets/stylesheets/views/_guide.scss
+++ b/app/assets/stylesheets/views/_guide.scss
@@ -11,4 +11,17 @@
     margin-left: 1.5em;
     padding-left: 0.3em;
   }
+
+  // FIXME: Remove when typography improvements made to
+  //        govspeak component
+  //
+  // Distinguish between part titles (27px) and h2s
+  // within content of part by reducing font-size
+  //
+  // Override h2 sizes to match frontend typography
+  .govuk-govspeak {
+    h2 {
+      @include bold-24;
+    }
+  }
 }

--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -7,13 +7,15 @@
         title: @content_item.title %>
     <%= render 'govuk_component/govspeak',
         content: @content_item.body,
-        direction: page_text_direction %>
-        <% #https://github.com/alphagov/government-frontend/pull/329#issuecomment-297681738 %>
-      <% if false && @content_item.last_updated %>
-        <p class="last-updated">
-          <%= t 'common.last_updated' %>: <%= @content_item.last_updated %>
-        </p>
-      <% end %>
+        direction: page_text_direction,
+        disable_youtube_expansions: true %>
+
+    <% #https://github.com/alphagov/government-frontend/pull/329#issuecomment-297681738 %>
+    <% if false && @content_item.last_updated %>
+      <p class="last-updated">
+        <%= t 'common.last_updated' %>: <%= @content_item.last_updated %>
+      </p>
+    <% end %>
   </div>
   <%= render 'shared/related_items', content_item: @content_item  %>
 </div>

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -16,7 +16,8 @@
         </h1>
         <%= render 'govuk_component/govspeak',
             content: part['body'],
-            direction: page_text_direction %>
+            direction: page_text_direction,
+            disable_youtube_expansions: true %>
       </section>
     <% end %>
   </div>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -21,7 +21,8 @@
 
       <%= render 'govuk_component/govspeak',
           content: @content_item.current_part_body,
-          direction: page_text_direction %>
+          direction: page_text_direction,
+          disable_youtube_expansions: true %>
 
       <%= render 'govuk_component/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
 


### PR DESCRIPTION
Part of https://trello.com/c/g01dZWdI/238-3-render-guides-in-government-frontend-sprint-2

## Tweak h2 styles on guides

### Before
![screen shot 2017-05-05 at 17 16 58](https://cloud.githubusercontent.com/assets/319055/25754352/bce66102-31b6-11e7-86bd-c1be6825541b.png)

### After
![screen shot 2017-05-05 at 17 16 44](https://cloud.githubusercontent.com/assets/319055/25754351/bcde0854-31b6-11e7-8ee4-076172e932e3.png)

### Live
![screen shot 2017-05-05 at 17 19 21](https://cloud.githubusercontent.com/assets/319055/25754423/00b53aa2-31b7-11e7-9092-0c1f8c153278.png)

## Disable YouTube video expansion

See: https://github.com/alphagov/static/pull/1020

Content on mainstream was not written with expansion enabled, some links to YouTube expand in ways that break content:

eg A link to a video in a list: http://www.gov.uk/attendance-allowance/what-youll-get


