### PR TITLE
[Do not merge] Standard JS linting with automatic fixes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,1 +1,1 @@
-//= require_tree ./modules
+// = require_tree ./modules

--- a/app/assets/javascripts/modules/ukvi_ab_test.js
+++ b/app/assets/javascripts/modules/ukvi_ab_test.js
@@ -1,4 +1,4 @@
-//= require govuk/multivariate-test
+// = require govuk/multivariate-test
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
@@ -8,31 +8,31 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   GOVUK.Modules.UkviAbTest = function () {
     this.start = function ($el) {
       var testType = $el.data('test-type'),
-          testLabel = $el.data('test-label'),
-          newContent = $el.html(),
-          testCallback = testType === "overview" ? updateOverviewSection : UpdateKnowledgeOfEnglishSection;
-      
+        testLabel = $el.data('test-label'),
+        newContent = $el.html(),
+        testCallback = testType === 'overview' ? updateOverviewSection : UpdateKnowledgeOfEnglishSection
+
       new GOVUK.MultivariateTest({
         name: testLabel,
         cookieDuration: 30, // set cookie expiry to 30 days
         customDimensionIndex: [13, 14],
         cohorts: {
-          original: { callback: function() {}, weight: 50},
+          original: { callback: function () {}, weight: 50},
           spouseProminent: {
             callback: testCallback,
             weight: 50
           }
         }
-      });
+      })
 
-      function updateOverviewSection() {
-        $("#exceptions").prevAll().hide();
-        $("#exceptions").before(newContent);
+      function updateOverviewSection () {
+        $('#exceptions').prevAll().hide()
+        $('#exceptions').before(newContent)
       }
 
-      function UpdateKnowledgeOfEnglishSection() {
-        $("#exemptions").prevAll().hide();
-        $("#exemptions").before(newContent);
+      function UpdateKnowledgeOfEnglishSection () {
+        $('#exemptions').prevAll().hide()
+        $('#exemptions').before(newContent)
       }
     }
   }

--- a/app/assets/javascripts/webchat.js
+++ b/app/assets/javascripts/webchat.js
@@ -4,27 +4,26 @@
 
 var $ = window.$
 
-
 EGAIN_NORMALISATION = {
-  0: "AVAILABLE",
-  1: "UNAVAILABLE",
-  2: "BUSY"
+  0: 'AVAILABLE',
+  1: 'UNAVAILABLE',
+  2: 'BUSY'
 }
 
