### PR TITLE
Add UKVI AB test with presenter and JS module

### DIFF
--- a/app/assets/javascripts/modules/ukvi_ab_test.js
+++ b/app/assets/javascripts/modules/ukvi_ab_test.js
@@ -1,0 +1,39 @@
+//= require govuk/multivariate-test
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (GOVUK) {
+  'use strict'
+
+  GOVUK.Modules.UkviAbTest = function () {
+    this.start = function ($el) {
+      var testType = $el.data('test-type'),
+          testLabel = $el.data('test-label'),
+          newContent = $el.html(),
+          testCallback = testType === "overview" ? updateOverviewSection : UpdateKnowledgeOfEnglishSection;
+      
+      new GOVUK.MultivariateTest({
+        name: testLabel,
+        cookieDuration: 30, // set cookie expiry to 30 days
+        customDimensionIndex: [13, 14],
+        cohorts: {
+          original: { callback: function() {}, weight: 50},
+          spouseProminent: {
+            callback: testCallback,
+            weight: 50
+          }
+        }
+      });
+
+      function updateOverviewSection() {
+        $("#exceptions").prevAll().hide();
+        $("#exceptions").before(newContent);
+      }
+
+      function UpdateKnowledgeOfEnglishSection() {
+        $("#exemptions").prevAll().hide();
+        $("#exemptions").before(newContent);
+      }
+    }
+  }
+})(window.GOVUK)

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -1,5 +1,6 @@
 class GuidePresenter < ContentItemPresenter
   include Parts
+  include UkviABTest
 
   def page_title
     if @part_slug

--- a/app/presenters/ukvi_ab_test.rb
+++ b/app/presenters/ukvi_ab_test.rb
@@ -1,0 +1,28 @@
+module UkviABTest
+  def ukvi_overview_section_test?
+    guide_in_ukvi_test? && (part_slug.nil? || part_slug == 'overview')
+  end
+
+  def ukvi_knowledge_section_test?
+    guide_in_ukvi_test? && part_slug == 'knowledge-of-english'
+  end
+
+  def ukvi_test_label
+    if guide_under_test.include?("remain-in-uk-family")
+      "ukviSpouseVisa_Remain_2017"
+    elsif guide_under_test.include?("join-family-in-uk")
+      "ukviSpouseVisa_Join_2017"
+    end
+  end
+
+private
+
+  def guide_under_test
+    base_path.split('/')
+  end
+
+  def guide_in_ukvi_test?
+    (guide_under_test.include?("remain-in-uk-family") ||
+      guide_under_test.include?("join-family-in-uk"))
+  end
+end

--- a/app/views/ab_testing/_ukvi_knowledge_of_english_section.html.erb
+++ b/app/views/ab_testing/_ukvi_knowledge_of_english_section.html.erb
@@ -1,0 +1,28 @@
+<script
+  type="text/html"
+  data-module="ukvi-ab-test"
+  data-test-type="knowledge"
+  data-test-label="<%= @content_item.ukvi_test_label %>"
+>
+  <p>You can apply to continue to live in the UK if you have a family member who is both:</p>
+
+  <ul>
+    <li>a British citizen or settled (they have 'indefinite leave to remain')</li>
+    <li>living permanently in the UK</li>
+  </ul>
+
+  <p>Your family member can be a:</p>
+  <ul>
+    <li>spouse</li>
+    <li>partner</li>
+    <li>fiancé or fiancée</li>
+    <li>child</li>
+    <li>relative who cares for you</li>
+  </ul>
+
+  <p>You can also apply if your partner has asylum or humanitarian protection in the UK.</p>
+
+  <div role='note' aria-label='Information' class='application-notice info-notice'>
+    <p>You don't need a visa if you're from the European Economic Area (EEA) or Switzerland.</p>
+  </div>
+</script>

