### PR TITLE
Add epilepsy driving start ab test

### DIFF
--- a/app/assets/stylesheets/helpers/_button.scss
+++ b/app/assets/stylesheets/helpers/_button.scss
@@ -21,6 +21,7 @@
     // We can't easily update .button-start to a placeholder pattern
     // scss-lint:disable PlaceholderInExtend
     @extend .button-start;
+    margin: 0.75em 0;
   }
 
   .button:focus,

--- a/app/assets/stylesheets/helpers/_button.scss
+++ b/app/assets/stylesheets/helpers/_button.scss
@@ -21,6 +21,8 @@
     // We can't easily update .button-start to a placeholder pattern
     // scss-lint:disable PlaceholderInExtend
     @extend .button-start;
+    // TODO: remove this when AB Test for DVLA Epilepsy and driving is finished:
+    // (see Trello card: https://trello.com/c/Q91ppDXf/628-remove-dvla-epilepsy-ab-test-when-finished)
     margin: 0.75em 0;
   }
 

--- a/app/controllers/concerns/epilepsy_driving_start_button_variant_ab_testable.rb
+++ b/app/controllers/concerns/epilepsy_driving_start_button_variant_ab_testable.rb
@@ -1,0 +1,25 @@
+module EpilepsyDrivingStartButtonVariantABTestable
+  EPILEPSY_AND_DRIVING_PATH = ['/epilepsy-and-driving'].freeze
+
+  def should_show_dvla_start_button_variant?
+    epilepsy_driving_start_button_variant.variant_b? && is_epilepsy_driving_tested_path?
+  end
+
+  def is_epilepsy_driving_tested_path?
+    EPILEPSY_AND_DRIVING_PATH.include? request.path
+  end
+
+  def epilepsy_driving_start_button_variant
+    @epilepsy_driving_start_button_variant ||= epilepsy_driving_ab_test.requested_variant request.headers
+  end
+
+  def set_epilepsy_driving_start_button_response_header
+    epilepsy_driving_start_button_variant.configure_response response
+  end
+
+private
+
+  def epilepsy_driving_ab_test
+    @ab_test ||= GovukAbTesting::AbTest.new("EpilepsyDrivingStart", dimension: 47)
+  end
+end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,11 +1,18 @@
 require 'gds_api/content_store'
 
 class ContentItemsController < ApplicationController
+  include EpilepsyDrivingStartButtonVariantABTestable
+
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from GdsApi::HTTPNotFound, with: :error_notfound
   rescue_from ActionView::MissingTemplate, with: :error_406
 
   attr_accessor :content_item
+
+  helper_method(:should_show_dvla_start_button_variant?,
+                :is_epilepsy_driving_tested_path?,
+                :epilepsy_driving_start_button_variant)
+
 
   def show
     load_content_item
@@ -48,6 +55,10 @@ private
     end
 
     request.variant = :print if params[:variant] == "print"
+
+    if is_epilepsy_driving_tested_path?
+      set_epilepsy_driving_start_button_response_header
+    end
 
     with_locale do
       render content_item_template

--- a/app/presenters/answer_presenter.rb
+++ b/app/presenters/answer_presenter.rb
@@ -6,7 +6,7 @@ class AnswerPresenter < ContentItemPresenter
     b_button = <<EOD
       <div class="transaction">
         <p class="get-started group">
-          <a id="epilepsy-driving-variant-b" class="button" href="https://www.driving-medical-condition.service.gov.uk/eligibility/entitlement-gb">
+          <a id="epilepsy-driving-variant-b" class="button button-start" href="https://www.driving-medical-condition.service.gov.uk/">
             Report your condition online
           </a>
         </p>

--- a/app/presenters/answer_presenter.rb
+++ b/app/presenters/answer_presenter.rb
@@ -1,4 +1,23 @@
 class AnswerPresenter < ContentItemPresenter
   include Body
   include LastUpdated