-var webChatNormalise = function(res){
+var webChatNormalise = function (res) {
   var $xml = $(res)
   var proxyResponse = parseInt($xml.find('checkEligibility').attr('responseType'), 10)
   var response = EGAIN_NORMALISATION[proxyResponse]
   if (!response) {
     return {
-      status: "failure",
-      response: "unknown"
+      status: 'failure',
+      response: 'unknown'
     }
   }
 
   return {
-    status: "success",
-      response: response
+    status: 'success',
+    response: response
   }
 }
 

--- a/app/assets/javascripts/webchat/library.js
+++ b/app/assets/javascripts/webchat/library.js
@@ -5,24 +5,23 @@
   if (typeof global.GOVUK === 'undefined') { global.GOVUK = {} }
   var GOVUK = global.GOVUK
 
-
   function Webchat (options) {
     var POLL_INTERVAL = 15 * 1000
-    var AJAX_TIMEOUT  = 5 * 1000
+    var AJAX_TIMEOUT = 5 * 1000
     var API_STATES = [
-      "BUSY",
-      "UNAVAILABLE",
-      "AVAILABLE",
-      "ERROR"
+      'BUSY',
+      'UNAVAILABLE',
+      'AVAILABLE',
+      'ERROR'
     ]
-    var $el                 = $(options.$el)
-    var openUrl             = $el.attr('data-open-url')
-    var availabilityUrl     = $el.attr('data-availability-url')
-    var $openButton         = $el.find('.js-webchat-open-button')
-    var webchatStateClass   = 'js-webchat-advisers-'
-    var responseNormaliser  = options.responseNormaliser
-    var intervalID          = null
-    var lastRecordedState   = null
+    var $el = $(options.$el)
+    var openUrl = $el.attr('data-open-url')
+    var availabilityUrl = $el.attr('data-availability-url')
+    var $openButton = $el.find('.js-webchat-open-button')
+    var webchatStateClass = 'js-webchat-advisers-'
+    var responseNormaliser = options.responseNormaliser
+    var intervalID = null
+    var lastRecordedState = null
 
     function init () {
       if (!availabilityUrl || !openUrl) throw 'urls for webchat not defined'
@@ -51,8 +50,8 @@
     function apiSuccess (result) {
       if (responseNormaliser) result = responseNormaliser(result)
 
-      var validState  = API_STATES.indexOf(result.response) != -1
-      var state       = validState ? result.response : "ERROR"
+      var validState = API_STATES.indexOf(result.response) != -1
+      var state = validState ? result.response : 'ERROR'
       advisorStateChange(state)
     }
 
@@ -63,7 +62,7 @@
 
     function advisorStateChange (state) {
       state = state.toLowerCase()
-      var currentState = $el.find("." + webchatStateClass + state)
+      var currentState = $el.find('.' + webchatStateClass + state)
       $el.find('[class^="' + webchatStateClass + '"]').addClass('hidden')
       currentState.removeClass('hidden')
       trackEvent(state)

--- a/spec/javascripts/webchat.spec.js
+++ b/spec/javascripts/webchat.spec.js
@@ -30,15 +30,14 @@ describe('Webchat', function () {
     }
   }
 
-
-  var jsonNormalisedAvailable = jsonNormalised("success","AVAILABLE")
-  var jsonNormalisedUnavailable = jsonNormalised("success","UNAVAILABLE")
-  var jsonNormalisedBusy = jsonNormalised("success","BUSY")
+  var jsonNormalisedAvailable = jsonNormalised('success', 'AVAILABLE')
+  var jsonNormalisedUnavailable = jsonNormalised('success', 'UNAVAILABLE')
+  var jsonNormalisedBusy = jsonNormalised('success', 'BUSY')
   var jsonNormalisedError = '404 not found'
 
-  var jsonMangledAvailable = jsonNormalised("success","FOOAVAILABLE")
-  var jsonMangledUnavailable = jsonNormalised("success","FOOUNAVAILABLE")
-  var jsonMangledBusy = jsonNormalised("success","FOOBUSY")
+  var jsonMangledAvailable = jsonNormalised('success', 'FOOAVAILABLE')
+  var jsonMangledUnavailable = jsonNormalised('success', 'FOOUNAVAILABLE')
+  var jsonMangledBusy = jsonNormalised('success', 'FOOBUSY')
   var jsonMangledError = 'FOO404 not found'
 
   beforeEach(function () {
@@ -49,7 +48,6 @@ describe('Webchat', function () {
     $advisersAvailable = $webchat.find('.js-webchat-advisers-available')
     $advisersError = $webchat.find('.js-webchat-advisers-error')
   })
-
 
   describe('on valid application locations that are pre normalised', function () {
     function mount () {
@@ -126,11 +124,11 @@ describe('Webchat', function () {
         jsonNormalisedError,
         jsonNormalisedError
       ]
-      var analyticsExpects = ['available','error']
+      var analyticsExpects = ['available', 'error']
       var analyticsReceived = []
       returnsNumber = 0
       analyticsCalled = 0
-      var clock = lolex.install();
+      var clock = lolex.install()
       spyOn($, 'ajax').and.callFake(function (options) {
         options.success(returns[returnsNumber])
         returnsNumber++
@@ -148,7 +146,7 @@ describe('Webchat', function () {
       expect($advisersError.hasClass('hidden')).toBe(true)
       expect($advisersUnavailable.hasClass('hidden')).toBe(true)
 
-      clock.tick("31");
+      clock.tick('31')
 
       expect($advisersError.hasClass('hidden')).toBe(false)
       expect($advisersAvailable.hasClass('hidden')).toBe(true)
@@ -156,10 +154,10 @@ describe('Webchat', function () {
       expect($advisersUnavailable.hasClass('hidden')).toBe(true)
       expect(analyticsCalled).toBe(2)
       expect(analyticsReceived).toEqual(analyticsExpects)
-      clock.tick("31");
+      clock.tick('31')
       expect(analyticsCalled).toBe(2)
       expect(analyticsReceived).toEqual(analyticsExpects)
-      clock.uninstall();
+      clock.uninstall()
     })
   })
 
@@ -172,11 +170,11 @@ describe('Webchat', function () {
           pollingEnabled: true,
           endPoints: {
             openUrl: CHILD_BENEFIT_API_URL,
-            proxyUrl: CHILD_BENEFIT_API_URL,
+            proxyUrl: CHILD_BENEFIT_API_URL
           },
-          responseNormaliser: function(res){
-            res.response = (res.response) ? res.response.replace("FOO", "") : ""
-            return res;
+          responseNormaliser: function (res) {
+            res.response = (res.response) ? res.response.replace('FOO', '') : ''
+            return res
           }
         })
       })
@@ -240,7 +238,6 @@ describe('Webchat', function () {
   })
 
   describe('egain normalisaton', function () {
-
     var egainResponse = function (responseType) {
       return $.parseXML(
         '<checkEligibility ' +
@@ -259,8 +256,8 @@ describe('Webchat', function () {
       expect(webChatNormalise(egainResponse(1))).toEqual(jsonNormalisedUnavailable)
       expect(webChatNormalise(egainResponse(2))).toEqual(jsonNormalisedBusy)
       expect(webChatNormalise(egainResponse(3))).toEqual({
-        status: "failure",
-        response: "unknown"
+        status: 'failure',
+        response: 'unknown'
       })
     })
   })


### PR DESCRIPTION
A test to see what the affects of linting using Standard JS would be on this repository.

Running `standard --fix`

There are a number of linting issues that can't be fixed automatically:
```
  /app/assets/javascripts/modules/ukvi_ab_test.js:10:7: Split initialized 'var' declarations into multiple statements.
  /app/assets/javascripts/modules/ukvi_ab_test.js:15:7: Do not use 'new' for side effects.
  /app/assets/javascripts/modules/ukvi_ab_test.js:20:21: Expected consistent spacing
  /app/assets/javascripts/modules/ukvi_ab_test.js:29:9: '$' is not defined.
  /app/assets/javascripts/modules/ukvi_ab_test.js:30:9: '$' is not defined.
  /app/assets/javascripts/modules/ukvi_ab_test.js:34:9: '$' is not defined.
  /app/assets/javascripts/modules/ukvi_ab_test.js:35:9: '$' is not defined.
  /app/assets/javascripts/webchat.js:7:1: 'EGAIN_NORMALISATION' is not defined.
  /app/assets/javascripts/webchat.js:16:18: 'EGAIN_NORMALISATION' is not defined.
  /app/assets/javascripts/webchat/library.js:4:7: 'windowOpen' is assigned a value but never used.
  /app/assets/javascripts/webchat/library.js:27:41: Expected an object to be thrown.
  /app/assets/javascripts/webchat/library.js:53:60: Expected '!==' and instead saw '!='.

  /spec/javascripts/webchat.spec.js:129:7: 'returnsNumber' is not defined.
  /spec/javascripts/webchat.spec.js:130:7: 'analyticsCalled' is not defined.
  /spec/javascripts/webchat.spec.js:131:19: 'lolex' is not defined.
  /spec/javascripts/webchat.spec.js:133:33: 'returnsNumber' is not defined.
  /spec/javascripts/webchat.spec.js:134:9: 'returnsNumber' is not defined.
  /spec/javascripts/webchat.spec.js:139:9: 'analyticsCalled' is not defined.
  /spec/javascripts/webchat.spec.js:155:14: 'analyticsCalled' is not defined.
  /spec/javascripts/webchat.spec.js:158:14: 'analyticsCalled' is not defined.
  /spec/javascripts/webchat.spec.js:255:14: 'webChatNormalise' is not defined.
  /spec/javascripts/webchat.spec.js:256:14: 'webChatNormalise' is not defined.
  /spec/javascripts/webchat.spec.js:257:14: 'webChatNormalise' is not defined.
  /spec/javascripts/webchat.spec.js:258:14: 'webChatNormalise' is not defined.
```

I'm not sure how we would fix this:
`/app/assets/javascripts/modules/ukvi_ab_test.js:15:7: Do not use 'new' for side effects.`

cc @nickcolley @mcgoooo