### PR TITLE
Ensure GdsAPI::InvalidUrl exception results in a 404

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -5,6 +5,7 @@ class ContentItemsController < ApplicationController
 
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from GdsApi::HTTPNotFound, with: :error_notfound
+  rescue_from GdsApi::InvalidUrl, with: :error_notfound
   rescue_from ActionView::MissingTemplate, with: :error_406
 
   attr_accessor :content_item

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -137,6 +137,15 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "returns 404 for invalid url" do
+    path = 'foreign-travel-advice/egypt]'
+
+    content_store_does_not_have_item('/' + path)
+
+    get :show, params: { path: path }
+    assert_response :not_found
+  end
+
   test "returns 404 for item not in content store" do
     path = 'government/case-studies/boost-chocolate-production'
 


### PR DESCRIPTION
I'm not sure this should be dealt with at this level since
I believe the characters used in our test (and seen in our error reporting)
is valid per the URL spec, but I'd like to make sure users see a
consistent error page and status code.

I'd love a better solution if anyone has any ideas.