### PR TITLE
Reduce timeout from 15s to 10s for Webchat availability polling

### DIFF
--- a/app/assets/javascripts/webchat/library.js
+++ b/app/assets/javascripts/webchat/library.js
@@ -7,7 +7,7 @@
 
 
   function Webchat (options) {
-    var POLL_INTERVAL = 15 * 1000
+    var POLL_INTERVAL = 10 * 1000
     var AJAX_TIMEOUT  = 5 * 1000
     var API_STATES = [
       "BUSY",

--- a/spec/javascripts/webchat.spec.js
+++ b/spec/javascripts/webchat.spec.js
@@ -1,6 +1,7 @@
 /* global describe beforeEach setFixtures it spyOn expect jasmine */
 
 var $ = window.jQuery
+var POLL_INTERVAL = '11' // Offset by one
 
 describe('Webchat', function () {
   var GOVUK = window.GOVUK
@@ -148,7 +149,7 @@ describe('Webchat', function () {
       expect($advisersError.hasClass('hidden')).toBe(true)
       expect($advisersUnavailable.hasClass('hidden')).toBe(true)
 
-      clock.tick("31");
+      clock.tick(POLL_INTERVAL)
 
       expect($advisersError.hasClass('hidden')).toBe(false)
       expect($advisersAvailable.hasClass('hidden')).toBe(true)
@@ -156,7 +157,7 @@ describe('Webchat', function () {
       expect($advisersUnavailable.hasClass('hidden')).toBe(true)
       expect(analyticsCalled).toBe(2)
       expect(analyticsReceived).toEqual(analyticsExpects)
-      clock.tick("31");
+      clock.tick(POLL_INTERVAL);
       expect(analyticsCalled).toBe(2)
       expect(analyticsReceived).toEqual(analyticsExpects)
       clock.uninstall();


### PR DESCRIPTION
HMRC (Jonathan Lewis I CDIO Digital Services) are trying to reduce the
amount of people going through to their webchat, they've asked us to
increase the timeout so that there's less chance of a user seeing a stale
'available' state which would allow them to proceed.

We want to make sure we can revert and deploy this if HMRC decide this has impacted them negatively.

Marked as [Do not merge] while we talk with HMRC about when we can deploy this.