### PR TITLE
Allow overriding the defaults for `--live`

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -5,8 +5,8 @@ bundle install
 if [[ $1 == "--live" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
-  PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api \
-  PLEK_SERVICE_STATIC_URI=assets.publishing.service.gov.uk \
+  PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
+  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
   bundle exec rails s -p 3090
 else
   bundle exec rails s -p 3090


### PR DESCRIPTION
If you use `./startup.sh --live`, you should also be able to override
the locations of static or the content store using the normal
environment variables