### PR TITLE
Translate print and page navigation into Welsh

### DIFF
--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -38,13 +38,13 @@ class GuidePresenter < ContentItemPresenter
 
     nav[:previous_page] = {
       url: "#{base_path}/#{previous_part['slug']}",
-      title: "Previous",
+      title: I18n.t('multi_page.previous_page'),
       label: previous_part['title']
     } if previous_part
 
     nav[:next_page] = {
       url: "#{base_path}/#{next_part['slug']}",
-      title: "Next",
+      title: I18n.t('multi_page.next_page'),
       label: next_part['title']
     } if next_part
 

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -28,7 +28,7 @@
 
       <% if @content_item.multi_page_guide? %>
         <div class="print-link">
-          <%= link_to "Print entire guide", @content_item.print_link, rel: 'alternate' %>
+          <%= link_to t("multi_page.print_entire_guide"), @content_item.print_link, rel: 'alternate' %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -32,7 +32,7 @@
         direction: page_text_direction %>
 
     <div class="print-link">
-      <%= link_to "Print entire guide", @content_item.print_link, rel: 'alternate' %>
+      <%= link_to t("multi_page.print_entire_guide"), @content_item.print_link, rel: 'alternate' %>
     </div>
   </div>
   <div class="column-one-third add-title-margin">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -345,3 +345,7 @@ cy:
     welsh_language_scheme_html: Dysgwch am ein hymrwymiad i %{link}.
     social_media_use_html: Darllenwch ein polisi ar %{link}
     about_our_services_html: Canfod %{link}
+  multi_page:
+      print_entire_guide: "Tudalen hawdd ei hargraffu"
+      previous_page: "Llywio i’r rhan flaenorol"
+      next_page: "Llywio i’r rhan nesaf"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,3 +263,7 @@ en:
       avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all travel to parts of the country.
       avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to the whole country.
       avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all travel to the whole country.
+  multi_page:
+      print_entire_guide: "Print entire guide"
+      previous_page: "Previous"
+      next_page: "Next"


### PR DESCRIPTION
* Port translations from alphagov/frontend: https://github.com/alphagov/frontend/blob/dab7d54bf45d1ca529896c0c618bde2f3d433cf9/config/locales/cy.yml
* Welsh literally means: “Navigate to next/previous part” and “Printer friendly page”

## Before
![screen shot 2017-05-09 at 13 37 36](https://cloud.githubusercontent.com/assets/319055/25851518/fdddc0e2-34bd-11e7-8479-07060b143049.png)

## After
![screen shot 2017-05-09 at 13 37 49](https://cloud.githubusercontent.com/assets/319055/25851517/fdda7e14-34bd-11e7-88fa-b637e213198b.png)