### PR TITLE
Move the Postcode line in the presented Postal Address

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -84,8 +84,8 @@ class ContactPresenter < ContentItemPresenter
           v_card_part('fn', group['title']),
           v_card_part('street-address', group['street_address']),
           v_card_part('locality', group['locality']),
-          v_card_part('postal-code', group['postal_code']),
           v_card_part('region', group['region']),
+          v_card_part('postal-code', group['postal_code']),
           v_card_part('country-name', group['world_location']),
         ]
       }

--- a/test/presenters/contact_presenter_test.rb
+++ b/test/presenters/contact_presenter_test.rb
@@ -61,7 +61,11 @@ class ContactPresenterTest
       post_address = schema_item['details']['post_addresses'][0]
       presented_post_address = presented_item.post[0]
       assert_equal post_address['description'].strip, presented_post_address[:description]
-      assert_equal post_address['title'].strip, presented_post_address[:v_card][0][:value]
+      rendered_presented_address = presented_post_address[:v_card].reduce('') { |acc, hash| acc << hash[:value].strip }
+      rendered_input_address = %w(title street_address locality region postal_code world_location).reduce('') do |acc, key|
+        acc << post_address[key].strip
+      end
+      assert_equal rendered_input_address, rendered_presented_address
       assert_equal 'fn', presented_post_address[:v_card][0][:v_card_class]
     end
 


### PR DESCRIPTION
The postcode was displaying in an odd position in address blocks,
between the locality and region. This moves the postcode down a line,
so it will display at the bottom of the address, just above the country.