### PR TITLE
Add pagination to travel advice

### DIFF
--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -32,36 +32,4 @@ class GuidePresenter < ContentItemPresenter
   def related_items
     @nav_helper.related_items
   end
-
-  def previous_and_next_navigation
-    nav = {}
-
-    nav[:previous_page] = {
-      url: "#{base_path}/#{previous_part['slug']}",
-      title: I18n.t('multi_page.previous_page'),
-      label: previous_part['title']
-    } if previous_part
-
-    nav[:next_page] = {
-      url: "#{base_path}/#{next_part['slug']}",
-      title: I18n.t('multi_page.next_page'),
-      label: next_part['title']
-    } if next_part
-
-    nav
-  end
-
-private
-
-  def next_part
-    parts[current_part_index + 1]
-  end
-
-  def previous_part
-    parts[current_part_index - 1] if current_part_index > 0
-  end
-
-  def current_part_index
-    parts.index(current_part)
-  end
 end

--- a/app/presenters/parts.rb
+++ b/app/presenters/parts.rb
@@ -40,6 +40,24 @@ module Parts
     part_navigation_group_size + 1
   end
 
+  def previous_and_next_navigation
+    nav = {}
+
+    nav[:previous_page] = {
+      url: previous_part['full_path'],
+      title: I18n.t('multi_page.previous_page'),
+      label: previous_part['title']
+    } if previous_part
+
+    nav[:next_page] = {
+      url: next_part['full_path'],
+      title: I18n.t('multi_page.next_page'),
+      label: next_part['title']
+    } if next_part
+
+    nav
+  end
+
 private
 
   def current_part
@@ -67,5 +85,17 @@ private
     else
       size.ceil
     end
+  end
+
+  def next_part
+    decorated_parts[current_part_index + 1]
+  end
+
+  def previous_part
+    decorated_parts[current_part_index - 1] if current_part_index > 0
+  end
+
+  def current_part_index
+    parts.index(current_part)
   end
 end

--- a/app/presenters/parts.rb
+++ b/app/presenters/parts.rb
@@ -5,6 +5,14 @@ module Parts
     content_item.dig("details", "parts") || []
   end
 
+  def decorated_parts
+    parts.each_with_index.map do |part, i|
+      # Link to base_path for first part
+      part['full_path'] = (i == 0) ? base_path : "#{base_path}/#{part['slug']}"
+      part
+    end
+  end
+
   # When requesting a part, the content store will return a content item
   # with a base path that's different to the one requested. That content
   # item contains all the parts for that document.
@@ -43,11 +51,9 @@ private
   end
 
   def part_links
-    parts.each_with_index.map do |part, i|
+    decorated_parts.map do |part|
       if part['slug'] != current_part['slug']
-        # Link to base_path for first part
-        link_href = (i == 0) ? base_path : "#{base_path}/#{part['slug']}"
-        link_to part['title'], link_href
+        link_to part['title'], part['full_path']
       else
         part['title']
       end

--- a/app/presenters/parts.rb
+++ b/app/presenters/parts.rb
@@ -43,9 +43,11 @@ private
   end
 
   def part_links
-    parts.map do |part|
+    parts.each_with_index.map do |part, i|
       if part['slug'] != current_part['slug']
-        link_to part['title'], "#{@base_path}/#{part['slug']}"
+        # Link to base_path for first part
+        link_href = (i == 0) ? base_path : "#{base_path}/#{part['slug']}"
+        link_to part['title'], link_href
       else
         part['title']
       end

--- a/app/presenters/parts.rb
+++ b/app/presenters/parts.rb
@@ -2,11 +2,7 @@ module Parts
   include ActionView::Helpers::UrlHelper
 
   def parts
-    content_item.dig("details", "parts") || []
-  end
-
-  def decorated_parts
-    parts.each_with_index.map do |part, i|
+    raw_parts.each_with_index.map do |part, i|
       # Link to base_path for first part
       part['full_path'] = (i == 0) ? base_path : "#{base_path}/#{part['slug']}"
       part
@@ -60,6 +56,10 @@ module Parts
 
 private
 
+  def raw_parts
+    content_item.dig("details", "parts") || []
+  end
+
   def current_part
     if part_slug
       parts.find { |part| part["slug"] == part_slug }
@@ -69,7 +69,7 @@ private
   end
 
   def part_links
-    decorated_parts.map do |part|
+    parts.map do |part|
       if part['slug'] != current_part['slug']
         link_to part['title'], part['full_path']
       else
@@ -88,11 +88,11 @@ private
   end
 
   def next_part
-    decorated_parts[current_part_index + 1]
+    parts[current_part_index + 1]
   end
 
   def previous_part
-    decorated_parts[current_part_index - 1] if current_part_index > 0
+    parts[current_part_index - 1] if current_part_index > 0
   end
 
   def current_part_index

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -112,27 +112,19 @@ class TravelAdvicePresenter < ContentItemPresenter
     Plek.current.website_root + content_item["base_path"]
   end
 
