### PR TITLE
Track document collection clicks

### DIFF
--- a/app/views/content_items/_document_collection_body.html.erb
+++ b/app/views/content_items/_document_collection_body.html.erb
@@ -2,18 +2,32 @@
   <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
 <% end %>
 
-<% @content_item.groups.each do |group| %>
+<% @content_item.groups.each_with_index do |group, group_index| %>
   <%= @content_item.group_heading(group) %>
   <% if group["body"].present? %>
     <%= render 'govuk_component/govspeak',
         content: group["body"],
         direction: page_text_direction %>
   <% end %>
-  <ol class="group-document-list">
-    <% @content_item.group_document_links(group).each do |link| %>
+  <ol class="group-document-list" data-module="track-click">
+    <% @content_item.group_document_links(group).each_with_index do |link, link_index| %>
       <li class="group-document-list-item">
         <h3 class="group-document-list-item-title">
-          <%= link_to(link[:title], link[:base_path]) %>
+          <%=
+            link_to(
+              link[:title],
+              link[:base_path],
+              data: {
+                track_category: 'navDocumentCollectionLinkClicked',
+                track_action: "#{group_index + 1}.#{link_index + 1}",
+                track_label: link[:base_path],
+                track_options: {
+                  dimension28: @content_item.group_document_links(group).count.to_s,
+                  dimension29: link[:title]
+                }
+              }
+            )
+          %>
         </h3>
         <ul class="group-document-list-item-attributes">
           <li>

--- a/app/views/content_items/_document_collection_body.html.erb
+++ b/app/views/content_items/_document_collection_body.html.erb
@@ -1,0 +1,29 @@
+<% if @content_item.body.present? %>
+  <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
+<% end %>
+
+<% @content_item.groups.each do |group| %>
+  <%= @content_item.group_heading(group) %>
+  <% if group["body"].present? %>
+    <%= render 'govuk_component/govspeak',
+        content: group["body"],
+        direction: page_text_direction %>
+  <% end %>
+  <ol class="group-document-list">
+    <% @content_item.group_document_links(group).each do |link| %>
+      <li class="group-document-list-item">
+        <h3 class="group-document-list-item-title">
+          <%= link_to(link[:title], link[:base_path]) %>
+        </h3>
+        <ul class="group-document-list-item-attributes">
+          <li>
+            <time datetime="<%= link[:public_updated_at].iso8601 %>">
+              <%= l(link[:public_updated_at], format: :short_ordinal) %>
+            </time>
+          </li>
+          <li><%= t("content_item.schema_name.#{link[:document_type]}", count: 1) %></li>
+        </ul>
+      </li>
+    <% end %>
+  </ol>
+<% end %>

--- a/app/views/content_items/document_collection.html+new_navigation.erb
+++ b/app/views/content_items/document_collection.html+new_navigation.erb
@@ -10,34 +10,7 @@
     <%= render 'shared/description', description: @content_item.description %>
     <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
 
-    <% if @content_item.body.present? %>
-      <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
-    <% end %>
-    <% @content_item.groups.each do |group| %>
-      <%= @content_item.group_heading(group) %>
-      <% if group["body"].present? %>
-        <%= render 'govuk_component/govspeak',
-                   content: group["body"],
-                   direction: page_text_direction %>
-      <% end %>
-      <ol class="group-document-list">
-        <% @content_item.group_document_links(group).each do |link| %>
-          <li class="group-document-list-item">
-            <h3 class="group-document-list-item-title">
-              <%= link_to(link[:title], link[:base_path]) %>
-            </h3>
-            <ul class="group-document-list-item-attributes">
-              <li>
-                <time datetime="<%= link[:public_updated_at].iso8601 %>">
-                  <%= l(link[:public_updated_at], format: :short_ordinal) %>
-                </time>
-              </li>
-              <li><%= t("content_item.schema_name.#{link[:document_type]}", count: 1) %></li>
-            </ul>
-          </li>
-        <% end %>
-      </ol>
-    <% end %>
+    <%= render 'document_collection_body' %>
   </div>
 
   <div class="column-third">

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -17,34 +17,7 @@
     </div>
   <% end %>
   <div class="column-two-thirds <% unless @content_item.contents.any? %>offset-one-third<% end %>">
