### PR TITLE
Visual regression testing across document_types

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This is a Ruby on Rails application that fetches documents from
 - [content-store](https://github.com/alphagov/content-store) - provides documents
 - [static](https://github.com/alphagov/static) - provides shared GOV.UK assets and templates.
 - [phantomjs](http://phantomjs.org/) Used by poltergeist for integration testing
+- [ImageMagick](http://brewformulas.org/Imagemagick) Used by Wraith for visual regression testing
 
 ### Running the application
 
@@ -121,14 +122,35 @@ bundle exec wraith latest test/wraith/config-examples.yaml
 
 #### Compare a document_type
 
-A rake task has been made to make this easy, given a document_type of about
-bundle exec wraith_document_type[about]
+A rake task has been made to make this easy, given a `document_type` of `about`
+
+```
+bundle exec rake wraith:document_type[about]
+```
 
 this will run against the 10 most popular pages as defined by the search api
 
+#### Compare all document_types
 
-If you wish to have your own local wip configs, wip* is in the .gitignore, so as an example
+```
+bundle exec rake wraith:all_document_types[:sample_size]
+```
+
+This will run against the 10 (can be overidden with `:sample_size`) most popular pages as defined by the search api,
+for each known `document_type` in the app (see: [Generate a config for known document_types and example pages](#generate-a-config-for-known-document_types-and-example-pages)).
+
+*Note:* If you wish to have your own local wip configs, wip* is in the .gitignore, so as an example
 `wip-kittens.yaml` will be ignored
+
+#### Generate a config for known document_types and example pages
+
+Running the rake task below will retrieve the `document_types` where `rendering_app = government-frontend` from the search api. It will then generate `test/wraith/wip-config-all-document-types.yaml`, this is a wraith config file containing the top 10 (can be overidden with `:sample_size`) example pages for each type. 
+
+The yaml file contains a custom key of `:document_types` not used by wraith but can be used to quickly scan and see which types the search api believes `government-frontend` is responsible for.
+
+```
+bundle exec rake wraith:update_document_types[:sample_size]
+```
 
 ### Adding a new format
 

--- a/lib/helpers/document_types_helper.rb
+++ b/lib/helpers/document_types_helper.rb
@@ -1,16 +1,22 @@
 require 'rest-client'
 
 class DocumentTypesHelper
-  SEARCH_ENDPOINT = "https://www.gov.uk/api/search.json?facet_content_store_document_type=100,example_scope:global,examples:%{sample_size}&filter_rendering_app=government-frontend&count=0".freeze
+  ALL_SEARCH_ENDPOINT = "https://www.gov.uk/api/search.json?facet_content_store_document_type=100,example_scope:global,examples:%{sample_size}&filter_rendering_app=government-frontend&count=0".freeze
+  SINGLE_SEARCH_ENDPOINT = "https://www.gov.uk/api/search.json?filter_content_store_document_type=%{document_type}&count=%{sample_size}".freeze
 
-  def initialize(sample_size)
-    @sample_size = sample_size || 10
+  def initialize(sample_size = 10)
+    @sample_size = sample_size
   end
 
-  def type_paths
-    response = RestClient.get(SEARCH_ENDPOINT % { sample_size: @sample_size })
+  def all_type_paths
+    response = RestClient.get(ALL_SEARCH_ENDPOINT % { sample_size: @sample_size })
     results = extract_results(JSON.parse(response.body))
     results.map { |result| extract_type(result) }.reduce({}, :merge)
+  end
+
+  def type_paths(type)
+    response = RestClient.get(SINGLE_SEARCH_ENDPOINT % { document_type: type, sample_size: @sample_size })
+    JSON.parse(response.body)["results"].map { |result| result["link"] }
   end
 
 private

--- a/lib/helpers/document_types_helper.rb
+++ b/lib/helpers/document_types_helper.rb
@@ -1,0 +1,26 @@
+require 'rest-client'
+
+class DocumentTypesHelper
+  SEARCH_ENDPOINT = "https://www.gov.uk/api/search.json?facet_content_store_document_type=100,example_scope:global,examples:%{sample_size}&filter_rendering_app=government-frontend&count=0".freeze
+
+  def initialize(sample_size)
+    @sample_size = sample_size || 10
+  end
+
+  def type_paths
+    response = RestClient.get(SEARCH_ENDPOINT % { sample_size: @sample_size })
+    results = extract_results(JSON.parse(response.body))
+    results.map { |result| extract_type(result) }.reduce({}, :merge)
+  end
+
+private
+
+  def extract_results(response_body)
+    response_body["facets"]["content_store_document_type"]["options"]
+  end
+
+  def extract_type(result)
+    type_examples = result["value"]["example_info"]["examples"].map { |example| example["link"] }
+    { result["value"]["slug"] => type_examples }
+  end
+end

--- a/lib/helpers/wraith_config_helper.rb
+++ b/lib/helpers/wraith_config_helper.rb
@@ -9,7 +9,7 @@ class WraithConfigHelper
     @paths = paths
   end
 
-  def create_config(extra_config)
+  def create_config(extra_config = {})
     config = load_template
     config["paths"] = build_paths
     config.merge!(extra_config) if extra_config.present?

--- a/lib/helpers/wraith_config_helper.rb
+++ b/lib/helpers/wraith_config_helper.rb
@@ -9,9 +9,10 @@ class WraithConfigHelper
     @paths = paths
   end
 
-  def create_config
+  def create_config(extra_config)
     config = load_template
     config["paths"] = build_paths
+    config.merge!(extra_config) if extra_config.present?
 
     write_config(config)
   end

--- a/lib/helpers/wraith_config_helper.rb
+++ b/lib/helpers/wraith_config_helper.rb
@@ -1,0 +1,50 @@
+class WraithConfigHelper
+  attr_accessor :name, :paths
+
+  TEMPLATE_PATH = "test/wraith/config.yaml".freeze
+  OUTPUT_PATH = 'test/wraith/wip-config-%{suffix}.yaml'.freeze
+
+  def initialize(name, paths)
+    @name = name
+    @paths = paths
+  end
+
+  def create_config
+    config = load_template
+    config["paths"] = build_paths
+
+    write_config(config)
+  end
+
+private
+
+  def load_template
+    YAML::load(File.open(TEMPLATE_PATH))
+  end
+
+  def build_paths
+    config_paths = {}
+
+    if @paths.is_a? Hash
+      @paths.keys.each do |key|
+        @paths.fetch(key).each_with_index do |path, index|
+          config_paths[path_index(key, index + 1)] = path
+        end
+      end
+    else
+      @paths.each_with_index { |path, index| config_paths[path_index(name, index + 1)] = path }
+    end
+
+    config_paths
+  end
+
+  def path_index(prefix, index)
+    "#{prefix}_#{index}"
+  end
+
+  def write_config(config)
+    file_name = OUTPUT_PATH % { suffix: @name }
+    File.open(file_name, 'w') { |f| f.write config.to_yaml }
+    file_name
+  end
+end

--- a/lib/tasks/wraith.rake
+++ b/lib/tasks/wraith.rake
@@ -3,13 +3,26 @@ require 'rest-client'
 desc "check top 10 content items for document_type using wraith"
 task :wraith_document_type, [:document_type] do |_t, args|
   document_type = args[:document_type]
+
+  paths = get_paths(document_type)
+
+  file_name = create_config_file(document_type, paths)
+
+  exec("bundle exec wraith capture #{file_name}")
+end
+
+def create_config_file(run_name, paths)
+  file_name = "test/wraith/wip-config-#{run_name}.yaml"
   wraith = YAML::load(File.open('test/wraith/config.yaml'))
-  search = RestClient.get "https://www.gov.uk/api/search.json?filter_content_store_document_type=#{document_type}&count=10"
-  links  = JSON.parse(search.body)["results"].map { |result| result["link"] }
-  file_name = "test/wraith/wip-config-#{document_type}.yaml"
   wraith["paths"] = {}
 
-  links.each_with_index { |link, index| wraith["paths"]["#{document_type}#{index}"] = link }
+  paths.each_with_index { |path, index| wraith["paths"]["#{run_name}#{index}"] = path }
+
   File.open(file_name, 'w') { |f| f.write wraith.to_yaml }
-  exec("bundle exec wraith capture #{file_name}")
+  file_name
+end
+
+def get_paths(document_type)
+  search = RestClient.get "https://www.gov.uk/api/search.json?filter_content_store_document_type=#{document_type}&count=10"
+  JSON.parse(search.body)["results"].map { |result| result["link"] }
 end

--- a/lib/tasks/wraith.rake
+++ b/lib/tasks/wraith.rake
@@ -1,5 +1,6 @@
 require 'rest-client'
 require "#{Rails.root}/lib/helpers/wraith_config_helper.rb"
+require "#{Rails.root}/lib/helpers/document_types_helper.rb"
 
 namespace :wraith do
   desc "check top 10 content items for document_type using wraith"
@@ -23,6 +24,14 @@ namespace :wraith do
     wraith_config_file = WraithConfigHelper.new("all-document-types", paths).create_config
 
     exec("bundle exec wraith capture #{wraith_config_file}")
+  end
+
+  desc "creates a wraith config of document type examples from the search api"
+  task :update_document_types, [:sample_size] do |_t, args|
+    args.with_defaults(sample_size: 10)
+    document_type_paths = DocumentTypesHelper.new(args[:sample_size]).type_paths
+    document_types = { "document_types" => document_type_paths.keys }
+    WraithConfigHelper.new("all-document-types", document_type_paths).create_config(document_types)
   end
 end
 

--- a/lib/tasks/wraith.rake
+++ b/lib/tasks/wraith.rake
@@ -6,22 +6,18 @@ namespace :wraith do
   desc "check top 10 content items for document_type using wraith"
   task :document_type, [:document_type] do |_t, args|
     document_type = args[:document_type]
-    paths = get_paths(document_type)
-    wraith_config_file = WraithConfigHelper.new(document_type, paths).create_config
+    document_type_paths = DocumentTypesHelper.new.type_paths(document_type)
+    wraith_config_file = WraithConfigHelper.new(document_type, document_type_paths).create_config
 
     exec("bundle exec wraith capture #{wraith_config_file}")
   end
 
   desc "check top 10 content items for all known document types"
-  task :all_document_types do
-    paths = {}
-    document_types = %w(case_study about)
-
-    document_types.each do |type|
-      paths[type] = get_paths(type)
-    end
-
-    wraith_config_file = WraithConfigHelper.new("all-document-types", paths).create_config
+  task :all_document_types, [:sample_size] do |_t, args|
+    args.with_defaults(sample_size: 10)
+    # Make sure an up to date document_types file exists
+    Rake::Task["wraith:update_document_types"].invoke args[:sample_size]
+    wraith_config_file = "test/wraith/wip-config-all-document-types.yaml"
 
     exec("bundle exec wraith capture #{wraith_config_file}")
   end
@@ -29,13 +25,9 @@ namespace :wraith do
   desc "creates a wraith config of document type examples from the search api"
   task :update_document_types, [:sample_size] do |_t, args|
     args.with_defaults(sample_size: 10)
-    document_type_paths = DocumentTypesHelper.new(args[:sample_size]).type_paths
+    document_type_paths = DocumentTypesHelper.new(args[:sample_size]).all_type_paths
     document_types = { "document_types" => document_type_paths.keys }
+
     WraithConfigHelper.new("all-document-types", document_type_paths).create_config(document_types)
   end
-end
-
-def get_paths(document_type)
-  search = RestClient.get "https://www.gov.uk/api/search.json?filter_content_store_document_type=#{document_type}&count=10"
-  JSON.parse(search.body)["results"].map { |result| result["link"] }
 end


### PR DESCRIPTION
# Motivation
__As__ a developer
__I want__ a up-to-date config of all document types in government-frontend
__So__ that I can use this for wraith testing with more confidence

Trello: https://trello.com/c/WqIzOp6X/358-1-make-wraith-rake-task-cover-all-document-in-government-frontend

# Description
This PR adds two new `rake` tasks:

`wraith:update_document_types` - generates a file of example pages and document_types rendered by `government_frontend`

`wraith:all_document_types` - runs visual regression tests across all examples found via `wraith:update_document_types`

# Example generated wraith config

http://axiomatic-reaction.surge.sh/wip-config-all-document-types.yaml
