### PR TITLE
Bump rack_strip_client_ip to 0.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ else
 end
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8'
-gem 'rack_strip_client_ip', '~> 0.0.0'
+gem 'rack_strip_client_ip', '~> 0.0.2'
 gem 'rails-i18n', '>= 4.0.4'
 gem 'rails_translation_manager', '~> 0.0.2'
 gem 'rails-controller-testing', '~> 0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rack_strip_client_ip (0.0.1)
+    rack_strip_client_ip (0.0.2)
     rails (5.0.0.1)
       actioncable (= 5.0.0.1)
       actionmailer (= 5.0.0.1)
@@ -301,7 +301,7 @@ DEPENDENCIES
   plek (= 1.11)
   poltergeist
   pry-byebug
-  rack_strip_client_ip (~> 0.0.0)
+  rack_strip_client_ip (~> 0.0.2)
   rails (~> 5.0)
   rails-controller-testing (~> 0.1)
   rails-i18n (>= 4.0.4)


### PR DESCRIPTION
* Rails 5 compatibility, stops deprecation warning

More details: https://github.com/alext/rack_strip_client_ip/pull/1