### PR TITLE
Revert "Adds SRI"

### DIFF
--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -1,7 +1,7 @@
 <%- if params[:medium] == 'print' %>
-  <%= stylesheet_link_tag "print.css", :media => "screen", integrity: true, crossorigin: "anonymous" %>
+  <%= stylesheet_link_tag "print.css", :media => "screen" %>
 <%- else %>
-  <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: "anonymous" %>
+  <%= stylesheet_link_tag "print.css", :media => "print" %>
 <%- end %>
 
 <%

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title><%= yield :title %> - GOV.UK</title>
-  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: true, crossorigin: "anonymous" %><!--<![endif]-->
+  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application" %><!--<![endif]-->
   <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><script>var ieVersion = 6;</script><![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><script>var ieVersion = 7;</script><![endif]-->
   <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><script>var ieVersion = 8;</script><![endif]-->
-  <%= javascript_include_tag "application", integrity: true, crossorigin: "anonymous" %>
+  <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
   <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item.content_item } %>
   <% if @content_item.description %>

--- a/app/views/shared/_webchat.html.erb
+++ b/app/views/shared/_webchat.html.erb
@@ -16,4 +16,4 @@
   </span>
 </span>
 <% # This is inline in the source however slimmer will optimize this. %>
-<%= javascript_include_tag "webchat", integrity: true, crossorigin: "anonymous" %>
+<%= javascript_include_tag "webchat" %>


### PR DESCRIPTION
# Description
Reverts alphagov/government-frontend#331

There is a bug in versions of Firefox < v52 (https://bugzilla.mozilla.org/show_bug.cgi?id=1269241) where the SHA integrity check fails as mismatched for stylesheets. 

This meant that older versions of Firefox did not receive `government-frontend` application specific styles - this lead to broken layouts in formats rendered by `government-frontend`.

Reverting this for now until we have time to investigate further cc: @h-lame 