### PR TITLE
[WIP] Add epilepsy and driving page start button ab test

### DIFF
--- a/app/controllers/concerns/epilepsy_driving_start_button_variant_ab_testable.rb
+++ b/app/controllers/concerns/epilepsy_driving_start_button_variant_ab_testable.rb
@@ -1,0 +1,25 @@
+module EpilepsyDrivingStartButtonVariantABTestable
+  EPILEPSY_AND_DRIVING_PATH = ['/epilepsy-and-driving'].freeze
+
+  def should_show_dvla_start_button_variant?
+    epilepsy_driving_start_button_variant.variant_b? && is_epilepsy_driving_tested_path?
+  end
+
+  def is_epilepsy_driving_tested_path?
+    EPILEPSY_AND_DRIVING_PATH.include? request.path
+  end
+
+  def epilepsy_driving_start_button_variant
+    @epilepsy_driving_start_button_variant ||= epilepsy_driving_ab_test.requested_variant request.headers
+  end
+
+  def set_epilepsy_driving_start_button_response_header
+    epilepsy_driving_start_button_variant.configure_response response
+  end
+
+private
+
+  def epilepsy_driving_ab_test
+    @ab_test ||= GovukAbTesting::AbTest.new("EpilepsyDrivingStart", dimension: 13)
+  end
+end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,11 +1,18 @@
 require 'gds_api/content_store'
 
 class ContentItemsController < ApplicationController
+  include EpilepsyDrivingStartButtonVariantABTestable
+
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from GdsApi::HTTPNotFound, with: :error_notfound
   rescue_from ActionView::MissingTemplate, with: :error_406
 
   attr_accessor :content_item
+
+  helper_method(:should_show_dvla_start_button_variant?,
+                :is_epilepsy_driving_tested_path?,
+                :epilepsy_driving_start_button_variant)
+
 
   def show
     load_content_item
@@ -48,6 +55,10 @@ private
     end
 
     request.variant = :print if params[:variant] == "print"
+
+    if is_epilepsy_driving_tested_path?
+      set_epilepsy_driving_start_button_response_header
+    end
 
     with_locale do
       render content_item_template

--- a/app/presenters/answer_presenter.rb
+++ b/app/presenters/answer_presenter.rb
@@ -1,4 +1,23 @@
 class AnswerPresenter < ContentItemPresenter
   include Body
   include LastUpdated
+
+  def ab_body
+    b_button = <<EOD
+      <div class=\"transaction\">
+        <p class=\"get-started group\">
+          <a class=\"button\" href=\"https://www.driving-medical-condition.service.gov.uk/eligibility/entitlement-gb\">
+            Report your condition online
+          </a>
+        </p>
+      </div>
+
+        <p>You can also <a href="/government/publications/fep1-confidential-medical-information">fill in form FEP1</a> and send it to DVLA. The address is on the form.</p>
+EOD
+
+    body.gsub(
+        /<p>You can either <a href="\/report-driving-medical-condition">report your condition online<\/a> or <a href="\/government\/publications\/fep1-confidential-medical-information">fill in form FEP1<\/a> and send it to <abbr title="Driver Vehicle and Licensing Agency">DVLA<\/abbr>. The address is on the form.<\/p>/,
+        b_button
+    )
+  end
 end

