### PR TITLE
Add link tracking to HTML Publication contents lists

### DIFF
--- a/app/assets/javascripts/modules/track-html-publication-contents.js
+++ b/app/assets/javascripts/modules/track-html-publication-contents.js
@@ -1,0 +1,33 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function(Modules) {
+  "use strict";
+
+  Modules.TrackHtmlPublicationContents = function () {
+    this.start = function (element) {
+      var category = element.data('track-category');
+      var action = element.data('track-action');
+      var trackable = 'a[href^="#"]';
+
+      element.on('click', trackable, trackClick);
+
+      function trackClick(evt) {
+        var $el = $(evt.target),
+            options = {
+              transport: 'beacon'
+            };
+
+        if (! $el.is(trackable)) {
+          $el = $el.parents(trackable);
+        }
+
+        options.label = $el.attr('href').substring(1);
+
+        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+          GOVUK.analytics.trackEvent(category, action, options);
+        }
+      }
+    };
+  };
+})(window.GOVUK.Modules);

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -34,7 +34,12 @@
   </div>
 
   <% if @content_item.contents? %>
-    <nav class="in-page-navigation">
+    <nav
+      class="in-page-navigation"
+      data-module="track-html-publication-contents"
+      data-track-category="contentsClicked"
+      data-track-action="blueBoxH2"
+    >
       <h2>
         <%= t("content_item.contents") %>
       </h2>

--- a/spec/javascripts/track-html-publication-contents.spec.js
+++ b/spec/javascripts/track-html-publication-contents.spec.js
@@ -1,0 +1,37 @@
+describe('An HTML Publication contents click tracker', function() {
+  "use strict";
+
+  var tracker,
+      element;
+
+  beforeEach(function() {
+    tracker = new GOVUK.Modules.TrackHtmlPublicationContents();
+    spyOn(GOVUK.analytics, 'trackEvent');
+    element = $('\
+      <div \
+        data-track-category="category"\
+        data-track-action="action">\
+        <a href="#the-link-id">Foo!</a>\
+        <ul><li><a href="#another-link"><span>1. </span> Bar</a></li></ul>\
+      </div>\
+    ');
+  });
+
+  it('tracks click events using category and action on parent and link href location as label', function() {
+    tracker.start(element);
+    element.find('a').trigger('click');
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'the-link-id', transport: 'beacon'});
+  });
+
+  it('tracks click events on any link', function() {
+    tracker.start(element);
+    element.find('a').eq(1).trigger('click');
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'another-link', transport: 'beacon'});
+  });
+
+  it('handles click events on spans inside links', function() {
+    tracker.start(element);
+    element.find('a span').trigger('click');
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'another-link', transport: 'beacon'});
+  });
+});


### PR DESCRIPTION
* Track clicks on contents lists
* We can’t modify HTML Pub contents lists easily, instead write a new
module to add event listeners on the parent and track links via click
events within it
* Use category and action defined on parent container
* Use the target of the link as the label

When we move the position of contents lists, and if we use the standard ContentsList functionality, then this custom tracking can be removed.

https://trello.com/c/z3YCn9zf/424-implement-ga-tracking-on-html-publication-content-list

@nickcolley @andysellick 