### PR TITLE
Fix world location links

### DIFF
--- a/app/presenters/linkable.rb
+++ b/app/presenters/linkable.rb
@@ -21,7 +21,7 @@ private
 
   def links(type)
     expanded_links_from_content_item(type).map do |link|
-      link_to(link["title"], link["base_path"])
+      link_for_type(type, link)
     end
   end
 
@@ -49,5 +49,15 @@ private
 
   def emphasised_organisations
     content_item["details"]["emphasised_organisations"] || []
+  end
+
+  def link_for_type(type, link)
+    return link_for_world_location(link) if type == "world_locations"
+    link_to(link["title"], link["base_path"])
+  end
+
+  def link_for_world_location(link)
+    base_path = WorldLocationBasePath.for(link)
+    link_to(link["title"], base_path)
   end
 end

--- a/app/services/world_location_base_path.rb
+++ b/app/services/world_location_base_path.rb
@@ -1,0 +1,41 @@
+#This is intended as a temporary solution while dependencies on other apps are
+#resolved. We are migrating world locations to a taxonomy based model but the
+#following problems have arisen that this approach temporarily solves:
+#
+# * we require world locations to be associated with content in Whitehall
+#   for email subscriptionas to work so we can't just get rid of them
+# * we also need them as not all content will be part of the taxonomy
+#   (e.g. news about the country)
+# * the taxon will take the base path (/world/<country-slug>) and so the
+#   WorldLocation can't occupy that
+# * we need to redirect old /government/world/<country-slug> urls to the new
+#   taxon but if we leave WorldLocation with that path it will a) overwrite
+#   the redirect route every time it is updated and b) we'll be knowingly
+#   linking to a redirect
+#
+#A slightly better solution will be for Whitehall to retrieve the taxon path from
+#publishing API and send that with the world location link as an additional field
+#in the links. We'll need the taxonomy to exist in order to implement this. Thiw
+#will still require frontend code to know about the links but will be similar
+#to prior art we have for some links to be affected by elements with `detail`.
+#
+class WorldLocationBasePath
+  EXCEPTIONAL_CASES = {
+    "Democratic Republic of Congo" => "democratic-republic-of-congo",
+    "South Georgia and the South Sandwich Islands" => "south-georgia-and-the-south-sandwich-islands",
+    "St Pierre & Miquelon" => "st-pierre-miquelon"
+  }.freeze
+
+  class << self
+    def for(world_location_link)
+      base_path = world_location_link["base_path"]
+      title = world_location_link["title"]
+      return base_path if base_path.present?
+
+      slug = EXCEPTIONAL_CASES[title] ||
+        title.parameterize
+
+      "/government/world/#{slug}"
+    end
+  end
+end

--- a/test/services/world_location_base_path_test.rb
+++ b/test/services/world_location_base_path_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class WorldLocationBasePathWhenPathExists < ActiveSupport::TestCase
+  test "returns the base_path" do
+    link = {
+      "base_path" => "/government/world/usa",
+      "government" => "USA"
+    }
+    assert_equal "/government/world/usa", WorldLocationBasePath.for(link)
+  end
+end
+
+class WorldLocationBasePathWithoutBasePath < ActiveSupport::TestCase
+  test "returns /world/usa" do
+    link = {
+      "title" => "USA"
+    }
+    assert_equal "/government/world/usa", WorldLocationBasePath.for(link)
+  end
+end
+
+class WorldLocationBasePathForExceptionalCase < ActiveSupport::TestCase
+  {
+   "Democratic Republic of Congo" => "democratic-republic-of-congo",
+   "South Georgia and the South Sandwich Islands" => "south-georgia-and-the-south-sandwich-islands",
+   "St Pierre & Miquelon" => "st-pierre-miquelon"
+  }.each do |title, expected_slug|
+    test "returns /government/world/#{expected_slug}" do
+      link = {
+        "title" => title
+      }
+      assert_equal "/government/world/#{expected_slug}", WorldLocationBasePath.for(link)
+    end
+  end
+end


### PR DESCRIPTION
World location links are becoming base_path-less and will no longer support translations. We still need to generate a link to these in the frontend end. 

Initially, in this commit the link will continue to point to the Whitehall representation of the world location.

In a subsequent commit, once the routing is in place, the `WorldLocationBasePath` class will be updated to generate a link to the new `/world/<slug>` taxon.

This PR needs https://github.com/alphagov/govuk-content-schemas/pull/629 to be deployed before CI will pass.

Part of [Trello](https://trello.com/c/6tio72jl/221-split-world-locations-from-international-delegations-in-whitehall)