--- a/app/views/ab_testing/_dvla_epilepsy_driving_start_button.html.erb
+++ b/app/views/ab_testing/_dvla_epilepsy_driving_start_button.html.erb
@@ -1,0 +1,127 @@
+<div class="govuk-govspeak direction-ltr rich-govspeak disable-youtube">
+
+  <div class="summary">
+    <p>You must tell <abbr title="Driver Vehicle and Licensing Agency">DVLA</abbr> if you’ve had any epileptic attacks, seizures, fits or blackouts.</p>
+  </div>
+
+  <p>You must stop driving straight away.</p>
+
+  <div role="note" aria-label="Help" class="application-notice help-notice">
+    <p>You can be fined up to £1,000 if you don’t tell <abbr title="Driver Vehicle and Licensing Agency">DVLA</abbr> about a medical condition that affects your driving. You may be prosecuted if you’re involved in an accident as a result.</p>
+  </div>
+
+  <h2 id="car-or-motorbike-licence">Car or motorbike licence</h2>
+
+  <div class="transaction">
+    <p class="get-started group">
+      <a class="button" href="https://www.driving-medical-condition.service.gov.uk/eligibility/entitlement-gb">Report your condition online</a>
+    </p>
+  </div>
+
+
+  <p>You can also <a href="/government/publications/fep1-confidential-medical-information">fill in form FEP1</a> and send it to <abbr title="Driver Vehicle and Licensing Agency">DVLA</abbr>. The address is on the form.</p>
+
+  <p>Your licence may be taken away. When you can reapply for it depends on the type of attack you had.</p>
+
+  <h3 id="youve-had-epileptic-attacks-while-awake-and-lost-consciousness">You’ve had epileptic attacks while awake and lost consciousness</h3>
+
+  <p>Your licence will be taken away. You can reapply if you haven’t had an attack for at least a year.</p>
+
+  <p>If you had a seizure because your doctor changed or reduced your anti-epilepsy medicine, you can reapply when:</p>
+
+  <ul>
+    <li>
+      <p>the seizure was more than 6 months ago</p>
+    </li>
+    <li>
+      <p>you’ve been back on your previous medication for 6 months</p>
+    </li>
+    <li>
+      <p>you haven’t had another seizure in that time</p>
+    </li>
+  </ul>
+
+  <h3 id="youve-had-a-one-off-seizure-while-awake-and-lost-consciousness">You’ve had a one-off seizure while awake and lost consciousness</h3>
+
+  <p>Your licence will be taken away. You can reapply when both the following are true:</p>
+
+  <ul>
+    <li>
+      <p>you haven’t had an attack for 6 months</p>
+    </li>
+    <li>
+      <p><abbr title="Driver Vehicle and Licensing Agency">DVLA</abbr>’s medical advisers decide there isn’t a high risk you’ll have another seizure</p>
+    </li>
+  </ul>
+
+  <p>Medical advisers will base their decision on information you and your doctors send them. If they need to carry out an investigation they’ll let you know.</p>
+
+  <p>Otherwise you can reapply after a year.</p>
+
+  <h3 id="youve-had-attacks-while-asleep-and-awake">You’ve had attacks while asleep and awake</h3>
+
+  <p>You may still qualify for a licence if the only attacks you’ve had in the past 3 years have been while you were asleep.  <abbr title="Driver Vehicle and Licensing Agency">DVLA</abbr> will let you know whether or not you qualify after you’ve filled in the form. Until you hear from them you must stop driving.</p>
+
+  <h3 id="youve-only-had-attacks-while-asleep">You’ve only had attacks while asleep</h3>
+
+  <p>You may still qualify for a licence if it’s been 12 months or more since your first attack. <abbr title="Driver Vehicle and Licensing Agency">DVLA</abbr> will let you know whether or not you qualify after you’ve filled in the form. Until you hear from them you must stop driving.</p>
+
+  <h3 id="youve-had-attacks-or-seizures-that-dont-affect-your-consciousness-or-driving">You’ve had attacks or seizures that don’t affect your consciousness or driving</h3>
+
+  <p>You may still qualify for a licence if these are the only type of attack you’ve ever had and the first one was 12 months ago. <abbr title="Driver Vehicle and Licensing Agency">DVLA</abbr> will let you know whether or not you need to give up your licence after you’ve filled in the form. Until you hear from them you must stop driving.</p>
+
+  <h2 id="bus-coach-or-lorry-licence">Bus, coach or lorry licence</h2>
+
+  <p>Fill in <a href="/government/publications/fep1v-online-confidential-medical-information">form FEP1V</a> and send it to <abbr title="Driver Vehicle and Licensing Agency">DVLA</abbr>. The address is on the form.</p>
+
+  <p>How long you will lose your licence for depends on what type of attack you have.</p>
+
+  <h3 id="youve-had-more-than-one-seizure">You’ve had more than one seizure</h3>
+
+  <p>Before you reapply for your licence, you must show you haven’t:</p>
+
+  <ul>
+    <li>
+      <p>had an epileptic attack for 10 years</p>
+    </li>
+    <li>
+      <p>taken any anti-epileptic medication for 10 years</p>
+    </li>
+    <li>
+      <p>got a 2% or higher risk of another seizure, according to <abbr title="Driver Vehicle and Licensing Agency">DVLA</abbr>’s medical advisers</p>
+    </li>
+  </ul>
+
+  <p>You must also have a car and motorbike licence.</p>
+
+  <h3 id="youve-had-a-one-off-seizure">You’ve had a one-off seizure</h3>
+
+  <p>Before you reapply for your licence, you must show:</p>
+
+  <ul>
+    <li>
+      <p>you haven’t had an epileptic attack for 5 years</p>
+    </li>
+    <li>
+      <p>you haven’t taken any anti-epileptic medication for 5 years</p>
+    </li>
+  </ul>
+
+  <p>You must also have:</p>
+
+  <ul>
+    <li>
+      <p>a car and motorbike licence</p>
+    </li>
+    <li>
+      <p>been assessed in the past 12 months by a neurologist</p>
+    </li>
+    <li>
+      <p>results from medical investigations for epilepsy that are satisfactory to <abbr title="Driver Vehicle and Licensing Agency">DVLA</abbr>’s medical advisers</p>
+    </li>
+  </ul>
+
+  <p>Medical advisers will base their decision on information you and your doctors send them. If they need to carry out an investigation they’ll let you know.</p>
+
+
+</div>