+  # Treat summary as the first part
+  def parts
+    [summary_part].concat(super)
+  end
+
 private
 
   def summary_part
     {
       "title" => "Summary",
+      "slug" => "",
       "body" => content_item["details"]["summary"]
     }
-  end
-
-  def current_part
-    if is_summary?
-      summary_part
-    else
-      super
-    end
-  end
-
-  def part_links
-    summary_link_title = 'Summary'
-    summary_part_link = is_summary? ? summary_link_title : link_to(summary_link_title, @base_path)
-    [summary_part_link] + super
   end
 
   def ordered_related_items

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -112,12 +112,12 @@ class TravelAdvicePresenter < ContentItemPresenter
     Plek.current.website_root + content_item["base_path"]
   end
 
+private
+
   # Treat summary as the first part
-  def parts
+  def raw_parts
     [summary_part].concat(super)
   end
-
-private
 
   def summary_part
     {

--- a/app/views/content_items/travel_advice.html+print.erb
+++ b/app/views/content_items/travel_advice.html+print.erb
@@ -9,22 +9,14 @@
 <div class="grid-row travel-advice-print">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>
-
-    <section>
-      <h1 class="part-title">
-        <%= @content_item.current_part_title %>
-      </h1>
-      <%= render 'shared/travel_advice_summary', content_item: @content_item %>
-      <%= render 'govuk_component/govspeak',
-          content: @content_item.current_part_body,
-          direction: page_text_direction %>
-    </section>
-
-    <% @content_item.parts.each do |part| %>
+    <% @content_item.parts.each_with_index do |part, i| %>
       <section>
         <h1 class="part-title">
           <%= part['title'] %>
         </h1>
+
+        <%= render 'shared/travel_advice_summary', content_item: @content_item if i == 0 %>
+
         <%= render 'govuk_component/govspeak',
             content: part['body'],
             direction: page_text_direction %>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -31,6 +31,8 @@
         content: @content_item.current_part_body,
         direction: page_text_direction %>
 
+    <%= render 'govuk_component/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
+
     <div class="print-link">
       <%= link_to t("multi_page.print_entire_guide"), @content_item.print_link, rel: 'alternate' %>
     </div>

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -24,7 +24,7 @@ class GuideTest < ActionDispatch::IntegrationTest
     end
 
     assert page.has_css?('h1', text: "1. #{@content_item['details']['parts'].first['title']}")
-
+    assert page.has_css?(shared_component_selector("previous_and_next_navigation"))
     assert page.has_css?('.print-link a[href$="/print"]')
   end
 

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -23,6 +23,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
       assert page.has_css?(".part-navigation li a[href*=\"#{part['slug']}\"]", text: part['title'])
     end
 
+    assert page.has_css?(shared_component_selector("previous_and_next_navigation"))
     assert page.has_css?('.print-link a[href$="/print"]')
   end
 

--- a/test/presenters/guide_presenter_test.rb
+++ b/test/presenters/guide_presenter_test.rb
@@ -48,7 +48,7 @@ class GuidePresenterTest
           title: "Next",
           label: parts[2]['title'] },
         previous_page: {
-          url: "#{schema_item['base_path']}/#{parts[0]['slug']}",
+          url: schema_item['base_path'],
           title: "Previous",
           label: parts[0]['title'] }
       }

--- a/test/presenters/parts_test.rb
+++ b/test/presenters/parts_test.rb
@@ -35,6 +35,16 @@ module PresentingFirstPartInContentItem
   end
 end
 
+module PresentingSecondPartInContentItem
+  def part_slug
+    'second-slug'
+  end
+
+  def requested_content_item_path
+    base_path
+  end
+end
+
 class PartsTest < ActiveSupport::TestCase
   def setup
     @parts = Object.new
@@ -44,6 +54,10 @@ class PartsTest < ActiveSupport::TestCase
 
   def presenting_first_part_in_content_item
     @parts.extend(PresentingFirstPartInContentItem)
+  end
+
+  def presenting_second_part_in_content_item
+    @parts.extend(PresentingSecondPartInContentItem)
   end
 
   test 'is not requesting a part when no parts exist' do
@@ -122,7 +136,13 @@ class PartsTest < ActiveSupport::TestCase
   test 'navigation items are presented as links unless they are the current part' do
     presenting_first_part_in_content_item
     assert_equal @parts.current_part_title, 'first-title'
-    assert_equal @parts.parts_navigation, [["first-title", "<a href=\"/second-slug\">second-title</a>"]]
+    assert_equal @parts.parts_navigation, [["first-title", "<a href=\"/base-path/second-slug\">second-title</a>"]]
+  end
+
+  test 'links to the first part ignore the part\'s slug and use the base path' do
+    presenting_second_part_in_content_item
+    assert_equal @parts.current_part_title, 'second-title'
+    assert_equal @parts.parts_navigation, [["<a href=\"/base-path\">first-title</a>", "second-title"]]
   end
 
   test 'navigation items link to all parts' do
