### PR TITLE
Append draft access token to parts links on guides

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -12,10 +12,17 @@ class ContentItemsController < ApplicationController
     set_up_education_navigation_ab_testing
     set_expiry
     set_access_control_allow_origin_header if request.format.atom?
+    set_guide_draft_access_token if @content_item.is_a?(GuidePresenter)
     render_template
   end
 
 private
+
+  # Allow guides to pass access token to each part to allow
+  # fact checking of all content
+  def set_guide_draft_access_token
+    @content_item.draft_access_token = params[:token]
+  end
 
   def load_content_item
     content_item = content_store.content_item(content_item_path)

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -2,6 +2,8 @@ class GuidePresenter < ContentItemPresenter
   include Parts
   include UkviABTest
 
+  attr_accessor :draft_access_token
+
   def page_title
     if @part_slug
       "#{title}: #{current_part_title}"
@@ -32,5 +34,22 @@ class GuidePresenter < ContentItemPresenter
 
   def related_items
     @nav_helper.related_items
+  end
+
+  # Append token parameters to part paths to allow fact-checkers to fact-check all pages
+  def parts
+    if draft_access_token
+      super.each do |part|
+        part['full_path'] = "#{part['full_path']}?#{draft_access_token_param}"
+      end
+    else
+      super
+    end
+  end
+
+private
+
+  def draft_access_token_param
+    "token=#{draft_access_token}" if draft_access_token
   end
 end

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -28,6 +28,14 @@ class GuideTest < ActionDispatch::IntegrationTest
     assert page.has_css?('.print-link a[href$="/print"]')
   end
 
+  test "draft access tokens are appended to part links within navigation" do
+    @content_item = JSON.parse(get_content_example("guide")).tap do |item|
+      visit("#{item['base_path']}?token=some_token")
+    end
+
+    assert page.has_css?('.part-navigation a[href$="?token=some_token"]')
+  end
+
   test "does not show part navigation, print link or part title when only one part" do
     setup_and_visit_content_item('single-page-guide')
 

--- a/test/presenters/guide_presenter_test.rb
+++ b/test/presenters/guide_presenter_test.rb
@@ -81,6 +81,25 @@ class GuidePresenterTest
       presented_item('no-part-guide').has_parts?
     end
 
+    test "presents access tokens in part links when provided" do
+      presented = presented_item('guide')
+      presented.draft_access_token = 'some_token'
+      expected_param = '?token=some_token'
+
+      presented.parts.each do |part|
+        assert part['full_path'].ends_with?(expected_param)
+      end
+
+      presented.parts_navigation.flatten.each_with_index do |link, i|
+        if i > 0
+          assert expected_param.in?(link)
+        end
+      end
+
+      nav = presented.previous_and_next_navigation
+      assert nav[:next_page][:url].ends_with?(expected_param)
+    end
+
   private
 
     def presented_item(type = format_name, part_slug = nil, overrides = {})


### PR DESCRIPTION
Fact checkers are given an access token to let them view content without a sign on account. For multi page content this token doesn’t persist when fact checkers click part navigation.

* When tokens exist append them to part links in navigation and pagination
* Loosely based on https://github.com/alphagov/frontend/pull/1133/files#diff-55c5b7aecfb519d0e4880eaf2788eb6eR127 (default_url_params don’t work unless you’re
using Rails path helpers)

Ideally government-frontend would only do this on the draft stack, but it has no knowledge of what content store/stack it is using.

cc @davidbasalla @whoojemaflip @suzannehamilton 