--- a/app/views/ab_testing/_ukvi_overview_section.html.erb
+++ b/app/views/ab_testing/_ukvi_overview_section.html.erb
@@ -1,0 +1,33 @@
+<script
+  type="text/html"
+  data-module="ukvi-ab-test"
+  data-test-type="overview"
+  data-test-label="<%= @content_item.ukvi_test_label %>"
+>
+  <p>If you want to come to the UK to live with a family member for more than 6 months, you’ll need a family visa.</p>
+
+  <div role='note' aria-label='Information' class='application-notice info-notice'>
+    <p>If you’re visiting for 6 months or less, check if you need a <a href='/check-uk-visa'>Standard Visitor visa</a>.</p>
+  </div>
+
+  <p>Your family member must be both:</p>
+  <ul>
+    <li>a British citizen or settled (they have 'indefinite leave to remain')</li>
+    <li>living permanently in the UK</li>
+  </ul>
+
+  <p>Your family member can be a:</p>
+  <ul>
+    <li>spouse</li>
+    <li>partner</li>
+    <li>fiancé or fiancée</li>
+    <li>child</li>
+    <li>relative who cares for you</li>
+  </ul>
+
+  <p>You can also apply if your partner has asylum or humanitarian protection in the UK.</p>
+
+  <div role='note' aria-label='Information' class='application-notice info-notice'>
+    <p>You don't need a visa if you're from the European Economic Area (EEA) or Switzerland.</p>
+  </div>
+</script>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -25,6 +25,12 @@
           disable_youtube_expansions: true,
           rich_govspeak: true %>
 
+      <% if @content_item.ukvi_overview_section_test? %>
+        <%= render partial: "ab_testing/ukvi_overview_section" %>
+      <% elsif @content_item.ukvi_knowledge_section_test? %>
+        <%= render partial: "ab_testing/ukvi_knowledge_of_english_section" %>
+      <% end %>
+
       <%= render 'govuk_component/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
 
       <% if @content_item.multi_page_guide? %>

--- a/test/presenters/ukvi_ab_test_test.rb
+++ b/test/presenters/ukvi_ab_test_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+module UkviStubs
+  def base_path
+    test_path
+  end
+
+  def part_slug
+    test_path.split('/').length > 2 ? test_path.split('/').last : nil
+  end
+end
+
+class UkviABTestTest < ActiveSupport::TestCase
+  def setup
+    @ukvi_test = OpenStruct.new
+    @ukvi_test.extend(UkviABTest)
+    @ukvi_test.extend(UkviStubs)
+  end
+
+  [
+    '/any-other-guide',
+    '/any-other-guide/overview',
+    '/remain-in-uk-family/a-different-part'
+  ].each do |test_path|
+    test "#{test_path} are not in test" do
+      @ukvi_test.test_path = test_path
+      refute @ukvi_test.ukvi_overview_section_test?
+      refute @ukvi_test.ukvi_knowledge_section_test?
+    end
+  end
+
+  [
+    '/remain-in-uk-family',
+    '/remain-in-uk-family/overview',
+    '/join-family-in-uk',
+    '/join-family-in-uk/overview'
+  ].each do |test_path|
+    test "#{test_path} is in overview test" do
+      @ukvi_test.test_path = test_path
+      assert @ukvi_test.ukvi_overview_section_test?
+    end
+  end
+
+  [
+    '/remain-in-uk-family/knowledge-of-english',
+    '/join-family-in-uk/knowledge-of-english'
+  ].each do |test_path|
+    test "#{test_path} is in knowledge of English test" do
+      @ukvi_test.test_path = test_path
+      assert @ukvi_test.ukvi_knowledge_section_test?
+    end
+  end
+
+  [
+    '/remain-in-uk-family',
+    '/remain-in-uk-family/overview',
+    '/remain-in-uk-family/knowledge-of-english'
+  ].each do |test_path|
+    test "#{test_path} is labelled as remain test" do
+      @ukvi_test.test_path = test_path
+      assert_equal @ukvi_test.ukvi_test_label, "ukviSpouseVisa_Remain_2017"
+    end
+  end
+
+  [
+    '/join-family-in-uk',
+    '/join-family-in-uk/overview',
+    '/join-family-in-uk/knowledge-of-english'
+  ].each do |test_path|
+    test "#{test_path} is labelled as join test" do
+      @ukvi_test.test_path = test_path
+      assert_equal @ukvi_test.ukvi_test_label, "ukviSpouseVisa_Join_2017"
+    end
+  end
+end


### PR DESCRIPTION
Supersedes https://github.com/alphagov/frontend/pull/1228
Still suffers from some of the problems highlighted here: https://github.com/alphagov/frontend/pull/1228#pullrequestreview-37664574
We want to avoid those problems but need to get the test out on Monday.

* Add unit test for Ukvi AB test – check that only two guides run the
test, and only on two specific parts
* Use JS module pattern for handling content switch on frontend

Sets up a frontend AB test for the following UKVI page sections:

- /remain-in-uk-family/*
- /join-family-in-uk/*

Cohorts across the aforementioned UKVI page sections fall under the
following:

- original (with a 50% weighting)
- spouseProminent (with a 50% weighting)