+
+  def ab_body
+    b_button = <<EOD
+      <div class="transaction">
+        <p class="get-started group">
+          <a id="epilepsy-driving-variant-b" class="button" href="https://www.driving-medical-condition.service.gov.uk/eligibility/entitlement-gb">
+            Report your condition online
+          </a>
+        </p>
+      </div>
+
+        <p>You can also <a href="/government/publications/fep1-confidential-medical-information">fill in form FEP1</a> and send it to DVLA. The address is on the form.</p>
+EOD
+
+    body.gsub(
+        /<p>You can either <a href="\/report-driving-medical-condition">report your condition online<\/a> or <a href="\/government\/publications\/fep1-confidential-medical-information">fill in form FEP1<\/a> and send it to <abbr title="Driver Vehicle and Licensing Agency">DVLA<\/abbr>. The address is on the form.<\/p>/,
+        b_button
+    )
+  end
 end

--- a/app/presenters/answer_presenter.rb
+++ b/app/presenters/answer_presenter.rb
@@ -16,8 +16,8 @@ class AnswerPresenter < ContentItemPresenter
 EOD
 
     body.gsub(
-        /<p>You can either <a href="\/report-driving-medical-condition">report your condition online<\/a> or <a href="\/government\/publications\/fep1-confidential-medical-information">fill in form FEP1<\/a> and send it to <abbr title="Driver Vehicle and Licensing Agency">DVLA<\/abbr>. The address is on the form.<\/p>/,
-        b_button
+      /<p>You can either <a href="\/report-driving-medical-condition">report your condition online<\/a> or <a href="\/government\/publications\/fep1-confidential-medical-information">fill in form FEP1<\/a> and send it to <abbr title="Driver Vehicle and Licensing Agency">DVLA<\/abbr>. The address is on the form.<\/p>/,
+      b_button
     )
   end
 end

--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -1,3 +1,7 @@
+<% if is_epilepsy_driving_tested_path? %>
+    <%= epilepsy_driving_start_button_variant.analytics_meta_tag.html_safe %>
+<% end %>
+
 <% content_for :simple_header, true %>
 <%= content_for :title, @content_item.title %>
 
@@ -5,11 +9,20 @@
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',
         title: @content_item.title %>
-    <%= render 'govuk_component/govspeak',
-        content: @content_item.body,
-        direction: page_text_direction,
-        disable_youtube_expansions: true,
-        rich_govspeak: true %>
+
+    <% if should_show_dvla_start_button_variant? %>
+      <%= render 'govuk_component/govspeak',
+          content: @content_item.ab_body,
+          direction: page_text_direction,
+          disable_youtube_expansions: true,
+          rich_govspeak: true %>
+    <% else %>
+      <%= render 'govuk_component/govspeak',
+          content: @content_item.body,
+          direction: page_text_direction,
+          disable_youtube_expansions: true,
+          rich_govspeak: true %>
+    <% end %>
 
     <% #https://github.com/alphagov/government-frontend/pull/329#issuecomment-297681738 %>
     <% if false && @content_item.last_updated %>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -304,23 +304,10 @@ class ContentItemsControllerTest < ActionController::TestCase
 
     get :show, params: { path: path_for(content_item) }
 
-    refute_match /epilepsy-driving-variant-b/, response.body, "Expected to not find Start button"
+    refute_match(/epilepsy-driving-variant-b/, response.body, "Expected to not find Start button")
   end
 
-  test "defaults to no start button in A variant for DVLA Epilepsy and driving AB Test" do
-    content_item = content_store_has_schema_example("answer", "answer")
-    path = "epilepsy-and-driving"
-    content_item["base_path"] = "/#{path}"
-
-    content_store_has_item(content_item['base_path'], content_item)
-
-    with_variant EpilepsyDrivingStart: "A" do
-      get :show, params: { path: path_for(content_item) }
-      refute_match /epilepsy-driving-variant-b/, response.body, "Expected to not find Start button"
-    end
-  end
-
-  test "shows start button for B variant of DVLA Epilepsy and driving AB Test" do
+  test "test each variant for DVLA Epilepsy and driving AB Test" do
     content_item = content_store_has_schema_example("answer", "answer")
     path = "epilepsy-and-driving"
     content_item["base_path"] = "/#{path}"
