### PR TITLE
Show old related links for selected Guides

### DIFF
--- a/config/mainstream_content_with_curated_sidebar.json
+++ b/config/mainstream_content_with_curated_sidebar.json
@@ -3,5 +3,20 @@
   "/teacher-training-funding",
   "/student-finance-for-existing-students",
   "/funding-for-postgraduate-study",
-  "/contact-student-finance-england"
+  "/contact-student-finance-england",
+  "/nhs-bursaries",
+  "/extra-money-pay-university",
+  "/career-development-loans",
+  "/travel-grants-students-england",
+  "/parents-learning-allowance",
+  "/social-work-bursaries",
+  "/adult-dependants-grant",
+  "/disabled-students-allowances-dsas",
+  "/apply-for-student-finance",
+  "/childcare-grant",
+  "/postgraduate-loan",
+  "/repaying-your-student-loan",
+  "/student-finance",
+  "/care-to-learn",
+  "/advanced-learner-loan"
 ]


### PR DESCRIPTION
We are in the process of releasing the new navigation for Education
content. One item that needs to be solved from a product perspective is
how to deal with curated related links. Until that's solved, some
content items still need to show the old related links instead of the
new navigation for users in the B group of our A/B test.

These overrides existed in the frontend application. Since guides
were ported to government-frontend, we also need to port the override.

Trello: https://trello.com/c/U6JKZN6s/115-make-sure-we-override-the-related-links-on-some-mainstream-content-that-was-recently-moved-to-government-frontend

In order to prevent this happening in the future, I added a Smokey test:
- https://github.com/alphagov/smokey/pull/262

Which is failing (tested the branch on staging pointing to production):
- https://deploy.staging.publishing.service.gov.uk/job/Smokey/5867/console