### PR TITLE
Allow HTML pub contents to render cleanly with custom numbers

### DIFF
--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -73,18 +73,22 @@
         line-height: 1.3;
       }
 
+      .contents-text,
+      .contents-number {
+        display: table-cell;
+      }
+
+      .contents-number {
+        min-width: 1.3em;
+      }
+
+      .contents-text {
+        padding-left: 0.2em;
+      }
+
       a {
+        display: table;
         text-decoration: none;
-
-        // Child spans are floated which creates a focus box around
-        // just the number. Set parent link to inline-block for
-        // correct appearance
-        display: inline-block;
-
-        // IE8 and below don't render inline-block correctly
-        @include ie-lte(8) {
-          display: block;
-        }
 
         &:hover {
           text-decoration: underline;
@@ -93,15 +97,6 @@
 
       @include media(false, $desktop-breakpoint) {
         box-shadow: none;
-      }
-
-      .contents-number {
-        float: left;
-      }
-
-      .contents-text {
-        display: block;
-        margin-left: 1.5em;
       }
 
       .direction-rtl & {

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -79,11 +79,11 @@
       }
 
       .contents-number {
-        min-width: 1.3em;
+        min-width: 1.5em;
       }
 
       .contents-text {
-        $contents-text-padding: 0.2em;
+        $contents-text-padding: 0.3em;
         padding-left: $contents-text-padding;
 
         .direction-rtl & {

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -83,7 +83,13 @@
       }
 
       .contents-text {
-        padding-left: 0.2em;
+        $contents-text-padding: 0.2em;
+        padding-left: $contents-text-padding;
+
+        .direction-rtl & {
+          padding-left: 0;
+          padding-right: $contents-text-padding;
+        }
       }
 
       a {
@@ -97,17 +103,6 @@
 
       @include media(false, $desktop-breakpoint) {
         box-shadow: none;
-      }
-
-      .direction-rtl & {
-        .contents-number {
-          float: right;
-        }
-
-        .contents-text {
-          margin-left: 0;
-          margin-right: 1.5em;
-        }
       }
     }
   }

--- a/app/helpers/contents_list_helper.rb
+++ b/app/helpers/contents_list_helper.rb
@@ -1,7 +1,13 @@
 module ContentsListHelper
   def wrap_numbers_with_spans(content_item_link)
     content_item_text = strip_tags(content_item_link) #just the text of the link
-    number = /^[0-9]*[.]/.match(content_item_text)
+
+    # Must start with a number
+    # Number must be between 1 and 999 (ie not 2014)
+    # Must be followed by a space
+    # May contain a period `1.`
+    # May be a decimal `1.2`
+    number = /^\d{1,3}(\.?|\.\d{1,2})(?=\s)/.match(content_item_text)
 
     if number
       words = content_item_text.sub(number.to_s, '').strip #remove the number from the text

--- a/test/helpers/contents_list_helper_test.rb
+++ b/test/helpers/contents_list_helper_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class ContentsListHelperTest < ActionView::TestCase
   test "it wraps the number and text in span elements" do
-    input = '<a href="#run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment">1. Run an effective welfare system that enables people to achieve financial independence by providing assistance and guidance into employment</a>'
-    expected = '<a href="#run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment"><span class="contents-number">1.</span><span class="contents-text">Run an effective welfare system that enables people to achieve financial independence by providing assistance and guidance into employment</span></a>'
+    input = '<a href="#first">1. Thing</a>'
+    expected = '<a href="#first"><span class="contents-number">1.</span><span class="contents-text">Thing</span></a>'
     assert_equal expected, wrap_numbers_with_spans(input)
   end
 

--- a/test/helpers/contents_list_helper_test.rb
+++ b/test/helpers/contents_list_helper_test.rb
@@ -1,15 +1,65 @@
 require 'test_helper'
 
 class ContentsListHelperTest < ActionView::TestCase
-  test "it wraps the number and text in span elements" do
+  test "it wraps a number and text in separate span elements" do
     input = '<a href="#first">1. Thing</a>'
     expected = '<a href="#first"><span class="contents-number">1.</span><span class="contents-text">Thing</span></a>'
+    assert_equal expected, wrap_numbers_with_spans(input)
+
+    input = '<a href="#vision">10. Vision</a>'
+    expected = '<a href="#vision"><span class="contents-number">10.</span><span class="contents-text">Vision</span></a>'
+    assert_equal expected, wrap_numbers_with_spans(input)
+
+    input = '<a href="#vision">100. Vision</a>'
+    expected = '<a href="#vision"><span class="contents-number">100.</span><span class="contents-text">Vision</span></a>'
+    assert_equal expected, wrap_numbers_with_spans(input)
+  end
+
+  test "it wraps a number and text in span elements if it's a number without a period" do
+    input = '<a href="#first">1 Thing</a>'
+    expected = '<a href="#first"><span class="contents-number">1</span><span class="contents-text">Thing</span></a>'
+    assert_equal expected, wrap_numbers_with_spans(input)
+  end
+
+  test "it wraps a number in the form X.Y" do
+    input = '<a href="#vision">1.2 Vision</a>'
+    expected = '<a href="#vision"><span class="contents-number">1.2</span><span class="contents-text">Vision</span></a>'
     assert_equal expected, wrap_numbers_with_spans(input)
   end
 
   test "it does nothing if no number is found" do
     input = '<a href="#vision">Vision</a>'
     expected = '<a href="#vision">Vision</a>'
+    assert_equal expected, wrap_numbers_with_spans(input)
+  end
+
+  test "it does nothing if it's just a number" do
+    input = '<a href="#first">1</a>'
+    expected = '<a href="#first">1</a>'
+    assert_equal expected, wrap_numbers_with_spans(input)
+  end
+
+  test "it does nothing if the number is part of the word" do
+    input = '<a href="#vision">1Vision</a>'
+    expected = '<a href="#vision">1Vision</a>'
+    assert_equal expected, wrap_numbers_with_spans(input)
+
+    input = '<a href="#vision">1.Vision</a>'
+    expected = '<a href="#vision">1.Vision</a>'
+    assert_equal expected, wrap_numbers_with_spans(input)
+  end
+
+  test "it does nothing if it starts with a number longer than 3 digits" do
+    input = '<a href="#vision">2014 Vision</a>'
+    expected = '<a href="#vision">2014 Vision</a>'
+    assert_equal expected, wrap_numbers_with_spans(input)
+
+    input = '<a href="#vision">2014. Vision</a>'
+    expected = '<a href="#vision">2014. Vision</a>'
+    assert_equal expected, wrap_numbers_with_spans(input)
+
+    input = '<a href="#vision">10001. Vision</a>'
+    expected = '<a href="#vision">10001. Vision</a>'
     assert_equal expected, wrap_numbers_with_spans(input)
   end
 


### PR DESCRIPTION
Publishers can enter custom numbers. Add support for the forms:

* Numbers without periods (1)
* Numbers with decimals (1.2)
* Allow long numbers to be spaced correctly and not wrap badly (100.)
* Ignore numbers bigger than 999 (eg 2014)
* Ignore contents items that are just numbers

A list of HTML publications with custom numbering:
https://gist.github.com/fofr/622c0c52dfee41cde9402c56ec5d67ea

## Hover and focus states

![screen shot 2017-06-29 at 17 04 31](https://user-images.githubusercontent.com/319055/27697756-14658226-5ced-11e7-8397-752ac5d6a2d6.png)

## Examples

https://www.gov.uk/government/publications/xbrl-guide-for-uk-businesses/xbrl-guide-for-uk-businesses

| Old | New |
|-|-|
|![screen shot 2017-06-29 at 16 49 17](https://user-images.githubusercontent.com/319055/27697106-3c9176ee-5ceb-11e7-8675-7a308e9f6833.png)|![screen shot 2017-06-29 at 16 51 16](https://user-images.githubusercontent.com/319055/27697105-3c8f2222-5ceb-11e7-9230-f6f15f35cd55.png)|
|![screen shot 2017-06-29 at 16 59 00](https://user-images.githubusercontent.com/319055/27697490-4d258120-5cec-11e7-8013-67d304eb286f.png)|![screen shot 2017-06-29 at 16 58 49](https://user-images.githubusercontent.com/319055/27697491-4d2b157c-5cec-11e7-9773-242184bc645c.png)|

https://www.gov.uk/government/publications/archived-case-reports/archived-case-reports

| Old | New |
|-|-|
|![screen shot 2017-06-29 at 16 53 04](https://user-images.githubusercontent.com/319055/27697206-7f3415e2-5ceb-11e7-9c5d-dcfaeb778a05.png)|![screen shot 2017-06-29 at 16 53 26](https://user-images.githubusercontent.com/319055/27697207-7f39ae26-5ceb-11e7-9771-d42b124b267d.png)|

https://www.gov.uk/government/publications/british-forces-air-strikes-in-iraq-monthly-list/raf-air-strikes-in-iraq-and-syria-december-2015

| Old | New |
|-|-|
|![screen shot 2017-06-29 at 16 54 27](https://user-images.githubusercontent.com/319055/27697290-b2aa4fa4-5ceb-11e7-86f3-98028c830368.png)|![screen shot 2017-06-29 at 16 54 49](https://user-images.githubusercontent.com/319055/27697291-b2aefd4c-5ceb-11e7-8ccf-918f7eade9fb.png)|

https://www.gov.uk/government/publications/vietnam-country-of-concern--2/vi-t-nam-bao-cao-nhan-quy-n-2014-c-a-b-ngo-i-giao-anh

| Old | New |
|-|-|
|![screen shot 2017-06-29 at 16 56 59](https://user-images.githubusercontent.com/319055/27697413-177e827e-5cec-11e7-8d8f-77dcf5572877.png)|![screen shot 2017-06-29 at 16 57 37](https://user-images.githubusercontent.com/319055/27697415-1798dc5a-5cec-11e7-8f99-0da735be5018.png)|

## Examples where new is not as good

https://www.gov.uk/government/publications/fifth-meeting-of-the-leadership-for-libraries-taskforce/minutes-of-the-fifth-meeting-of-the-leadership-for-libraries-taskforce

| Old | New |
|-|-|
|![screen shot 2017-06-29 at 17 11 13](https://user-images.githubusercontent.com/319055/27698167-31c16276-5cee-11e7-8cb2-a8728cc6f7e7.png)|![screen shot 2017-06-29 at 17 12 41](https://user-images.githubusercontent.com/319055/27698166-31c1089e-5cee-11e7-9e0b-356824a691d3.png)|