### PR TITLE
Style buttons in govspeak as start buttons

### DIFF
--- a/app/assets/stylesheets/helpers/_button.scss
+++ b/app/assets/stylesheets/helpers/_button.scss
@@ -8,8 +8,23 @@
 // https://github.com/alphagov/govuk_elements/blob/874e287/public/sass/elements/_helpers.scss#L36
 @import "elements/buttons";
 
-.button-info {
+.button-info-text {
   display: block;
   margin-top: .5em;
   max-width: 14em;
+}
+
+.govuk-govspeak {
+  .button {
+    text-decoration: none;
+
+    // We can't easily update .button-start to a placeholder pattern
+    // scss-lint:disable PlaceholderInExtend
+    @extend .button-start;
+  }
+
+  .button:focus,
+  .button:active {
+    color: $white;
+  }
 }

--- a/app/views/shared/_button.html.erb
+++ b/app/views/shared/_button.html.erb
@@ -18,7 +18,7 @@
   <%= yield %>
 </a>
 <% if info %>
-  <span class="button-info">
+  <span class="button-info-text">
     <%= info.try(:html_safe) %>
   </span>
 <% end %>

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -167,7 +167,7 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
       assert_text('Find out more')
     end
 
-    button_info_selector = '.button-info'
+    button_info_selector = '.button-info-text'
     assert page.has_css?(button_info_selector)
     within button_info_selector do
       assert_text('on the Big Issue Invest website')


### PR DESCRIPTION
Publishers copy and paste markup into mainstream content to render
buttons. Buttons should be a markdown pattern/component/combination.

* For now, make sure they render correctly so we can switch guides
* Fix bug on live where focus/active state shows in blue (Element button styles aren’t specific enough to override govspeak ones)
* Rename `button-info` to `button-info-text` so it’s not confused as a button type.

Steps to take after this:
* Add markdown pattern for buttons and start buttons
* Move styling of buttons into static component that can be shared with govspeak

## Before
![screen shot 2017-05-08 at 12 24 49](https://cloud.githubusercontent.com/assets/319055/25802248/6361f274-33e9-11e7-8700-76984169c8eb.png)

## After
![screen shot 2017-05-08 at 12 24 11](https://cloud.githubusercontent.com/assets/319055/25802247/635d569c-33e9-11e7-9b00-c07f387bcad2.png)