@@ -197,8 +217,8 @@ class PartsTest < ActiveSupport::TestCase
     end
 
     assert_equal @parts.parts_navigation, [
-        ["first-title", "<a href=\"/second-slug\">second-title</a>"],
-        ["<a href=\"/third-slug\">third-title</a>", "<a href=\"/fourth-slug\">fourth-title</a>"]
+        ["first-title", "<a href=\"/base-path/second-slug\">second-title</a>"],
+        ["<a href=\"/base-path/third-slug\">third-title</a>", "<a href=\"/base-path/fourth-slug\">fourth-title</a>"]
       ]
   end
 end

--- a/test/presenters/travel_advice_presenter_test.rb
+++ b/test/presenters/travel_advice_presenter_test.rb
@@ -137,6 +137,52 @@ class TravelAdvicePresenterTest
       assert_equal "#{schema_item('full-country')['base_path']}/print", presented_item("full-country").print_link
     end
 
+    test "presents only next navigation when on the summary" do
+      example = schema_item('full-country')
+      parts = example['details']['parts']
+      nav = presented_item('full-country').previous_and_next_navigation
+      expected_nav = {
+        next_page: {
+          url: "#{example['base_path']}/#{parts[0]['slug']}",
+          title: "Next",
+          label: parts[0]['title'] }
+      }
+
+      assert_equal nav, expected_nav
+    end
+
+    test "presents previous and next navigation" do
+      example = schema_item('full-country')
+      parts = example['details']['parts']
+      nav = presented_item('full-country', parts[0]['slug']).previous_and_next_navigation
+      expected_nav = {
+        next_page: {
+          url: "#{example['base_path']}/#{parts[1]['slug']}",
+          title: "Next",
+          label: parts[1]['title'] },
+        previous_page: {
+          url: example['base_path'],
+          title: "Previous",
+          label: 'Summary' }
+      }
+
+      assert_equal nav, expected_nav
+    end
+
+    test "presents only previous navigation when last part" do
+      example = schema_item('full-country')
+      parts = example['details']['parts']
+      nav = presented_item('full-country', parts.last['slug']).previous_and_next_navigation
+      expected_nav = {
+        previous_page: {
+          url: "#{example['base_path']}/#{parts[-2]['slug']}",
+          title: "Previous",
+          label: parts[-2]['title'] }
+      }
+
+      assert_equal nav, expected_nav
+    end
+
     test "presents alert statuses" do
       example = schema_item("full-country")
       example["details"]["alert_status"] = %w{avoid_all_but_essential_travel_to_parts avoid_all_travel_to_parts}

--- a/test/presenters/travel_advice_presenter_test.rb
+++ b/test/presenters/travel_advice_presenter_test.rb
@@ -259,7 +259,10 @@ class TravelAdvicePresenterTest
       parts = presented_item("full-country").parts.clone
       summary = parts.shift
 
-      assert_equal example_parts, parts
+      parts.each_with_index do |part, i|
+        assert_equal example_parts[i]['body'], part['body']
+        assert_equal example_parts[i]['slug'], part['slug']
+      end
       assert_equal "Summary", summary["title"]
       assert_equal schema_item("full-country")["details"]["summary"], summary["body"]
     end

--- a/test/presenters/travel_advice_presenter_test.rb
+++ b/test/presenters/travel_advice_presenter_test.rb
@@ -208,11 +208,14 @@ class TravelAdvicePresenterTest
       assert_equal "<p>Test&lt;br&gt;XML</p>", present_example(example).atom_change_description
     end
 
-    test "presents all parts for the print view" do
+    test "presents all parts including summary for the print view" do
       example_parts = schema_item("full-country")["details"]["parts"]
-      presented = presented_item("full-country")
+      parts = presented_item("full-country").parts.clone
+      summary = parts.shift
 
-      assert_equal example_parts, presented.parts
+      assert_equal example_parts, parts
+      assert_equal "Summary", summary["title"]
+      assert_equal schema_item("full-country")["details"]["summary"], summary["body"]
     end
 
   private


### PR DESCRIPTION
* When linking to the first part of a guide, link to the base path. eg: www.gov.uk/attendance-allowance/overview is identical to www.gov.uk/attendance-allowance – avoids duplicate URLs with the same content.
* This also works with travel advice summaries. Summaries are not included as a part by the content item, but for all purposes, the frontend renders it as a part. Coerce summary into being the first part, which conveniently has no slug, so links to the base_path like the first part of a guide.
* Now parts logic is common between travel advice and guides the logic for next and previous pagination can be shared
* Add pagination to travel advice, ensuring that the link to the first part is without slug

## Screenshots 
![screen shot 2017-05-10 at 11 40 56](https://cloud.githubusercontent.com/assets/319055/25894915/a5397798-3575-11e7-850b-c34cf357d66d.png)
![screen shot 2017-05-10 at 11 41 11](https://cloud.githubusercontent.com/assets/319055/25894916/a539aace-3575-11e7-8fe5-a157831d0e4a.png)
![screen shot 2017-05-10 at 11 41 24](https://cloud.githubusercontent.com/assets/319055/25894914/a537d578-3575-11e7-871a-2a4590833395.png)
