### PR TITLE
Update WorldLocationBasePath for new route

### DIFF
--- a/app/services/world_location_base_path.rb
+++ b/app/services/world_location_base_path.rb
@@ -35,7 +35,7 @@ class WorldLocationBasePath
       slug = EXCEPTIONAL_CASES[title] ||
         title.parameterize
 
-      "/government/world/#{slug}"
+      "/world/#{slug}"
     end
   end
 end

--- a/test/integration/case_study_test.rb
+++ b/test/integration/case_study_test.rb
@@ -30,7 +30,7 @@ class CaseStudyTest < ActionDispatch::IntegrationTest
   test "world location part of link" do
     setup_and_visit_content_item('translated')
 
-    part_of = "<a href=\"/government/world/spain\">Spain</a>"
+    part_of = "<a href=\"/world/spain\">Spain</a>"
 
     assert_has_component_metadata_pair("part_of", [part_of])
     assert_has_component_document_footer_pair("part_of", [part_of])

--- a/test/integration/world_location_news_article_test.rb
+++ b/test/integration/world_location_news_article_test.rb
@@ -18,7 +18,7 @@ class WorldLocationNewsArticleTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('world_location_news_article')
 
     from = "<a href=\"/government/world/organisations/british-high-commission-nairobi\">British High Commission Nairobi</a>"
-    part_of = "<a href=\"/government/world/kenya\">Kenya</a>"
+    part_of = "<a href=\"/world/kenya\">Kenya</a>"
 
     assert_has_component_metadata_pair("first_published", "24 November 2015")
     assert_has_component_document_footer_pair("published", "24 November 2015")

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -62,7 +62,7 @@ class CaseStudyPresenterTest < PresenterTestCase
     expected_part_of_links = [
       link_to('Work Programme real life stories', '/government/collections/work-programme-real-life-stories'),
       link_to('Cheese', '/policy/cheese'),
-      link_to('Pakistan', '/government/world/pakistan'),
+      link_to('Pakistan', '/world/pakistan'),
     ]
     assert_equal expected_part_of_links, presented_item(schema_name, with_extras).part_of
   end

--- a/test/services/world_location_base_path_test.rb
+++ b/test/services/world_location_base_path_test.rb
@@ -15,7 +15,7 @@ class WorldLocationBasePathWithoutBasePath < ActiveSupport::TestCase
     link = {
       "title" => "USA"
     }
-    assert_equal "/government/world/usa", WorldLocationBasePath.for(link)
+    assert_equal "/world/usa", WorldLocationBasePath.for(link)
   end
 end
 
@@ -29,7 +29,7 @@ class WorldLocationBasePathForExceptionalCase < ActiveSupport::TestCase
       link = {
         "title" => title
       }
-      assert_equal "/government/world/#{expected_slug}", WorldLocationBasePath.for(link)
+      assert_equal "/world/#{expected_slug}", WorldLocationBasePath.for(link)
     end
   end
 end


### PR DESCRIPTION
Content that was previously at `/government/world/` has been moved to `/world/`. This commit updates the `WorldLocationBasePath` class to use the new `base_path` prefix for world links.

[Trello](https://trello.com/c/081lboCr/253-update-government-frontend-worldlocationbasepath-to-point-to-world)