### PR TITLE
Update tests for new world location links

### DIFF
--- a/test/integration/case_study_test.rb
+++ b/test/integration/case_study_test.rb
@@ -26,4 +26,13 @@ class CaseStudyTest < ActionDispatch::IntegrationTest
       assert page.has_css?("time[datetime='#{@content_item['withdrawn_notice']['withdrawn_at']}']")
     end
   end
+
+  test "world location part of link" do
+    setup_and_visit_content_item('translated')
+
+    part_of = "<a href=\"/government/world/spain\">Spain</a>"
+
+    assert_has_component_metadata_pair("part_of", [part_of])
+    assert_has_component_document_footer_pair("part_of", [part_of])
+  end
 end

--- a/test/integration/world_location_news_article_test.rb
+++ b/test/integration/world_location_news_article_test.rb
@@ -18,11 +18,7 @@ class WorldLocationNewsArticleTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('world_location_news_article')
 
     from = "<a href=\"/government/world/organisations/british-high-commission-nairobi\">British High Commission Nairobi</a>"
-    #TODO: This test has the wrong base path.
-    #to allow the correction in schemas to pass CI
-    #the test below has been commented. This will be reinstated in a subsequent
-    #commit.
-    # part_of = "<a href=\"/government/world/organisations/british-high-commission-nairobi\">Kenya</a>"
+    part_of = "<a href=\"/government/world/kenya\">Kenya</a>"
 
     assert_has_component_metadata_pair("first_published", "24 November 2015")
     assert_has_component_document_footer_pair("published", "24 November 2015")
@@ -30,8 +26,8 @@ class WorldLocationNewsArticleTest < ActionDispatch::IntegrationTest
     assert_has_component_metadata_pair("from", [from])
     assert_has_component_document_footer_pair("from", [from])
 
-    # assert_has_component_metadata_pair("part_of", [part_of])
-    # assert_has_component_document_footer_pair("part_of", [part_of])
+    assert_has_component_metadata_pair("part_of", [part_of])
+    assert_has_component_document_footer_pair("part_of", [part_of])
   end
 
   test "renders translation links when there is more than one translation" do


### PR DESCRIPTION
The links for world locations are now base_path-less in the schema examples. 

This PR:

* removes a temporary fix to a test that was preventing the schema changes from being merged. 
* adds a test on a document type other than `WorldLocationNewsArticle` for the base_path-less world location links as WLNA will be being removed very soon


[Trello](https://trello.com/c/6tio72jl/221-split-world-locations-from-international-delegations-in-whitehall)