### PR TITLE
Move HTML Publication contents list from top to left

### DIFF
--- a/app/assets/stylesheets/helpers/_back-to-content.scss
+++ b/app/assets/stylesheets/helpers/_back-to-content.scss
@@ -13,6 +13,11 @@
   // TODO: Update grid to allow this behaviour without this hack
   .sidebar-with-body & {
     margin-left: $gutter-half;
+
+    .direction-rtl & {
+      margin-left: 0;
+      margin-right: $gutter-half;
+    }
   }
 
   @media print {

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,5 +1,3 @@
 // PRINT STYLESHEET COMPILER
 
-.print-wrapper {
-  @import "print/html-publication";
-}
+@import "print/html-publication";

--- a/app/assets/stylesheets/print/_html-publication.scss
+++ b/app/assets/stylesheets/print/_html-publication.scss
@@ -1,13 +1,22 @@
-.print-meta-data {
-  page-break-before: always;
-  page-break-after: always;
-  display: block;
+.print-wrapper {
+  .print-meta-data {
+    page-break-before: always;
+    page-break-after: always;
+    display: block;
 
-  .print-meta-data-licence {
-    width: 78px;
-    height: auto;
-    margin-top: 60px;
-    margin-bottom: 40px;
+    .print-meta-data-licence {
+      width: 78px;
+      height: auto;
+      margin-top: 60px;
+      margin-bottom: 40px;
+    }
   }
 }
 
+.html-publication {
+  .contents-list {
+    li {
+      list-style: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -58,6 +58,7 @@
     @include grid-column( 1 / 4, $full-width: desktop );
 
     .direction-rtl & {
+      float: right;
       direction: rtl;
       text-align: start;
     }
@@ -111,6 +112,10 @@
 
   .contents-wrapper {
     @include grid-column( 3 / 4, $full-width: desktop );
+
+    .direction-rtl & {
+      float: right;
+    }
   }
 
   .offset-one-quarter {

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -130,18 +130,6 @@
     }
   }
 
-  h3 .number,
-  h4 .number,
-  h5 .number,
-  h6 .number {
-    margin-right: 0.1em;
-
-    .direction-rtl & {
-      margin-right: 0;
-      margin-left: 0.1em;
-    }
-  }
-
   .print-meta-data {
     display: none;
   }

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -55,7 +55,7 @@
   }
 
   .contents-list-wrapper {
-    @include grid-column( 1/4, $full-width: desktop );
+    @include grid-column( 1 / 4, $full-width: desktop );
 
     .direction-rtl & {
       direction: rtl;
@@ -110,7 +110,7 @@
   }
 
   .contents-wrapper {
-    @include grid-column( 3/4, $full-width: desktop );
+    @include grid-column( 3 / 4, $full-width: desktop );
   }
 
   .offset-one-quarter {

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -29,19 +29,16 @@
   }
 
   .publication-header {
+    @include core-19;
     color: $white;
     background: $light-blue;
     padding: $gutter;
     margin-bottom: $gutter * 2;
   }
 
-  .headings {
-    @include core-16;
-  }
-
   // Based on the govuk-title component
   .html-publication-title {
-    margin-bottom: 10px;
+    margin-bottom: $gutter;
 
     .context {
       @include core-27;

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -29,8 +29,6 @@
   }
 
   .publication-header {
-    @include white-links;
-    @include core-19;
     color: $white;
     background: $light-blue;
     padding: $gutter;

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -1,6 +1,8 @@
 @import "grid_layout";
 
 .html-publication {
+  @include sidebar-with-body;
+
   .publication-external {
     @extend %grid-row;
     margin-bottom: $gutter-two-thirds;
@@ -16,9 +18,28 @@
     }
   }
 
+  .publication-header {
+    @include white-links;
+    @include core-19;
+    color: $white;
+
+    background: $light-blue;
+    padding: $gutter;
+    margin-bottom: $gutter;
+
+    &.direction-rtl {
+      direction: rtl;
+      text-align: start;
+    }
+  }
+
+  .headings {
+    @include core-16;
+  }
+
   // Based on the govuk-title component
   .html-publication-title {
-    @include responsive-vertical-margins;
+    margin-bottom: 10px;
 
     .context {
       @include core-27;
@@ -31,88 +52,85 @@
     }
   }
 
-  .publication-header {
-    @include white-links;
-    @include core-19;
-    color: $white;
+  .html-publication-grid-row {
+    @extend %grid-row;
+    //margin: 0 0 45px 0;
 
-    background: $light-blue;
-    padding: $gutter $gutter $gutter / 3;
-    margin-bottom: $gutter;
-
-    @include media(tablet) {
-      margin-bottom: $gutter * 2;
+    .column-sidebar {
+      @include grid-column(1 / 4, desktop);
     }
 
-    &.direction-rtl {
-      direction: rtl;
-      text-align: start;
+    .column-content {
+      @include grid-column(3 / 4, desktop);
+    }
+
+    .offset-one-quarter {
+      margin-left: 25%;
+    }
+
+    @include media(false, $desktop-breakpoint) {
+      .govuk-sticky-element--enabled {
+        position: static;
+      }
+
+      .offset-one-quarter {
+        margin-left: 0;
+      }
     }
   }
 
-  .headings {
-    margin-bottom: $gutter;
-  }
+  .contents-list {
+    padding-bottom: $gutter;
+    list-style: none;
 
-  .in-page-navigation {
-    margin-bottom: $gutter;
+    li {
+      padding-top: $gutter / 4;
+      line-height: 1.3;
 
-    @include media(tablet) {
-      width: 70%;
-    }
-
-    h2 {
-      font-weight: bold;
-    }
-
-    ol {
-      padding-left: $gutter;
-
-      .direction-rtl & {
-        padding-right: $gutter;
-        padding-left: 0;
+      @media print {
+        display: none;
+        list-style: none;
       }
-
-      li {
-        list-style: decimal;
-        font-weight: bold;
-      }
-
-      &.unnumbered {
-        padding-left: 0;
-
-        li {
-          list-style: none;
-        }
-      }
-    }
-
-    .numbered {
-      margin-left: $gutter-two-thirds;
-
-      @include media(desktop) {
-        margin-left: $gutter;
-      }
-    }
-
-    .heading-number {
-      @include bold-19($tabular-numbers: true);
-      margin-left: -18px;
     }
 
     a {
-      color: $white;
       text-decoration: none;
-      font-weight: normal;
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
 
-    a:hover,
-    a:focus,
-    a:active {
-      text-decoration: underline;
+    .contents-number {
+      float: left;
+    }
+
+    .contents-text {
+      display: block;
+      margin-left: 1.5em;
     }
   }
 
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    position: relative;
+  }
+/*
+  .number {
+    position: absolute;
+    top: 0;
+    right: 100%;
+    margin-right: 10px;
+
+    @include media(mobile) {
+      position: relative;
+      right: auto;
+    }
+  }
+*/
   .print-meta-data {
     display: none;
   }

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -79,6 +79,16 @@
       a {
         text-decoration: none;
 
+        // Child spans are floated which creates a focus box around
+        // just the number. Set parent link to inline-block for
+        // correct appearance
+        display: inline-block;
+
+        // IE8 and below don't render inline-block correctly
+        @include ie-lte(8) {
+          display: block;
+        }
+
         &:hover {
           text-decoration: underline;
         }

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -3,6 +3,11 @@
 .html-publication {
   @include sidebar-with-body;
 
+  .direction-rtl & {
+    direction: rtl;
+    text-align: start;
+  }
+
   .publication-external {
     @extend %grid-row;
     margin-bottom: $gutter-two-thirds;
@@ -16,21 +21,19 @@
         padding-bottom: $gutter-one-third;
       }
     }
+
+    .direction-rtl & {
+      direction: ltr;
+    }
   }
 
   .publication-header {
     @include white-links;
     @include core-19;
     color: $white;
-
     background: $light-blue;
     padding: $gutter;
-    margin-bottom: $gutter;
-
-    &.direction-rtl {
-      direction: rtl;
-      text-align: start;
-    }
+    margin-bottom: $gutter * 2;
   }
 
   .headings {
@@ -52,85 +55,84 @@
     }
   }
 
-  .html-publication-grid-row {
-    @extend %grid-row;
-    //margin: 0 0 45px 0;
+  .offset-one-quarter {
+    margin-left: 25%;
 
-    .column-sidebar {
-      @include grid-column(1 / 4, desktop);
+    .direction-rtl & {
+      margin-left: 0;
+      margin-right: 25%;
     }
-
-    .column-content {
-      @include grid-column(3 / 4, desktop);
-    }
-
-    .offset-one-quarter {
-      margin-left: 25%;
-    }
-
-    @include media(false, $desktop-breakpoint) {
-      .govuk-sticky-element--enabled {
-        position: static;
-      }
-
-      .offset-one-quarter {
-        margin-left: 0;
-      }
-    }
-  }
-
-  .contents-list {
-    padding-bottom: $gutter;
-    list-style: none;
-
-    li {
-      padding-top: $gutter / 4;
-      line-height: 1.3;
-
-      @media print {
-        display: none;
-        list-style: none;
-      }
-    }
-
-    a {
-      text-decoration: none;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
-
-    .contents-number {
-      float: left;
-    }
-
-    .contents-text {
-      display: block;
-      margin-left: 1.5em;
-    }
-  }
-
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    position: relative;
-  }
-/*
-  .number {
-    position: absolute;
-    top: 0;
-    right: 100%;
-    margin-right: 10px;
 
     @include media(mobile) {
-      position: relative;
-      right: auto;
+      margin: 0;
+
+      .direction-rtl & {
+        margin: 0;
+      }
     }
   }
-*/
+
+  .contents-list-wrapper {
+    .direction-rtl & {
+      direction: rtl;
+      text-align: start;
+    }
+
+    .contents-list {
+      position: relative;
+      z-index: 1;
+      padding-bottom: $gutter;
+      list-style: none;
+      background: $white;
+      box-shadow: 0 20px 15px -10px $white;
+
+      li {
+        padding-top: $gutter / 4;
+        line-height: 1.3;
+      }
+
+      a {
+        text-decoration: none;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+
+      .contents-number {
+        float: left;
+      }
+
+      .contents-text {
+        display: block;
+        margin-left: 1.5em;
+      }
+
+      .direction-rtl & {
+        .contents-number {
+          float: right;
+        }
+
+        .contents-text {
+          margin-left: 0;
+          margin-right: 1.5em;
+        }
+      }
+    }
+  }
+
+  h3 .number,
+  h4 .number,
+  h5 .number,
+  h6 .number {
+    margin-right: 0.1em;
+
+    .direction-rtl & {
+      margin-right: 0;
+      margin-left: 0.1em;
+    }
+  }
+
   .print-meta-data {
     display: none;
   }

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -22,6 +22,7 @@
       }
     }
 
+    // design calls for the logos at the top to always be left aligned
     .direction-rtl & {
       direction: ltr;
     }
@@ -55,24 +56,9 @@
     }
   }
 
-  .offset-one-quarter {
-    margin-left: 25%;
-
-    .direction-rtl & {
-      margin-left: 0;
-      margin-right: 25%;
-    }
-
-    @include media(mobile) {
-      margin: 0;
-
-      .direction-rtl & {
-        margin: 0;
-      }
-    }
-  }
-
   .contents-list-wrapper {
+    @include grid-column( 1/4, $full-width: desktop );
+
     .direction-rtl & {
       direction: rtl;
       text-align: start;
@@ -99,6 +85,10 @@
         }
       }
 
+      @include media(false, $desktop-breakpoint) {
+        box-shadow: none;
+      }
+
       .contents-number {
         float: left;
       }
@@ -121,6 +111,27 @@
     }
   }
 
+  .contents-wrapper {
+    @include grid-column( 3/4, $full-width: desktop );
+  }
+
+  .offset-one-quarter {
+    margin-left: 25%;
+
+    .direction-rtl & {
+      margin-left: 0;
+      margin-right: 25%;
+    }
+
+    @include media(false, $desktop-breakpoint) {
+      margin: 0;
+
+      .direction-rtl & {
+        margin: 0;
+      }
+    }
+  }
+
   h3 .number,
   h4 .number,
   h5 .number,
@@ -135,5 +146,11 @@
 
   .print-meta-data {
     display: none;
+  }
+
+  @include media(false, $desktop-breakpoint) {
+    .govuk-sticky-element--enabled {
+      position: static;
+    }
   }
 }

--- a/app/helpers/contents_list_helper.rb
+++ b/app/helpers/contents_list_helper.rb
@@ -1,14 +1,13 @@
 module ContentsListHelper
-  def insert_spans(text)
-    no_tags = strip_tags(text) #just the text of the link
-    number = /^[0-9]*[.]/.match(no_tags)
+  def wrap_numbers_with_spans(content_item_link)
+    content_item_text = strip_tags(content_item_link) #just the text of the link
+    number = /^[0-9]*[.]/.match(content_item_text)
 
     if number
-      link_text = no_tags.sub number.to_s, '' #remove the number from the text
-      text.sub! no_tags, '<span class="contents-number">' + number.to_s + '</span><span class="contents-text">' + link_text.strip + '</span>'
-      text = text.squish.html_safe
+      words = content_item_text.sub(number.to_s, '').strip #remove the number from the text
+      content_item_link.sub(content_item_text, "<span class=\"contents-number\">#{number}</span><span class=\"contents-text\">#{words}</span>").squish.html_safe
+    else
+      content_item_link
     end
-
-    text
   end
 end

--- a/app/helpers/contents_list_helper.rb
+++ b/app/helpers/contents_list_helper.rb
@@ -1,0 +1,14 @@
+module ContentsListHelper
+  def insert_spans(text)
+    no_tags = strip_tags(text) #just the text of the link
+    number = /^[0-9]*[.]/.match(no_tags)
+
+    if number
+      link_text = no_tags.sub number.to_s, '' #remove the number from the text
+      text.sub! no_tags, '<span class="contents-number">' + number.to_s + '</span><span class="contents-text">' + link_text.strip + '</span>'
+      text = text.squish.html_safe
+    end
+
+    text
+  end
+end

--- a/app/presenters/contents_list.rb
+++ b/app/presenters/contents_list.rb
@@ -3,7 +3,7 @@ module ContentsList
   include TypographyHelper
 
   def contents
-    contents_items.map do |item|
+    @contents ||= contents_items.map do |item|
       contents_link(item[:text], item[:id])
     end
   end

--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -1,14 +1,7 @@
 class HtmlPublicationPresenter < ContentItemPresenter
   include Body
   include OrganisationBranding
-
-  def contents?
-    contents && contents != '<ol></ol>'
-  end
-
-  def contents
-    content_item["details"]["headings"].try(:html_safe)
-  end
+  include ContentsList
 
   def isbn
     content_item["details"]["isbn"]

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -7,9 +7,6 @@
 <%
   content_for :title, @content_item.title
   content_for :simple_header, true
-
-  direction_css_class = ""
-  direction_css_class = " direction-#{page_text_direction}" if page_text_direction
 %>
 
 <div class="publication-external">
@@ -22,7 +19,7 @@
   </ol>
 </div>
 
-<header class="publication-header<%= direction_css_class %>" id="contents">
+<header class="publication-header" id="contents">
   <div class="headings">
     <div class="html-publication-title">
       <% if @content_item.format_sub_type %>
@@ -32,29 +29,30 @@
     </div>
     <%= @content_item.last_changed %>
   </div>
+</header>
+
+<div
+  class="grid-row sidebar-with-body"
+  data-module="sticky-element-container"
+>
+  <% if @content_item.contents.any? %>
+    <div class="column-quarter contents-list-wrapper">
+      <%= render 'shared/sidebar_contents', contents: @content_item.contents, list_class: 'contents-list', format_numbers: true %>
+    </div>
+  <% end %>
 
   <div class="print-wrapper">
     <div class="print-meta-data">
       <%= render partial: "content_items/html_publication/print_meta_data" %>
     </div>
   </div>
-</header>
 
-<div
-  class="html-publication-grid-row sidebar-with-body"
-  data-module="sticky-element-container"
->
-  <% if @content_item.contents.any? %>
-    <div class="column-sidebar">
-      <%= render 'shared/sidebar_contents', contents: @content_item.contents, list_class: 'contents-list' %>
-    </div>
-  <% end %>
-  <div class="column-content <% unless @content_item.contents.any? %>offset-one-quarter<% end %>">
+  <div class="column-three-quarters <% unless @content_item.contents.any? %>offset-one-quarter<% end %>">
     <%= render 'govuk_component/govspeak_html_publication', @content_item.govspeak_body %>
   </div>
+
   <div data-sticky-element class="govuk-sticky-element">
     <%= render 'shared/back_to_content_link' %>
   </div>
 </div>
-
 

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -20,15 +20,13 @@
 </div>
 
 <header class="publication-header" id="contents">
-  <div class="headings">
-    <div class="html-publication-title">
-      <% if @content_item.format_sub_type %>
-        <p class="context"><%= I18n.t("content_item.schema_name.#{@content_item.format_sub_type}", count: 1) %></p>
-      <% end %>
-      <h1><%= @content_item.title %></h1>
-    </div>
-    <%= @content_item.last_changed %>
+  <div class="html-publication-title">
+    <% if @content_item.format_sub_type %>
+      <p class="context"><%= I18n.t("content_item.schema_name.#{@content_item.format_sub_type}", count: 1) %></p>
+    <% end %>
+    <h1><%= @content_item.title %></h1>
   </div>
+  <%= @content_item.last_changed %>
 </header>
 
 <div
@@ -55,4 +53,3 @@
     <%= render 'shared/back_to_content_link' %>
   </div>
 </div>
-

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -33,20 +33,6 @@
     <%= @content_item.last_changed %>
   </div>
 
-  <% if @content_item.contents? %>
-    <nav
-      class="in-page-navigation"
-      data-module="track-html-publication-contents"
-      data-track-category="contentsClicked"
-      data-track-action="blueBoxH2"
-    >
-      <h2>
-        <%= t("content_item.contents") %>
-      </h2>
-      <%= @content_item.contents %>
-    </nav>
-  <% end %>
-
   <div class="print-wrapper">
     <div class="print-meta-data">
       <%= render partial: "content_items/html_publication/print_meta_data" %>
@@ -54,10 +40,21 @@
   </div>
 </header>
 
+<div
+  class="html-publication-grid-row sidebar-with-body"
+  data-module="sticky-element-container"
+>
+  <% if @content_item.contents.any? %>
+    <div class="column-sidebar">
+      <%= render 'shared/sidebar_contents', contents: @content_item.contents, list_class: 'contents-list' %>
+    </div>
+  <% end %>
+  <div class="column-content <% unless @content_item.contents.any? %>offset-one-quarter<% end %>">
+    <%= render 'govuk_component/govspeak_html_publication', @content_item.govspeak_body %>
+  </div>
+  <div data-sticky-element class="govuk-sticky-element">
+    <%= render 'shared/back_to_content_link' %>
+  </div>
+</div>
 
-<%= render partial: 'govuk_component/govspeak_html_publication',
-    locals: {
-      content: @content_item.body,
-      direction: page_text_direction,
-      sticky_footer_html: (render partial: 'shared/back_to_content_link'),
-    } %>
+

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -36,7 +36,7 @@
   data-module="sticky-element-container"
 >
   <% if @content_item.contents.any? %>
-    <div class="column-quarter contents-list-wrapper">
+    <div class="contents-list-wrapper">
       <%= render 'shared/sidebar_contents', contents: @content_item.contents, list_class: 'contents-list', format_numbers: true %>
     </div>
   <% end %>
@@ -47,7 +47,7 @@
     </div>
   </div>
 
-  <div class="column-three-quarters <% unless @content_item.contents.any? %>offset-one-quarter<% end %>">
+  <div class="contents-wrapper <% unless @content_item.contents.any? %>offset-one-quarter<% end %>">
     <%= render 'govuk_component/govspeak_html_publication', @content_item.govspeak_body %>
   </div>
 

--- a/app/views/shared/_sidebar_contents.html.erb
+++ b/app/views/shared/_sidebar_contents.html.erb
@@ -1,10 +1,14 @@
+<%
+  list_class ||= "dash-list"
+%>
+
 <% if contents.any? %>
   <nav role="navigation">
     <h2><%= t("content_item.contents") %></h2>
-    <ol class="dash-list" data-module="track-click">
+    <ol class="<%= list_class %>" data-module="track-click">
       <% contents.each do |heading| %>
         <li>
-          <%= heading %>
+          <%= insert_spans(heading) %>
         </li>
       <% end %>
     </ol>

--- a/app/views/shared/_sidebar_contents.html.erb
+++ b/app/views/shared/_sidebar_contents.html.erb
@@ -1,5 +1,6 @@
 <%
   list_class ||= "dash-list"
+  format_numbers ||= nil
 %>
 
 <% if contents.any? %>
@@ -8,7 +9,11 @@
     <ol class="<%= list_class %>" data-module="track-click">
       <% contents.each do |heading| %>
         <li>
-          <%= insert_spans(heading) %>
+          <% if format_numbers %>
+            <%= insert_spans(heading) %>
+          <% else %>
+            <%= heading %>
+          <% end %>
         </li>
       <% end %>
     </ol>

--- a/app/views/shared/_sidebar_contents.html.erb
+++ b/app/views/shared/_sidebar_contents.html.erb
@@ -1,6 +1,6 @@
 <%
   list_class ||= "dash-list"
-  format_numbers ||= nil
+  format_numbers ||= false
 %>
 
 <% if contents.any? %>
@@ -10,7 +10,7 @@
       <% contents.each do |heading| %>
         <li>
           <% if format_numbers %>
-            <%= insert_spans(heading) %>
+            <%= wrap_numbers_with_spans(heading) %>
           <% else %>
             <%= heading %>
           <% end %>

--- a/test/helpers/contents_list_helper_test.rb
+++ b/test/helpers/contents_list_helper_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class ContentsListHelperTest < ActionView::TestCase
+  test "it wraps the number and text in span elements" do
+    input = '<a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment" href="#run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment">1. Run an effective welfare system that enables people to achieve financial independence by providing assistance and guidance into employment</a>'
+    expected = '<a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment" href="#run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment"><span class="contents-number">1.</span><span class="contents-text">Run an effective welfare system that enables people to achieve financial independence by providing assistance and guidance into employment</span></a>'
+    assert_equal expected, insert_spans(input)
+  end
+
+  test "it does nothing if no number is found" do
+    input = '<a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="vision" href="#vision">Vision</a>'
+    expected = '<a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="vision" href="#vision">Vision</a>'
+    assert_equal expected, insert_spans(input)
+  end
+end

--- a/test/helpers/contents_list_helper_test.rb
+++ b/test/helpers/contents_list_helper_test.rb
@@ -2,14 +2,14 @@ require 'test_helper'
 
 class ContentsListHelperTest < ActionView::TestCase
   test "it wraps the number and text in span elements" do
-    input = '<a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment" href="#run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment">1. Run an effective welfare system that enables people to achieve financial independence by providing assistance and guidance into employment</a>'
-    expected = '<a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment" href="#run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment"><span class="contents-number">1.</span><span class="contents-text">Run an effective welfare system that enables people to achieve financial independence by providing assistance and guidance into employment</span></a>'
+    input = '<a href="#run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment">1. Run an effective welfare system that enables people to achieve financial independence by providing assistance and guidance into employment</a>'
+    expected = '<a href="#run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment"><span class="contents-number">1.</span><span class="contents-text">Run an effective welfare system that enables people to achieve financial independence by providing assistance and guidance into employment</span></a>'
     assert_equal expected, insert_spans(input)
   end
 
   test "it does nothing if no number is found" do
-    input = '<a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="vision" href="#vision">Vision</a>'
-    expected = '<a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="vision" href="#vision">Vision</a>'
+    input = '<a href="#vision">Vision</a>'
+    expected = '<a href="#vision">Vision</a>'
     assert_equal expected, insert_spans(input)
   end
 

--- a/test/helpers/contents_list_helper_test.rb
+++ b/test/helpers/contents_list_helper_test.rb
@@ -4,18 +4,18 @@ class ContentsListHelperTest < ActionView::TestCase
   test "it wraps the number and text in span elements" do
     input = '<a href="#run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment">1. Run an effective welfare system that enables people to achieve financial independence by providing assistance and guidance into employment</a>'
     expected = '<a href="#run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment"><span class="contents-number">1.</span><span class="contents-text">Run an effective welfare system that enables people to achieve financial independence by providing assistance and guidance into employment</span></a>'
-    assert_equal expected, insert_spans(input)
+    assert_equal expected, wrap_numbers_with_spans(input)
   end
 
   test "it does nothing if no number is found" do
     input = '<a href="#vision">Vision</a>'
     expected = '<a href="#vision">Vision</a>'
-    assert_equal expected, insert_spans(input)
+    assert_equal expected, wrap_numbers_with_spans(input)
   end
 
   test "it does nothing if a number is present but not at the start" do
     input = '<a href="#run-an-effective-welfare-system">Run an effective welfare system part 1. Social Care</a>'
     expected = '<a href="#run-an-effective-welfare-system">Run an effective welfare system part 1. Social Care</a>'
-    assert_equal expected, insert_spans(input)
+    assert_equal expected, wrap_numbers_with_spans(input)
   end
 end

--- a/test/helpers/contents_list_helper_test.rb
+++ b/test/helpers/contents_list_helper_test.rb
@@ -12,4 +12,10 @@ class ContentsListHelperTest < ActionView::TestCase
     expected = '<a data-track-category="contentsClicked" data-track-action="leftColumnH2" data-track-label="vision" href="#vision">Vision</a>'
     assert_equal expected, insert_spans(input)
   end
+
+  test "it does nothing if a number is present but not at the start" do
+    input = '<a href="#run-an-effective-welfare-system">Run an effective welfare system part 1. Social Care</a>'
+    expected = '<a href="#run-an-effective-welfare-system">Run an effective welfare system part 1. Social Care</a>'
+    assert_equal expected, insert_spans(input)
+  end
 end

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -13,7 +13,11 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     link2 = "<a href=\"/topic/business-tax\">Business tax</a>"
     assert_has_component_metadata_pair("part_of", [link1, link2])
     assert_has_component_document_footer_pair("part_of", [link1, link2])
-    assert page.has_css?(".back-to-content")
+  end
+
+  test "renders back to contents elements" do
+    setup_and_visit_content_item('detailed_guide')
+    assert page.has_css?(".back-to-content[href='#contents']")
   end
 
   test "withdrawn detailed guide" do

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -30,6 +30,7 @@ class GuideTest < ActionDispatch::IntegrationTest
 
   test "draft access tokens are appended to part links within navigation" do
     setup_and_visit_content_item('guide', '?token=some_token')
+
     assert page.has_css?('.part-navigation a[href$="?token=some_token"]')
   end
 

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -15,9 +15,11 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       assert page.has_text?(@content_item["title"])
 
       assert page.has_text?("Published 17 January 2016")
+    end
 
+    within ".sidebar-with-body" do
       assert page.has_text?("Contents")
-      assert page.has_css?('ol.unnumbered')
+      assert page.has_css?('ol.contents-list')
     end
 
     within ".organisation-logos" do

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -32,7 +32,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   test "html publications with meta data" do
     setup_and_visit_content_item("print_with_meta_data")
 
-    within ".publication-header" do
+    within ".grid-row" do
       assert page.find(".print-meta-data", visible: false)
 
       assert page.has_no_text?("© Crown copyright #{@content_item['details']['public_timestamp'].to_date.year}")
@@ -46,7 +46,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   test "html publications with meta data - print version" do
     setup_and_visit_content_item("print_with_meta_data", "?medium=print")
 
-    within ".publication-header" do
+    within ".grid-row" do
       assert page.find(".print-meta-data", visible: true)
 
       assert page.has_text?("© Crown copyright #{@content_item['details']['public_timestamp'].to_date.year}")
@@ -54,6 +54,11 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       assert page.has_text?((@content_item['details']['print_meta_data_contact_address']).to_s)
       assert page.has_text?("Print ISBN: #{@content_item['details']['isbn']}")
     end
+  end
+
+  test "renders back to contents elements" do
+    setup_and_visit_content_item('published')
+    assert page.has_css?(".back-to-content[href='#contents']")
   end
 
   test "prime minister office organisation html publication" do
@@ -71,7 +76,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
 
   test "html publication with rtl text direction" do
     setup_and_visit_content_item("arabic_translation")
-    assert page.has_css?(".publication-header.direction-rtl"), "has .direction-rtl class on .publication-header element"
+    assert page.has_css?("#wrapper.direction-rtl"), "has .direction-rtl class on #wrapper element"
   end
 
   def assert_has_component_govspeak_html_publication(content)

--- a/test/presenters/contents_list_test.rb
+++ b/test/presenters/contents_list_test.rb
@@ -1,40 +1,80 @@
 require 'test_helper'
 
 class ContentsListTest < ActiveSupport::TestCase
-  include ContentsList
+  def setup
+    @contents_list = Object.new
+    @contents_list.extend(ContentsList)
+  end
+
+  test "memoises the contents to avoid repeated processing and extraction" do
+    class << @contents_list
+      def body
+        '<h2 id="custom">A heading</h2>'
+      end
+    end
+
+    @contents_list.expects(:contents_items).returns([{ text: "A heading", id: 'custom' }]).once
+    @contents_list.contents
+    @contents_list.contents
+  end
 
   test "extracts a single h2" do
-    html = '<h2 id="custom">A heading</h2>'
-    assert_equal [{ text: "A heading", id: 'custom' }], extract_headings_with_ids(html)
+    class << @contents_list
+      def body
+        '<h2 id="custom">A heading</h2>'
+      end
+    end
+
+    assert_equal [{ text: "A heading", id: 'custom' }], @contents_list.contents_items
   end
 
   test "removes trailing colons from headings" do
-    html = '<h2 id="custom">List:</h2>'
-    assert_equal [{ text: "List", id: 'custom' }], extract_headings_with_ids(html)
+    class << @contents_list
+      def body
+        '<h2 id="custom">List:</h2>'
+      end
+    end
+
+    assert_equal [{ text: "List", id: 'custom' }], @contents_list.contents_items
   end
 
   test "removes only trailing colons from headings" do
-    html = '<h2 id="custom">Part 2: List:</h2>'
-    assert_equal [{ text: "Part 2: List", id: 'custom' }], extract_headings_with_ids(html)
+    class << @contents_list
+      def body
+        '<h2 id="custom">Part 2: List:</h2>'
+      end
+    end
+
+    assert_equal [{ text: "Part 2: List", id: 'custom' }], @contents_list.contents_items
   end
 
   test "ignores headings without an id" do
-    html = '<h2>John Doe</h2>'
-    assert_empty extract_headings_with_ids(html)
+    class << @contents_list
+      def body
+        '<h2>John Doe</h2>'
+      end
+    end
+
+    assert_empty @contents_list.contents_items
   end
 
   test "extracts multiple h2s" do
-    html = '<h2 id="one">One</h2>
-            <p>One is the loneliest number</p>
-            <h2 id="two">Two</h2>
-            <p>Two can be as bad as one</p>
-            <h2 id="three">Three</h2>
-            <h3>Pi</h3>
-            <h2 id="four">Four</h2>'
+    class << @contents_list
+      def body
+        '<h2 id="one">One</h2>
+         <p>One is the loneliest number</p>
+         <h2 id="two">Two</h2>
+         <p>Two can be as bad as one</p>
+         <h2 id="three">Three</h2>
+         <h3>Pi</h3>
+         <h2 id="four">Four</h2>'
+      end
+    end
+
     assert_equal [
       { text: "One", id: "one" },
       { text: "Two", id: "two" },
       { text: "Three", id: "three" },
-      { text: "Four", id: "four" }], extract_headings_with_ids(html)
+      { text: "Four", id: "four" }], @contents_list.contents_items
   end
 end

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -22,11 +22,6 @@ class HtmlPublicationPresenterTest < PresenterTestCase
     assert_equal schema_item("print_with_meta_data")['details']['print_meta_data_contact_address'], presented_item("print_with_meta_data").print_meta_data_contact_address
   end
 
-  test 'presents no contents when headings is an empty list' do
-    assert_equal schema_item("prime_ministers_office")['details']['headings'], '<ol></ol>'
-    assert_empty presented_item("prime_ministers_office").contents
-  end
-
   test 'presents the last change date' do
     published = presented_item("published")
     assert_equal "Published 17 January 2016", published.last_changed

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -13,7 +13,6 @@ class HtmlPublicationPresenterTest < PresenterTestCase
   end
 
   test 'presents a list of contents extracted from headings in the body' do
-    #assert_equal schema_item("published")['details']['headings'], presented_item("published").contents
     assert_equal "<a #{contents_link_attributes} data-track-label=\"details-of-the-application\" href=\"#details-of-the-application\">Details of the application</a>", presented_item("published").contents[0]
   end
 

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -10,7 +10,11 @@ class HtmlPublicationPresenterTest < PresenterTestCase
     assert_equal schema_item("published")['links']['parent'][0]['document_type'], presented_item("published").format_sub_type
     assert_equal schema_item("published")['title'], presented_item("published").title
     assert_equal schema_item("published")['details']['body'], presented_item("published").body
-    assert_equal schema_item("published")['details']['headings'], presented_item("published").contents
+  end
+
+  test 'presents a list of contents extracted from headings in the body' do
+    #assert_equal schema_item("published")['details']['headings'], presented_item("published").contents
+    assert_equal "<a #{contents_link_attributes} data-track-label=\"details-of-the-application\" href=\"#details-of-the-application\">Details of the application</a>", presented_item("published").contents[0]
   end
 
   test 'presents the meta data info of a content item' do
@@ -21,7 +25,7 @@ class HtmlPublicationPresenterTest < PresenterTestCase
 
   test 'presents no contents when headings is an empty list' do
     assert_equal schema_item("prime_ministers_office")['details']['headings'], '<ol></ol>'
-    refute presented_item("prime_ministers_office").contents?
+    assert_empty presented_item("prime_ministers_office").contents
   end
 
   test 'presents the last change date' do

--- a/test/wraith/config.yaml
+++ b/test/wraith/config.yaml
@@ -85,6 +85,11 @@ paths:
   html_publication_9: /government/publications/apprenticeship-levy-how-it-will-work/apprenticeship-levy-how-it-will-work
   html_publication_10: /government/publications/financial-sanctions-consolidated-list-of-targets/consolidated-list-of-targets
 
+  # Right to left HTML publications
+  rtl_publication_1: /government/publications/saudi-arabia-country-of-concern--2/968738
+  rtl_publication_2: /government/publications/apply-for-a-uk-visa-in-saudi-arabia/%D8%B7%D9%84%D8%A8-%D8%AA%D8%A3%D8%B4%D9%8A%D8%B1%D8%A9-%D9%84%D9%84%D9%85%D9%84%D9%83%D8%A9-%D8%A7%D9%84%D9%85%D8%AA%D8%AD%D8%AF%D8%A9-%D9%85%D9%86-%D8%A7%D9%84%D9%85%D9%85%D9%84%D9%83%D8%A9-%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9-%D8%A7%D9%84%D8%B3%D8%B9%D9%88%D8%AF%D9%8A%D8%A9-%D8%B9%D9%85%D9%84%D9%8A%D8%A9-%D8%A7%D9%84%D8%B7%D9%84%D8%A8
+  rtl_publication_3: /government/publications/apply-for-a-uk-visa-in-kuwait/%D8%B7%D9%84%D8%A8-%D8%AA%D8%A3%D8%B4%D9%8A%D8%B1%D8%A9-%D9%84%D8%AF%D9%88%D9%84%D8%A9-%D9%85%D9%86-%D8%AF%D9%88%D9%84-%D8%A7%D9%84%D9%83%D9%88%D9%85%D9%88%D9%86%D9%88%D9%84%D8%AB-%D8%A3%D9%88-%D8%A3%D9%82%D8%A7%D9%84%D9%8A%D9%85-%D9%85%D8%A7-%D9%88%D8%B1%D8%A7%D8%A1-%D8%A7%D9%84%D8%A8%D8%AD%D8%A7%D8%B1-%D8%A7%D9%84%D8%A8%D8%B1%D9%8A%D8%B7%D8%A7%D9%86%D9%8A%D8%A9-%D9%85%D9%86-%D8%A7%D8%B3%D9%85-%D8%A7%D9%84%D8%AF%D9%88%D9%84%D8%A9
+
   # Most popular from https://docs.publishing.service.gov.uk/document-types/help+page.html (19 April 2017)
   help_page_0: '/help/cookies'
   help_page_1: '/help/accessibility'

--- a/test/wraith/config.yaml
+++ b/test/wraith/config.yaml
@@ -73,6 +73,18 @@ paths:
   contact_9: /government/organisations/hm-revenue-customs/contact/gambling-duties
   contact_10: /government/organisations/hm-revenue-customs/contact/welsh-language-helpline-for-debt-management
 
+  # Most popular HTML publications
+  html_publication_1: /government/publications/car-show-me-tell-me-vehicle-safety-questions/car-show-me-tell-me-vehicle-safety-questions
+  html_publication_2: /government/publications/tax-and-tax-credit-rates-and-thresholds-for-2017-18/tax-and-tax-credit-rates-and-thresholds-for-2017-18
+  html_publication_3: /government/publications/rates-and-allowances-national-insurance-contributions/rates-and-allowances-national-insurance-contributions
+  html_publication_4: /government/publications/rates-and-allowances-income-tax/income-tax-rates-and-allowances-current-and-past
+  html_publication_5: /government/publications/income-tax-personal-allowance-and-basic-rate-limit-for-2017-to-2018/income-tax-personal-allowance-and-basic-rate-limit-for-2017-to-2018
+  html_publication_6: /government/publications/recognising-the-terrorist-threat/recognising-the-terrorist-threat
+  html_publication_7: /government/publications/tax-and-tax-credit-rates-and-thresholds-for-2016-17/tax-and-tax-credit-rates-and-thresholds-for-2016-17
+  html_publication_8: /government/publications/advisory-fuel-rates/advisory-fuel-rates-from-1-march-2016
+  html_publication_9: /government/publications/apprenticeship-levy-how-it-will-work/apprenticeship-levy-how-it-will-work
+  html_publication_10: /government/publications/financial-sanctions-consolidated-list-of-targets/consolidated-list-of-targets
+
   # Most popular from https://docs.publishing.service.gov.uk/document-types/help+page.html (19 April 2017)
   help_page_0: '/help/cookies'
   help_page_1: '/help/accessibility'


### PR DESCRIPTION
Goes alongside this static PR: https://github.com/alphagov/static/issues/1073

* Contents moved into left nav area and uses ContentsList for output
* Contents adjusted so number and text of link are wrapped in separate spans for better styling and test added
* Contents styled with indented numbering if numbering present
* Contents link overlap fixed with some z-indexing, background and box shadow on contents list, so the contents link disappears behind
* Content heading numbering size reduced and repositioned to be inline
* Publication header (blue box) padding made even and publication date font size reduced and moved up
* Print view fixed following layout changes, print styles updated and hidden crown copyright text moved out of header and below contents list to maintain original print layout
* Right to left content checked and amended following layout changes.

https://trello.com/c/eDpJIHQG/410-html-publication-move-content-list-to-left-hand-side-3

**Before:**

<img width="978" alt="screen shot 2017-06-21 at 16 26 58" src="https://user-images.githubusercontent.com/861310/27392420-8d3eb9c4-569e-11e7-96d1-1c24b0277a32.png">

**After:**

<img width="980" alt="screen shot 2017-06-23 at 08 28 17" src="https://user-images.githubusercontent.com/861310/27470958-f851f898-57ed-11e7-9266-7a3173276f43.png">