--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -1,3 +1,7 @@
+<% if is_epilepsy_driving_tested_path? %>
+    <%= epilepsy_driving_start_button_variant.analytics_meta_tag.html_safe %>
+<% end %>
+
 <% content_for :simple_header, true %>
 <%= content_for :title, @content_item.title %>
 
@@ -5,11 +9,16 @@
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
         title: @content_item.title %>
-    <%= render 'govuk_component/govspeak',
-        content: @content_item.body,
-        direction: page_text_direction,
-        disable_youtube_expansions: true,
-        rich_govspeak: true %>
+    
+    <% if should_show_dvla_start_button_variant? %>
+      <%= render 'ab_testing/dvla_epilepsy_driving_start_button' %>
+    <% else %>
+      <%= render 'govuk_component/govspeak',
+          content: @content_item.body,
+          direction: page_text_direction,
+          disable_youtube_expansions: true,
+          rich_govspeak: true %>
+    <% end %>
 
     <% #https://github.com/alphagov/government-frontend/pull/329#issuecomment-297681738 %>
     <% if false && @content_item.last_updated %>

--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -9,9 +9,13 @@
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
         title: @content_item.title %>
-    
+
     <% if should_show_dvla_start_button_variant? %>
-      <%= render 'ab_testing/dvla_epilepsy_driving_start_button' %>
+      <%= render 'govuk_component/govspeak',
+          content: @content_item.ab_body,
+          direction: page_text_direction,
+          disable_youtube_expansions: true,
+          rich_govspeak: true %>
     <% else %>
       <%= render 'govuk_component/govspeak',
           content: @content_item.body,

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -293,6 +293,32 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_response_not_modified_for_ab_test('EducationNavigation')
   end
 
