### PR TITLE
Strip client IP and remove noisy errors in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ else
 end
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8'
+gem 'rack_strip_client_ip', '~> 0.0.0'
 gem 'rails-i18n', '>= 4.0.4'
 gem 'rails_translation_manager', '~> 0.0.2'
 gem 'rails-controller-testing', '~> 0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,7 @@ GEM
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
+    rack_strip_client_ip (0.0.1)
     rails (5.0.0.1)
       actioncable (= 5.0.0.1)
       actionmailer (= 5.0.0.1)
@@ -300,6 +301,7 @@ DEPENDENCIES
   plek (= 1.11)
   poltergeist
   pry-byebug
+  rack_strip_client_ip (~> 0.0.0)
   rails (~> 5.0)
   rails-controller-testing (~> 0.1)
   rails-i18n (>= 4.0.4)


### PR DESCRIPTION
We're trying to make government-frontend's errors less noisy so they're more actionable.

Example of the error in errbit: https://errbit.publishing.service.gov.uk/apps/546493f90da1150e4e001cfc/problems/5908989565786317fcf23200

This change adds a gem that was present in alphagov/frontend (https://github.com/alphagov/frontend/blob/master/Gemfile#L15)

Up for discussion if there's a better way to do this these days though, let me know 👍 

https://trello.com/c/mA90nTTZ/89-silence-ip-spoofing-warnings-in-errbit