### PR TITLE
[Do not merge] Enable sass linting in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,5 @@ REPOSITORY = 'government-frontend'
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.buildProject()
+  govuk.buildProject(sassLint: true)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,5 @@ REPOSITORY = 'government-frontend'
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.buildProject(sassLint: true)
+  govuk.buildProject()
 }

--- a/app/assets/stylesheets/helpers/_available-languages.scss
+++ b/app/assets/stylesheets/helpers/_available-languages.scss
@@ -1,3 +1,7 @@
+#failing-lint {
+  color: #000;
+}
+
 .available-languages {
   margin-bottom: $gutter;
   border-bottom: 1px solid $border-colour;


### PR DESCRIPTION
Jenkinsfile docs suggest that sass linting is on by default:
```
“but aren't linting your SASS yet (you should), you can disable linting”
“sassLint Whether or not to run the SASS linter. Default: true”
```

But the logic says:
`if (hasAssets() && hasLint() && options.sassLint)`

If the option is omitted, it will default to false.

Before this PR, the Sass linter does not run:
https://ci.integration.publishing.service.gov.uk/job/government-frontend/job/display-curated-links-in-sidebar/5/console

You can see it does run now:
https://ci.integration.publishing.service.gov.uk/job/government-frontend/job/enable-sass-linting/1/console