### PR TITLE
Handle `special_route` document type correctly

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,11 +1,14 @@
 require 'gds_api/content_store'
 
 class ContentItemsController < ApplicationController
+  class SpecialRouteReturned < StandardError; end
+
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from GdsApi::HTTPNotFound, with: :error_notfound
   rescue_from GdsApi::InvalidUrl, with: :error_notfound
   rescue_from ActionView::MissingTemplate, with: :error_406
   rescue_from ActionController::UnknownFormat, with: :error_406
+  rescue_from SpecialRouteReturned, with: :error_notfound
 
   attr_accessor :content_item
 
@@ -28,7 +31,12 @@ private
 
   def load_content_item
     content_item = content_store.content_item(content_item_path)
+    raise SpecialRouteReturned if special_route?(content_item)
     @content_item = present(content_item)
+  end
+
+  def special_route?(content_item)
+    content_item && content_item['document_type'] == "special_route"
   end
 
   def present(content_item)

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -190,6 +190,18 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
+  test "returns 404 if content store falls through to special route" do
+    path = 'government/item-not-here'
+
+    content_item = content_store_has_schema_example('special_route', 'special_route')
+    content_item['base_path'] = '/government'
+
+    content_store_has_item("/#{path}", content_item)
+
+    get :show, params: { path: path }
+    assert_response :not_found
+  end
+
   test "returns 403 for access-limited item" do
     path = 'government/case-studies/super-sekrit-document'
     url = content_store_endpoint + "/content/" + path


### PR DESCRIPTION
Content store now falls through to any matching prefix when a content item is not found. This commit adds support for this returning a 404 when a `special_route` is returned by content store. Currently this causes a 500.

This PR requires https://github.com/alphagov/govuk-content-schemas/pull/639 to be deployed.