+  test "show original body for 'A' version" do
+    setup_ab_variant "EpilepsyDrivingStart", "A"
+
+    content_item = content_store_has_schema_example("answer", "answer")
+    path = "epilepsy-and-driving"
+    content_item["base_path"] = "/#{path}"
+
+    content_store_has_item(content_item["base_path"], content_item)
+
+    get :show, params: { path: path_for(content_item) }
+    refute_match(/get-started group/, response.body)
+  end
+
+  test "show variant body for 'B' version" do
+    setup_ab_variant "EpilepsyDrivingStart", "B"
+
+    content_item = content_store_has_schema_example("answer", "answer")
+    path = "epilepsy-and-driving"
+    content_item["base_path"] = "/#{path}"
+
+    content_store_has_item(content_item["base_path"], content_item)
+
+    get :show, params: { path: path_for(content_item) }
+    assert_match(/get-started group/, response.body)
+  end
+
   test "sets the Access-Control-Allow-Origin header for atom pages" do
     content_store_has_schema_example('travel_advice', 'full-country')
     get :show, params: { path: 'foreign-travel-advice/albania', format: 'atom' }

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -293,30 +293,28 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_response_not_modified_for_ab_test('EducationNavigation')
   end
 
-  test "show original body for 'A' version" do
-    setup_ab_variant "EpilepsyDrivingStart", "A"
-
+  test "shows start button for B variant of DVLA Epilepsy and driving AB Test" do
     content_item = content_store_has_schema_example("answer", "answer")
     path = "epilepsy-and-driving"
     content_item["base_path"] = "/#{path}"
 
-    content_store_has_item(content_item["base_path"], content_item)
+    content_store_has_item(content_item['base_path'], content_item)
 
-    get :show, params: { path: path_for(content_item) }
-    refute_match(/get-started group/, response.body)
-  end
+    with_variant EpilepsyDrivingStart: "A" do
+      get :show, params: { path: path_for(content_item) }
+      refute(
+          start_button,
+          "Expected no start button"
+      )
+    end
 
-  test "show variant body for 'B' version" do
-    setup_ab_variant "EpilepsyDrivingStart", "B"
-
-    content_item = content_store_has_schema_example("answer", "answer")
-    path = "epilepsy-and-driving"
-    content_item["base_path"] = "/#{path}"
-
-    content_store_has_item(content_item["base_path"], content_item)
-
-    get :show, params: { path: path_for(content_item) }
-    assert_match(/get-started group/, response.body)
+    with_variant EpilepsyDrivingStart: "B" do
+      get :show, params: { path: path_for(content_item) }
+      assert(
+          start_button,
+          "Expected to find start button"
+      )
+    end
   end
 
   test "sets the Access-Control-Allow-Origin header for atom pages" do
@@ -342,5 +340,9 @@ class ContentItemsControllerTest < ActionController::TestCase
     Nokogiri::HTML.parse(response.body).at_css(
       shared_component_selector("taxonomy_sidebar")
     )
+  end
+
+  def start_button
+    Nokogiri::HTML.parse(response.body).css("p[class='get-started']")
   end
 end

--- a/test/presenters/answer_presenter_test.rb
+++ b/test/presenters/answer_presenter_test.rb
@@ -12,4 +12,8 @@ class AnswerPresenterTest < PresenterTestCase
   test 'presents the body' do
     assert_equal schema_item['details']['body'], presented_item.body
   end
+
+  test 'presents the ab_body' do
+    assert_match /get-started/, presented_item.ab_body
+  end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/9ZPkxHjH

Content Team want to AB Test changing the call to action on [Epilepsy and Driving](https://www.gov.uk/epilepsy-and-driving) page from a link within the body of text to a Start Button.

The test is to run for 30 days. Related PR for Fastly config is https://github.com/alphagov/fastly-configure/pull/23

The downside is that as the B variant body content is hard coded, the A variant can't be changed during the course of the test.

## Expected outcomes

[Page on GOV.UK](https://www.gov.uk/epilepsy-and-driving)
[Preview](https://government-frontend-pr-369.herokuapp.com/epilepsy-and-driving)

If you have the `GOVUK-ABTest-EpilepsyDrivingStart` request header set with a value of `B` you will see the start button.

### Before
![image](https://cloud.githubusercontent.com/assets/424772/26258732/e4dd63ec-3cbd-11e7-8030-767d9e3e843a.png)

### After
![image](https://cloud.githubusercontent.com/assets/424772/26258741/ef356bd2-3cbd-11e7-8040-cc2e5559d215.png)
