### PR TITLE
Add sri again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'govuk_ab_testing', '~> 2.0'
 gem 'htmlentities', '4.3.4'
 gem 'statsd-ruby', '1.3.0', require: 'statsd'
 gem 'dalli'
+gem 'asset_bom_removal-rails', '~> 1.0.0'
 
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,9 @@ GEM
       nokogiri (>= 1.3.0)
       robotex (>= 1.0.0)
     arel (7.1.1)
+    asset_bom_removal-rails (1.0.0)
+      rails (>= 4.2)
+      sass (> 3.4)
     ast (2.3.0)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -280,6 +283,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 5.5)
   airbrake-ruby (= 1.5)
+  asset_bom_removal-rails (~> 1.0.0)
   better_errors
   binding_of_caller
   capybara

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -1,7 +1,7 @@
 <%- if params[:medium] == 'print' %>
-  <%= stylesheet_link_tag "print.css", :media => "screen" %>
+  <%= stylesheet_link_tag "print.css", :media => "screen", integrity: true, crossorigin: 'anonymous' %>
 <%- else %>
-  <%= stylesheet_link_tag "print.css", :media => "print" %>
+  <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: 'anonymous' %>
 <%- end %>
 
 <%

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title><%= yield :title %> - GOV.UK</title>
-  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application" %><!--<![endif]-->
+  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %><!--<![endif]-->
   <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><script>var ieVersion = 6;</script><![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><script>var ieVersion = 7;</script><![endif]-->
   <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><script>var ieVersion = 8;</script><![endif]-->
-  <%= javascript_include_tag "application" %>
+  <%= javascript_include_tag "application", integrity: true, crossorigin: 'anonymous' %>
   <%= csrf_meta_tags %>
   <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item.content_item } %>
   <% if @content_item.description %>

--- a/app/views/shared/_webchat.html.erb
+++ b/app/views/shared/_webchat.html.erb
@@ -16,4 +16,4 @@
   </span>
 </span>
 <% # This is inline in the source however slimmer will optimize this. %>
-<%= javascript_include_tag "webchat" %>
+<%= javascript_include_tag "webchat", integrity: true, crossorigin: 'anonymous' %>


### PR DESCRIPTION
This is take 2 of: https://trello.com/c/oFhtO0Gm/146-enable-subresource-integrity-sri-on-government-frontend-l

This attempt uses the new [asset_bom_removal-rails](https://github.com/alphagov/asset_bom_removal-rails) gem to remove the utf-8 BOM from compressed CSS files and avoid triggering the bug in Firefox < 52 that was stopping us from deploying the previous version (see https://trello.com/c/UcJJBH0k/183-investigate-bom-issue-with-asset-compilation for more details on this).

Take 1 of this was done in #331, and subsequently reverted in #368 when we found the bug.