### PR TITLE
Add bold back into mainstream content

### DIFF
--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -8,7 +8,8 @@
     <%= render 'govuk_component/govspeak',
         content: @content_item.body,
         direction: page_text_direction,
-        disable_youtube_expansions: true %>
+        disable_youtube_expansions: true,
+        rich_govspeak: true %>
 
     <% #https://github.com/alphagov/government-frontend/pull/329#issuecomment-297681738 %>
     <% if false && @content_item.last_updated %>

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -17,7 +17,8 @@
         <%= render 'govuk_component/govspeak',
             content: part['body'],
             direction: page_text_direction,
-            disable_youtube_expansions: true %>
+            disable_youtube_expansions: true,
+            rich_govspeak: true %>
       </section>
     <% end %>
   </div>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -22,7 +22,8 @@
       <%= render 'govuk_component/govspeak',
           content: @content_item.current_part_body,
           direction: page_text_direction,
-          disable_youtube_expansions: true %>
+          disable_youtube_expansions: true,
+          rich_govspeak: true %>
 
       <%= render 'govuk_component/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
 


### PR DESCRIPTION
we missed this out on the migration, it is generally not allowed,
but mainstream uses it quite a lot.