### PR TITLE
Run AB tests on guides and contacts

### DIFF
--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -1,6 +1,6 @@
 class EducationNavigationAbTestRequest
   NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS =
-    %w{answer contact detailed_guide document_collection publication}.freeze
+    %w{answer contact guide detailed_guide document_collection publication}.freeze
 
   attr_accessor :requested_variant
 

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -95,7 +95,5 @@
 
     <%= render 'govuk_component/govspeak', content: body, rich_govspeak: true %>
   </div>
-  <div class="column-one-third add-title-margin">
-    <%= render 'govuk_component/related_items', @content_item.related_items %>
-  </div>
+  <%= render 'shared/related_items', content_item: @content_item  %>
 </div>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -33,7 +33,5 @@
       <% end %>
     <% end %>
   </div>
-  <div class="column-one-third add-title-margin">
-    <%= render 'govuk_component/related_items', @content_item.related_items %>
-  </div>
+  <%= render 'shared/related_items', content_item: @content_item  %>
 </div>

--- a/app/views/shared/_related_items.html+new_navigation.erb
+++ b/app/views/shared/_related_items.html+new_navigation.erb
@@ -1,5 +1,3 @@
-<div class="column-third">
-  <div class="add-title-margin">
-    <%= render partial: 'govuk_component/taxonomy_sidebar', locals: content_item.taxonomy_sidebar %>
-  </div>
+<div class="column-third add-title-margin">
+  <%= render partial: 'govuk_component/taxonomy_sidebar', locals: content_item.taxonomy_sidebar %>
 </div>

--- a/app/views/shared/_related_items.html.erb
+++ b/app/views/shared/_related_items.html.erb
@@ -1,5 +1,3 @@
-<div class="column-third">
-  <div class="add-title-margin">
-    <%= render partial: 'govuk_component/related_items', locals: content_item.related_items %>
-  </div>
+<div class="column-third add-title-margin">
+  <%= render partial: 'govuk_component/related_items', locals: content_item.related_items %>
 </div>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -162,49 +162,51 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_response :not_acceptable
   end
 
-  test "defaults to 'A' view without AB Testing cookie for Detailed Guides" do
-    content_item = content_store_has_schema_example('detailed_guide', 'detailed_guide')
-    path = 'government/abtest/detailed-guide'
-    content_item['base_path'] = "/#{path}"
-    content_item['links'] = {
-      'taxons' => [
-        {
-          'title' => 'A Taxon',
-          'base_path' => '/a-taxon',
-        }
-      ]
-    }
+  EducationNavigationAbTestRequest::NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS.each do |schema_name|
+    test "defaults to 'A' view without AB Testing cookie for #{schema_name}" do
+      content_item = content_store_has_schema_example(schema_name, schema_name)
+      path = "government/abtest/#{schema_name}"
+      content_item['base_path'] = "/#{path}"
+      content_item['links'] = {
+        'taxons' => [
+          {
+            'title' => 'A Taxon',
+            'base_path' => '/a-taxon',
+          }
+        ]
+      }
 
-    content_store_has_item(content_item['base_path'], content_item)
+      content_store_has_item(content_item['base_path'], content_item)
 
-    get :show, params: { path: path_for(content_item) }
-    assert_equal [], @request.variant
-    refute_match(/A Taxon/, taxonomy_sidebar)
-  end
-
-  test "honours Education Navigation AB Testing cookie for Detailed Guides" do
-    content_item = content_store_has_schema_example('detailed_guide', 'detailed_guide')
-    path = 'government/abtest/detailed-guide'
-    content_item['base_path'] = "/#{path}"
-    content_item['links'] = {
-      'taxons' => [
-        {
-          'title' => 'A Taxon',
-          'base_path' => '/a-taxon',
-        }
-      ]
-    }
-
-    content_store_has_item(content_item['base_path'], content_item)
-
-    with_variant EducationNavigation: "A" do
       get :show, params: { path: path_for(content_item) }
+      assert_equal [], @request.variant
       refute_match(/A Taxon/, taxonomy_sidebar)
     end
 
-    with_variant EducationNavigation: "B" do
-      get :show, params: { path: path_for(content_item) }
-      assert_match(/A Taxon/, taxonomy_sidebar)
+    test "honours Education Navigation AB Testing cookie for #{schema_name}" do
+      content_item = content_store_has_schema_example(schema_name, schema_name)
+      path = "government/abtest/#{schema_name}"
+      content_item['base_path'] = "/#{path}"
+      content_item['links'] = {
+        'taxons' => [
+          {
+            'title' => 'A Taxon',
+            'base_path' => '/a-taxon',
+          }
+        ]
+      }
+
+      content_store_has_item(content_item['base_path'], content_item)
+
+      with_variant EducationNavigation: "A" do
+        get :show, params: { path: path_for(content_item) }
+        refute_match(/A Taxon/, taxonomy_sidebar)
+      end
+
+      with_variant EducationNavigation: "B" do
+        get :show, params: { path: path_for(content_item) }
+        assert_match(/A Taxon/, taxonomy_sidebar)
+      end
     end
   end
 


### PR DESCRIPTION
* AB tests are being run against guides on frontend, port the same logic here
* Update contacts so AB tests for contacts  work
* Run test suite for AB tests against all supported test schemas
* Switch to shared related links template to pick up ‘new navigation’ variant on contacts and guides

cc @nickcolley @carvil 