### PR TITLE
Consistently allow iframing of pages

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,5 +48,10 @@ module GovernmentFrontend
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true
+
+    # Override Rails default which restricts framing to SAMEORIGIN.
+    config.action_dispatch.default_headers = {
+      'X-Frame-Options' => 'ALLOWALL'
+    }
   end
 end


### PR DESCRIPTION
The `frontend` (except for transactions), `collections` and `whitehall` applications allow iframing. This commit makes this app allow it too for consistency. We'd like to iframe content pages in content-performance-manager to make it easier for content designers to generate taxonomies (https://github.com/alphagov/content-performance-manager/pull/173).

Collections:

```
$ curl -sI https://www.gov.uk/browse/benefits | grep X-Frame
X-Frame-Options: ALLOWALL
```

Frontend:

```
$ curl -sI https://www.gov.uk/search | grep X-Frame
X-Frame-Options: ALLOWALL
```

Whitehall:

```
$ curl -sI https://www.gov.uk/government/organisations/office-for-low-emission-vehicles | grep X-Frame
X-Frame-Options: ALLOWALL
```

https://trello.com/c/4IT79oPH