-    <% if @content_item.body.present? %>
-      <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
-    <% end %>
-    <% @content_item.groups.each do |group| %>
-      <%= @content_item.group_heading(group) %>
-      <% if group["body"].present? %>
-        <%= render 'govuk_component/govspeak',
-            content: group["body"],
-            direction: page_text_direction %>
-      <% end %>
-      <ol class="group-document-list">
-        <% @content_item.group_document_links(group).each do |link| %>
-          <li class="group-document-list-item">
-            <h3 class="group-document-list-item-title">
-              <%= link_to(link[:title], link[:base_path]) %>
-            </h3>
-            <ul class="group-document-list-item-attributes">
-              <li>
-                <time datetime="<%= link[:public_updated_at].iso8601 %>">
-                  <%= l(link[:public_updated_at], format: :short_ordinal) %>
-                </time>
-              </li>
-              <li><%= t("content_item.schema_name.#{link[:document_type]}", count: 1) %></li>
-            </ul>
-          </li>
-        <% end %>
-      </ol>
-    <% end %>
+    <%= render 'document_collection_body' %>
   </div>
   <div data-sticky-element class="govuk-sticky-element">
     <%= render 'shared/back_to_content_link' %>

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -60,6 +60,56 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'includes tracking data on all collection documents' do
+    setup_and_visit_content_item('document_collection')
+    groups = page.all('.group-document-list')
+
+    groups.each do |group|
+      assert_equal(
+        "track-click",
+        group['data-module'],
+        "Expected the module 'track-click' to be set in the group #{group.inspect}"
+      )
+    end
+
+    first_section_links = groups.first.all('.group-document-list-item-title a')
+    first_link = first_section_links.first
+
+    assert_equal(
+      'navDocumentCollectionLinkClicked',
+      first_link['data-track-category'],
+      'Expected a tracking category to be set in the data attributes'
+    )
+
+    assert_equal(
+      '1.1',
+      first_link['data-track-action'],
+      'Expected the link position to be set in the data attributes'
+    )
+
+    assert_match(
+      first_link['data-track-label'],
+      first_link[:href],
+      'Expected the content item base path to be set in the data attributes'
+    )
+
+    assert first_link['data-track-options'].present?
+
+    data_options = JSON.parse(first_link['data-track-options'])
+
+    assert_equal(
+      first_section_links.count.to_s,
+      data_options['dimension28'],
+      'Expected the total number of content items within the section to be present in the tracking options'
+    )
+
+    assert_equal(
+      first_link.text,
+      data_options['dimension29'],
+      'Expected the subtopic title to be present in the tracking options'
+    )
+  end
+
   test "withdrawn collection" do
     setup_and_visit_content_item('document_collection_withdrawn')
     assert page.has_css?('title', text: "[Withdrawn]", visible: false)


### PR DESCRIPTION
In this PR:

- Move the main body of document collections into partial, in order to reuse across the old and new navigation partials;
- Add tracking attributes to all links within document collections.

Here is an example tracking event:

```
ga("send", {hitType: "event", eventCategory: "navDocumentCollectionLinkClicked", eventAction: "3.2", eventLabel: "/government/publications/2017-national-curriculum-assessment-results-at-the-end-of-key-stage-2-information-for-parents", dimension15: "200", dimension16: "unknown", dimension11: "2", dimension2: "document_collection", dimension3: "education", dimension4: "e1046852-d15f-4990-a2d5-d813926b2edb", dimension6: "2015-conservative-government", dimension7: "non-political", dimension9: "<EA243>", dimension17: "document_collection", dimension20: "government-frontend", dimension32: "none", dimension33: "finding", dimension34: "guidance", dimension56: "school-performance-measures", dimension57: "dbb52b1a-55ba-498c-9097-80787ee74e24", dimension58: "school-performance-measures,primary-curriculum-key-stage-1-tests-and-assessments,primary-curriculum-key-stage-2-tests-and-assessments", dimension59: "dbb52b1a-55ba-498c-9097-80787ee74e24,1ddd7a85-6c64-4b1e-9e54-55b50a0ae3f3,bf9ba557-b3d8-4c4e-8e39-0d09466808b4", dimension39: "true", dimension26: "3", dimension27: "9", dimension41: "EducationNavigation:B", transport: "beacon", dimension28: "2", dimension29: "2017 national curriculum assessment results at the end of key stage 2: information for parents"})
```

The most important attributes here are:
- `eventCategory: "navDocumentCollectionLinkClicked"`;
- `eventAction: "3.2"` - meaning it's the 2nd link from the 3rd section;
- `eventLabel: "/government/publications/2017-national-curriculum-assessment-results-at-the-end-of-key-stage-2-information-for-parents"` - the href of the link we clicked;
- `dimension28: "2"` - there were 2 links on the section;
- `dimension29: "2017 national curriculum assessment results at the end of key stage 2: information for parents".

Trello: https://trello.com/c/1zi6Nr3B/31-add-link-position-tracking-to-whitehall-navigation