### PR TITLE
Fix intermittent test failure on guides

### DIFF
--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -29,10 +29,7 @@ class GuideTest < ActionDispatch::IntegrationTest
   end
 
   test "draft access tokens are appended to part links within navigation" do
-    @content_item = JSON.parse(get_content_example("guide")).tap do |item|
-      visit("#{item['base_path']}?token=some_token")
-    end
-
+    setup_and_visit_content_item('guide', '?token=some_token')
     assert page.has_css?('.part-navigation a[href$="?token=some_token"]')
   end
 

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -42,7 +42,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   end
 
   test "html publications with meta data - print version" do
-    setup_and_visit_content_item("print_with_meta_data", true)
+    setup_and_visit_content_item("print_with_meta_data", "?medium=print")
 
     within ".publication-header" do
       assert page.find(".print-meta-data", visible: true)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -115,10 +115,10 @@ class ActionDispatch::IntegrationTest
     assert page.has_css? "meta[#{key}=\"#{value}\"]", visible: false
   end
 
-  def setup_and_visit_content_item(name, print = false)
+  def setup_and_visit_content_item(name, parameter_string = '')
     @content_item = JSON.parse(get_content_example(name)).tap do |item|
       content_store_has_item(item["base_path"], item.to_json)
-      print ? visit("#{item['base_path']}?medium=print") : visit(item['base_path'])
+      visit("#{item['base_path']}#{parameter_string}")
     end
   end
 


### PR DESCRIPTION
The `JSON.parse` method omitted `content_store_has_item` which meant the content store wasn’t always stubbed with the example – sometimes this test would fail, sometimes it would pass, depending on the tests that ran before it.

Avoid risk that this could happen again by updating `setup_and_visit_content_item` to take URL params.