### PR TITLE
Add a meta tag to show if the content item has history

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,9 @@
   <% if @content_item.description %>
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
+  <% if @content_item.respond_to?(:history) %>
+    <meta name="govuk:content-has-history" content="<%= @content_item.history.any? %>" />
+  <% end %>
   <meta name="govuk:content-id" content="<%= @content_item.content_id %>" />
   <%= @education_navigation_ab_test.analytics_meta_tag.html_safe if @education_navigation_ab_test.ab_test_applies? %>
   <%= yield :extra_head_content %>


### PR DESCRIPTION
This will be used by the analytics to include that information as a custom dimension.

[Trello Card](https://trello.com/c/uHiHx5RQ/56-custom-dimension-to-identify-session-where-content-history-is-available)