### PR TITLE
Revert "Add sri again"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem 'govuk_ab_testing', '~> 2.0'
 gem 'htmlentities', '4.3.4'
 gem 'statsd-ruby', '1.3.0', require: 'statsd'
 gem 'dalli'
-gem 'asset_bom_removal-rails', '~> 1.0.0'
 
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,9 +47,6 @@ GEM
       nokogiri (>= 1.3.0)
       robotex (>= 1.0.0)
     arel (7.1.1)
-    asset_bom_removal-rails (1.0.0)
-      rails (>= 4.2)
-      sass (> 3.4)
     ast (2.3.0)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -283,7 +280,6 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 5.5)
   airbrake-ruby (= 1.5)
-  asset_bom_removal-rails (~> 1.0.0)
   better_errors
   binding_of_caller
   capybara

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -1,7 +1,7 @@
 <%- if params[:medium] == 'print' %>
-  <%= stylesheet_link_tag "print.css", :media => "screen", integrity: true, crossorigin: 'anonymous' %>
+  <%= stylesheet_link_tag "print.css", :media => "screen" %>
 <%- else %>
-  <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: 'anonymous' %>
+  <%= stylesheet_link_tag "print.css", :media => "print" %>
 <%- end %>
 
 <%

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title><%= yield :title %> - GOV.UK</title>
-  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %><!--<![endif]-->
+  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application" %><!--<![endif]-->
   <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><script>var ieVersion = 6;</script><![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><script>var ieVersion = 7;</script><![endif]-->
   <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><script>var ieVersion = 8;</script><![endif]-->
-  <%= javascript_include_tag "application", integrity: true, crossorigin: 'anonymous' %>
+  <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
   <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item.content_item } %>
   <% if @content_item.description %>

--- a/app/views/shared/_webchat.html.erb
+++ b/app/views/shared/_webchat.html.erb
@@ -16,4 +16,4 @@
   </span>
 </span>
 <% # This is inline in the source however slimmer will optimize this. %>
-<%= javascript_include_tag "webchat", integrity: true, crossorigin: 'anonymous' %>
+<%= javascript_include_tag "webchat" %>


### PR DESCRIPTION
Reverts alphagov/government-frontend#400

Turns out the BOM removal does it's job too well and strips 2 characters from the start of the CSS file as well as the BOM.  We need to roll this back while we fix the BOM removal gem.  (See https://assets.publishing.service.gov.uk/government-frontend/application-acf2d14564cab50b1e96d787cd3889dae8d548ec68a47a165b5f93fcb0606dfc.css which starts `vailable-languages` and should be `.available-languages`)