### PR TITLE
Rename format to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ parts of the [Whitehall](https://github.com/alphagov/whitehall) application.
 
 ![A  Case Study](https://raw.githubusercontent.com/alphagov/government-frontend/master/docs/assets/case-study-screenshot.png)
 
-## Formats
+## Schemas
 
-Not all formats that this app can handle are rendered by it in production.
+Not all schemas that this app can handle are rendered by it in production.
 
-| Format | Live example | Production status |
+| Schema | Live example | Production status |
 |---|---|---|
 | Answer | [View on GOV.UK](https://www.gov.uk/national-minimum-wage-rates) | Migrated |
 | Case study | [View on GOV.UK](https://www.gov.uk/government/case-studies/2013-elections-in-swaziland) | Migrated |

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -38,7 +38,7 @@ private
   end
 
   def content_item_template
-    @content_item.format
+    @content_item.schema_name
   end
 
   def render_template

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -6,7 +6,7 @@ class ContentItemPresenter
               :base_path,
               :title,
               :description,
-              :format,
+              :schema_name,
               :locale,
               :phase,
               :part_slug,
@@ -18,7 +18,7 @@ class ContentItemPresenter
     @base_path = content_item["base_path"]
     @title = content_item["title"]
     @description = content_item["description"]
-    @format = content_item["schema_name"]
+    @schema_name = content_item["schema_name"]
     @locale = content_item["locale"] || "en"
     @phase = content_item["phase"]
     @document_type = content_item["document_type"]

--- a/app/presenters/national_applicability.rb
+++ b/app/presenters/national_applicability.rb
@@ -16,7 +16,7 @@ module NationalApplicability
           .map { |n| link_to(n['label'], n['alternative_url'], rel: :external) }
           .to_sentence
 
-        applies_to += " (see #{translated_format_name(nations_with_alt_urls.count)} for #{alternate_links})"
+        applies_to += " (see #{translated_schema_name(nations_with_alt_urls.count)} for #{alternate_links})"
       end
     end
 
@@ -31,8 +31,8 @@ module NationalApplicability
 
 private
 
-  def translated_format_name(count)
-    I18n.t("content_item.format.#{format}", count: count).downcase
+  def translated_schema_name(count)
+    I18n.t("content_item.schema_name.#{schema_name}", count: count).downcase
   end
 
   def national_applicability

--- a/app/presenters/title_and_context.rb
+++ b/app/presenters/title_and_context.rb
@@ -2,7 +2,7 @@ module TitleAndContext
   def title_and_context
     {
       title: title,
-      context: I18n.t("content_item.format.#{document_type}", count: 1),
+      context: I18n.t("content_item.schema_name.#{document_type}", count: 1),
       average_title_length: "long"
     }
   end

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
+<%= content_for :title, "#{@content_item.page_title} - #{t("content_item.schema_name.#{@content_item.document_type}", count: 1)}" %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>

--- a/app/views/content_items/document_collection.html+new_navigation.erb
+++ b/app/views/content_items/document_collection.html+new_navigation.erb
@@ -32,7 +32,7 @@
                   <%= l(link[:public_updated_at], format: :short_ordinal) %>
                 </time>
               </li>
-              <li><%= t("content_item.format.#{link[:document_type]}", count: 1) %></li>
+              <li><%= t("content_item.schema_name.#{link[:document_type]}", count: 1) %></li>
             </ul>
           </li>
         <% end %>

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -35,7 +35,7 @@
                   <%= l(link[:public_updated_at], format: :short_ordinal) %>
                 </time>
               </li>
-              <li><%= t("content_item.format.#{link[:document_type]}", count: 1) %></li>
+              <li><%= t("content_item.schema_name.#{link[:document_type]}", count: 1) %></li>
             </ul>
           </li>
         <% end %>

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, "#{@content_item.page_title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
+<%= content_for :title, "#{@content_item.page_title} - #{t("content_item.schema_name.#{@content_item.document_type}", count: 1)}" %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -26,7 +26,7 @@
   <div class="headings">
     <div class="html-publication-title">
       <% if @content_item.format_sub_type %>
-        <p class="context"><%= I18n.t("content_item.format.#{@content_item.format_sub_type}", count: 1) %></p>
+        <p class="context"><%= I18n.t("content_item.schema_name.#{@content_item.format_sub_type}", count: 1) %></p>
       <% end %>
       <h1><%= @content_item.title %></h1>
     </div>

--- a/app/views/content_items/publication.html+new_navigation.erb
+++ b/app/views/content_items/publication.html+new_navigation.erb
@@ -4,7 +4,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
-               context: t("content_item.format.#{@content_item.document_type}", count: 1),
+               context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
                title: @content_item.title,
                average_title_length: "long" %>
 

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -3,7 +3,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.document_type}", count: 1),
+        context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
         title: @content_item.title,
         average_title_length: "long" %>
   </div>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, "#{@content_item.title} - #{t("content_item.format.#{@content_item.document_type}", count: 1)}" %>
+<%= content_for :title, "#{@content_item.title} - #{t("content_item.schema_name.#{@content_item.document_type}", count: 1)}" %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
   <% end %>
 
   <div id="wrapper" class="<%= wrapper_class %>">
-    <main role="main" id="content" class="<%= @content_item.format.dasherize %>" lang="<%= I18n.locale %>">
+    <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">
       <%= render_phase_label @content_item, content_for(:phase_message) %>
       <%= render 'shared/breadcrumbs' %>
       <%= yield %>

--- a/app/views/shared/_withdrawal_notice.html.erb
+++ b/app/views/shared/_withdrawal_notice.html.erb
@@ -1,7 +1,7 @@
 <% if content_item.withdrawn? %>
   <div class="withdrawal-notice">
     <h2>
-      This <%= t("content_item.format.#{content_item.schema_name}", count: 1).downcase %>
+      This <%= t("content_item.schema_name.#{content_item.schema_name}", count: 1).downcase %>
       was withdrawn on <%= content_item.withdrawal_notice[:time] %>
     </h2>
     <%= render 'govuk_component/govspeak', content: content_item.withdrawal_notice[:explanation] %>

--- a/app/views/shared/_withdrawal_notice.html.erb
+++ b/app/views/shared/_withdrawal_notice.html.erb
@@ -1,7 +1,7 @@
 <% if content_item.withdrawn? %>
   <div class="withdrawal-notice">
     <h2>
-      This <%= t("content_item.format.#{content_item.format}", count: 1).downcase %>
+      This <%= t("content_item.format.#{content_item.schema_name}", count: 1).downcase %>
       was withdrawn on <%= content_item.withdrawal_notice[:time] %>
     </h2>
     <%= render 'govuk_component/govspeak', content: content_item.withdrawal_notice[:explanation] %>

--- a/config/locale_mapping.yml
+++ b/config/locale_mapping.yml
@@ -1,4 +1,4 @@
 language_names: language_names
-document.type: content_item.format
+document.type: content_item.schema_name
 document.published: content_item.metadata.published
 document.updated: content_item.metadata.updated

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -4,7 +4,7 @@ ar:
   language_names:
     ar: "العربية"
   content_item:
-    format:
+    schema_name:
       announcement:
         zero:
         one: "إعلان"

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -2,7 +2,7 @@ az:
   language_names:
     az: Azərbaycanca
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Elan
         other: Elanlar

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -2,7 +2,7 @@ be:
   language_names:
     be: "Беларуская"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "Аб'ява"
         few:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -2,7 +2,7 @@ bg:
   language_names:
     bg: "български"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "Съобщение"
         other: "Съобщения"

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -2,7 +2,7 @@ bn:
   language_names:
     bn: "বাংলা"
   content_item:
-    format:
+    schema_name:
       announcement:
         one:
         other:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -2,7 +2,7 @@ cs:
   language_names:
     cs: "Česky"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Oznámení
         few:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -4,7 +4,7 @@ cy:
   common:
     last_updated: "Diweddarwyd diwethaf"
   content_item:
-    format:
+    schema_name:
       announcement:
         zero:
         one: Cyhoeddiad

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2,7 +2,7 @@ de:
   language_names:
     de: Deutsch
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Meldung
         other: Meldungen

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -2,7 +2,7 @@ dr:
   language_names:
     dr: "دری"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "اعلان"
         other: "اعلانات"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -2,7 +2,7 @@ el:
   language_names:
     el: "Ελληνικά "
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "Ανακοίνωση"
         other: "Ανακοινώσεις"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,7 +77,7 @@ en:
     uz: Uzbeki
     id: Indonesian
   content_item:
-    format:
+    schema_name:
       # `national` & `official` are old document types for
       # `national_statistics_announcement` and `official_statistics_announcement`.
       # They can be removed once https://github.com/alphagov/whitehall/pull/2783 is

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -2,7 +2,7 @@ es-419:
   language_names:
     es-419: Español
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Novedades
         other: Novedades

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2,7 +2,7 @@ es:
   language_names:
     es: Español
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Anuncio
         other: Anuncios

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -2,7 +2,7 @@ et:
   language_names:
     et: Eesti
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Teadaanne
         other: Teadaanded

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -2,7 +2,7 @@ fa:
   language_names:
     fa: "فارسی"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "اعلامیه"
         other: "اعلامیه ها"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2,7 +2,7 @@ fr:
   language_names:
     fr: Français
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Annonce
         other: Annonces

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2,7 +2,7 @@ he:
   language_names:
     he: "עברית"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "הודעה"
         two:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -2,7 +2,7 @@ hi:
   language_names:
     hi: "हिंदी"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "घोषणा"
         other: "घोषणाएं"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -2,7 +2,7 @@ hu:
   language_names:
     hu: Magyar
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Bejelentés
         other: Bejelentések

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -2,7 +2,7 @@ hy:
   language_names:
     hy: "Հայերեն"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "Հայտարարություն"
         other: "Հայտարարություններ"

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -2,7 +2,7 @@ id:
   language_names:
     id: Bahasa Indonesia
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Pengumuman
         other: Pengumuman-pengumuman

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -2,7 +2,7 @@ it:
   language_names:
     it: Italiano
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Annuncio
         other: Annunci

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,7 +2,7 @@ ja:
   language_names:
     ja: "日本語"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "ニュース"
         other: "ニュース"

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -2,7 +2,7 @@ ka:
   language_names:
     ka: "ქართული"
   content_item:
-    format:
+    schema_name:
       announcement:
         one:
         other:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -2,7 +2,7 @@ ko:
   language_names:
     ko: "한국어"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "공지"
         other: "공지"

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -2,7 +2,7 @@ lt:
   language_names:
     lt: Lietuvių
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Pranešimas
         few:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -2,7 +2,7 @@ lv:
   language_names:
     lv: Latviešu
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Paziņojums
         other: Paziņojumi

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -2,7 +2,7 @@ ms:
   language_names:
     ms: Bahasa Melayu
   content_item:
-    format:
+    schema_name:
       announcement:
         one:
         other:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -2,7 +2,7 @@ pl:
   language_names:
     pl: Polski
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Ogłoszenie
         few:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -2,7 +2,7 @@ ps:
   language_names:
     ps: "پښتو"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "خبرتیا"
         other: "خبرتیاوې"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -2,7 +2,7 @@ pt:
   language_names:
     pt: Português
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Anúncio
         other: Anúncios

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -2,7 +2,7 @@ ro:
   language_names:
     ro: Română
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "Știre"
         few:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -2,7 +2,7 @@ ru:
   language_names:
     ru: "Русский"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "Объявление"
         few:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -2,7 +2,7 @@ si:
   language_names:
     si: "සිංහල"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "නිවේදනය"
         other: "නිවේදන"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -2,7 +2,7 @@ sk:
   language_names:
     sk: Slovenčina
   content_item:
-    format:
+    schema_name:
       announcement:
         one:
         few:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -2,7 +2,7 @@ so:
   language_names:
     so: Soomaaliga
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Ogeysiis
         other: Ogeysiisyo

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -2,7 +2,7 @@ sq:
   language_names:
     sq: Shqip
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Lajmerim
         other: Lajmerime

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -2,7 +2,7 @@ sr:
   language_names:
     sr: Srpski
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Najava
         few:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -2,7 +2,7 @@ sw:
   language_names:
     sw: Kiswahili
   content_item:
-    format:
+    schema_name:
       announcement:
         one:
         other:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -2,7 +2,7 @@ ta:
   language_names:
     ta: "தமிழ்"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "அறிவிப்பு"
         other: "அறிவிப்புகள்"

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -2,7 +2,7 @@ th:
   language_names:
     th: "ไทย"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "ข่าวสาร"
         other: "ข่าวสาร"

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -2,7 +2,7 @@ tk:
   language_names:
     tk: Türkmençe
   content_item:
-    format:
+    schema_name:
       announcement:
         one:
         other:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -2,7 +2,7 @@ tr:
   language_names:
     tr: Türkçe
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Duyuru
         other: Duyurular

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -2,7 +2,7 @@ uk:
   language_names:
     uk: "Українська"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "Оголошення"
         few:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -2,7 +2,7 @@ ur:
   i18n:
     direction: rtl
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "اعلان"
         other: "اعلانات"

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -2,7 +2,7 @@ uz:
   language_names:
     uz: O'zbekcha
   content_item:
-    format:
+    schema_name:
       announcement:
         one: E'lon
         other: E'lonlar

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -2,7 +2,7 @@ vi:
   language_names:
     vi: Tiếng Việt
   content_item:
-    format:
+    schema_name:
       announcement:
         one: Thông báo
         other: Các thông báo

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -2,7 +2,7 @@ zh-hk:
   language_names:
     zh-hk: "中文"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "公告"
         other: "其他公告"

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -2,7 +2,7 @@ zh-tw:
   language_names:
     zh-tw: "中文"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "公告"
         other: "其他公告"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -4,7 +4,7 @@ zh:
   language_names:
     zh: "中文"
   content_item:
-    format:
+    schema_name:
       announcement:
         one: "公告"
         other: "公告"

--- a/lib/generators/format/templates/format.html.erb
+++ b/lib/generators/format/templates/format.html.erb
@@ -3,7 +3,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%%= render 'govuk_component/title',
-        context: t("content_item.format.#{@content_item.document_type}", count: 1),
+        context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
         title: @content_item.title %>
   </div>
 </div>

--- a/lib/generators/format/templates/format_presenter_test.rb.erb
+++ b/lib/generators/format/templates/format_presenter_test.rb.erb
@@ -2,12 +2,12 @@ require 'presenter_test_helper'
 
 class <%= "#{@camel_name}PresenterTest" %>
   class <%= "Presented#{@camel_name}" %> < PresenterTestCase
-    def format_name
+    def schema_name
       "<%= @format_name %>"
     end
 
-    test 'presents the format' do
-      assert_equal schema_item['format'], presented_item.format
+    test 'presents the schema_name' do
+      assert_equal schema_item['schema_name'], presented_item.schema_name
     end
   end
 end

--- a/test/contracts/govuk_content_schemas_test.rb
+++ b/test/contracts/govuk_content_schemas_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class GovukContentSchemasTest < ActionDispatch::IntegrationTest
   include GovukContentSchemaExamples
 
-  all_examples_for_supported_formats.each do |content_item|
+  all_examples_for_supported_schemas.each do |content_item|
     test "can successfully render #{content_item['base_path']} schema example" do
       content_store_has_item(content_item['base_path'], content_item)
 

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -106,7 +106,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     get :show, params: { path: path_for(content_item, locale), locale: locale }
 
     assert_response :success
-    assert_select "title", %r(#{translated_format_name})
+    assert_select "title", %r(#{translated_schema_name})
   end
 
   test "renders atom feeds" do

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -101,7 +101,7 @@ class ContentItemsControllerTest < ActionController::TestCase
   test "renders translated content items in their locale" do
     content_item = content_store_has_schema_example('case_study', 'translated')
     locale = content_item['locale']
-    translated_format_name = I18n.t("content_item.format.case_study", count: 1, locale: locale)
+    translated_schema_name = I18n.t("content_item.schema_name.case_study", count: 1, locale: locale)
 
     get :show, params: { path: path_for(content_item, locale), locale: locale }
 

--- a/test/integration/content_item_test.rb
+++ b/test/integration/content_item_test.rb
@@ -2,12 +2,12 @@ require 'test_helper'
 
 class ContentItemTest < ActionDispatch::IntegrationTest
   def test_examples
-    formats = %w( case_study coming_soon detailed_guide document_collection
-                  fatality_notice gone html_publication publication statistics_announcement
-                  take_part topical_event_about_page unpublishing working_group )
+    schema_types = %w( case_study coming_soon detailed_guide document_collection
+                       fatality_notice gone html_publication publication statistics_announcement
+                       take_part topical_event_about_page unpublishing working_group )
 
-    result = formats.inject({}) do |examples, format|
-      examples[format] = format
+    result = schema_types.inject({}) do |examples, schema_type|
+      examples[schema_type] = schema_type
       examples
     end
     result["html_publication"] = "arabic_translation"
@@ -17,8 +17,8 @@ class ContentItemTest < ActionDispatch::IntegrationTest
   end
 
   test "content id" do
-    test_examples.each do |format, example|
-      define_singleton_method("schema_format") { format }
+    test_examples.each do |schema_type, example|
+      define_singleton_method("schema_type") { schema_type }
 
       setup_and_visit_content_item(example)
       has_component_metadata("name", "govuk:content-id")

--- a/test/integration/government_navigation_test.rb
+++ b/test/integration/government_navigation_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class GovernmentNavigationTest < ActionDispatch::IntegrationTest
   test "includes government navigation and sets the correct active item" do
-    example_body = get_content_example_by_format_and_name("case_study", "case_study")
+    example_body = get_content_example_by_schema_and_name("case_study", "case_study")
     base_path = JSON.parse(example_body).fetch("base_path")
     content_store_has_item(base_path, example_body)
 

--- a/test/integration/guide_print_test.rb
+++ b/test/integration/guide_print_test.rb
@@ -28,7 +28,7 @@ class GuidePrint < ActionDispatch::IntegrationTest
   end
 
   def setup_and_visit_guide_print(name)
-    example = get_content_example_by_format_and_name('guide', name)
+    example = get_content_example_by_schema_and_name('guide', name)
     @content_item = JSON.parse(example).tap do |item|
       content_store_has_item(item["base_path"], item.to_json)
       visit "#{item['base_path']}/print"

--- a/test/integration/travel_advice_atom_feed_test.rb
+++ b/test/integration/travel_advice_atom_feed_test.rb
@@ -32,7 +32,7 @@ class TravelAdviceAtomFeed < ActionDispatch::IntegrationTest
   end
 
   def setup_and_visit_travel_advice_atom_feed(name)
-    example = get_content_example_by_format_and_name('travel_advice', name)
+    example = get_content_example_by_schema_and_name('travel_advice', name)
     @content_item = JSON.parse(example).tap do |item|
       content_store_has_item(item["base_path"], item.to_json)
       visit "#{item['base_path']}.atom"

--- a/test/integration/travel_advice_print_test.rb
+++ b/test/integration/travel_advice_print_test.rb
@@ -44,7 +44,7 @@ class TravelAdvicePrint < ActionDispatch::IntegrationTest
   end
 
   def setup_and_visit_travel_advice_print(name)
-    example = get_content_example_by_format_and_name('travel_advice', name)
+    example = get_content_example_by_schema_and_name('travel_advice', name)
     @content_item = JSON.parse(example).tap do |item|
       content_store_has_item(item["base_path"], item.to_json)
       visit "#{item['base_path']}/print"

--- a/test/presenter_test_helper.rb
+++ b/test/presenter_test_helper.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class PresenterTestCase < ActiveSupport::TestCase
-  def format_name
+  def schema_name
     raise NotImplementedError, "Override this method in your test class"
   end
 
@@ -11,16 +11,16 @@ class PresenterTestCase < ActiveSupport::TestCase
 
 private
 
-  def presented_item(type = format_name, overrides = {})
+  def presented_item(type = schema_name, overrides = {})
     example = schema_item(type)
     present_example(example.merge(overrides))
   end
 
   def present_example(example)
-    "#{format_name.classify}Presenter".safe_constantize.new(example)
+    "#{schema_name.classify}Presenter".safe_constantize.new(example)
   end
 
-  def schema_item(type = format_name)
-    govuk_content_schema_example(format_name, type)
+  def schema_item(type = schema_name)
+    govuk_content_schema_example(schema_name, type)
   end
 end

--- a/test/presenters/answer_presenter_test.rb
+++ b/test/presenters/answer_presenter_test.rb
@@ -1,7 +1,7 @@
 require 'presenter_test_helper'
 
 class AnswerPresenterTest < PresenterTestCase
-  def format_name
+  def schema_name
     "answer"
   end
 

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -3,13 +3,13 @@ require 'presenter_test_helper'
 class CaseStudyPresenterTest < PresenterTestCase
   include ActionView::Helpers::UrlHelper
 
-  def format_name
+  def schema_name
     "case_study"
   end
 
   test 'presents the basic details of a content item' do
     assert_equal schema_item['description'], presented_item.description
-    assert_equal schema_item['schema_name'], presented_item.format
+    assert_equal schema_item['schema_name'], presented_item.schema_name
     assert_equal schema_item['locale'], presented_item.locale
     assert_equal schema_item['title'], presented_item.title
     assert_equal schema_item['details']['body'], presented_item.body
@@ -47,7 +47,7 @@ class CaseStudyPresenterTest < PresenterTestCase
       link_to('DFID Pakistan', '/government/world/organisations/dfid-pakistan'),
     ]
 
-    assert_equal expected_from_links, presented_item(format_name, with_organisations).from
+    assert_equal expected_from_links, presented_item(schema_name, with_organisations).from
   end
 
   test '#part_of returns an array of document_collections, related policies and world locations' do
@@ -64,7 +64,7 @@ class CaseStudyPresenterTest < PresenterTestCase
       link_to('Cheese', '/policy/cheese'),
       link_to('Pakistan', '/government/world/pakistan'),
     ]
-    assert_equal expected_part_of_links, presented_item(format_name, with_extras).part_of
+    assert_equal expected_part_of_links, presented_item(schema_name, with_extras).part_of
   end
 
   test '#history returns an empty array if the content item has no updates' do
@@ -102,6 +102,6 @@ class CaseStudyPresenterTest < PresenterTestCase
     with_history['details']['change_history'] = [{ 'note' => 'Something changed', 'public_timestamp' => march_21_2013 }]
     with_history['public_updated_at'] = march_21_2013
 
-    presented_item(format_name, with_history)
+    presented_item(schema_name, with_history)
   end
 end

--- a/test/presenters/coming_soon_presenter_test.rb
+++ b/test/presenters/coming_soon_presenter_test.rb
@@ -1,13 +1,13 @@
 require 'presenter_test_helper'
 
 class ComingSoonPresenterTest < PresenterTestCase
-  def format_name
+  def schema_name
     "coming_soon"
   end
 
   test 'presents the basic details required to display a coming soon item' do
     assert_equal schema_item['title'], presented_item.title
-    assert_equal schema_item['schema_name'], presented_item.format
+    assert_equal schema_item['schema_name'], presented_item.schema_name
     assert_equal schema_item['locale'], presented_item.locale
     assert_equal schema_item['details']['publish_time'], presented_item.publish_time
   end

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -2,11 +2,11 @@ require 'presenter_test_helper'
 
 class ConsultationPresenterTest
   class PresentedConsultation < PresenterTestCase
-    def format_name
+    def schema_name
       "consultation"
     end
 
-    test 'presents the format' do
+    test 'presents the schema name' do
       assert_equal schema_item("open_consultation")['document_type'], presented_item("open_consultation").document_type
       assert_equal schema_item("open_consultation")['details']['body'], presented_item("open_consultation").body
     end

--- a/test/presenters/contact_presenter_test.rb
+++ b/test/presenters/contact_presenter_test.rb
@@ -2,7 +2,7 @@ require 'presenter_test_helper'
 
 class ContactPresenterTest
   class PresentedContact < PresenterTestCase
-    def format_name
+    def schema_name
       "contact"
     end
 

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -9,8 +9,8 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     assert_equal "Description", ContentItemPresenter.new("description" => "Description").description
   end
 
-  test "#format" do
-    assert_equal "Format", ContentItemPresenter.new("schema_name" => "Format").format
+  test "#schema_name" do
+    assert_equal "Schema name", ContentItemPresenter.new("schema_name" => "Schema name").schema_name
   end
 
   test "#locale" do

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -2,7 +2,7 @@ require 'presenter_test_helper'
 
 class CorporateInformationPagePresenterTest
   class PresentedCorporateInformationPage < PresenterTestCase
-    def format_name
+    def schema_name
       "corporate_information_page"
     end
 
@@ -15,7 +15,7 @@ class CorporateInformationPagePresenterTest
     end
 
     test 'does not present an organisation in the title when it is not present in links' do
-      presented_item = presented_item(format_name, "links" => {})
+      presented_item = presented_item(schema_name, "links" => {})
       assert_equal "About us", presented_item.page_title
     end
 

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -1,13 +1,13 @@
 require 'presenter_test_helper'
 
 class DetailedGuidePresenterTest < PresenterTestCase
-  def format_name
+  def schema_name
     "detailed_guide"
   end
 
   test 'presents the basic details of a content item' do
     assert_equal schema_item['description'], presented_item.description
-    assert_equal schema_item['schema_name'], presented_item.format
+    assert_equal schema_item['schema_name'], presented_item.schema_name
     assert_equal schema_item['title'], presented_item.title
     assert_equal schema_item['details']['body'], presented_item.body
   end

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -2,7 +2,7 @@ require 'presenter_test_helper'
 
 class DocumentCollectionPresenterTest
   class TestCase < PresenterTestCase
-    def format_name
+    def schema_name
       "document_collection"
     end
   end
@@ -16,8 +16,8 @@ class DocumentCollectionPresenterTest
       assert_equal schema_item['description'], presented_item.description
     end
 
-    test 'presents the format' do
-      assert_equal schema_item['schema_name'], presented_item.format
+    test 'presents the schema name' do
+      assert_equal schema_item['schema_name'], presented_item.schema_name
     end
 
     test 'presents the body' do

--- a/test/presenters/fatality_notice_presenter_test.rb
+++ b/test/presenters/fatality_notice_presenter_test.rb
@@ -1,7 +1,7 @@
 require 'presenter_test_helper'
 
 class FatalityNoticePresenterTest < PresenterTestCase
-  def format_name
+  def schema_name
     "fatality_notice"
   end
 

--- a/test/presenters/guide_presenter_test.rb
+++ b/test/presenters/guide_presenter_test.rb
@@ -2,7 +2,7 @@ require 'presenter_test_helper'
 
 class GuidePresenterTest
   class PresentedGuide < PresenterTestCase
-    def format_name
+    def schema_name
       "guide"
     end
 
@@ -102,7 +102,7 @@ class GuidePresenterTest
 
   private
 
-    def presented_item(type = format_name, part_slug = nil, overrides = {})
+    def presented_item(type = schema_name, part_slug = nil, overrides = {})
       schema_example_content_item = schema_item(type)
       part_slug = "/#{part_slug}" if part_slug
 

--- a/test/presenters/help_page_presenter_test.rb
+++ b/test/presenters/help_page_presenter_test.rb
@@ -1,7 +1,7 @@
 require 'presenter_test_helper'
 
 class HelpPagePresenterTest < PresenterTestCase
-  def format_name
+  def schema_name
     "help_page"
   end
 

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -1,12 +1,12 @@
 require 'presenter_test_helper'
 
 class HtmlPublicationPresenterTest < PresenterTestCase
-  def format_name
+  def schema_name
     "html_publication"
   end
 
   test 'presents the basic details of a content item' do
-    assert_equal schema_item("published")['schema_name'], presented_item("published").format
+    assert_equal schema_item("published")['schema_name'], presented_item("published").schema_name
     assert_equal schema_item("published")['links']['parent'][0]['document_type'], presented_item("published").format_sub_type
     assert_equal schema_item("published")['title'], presented_item("published").title
     assert_equal schema_item("published")['details']['body'], presented_item("published").body

--- a/test/presenters/news_article_presenter_test.rb
+++ b/test/presenters/news_article_presenter_test.rb
@@ -4,7 +4,7 @@ class NewsArticlePresenterTest
   class NewsArticlePresenterTestCase < PresenterTestCase
     attr_accessor :example_schema_name
 
-    def format_name
+    def schema_name
       "news_article"
     end
   end

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -1,13 +1,13 @@
 require 'presenter_test_helper'
 
 class PublicationPresenterTest < PresenterTestCase
-  def format_name
+  def schema_name
     "publication"
   end
 
   test 'presents the basic details of a content item' do
     assert_equal schema_item['description'], presented_item.description
-    assert_equal schema_item['schema_name'], presented_item.format
+    assert_equal schema_item['schema_name'], presented_item.schema_name
     assert_equal schema_item['title'], presented_item.title
     assert_equal schema_item['details']['body'], presented_item.details
     assert_equal schema_item['details']['documents'].join(''), presented_item.documents

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -2,14 +2,14 @@ require 'presenter_test_helper'
 
 class SpecialistDocumentPresenterTest
   class SpecialistDocumentTestCase < PresenterTestCase
-    def format_name
+    def schema_name
       "specialist_document"
     end
   end
 
   class PresentedSpecialistDocument < SpecialistDocumentTestCase
-    test 'presents the format' do
-      assert_equal schema_item('aaib-reports')['schema_name'], presented_item('aaib-reports').format
+    test 'presents the schema name' do
+      assert_equal schema_item('aaib-reports')['schema_name'], presented_item('aaib-reports').schema_name
     end
 
     test 'presents the body' do

--- a/test/presenters/speech_presenter_test.rb
+++ b/test/presenters/speech_presenter_test.rb
@@ -2,14 +2,14 @@ require 'presenter_test_helper'
 
 class SpeechPresenterTest
   class SpeechTestCase < PresenterTestCase
-    def format_name
+    def schema_name
       "speech"
     end
   end
 
   class PresentedSpeech < SpeechTestCase
-    test 'presents the format' do
-      assert_equal schema_item['schema_name'], presented_item.format
+    test 'presents the schema name' do
+      assert_equal schema_item['schema_name'], presented_item.schema_name
     end
 
     test '#published returns a formatted date of the day the content item became public' do

--- a/test/presenters/statistical_data_set_presenter_test.rb
+++ b/test/presenters/statistical_data_set_presenter_test.rb
@@ -2,14 +2,14 @@ require 'presenter_test_helper'
 
 class StatisticalDataSetPresenterTest
   class StatisticalDataSetTestCase < PresenterTestCase
-    def format_name
+    def schema_name
       "statistical_data_set"
     end
   end
 
   class PresentedStatisticalDataSet < StatisticalDataSetTestCase
-    test 'presents the format' do
-      assert_equal schema_item['schema_name'], presented_item.format
+    test 'presents the schema name' do
+      assert_equal schema_item['schema_name'], presented_item.schema_name
     end
 
     test 'presents a list of contents extracted from headings in the body' do

--- a/test/presenters/statistics_announcement_presenter_test.rb
+++ b/test/presenters/statistics_announcement_presenter_test.rb
@@ -3,7 +3,7 @@ require 'presenter_test_helper'
 class StatisticsAnnouncementPresenterTest < PresenterTestCase
   include ActionView::Helpers::UrlHelper
 
-  def format_name
+  def schema_name
     "statistics_announcement"
   end
 

--- a/test/presenters/take_part_presenter_test.rb
+++ b/test/presenters/take_part_presenter_test.rb
@@ -1,13 +1,13 @@
 require 'presenter_test_helper'
 
 class TakePartPresenterTest < PresenterTestCase
-  def format_name
+  def schema_name
     "take_part"
   end
 
   test 'presents the basic details of a content item' do
     assert_equal schema_item['description'], presented_item.description
-    assert_equal schema_item['schema_name'], presented_item.format
+    assert_equal schema_item['schema_name'], presented_item.schema_name
     assert_equal schema_item['locale'], presented_item.locale
     assert_equal schema_item['title'], presented_item.title
     assert_equal schema_item['details']['body'], presented_item.body

--- a/test/presenters/topical_event_about_page_presenter_test.rb
+++ b/test/presenters/topical_event_about_page_presenter_test.rb
@@ -1,13 +1,13 @@
 require 'presenter_test_helper'
 
 class TopicalEventAboutPagePresenterTest < PresenterTestCase
-  def format_name
+  def schema_name
     "topical_event_about_page"
   end
 
   test 'presents the basic details of a content item' do
     assert_equal schema_item['description'], presented_item.description
-    assert_equal schema_item['schema_name'], presented_item.format
+    assert_equal schema_item['schema_name'], presented_item.schema_name
     assert_equal schema_item['title'], presented_item.title
     assert_equal schema_item['details']['body'], presented_item.body
   end

--- a/test/presenters/travel_advice_presenter_test.rb
+++ b/test/presenters/travel_advice_presenter_test.rb
@@ -2,7 +2,7 @@ require 'presenter_test_helper'
 
 class TravelAdvicePresenterTest
   class PresentedTravelAdvice < PresenterTestCase
-    def format_name
+    def schema_name
       "travel_advice"
     end
 
@@ -279,7 +279,7 @@ class TravelAdvicePresenterTest
       presented.metadata[:other]["Latest update"]
     end
 
-    def presented_item(type = format_name, part_slug = nil, overrides = {})
+    def presented_item(type = schema_name, part_slug = nil, overrides = {})
       schema_example_content_item = schema_item(type)
       part_slug = "/#{part_slug}" if part_slug
 

--- a/test/presenters/unpublishing_presenter_test.rb
+++ b/test/presenters/unpublishing_presenter_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class UnpublishingPresenterTest < ActiveSupport::TestCase
   test 'presents the basic details required to display an unpublishing' do
-    assert_equal unpublishing['schema_name'], presented_unpublishing.format
+    assert_equal unpublishing['schema_name'], presented_unpublishing.schema_name
     assert_equal unpublishing['locale'], presented_unpublishing.locale
     assert_equal unpublishing['details']['explanation'], presented_unpublishing.explanation
     assert_equal unpublishing['details']['alternative_url'], presented_unpublishing.alternative_url

--- a/test/presenters/world_location_news_article_presenter_test.rb
+++ b/test/presenters/world_location_news_article_presenter_test.rb
@@ -4,7 +4,7 @@ class WorldLocationNewsArticlePresenterTest
   class WorldLocationNewsArticlePresenterTestCase < PresenterTestCase
     attr_accessor :example_schema_name
 
-    def format_name
+    def schema_name
       "world_location_news_article"
     end
   end
@@ -30,8 +30,8 @@ class WorldLocationNewsArticlePresenterTest
       assert presented_item.is_a?(Political)
     end
 
-    test 'presents the format' do
-      assert_equal schema_item['schema_name'], presented_item.format
+    test 'presents the schema name' do
+      assert_equal schema_item['schema_name'], presented_item.schema_name
     end
 
     test 'presents a description' do

--- a/test/support/govuk_content_schema_examples.rb
+++ b/test/support/govuk_content_schema_examples.rb
@@ -36,13 +36,13 @@ module GovukContentSchemaExamples
   end
 
   module ClassMethods
-    def all_examples_for_supported_formats
-      GovukContentSchemaTestHelpers::Examples.new.get_all_for_formats(supported_formats).map do |string|
+    def all_examples_for_supported_schemas
+      GovukContentSchemaTestHelpers::Examples.new.get_all_for_formats(supported_schemas).map do |string|
         JSON.parse(string)
       end
     end
 
-    def supported_formats
+    def supported_schemas
       %w{
         case_study
         coming_soon

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -122,8 +122,8 @@ class ActionDispatch::IntegrationTest
     end
   end
 
-  def setup_and_visit_random_content_item(document_type: schema_format)
-    schema = GovukSchemas::Schema.find(frontend_schema: schema_format)
+  def setup_and_visit_random_content_item(document_type: schema_type)
+    schema = GovukSchemas::Schema.find(frontend_schema: schema_type)
     random_example = GovukSchemas::RandomExample.new(schema: schema)
 
     payload = random_example.merge_and_validate(document_type: document_type)
@@ -136,15 +136,15 @@ class ActionDispatch::IntegrationTest
   end
 
   def get_content_example(name)
-    get_content_example_by_format_and_name(schema_format, name)
+    get_content_example_by_schema_and_name(schema_type, name)
   end
 
-  def get_content_example_by_format_and_name(format, name)
-    GovukContentSchemaTestHelpers::Examples.new.get(format, name)
+  def get_content_example_by_schema_and_name(schema_type, name)
+    GovukContentSchemaTestHelpers::Examples.new.get(schema_type, name)
   end
 
   # Override this method if your test file doesn't match the convention
-  def schema_format
+  def schema_type
     self.class.to_s.gsub('Test', '').underscore
   end
 end


### PR DESCRIPTION
As part of a move to eradicate `format` from the schemas, publishing API and content-store (https://github.com/alphagov/govuk-content-schemas/pull/620), also refactor usage here to use the correct `schema_name` rather than `format`.

* Format pointed to `schema_name` on the content_item
* Format is deprecated
* Use consistent language