### PR TITLE
Show old related links for selected content items

### DIFF
--- a/app/services/mainstream_content_fetcher.rb
+++ b/app/services/mainstream_content_fetcher.rb
@@ -1,0 +1,12 @@
+class MainstreamContentFetcher
+  def self.with_curated_sidebar
+    JSON.parse(
+      File.read(
+        Rails.root.join(
+          "config",
+          "mainstream_content_with_curated_sidebar.json"
+        )
+      )
+    )
+  end
+end

--- a/app/views/shared/_related_items.html+new_navigation.erb
+++ b/app/views/shared/_related_items.html+new_navigation.erb
@@ -1,3 +1,15 @@
 <div class="column-third add-title-margin">
-  <%= render partial: 'govuk_component/taxonomy_sidebar', locals: content_item.taxonomy_sidebar %>
+  <% if MainstreamContentFetcher.with_curated_sidebar.include?(content_item.base_path) %>
+    <%=
+      render(
+        partial: 'govuk_component/related_items',
+        locals: content_item.related_items
+      ) %>
+  <% else %>
+    <%=
+      render(
+        partial: 'govuk_component/taxonomy_sidebar',
+        locals: content_item.taxonomy_sidebar
+      ) %>
+  <% end %>
 </div>

--- a/config/mainstream_content_with_curated_sidebar.json
+++ b/config/mainstream_content_with_curated_sidebar.json
@@ -1,0 +1,7 @@
+[
+  "/dance-drama-awards",
+  "/teacher-training-funding",
+  "/student-finance-for-existing-students",
+  "/funding-for-postgraduate-study",
+  "/contact-student-finance-england"
+]

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -227,12 +227,26 @@ class ContentItemsControllerTest < ActionController::TestCase
 
       with_variant EducationNavigation: "A" do
         get :show, params: { path: path_for(content_item) }
-        refute_match(/A Taxon/, taxonomy_sidebar)
+        assert(
+          related_links_sidebar,
+          "Expected to find the related links component"
+        )
+        assert_nil(
+          taxonomy_sidebar,
+          "Does not expect to find the new taxonomy sidebar"
+        )
       end
 
       with_variant EducationNavigation: "B" do
         get :show, params: { path: path_for(content_item) }
-        refute_match(/A Taxon/, taxonomy_sidebar)
+        assert(
+          related_links_sidebar,
+          "Expected to find the related links component"
+        )
+        assert_nil(
+          taxonomy_sidebar,
+          "Does not expect to find the new taxonomy sidebar"
+        )
       end
     end
   end
@@ -292,7 +306,15 @@ class ContentItemsControllerTest < ActionController::TestCase
     base_path
   end
 
+  def related_links_sidebar
+    Nokogiri::HTML.parse(response.body).at_css(
+      shared_component_selector("related_items")
+    )
+  end
+
   def taxonomy_sidebar
-    Nokogiri::HTML.parse(response.body).at_css(".column-third")
+    Nokogiri::HTML.parse(response.body).at_css(
+      shared_component_selector("taxonomy_sidebar")
+    )
   end
 end

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -210,6 +210,33 @@ class ContentItemsControllerTest < ActionController::TestCase
     end
   end
 
+  MainstreamContentFetcher.with_curated_sidebar.each do |base_path|
+    test "defaults to the old related links for #{base_path} in Education Navigation AB Testing" do
+      content_item = content_store_has_schema_example('answer', 'answer')
+      content_item['base_path'] = base_path
+      content_item['links'] = {
+        'taxons' => [
+          {
+            'title' => 'A Taxon',
+            'base_path' => '/a-taxon',
+          }
+        ]
+      }
+
+      content_store_has_item(content_item['base_path'], content_item)
+
+      with_variant EducationNavigation: "A" do
+        get :show, params: { path: path_for(content_item) }
+        refute_match(/A Taxon/, taxonomy_sidebar)
+      end
+
+      with_variant EducationNavigation: "B" do
+        get :show, params: { path: path_for(content_item) }
+        refute_match(/A Taxon/, taxonomy_sidebar)
+      end
+    end
+  end
+
   test "does not show new navigation when no taxons are tagged to Detailed Guides" do
     content_item = content_store_has_schema_example('detailed_guide', 'detailed_guide')
     path = 'government/abtest/detailed-guide'


### PR DESCRIPTION
We are in the process of releasing the new navigation for Education
content. One item that needs to be solved from a product perspective is
how to deal with curated related links. Until that's solved, some
content items still need to show the old related links instead of the
new navigation for users in the B group of our A/B test.

These overrides existed in the `frontend` application. Since `answers`
were ported to `government-frontend`, we also need to port the override.

Trello: https://trello.com/c/U6JKZN6s/115-make-sure-we-override-the-related-links-on-some-mainstream-content-that-was-recently-moved-to-government-frontend