@@ -328,10 +315,15 @@ class ContentItemsControllerTest < ActionController::TestCase
 
     content_store_has_item(content_item['base_path'], content_item)
 
+    with_variant EpilepsyDrivingStart: "A" do
+      get :show, params: { path: path_for(content_item) }
+      refute_match(/epilepsy-driving-variant-b/, response.body, "Expected to not find Start button")
+    end
+
     with_variant EpilepsyDrivingStart: "B" do
       get :show, params: { path: path_for(content_item) }
 
-      assert_match /epilepsy-driving-variant-b/, response.body
+      assert_match(/epilepsy-driving-variant-b/, response.body, "Expected to find Start button")
     end
   end
 

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -293,6 +293,48 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_response_not_modified_for_ab_test('EducationNavigation')
   end
 
+  test "no change for pages not in test" do
+    content_item = content_store_has_schema_example("answer", "answer")
+    path = "another-page"
+    content_item["base_path"] = "/#{path}"
+
+    content_store_has_item(content_item['base_path'], content_item)
+
+    setup_ab_variant "EpilepsyDrivingStart", "B"
+
+    get :show, params: { path: path_for(content_item) }
+
+    refute_match /epilepsy-driving-variant-b/, response.body, "Expected to not find Start button"
+  end
+
+  test "defaults to no start button in A variant for DVLA Epilepsy and driving AB Test" do
+    content_item = content_store_has_schema_example("answer", "answer")
+    path = "epilepsy-and-driving"
+    content_item["base_path"] = "/#{path}"
+
+    content_store_has_item(content_item['base_path'], content_item)
+
+    with_variant EpilepsyDrivingStart: "A" do
+      get :show, params: { path: path_for(content_item) }
+      refute_match /epilepsy-driving-variant-b/, response.body, "Expected to not find Start button"
+    end
+  end
+
+  test "shows start button for B variant of DVLA Epilepsy and driving AB Test" do
+    content_item = content_store_has_schema_example("answer", "answer")
+    path = "epilepsy-and-driving"
+    content_item["base_path"] = "/#{path}"
+    content_item["details"]["body"].insert(0, '<p>You can either <a href="/report-driving-medical-condition">report your condition online</a> or <a href="/government/publications/fep1-confidential-medical-information">fill in form FEP1</a> and send it to <abbr title="Driver Vehicle and Licensing Agency">DVLA</abbr>. The address is on the form.</p>')
+
+    content_store_has_item(content_item['base_path'], content_item)
+
+    with_variant EpilepsyDrivingStart: "B" do
+      get :show, params: { path: path_for(content_item) }
+
+      assert_match /epilepsy-driving-variant-b/, response.body
+    end
+  end
+
   test "sets the Access-Control-Allow-Origin header for atom pages" do
     content_store_has_schema_example('travel_advice', 'full-country')
     get :show, params: { path: 'foreign-travel-advice/albania', format: 'atom' }


### PR DESCRIPTION
Trello card: https://trello.com/c/9ZPkxHjH

Content Team want to AB Test changing the call to action on [Epilepsy and Driving](https://www.gov.uk/epilepsy-and-driving) page from a link within the body of text to a Start Button.

The test is to run for 30 days. Related PR for Fastly config is https://github.com/alphagov/fastly-configure/pull/23

The downside is that as the B variant body content is hard coded, the A variant can't be changed during the course of the test.

## Expected outcomes

[Page on GOV.UK](https://www.gov.uk/epilepsy-and-driving)
[Preview](https://government-frontend-pr-369.herokuapp.com/epilepsy-and-driving)

If you have the `GOVUK-ABTest-EpilepsyDrivingStart` request header set with a value of `B` you will see the start button.

### Before
![image](https://cloud.githubusercontent.com/assets/424772/26258732/e4dd63ec-3cbd-11e7-8030-767d9e3e843a.png)

### After
![image](https://cloud.githubusercontent.com/assets/424772/26258741/ef356bd2-3cbd-11e7-8040-cc2e5559d215.png)
