### PR TITLE
Add `world_news_story` to en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,6 +230,9 @@ en:
       world_location_news_article:
         one: News article
         other: News articles
+      world_news_story:
+        one: World news story
+        other: World news stories
       written_statement:
         one: Written statement to Parliament
         other: Written statements to Parliament


### PR DESCRIPTION
`world_news_story` is a new sub-type of `NewsArticle` that we are migrating the `WorldLocationNewsArticle` format to.

This commit adds it to the `en.yml` file to allow it to be rendered without a missing translation warning.