### PR TITLE
Create lead paragraph component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   gem 'govuk-lint'
   gem 'pry-byebug'
   gem 'jasmine-rails', '~> 0.14.0'
-  gem 'govuk_publishing_components', '~> 0.1.0'
+  gem 'govuk_publishing_components', '~> 0.2.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
       sass (>= 3.2.0)
     govuk_navigation_helpers (6.3.0)
       gds-api-adapters (>= 43.0)
-    govuk_publishing_components (0.1.0)
+    govuk_publishing_components (0.2.0)
       govuk_frontend_toolkit
       rails (~> 5.0.0, >= 5.0.0.1)
       sass-rails (~> 5.0.4)
@@ -299,7 +299,7 @@ DEPENDENCIES
   govuk_elements_rails (= 3.0.1)
   govuk_frontend_toolkit (= 5.1.0)
   govuk_navigation_helpers (~> 6.3)
-  govuk_publishing_components (~> 0.1.0)
+  govuk_publishing_components (~> 0.2.0)
   govuk_schemas
   htmlentities (= 4.3.4)
   jasmine-rails (~> 0.14.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,7 +14,6 @@
 @import 'helpers/available-languages';
 @import 'helpers/back-to-content';
 @import 'helpers/contents-list';
-@import 'helpers/description';
 @import 'helpers/sidebar-with-body';
 @import 'helpers/share-buttons';
 @import 'helpers/national_statistics_logo';
@@ -55,3 +54,4 @@
 // components
 @import 'components/print-link';
 @import 'components/download-link';
+@import 'components/lead-paragraph';

--- a/app/assets/stylesheets/components/_lead-paragraph.scss
+++ b/app/assets/stylesheets/components/_lead-paragraph.scss
@@ -1,0 +1,6 @@
+.app-c-lead-paragraph {
+  @include core-24;
+  @include responsive-bottom-margin;
+  // Ensure the text has a line-length of around 60 characters
+  max-width: 30em;
+}

--- a/app/assets/stylesheets/helpers/_description.scss
+++ b/app/assets/stylesheets/helpers/_description.scss
@@ -1,8 +1,0 @@
-@mixin description {
-  .description {
-    @include core-24;
-    @include responsive-bottom-margin;
-    // Ensure the text has a line-length of around 60 characters
-    max-width: 30em;
-  }
-}

--- a/app/assets/stylesheets/views/_case-studies.scss
+++ b/app/assets/stylesheets/views/_case-studies.scss
@@ -1,5 +1,4 @@
 .case-study {
-  @include description;
   @include sidebar-with-body;
   @include withdrawal-notice;
 

--- a/app/assets/stylesheets/views/_corporate-information-page.scss
+++ b/app/assets/stylesheets/views/_corporate-information-page.scss
@@ -1,5 +1,4 @@
 .corporate-information-page {
-  @include description;
   @include sidebar-with-body;
   @include organisation-links;
 

--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -1,5 +1,4 @@
 .detailed-guide {
-  @include description;
   @include sidebar-with-body;
   @include history-notice;
   @include withdrawal-notice;

--- a/app/assets/stylesheets/views/_document-collection.scss
+++ b/app/assets/stylesheets/views/_document-collection.scss
@@ -1,5 +1,4 @@
 .document-collection {
-  @include description;
   @include sidebar-with-body;
   @include history-notice;
   @include withdrawal-notice;

--- a/app/assets/stylesheets/views/_fatality-notice.scss
+++ b/app/assets/stylesheets/views/_fatality-notice.scss
@@ -1,5 +1,4 @@
 .fatality-notice {
-  @include description;
   @include sidebar-with-body;
   @include withdrawal-notice;
 }

--- a/app/assets/stylesheets/views/_news-article.scss
+++ b/app/assets/stylesheets/views/_news-article.scss
@@ -1,5 +1,4 @@
 .news-article {
-  @include description;
   @include sidebar-with-body;
   @include history-notice;
   @include withdrawal-notice;

--- a/app/assets/stylesheets/views/_publication.scss
+++ b/app/assets/stylesheets/views/_publication.scss
@@ -1,5 +1,4 @@
 .publication {
-  @include description;
   @include sidebar-with-body;
   @include history-notice;
   @include withdrawal-notice;

--- a/app/assets/stylesheets/views/_specialist-document.scss
+++ b/app/assets/stylesheets/views/_specialist-document.scss
@@ -1,4 +1,3 @@
 .specialist-document {
-  @include description;
   @include sidebar-with-body;
 }

--- a/app/assets/stylesheets/views/_speech.scss
+++ b/app/assets/stylesheets/views/_speech.scss
@@ -1,6 +1,5 @@
 .speech {
   @include sidebar-with-body;
-  @include description;
   @include history-notice;
   @include withdrawal-notice;
 

--- a/app/assets/stylesheets/views/_statistical-data-set.scss
+++ b/app/assets/stylesheets/views/_statistical-data-set.scss
@@ -1,5 +1,4 @@
 .statistical-data-set {
-  @include description;
   @include sidebar-with-body;
   @include history-notice;
   @include withdrawal-notice;

--- a/app/assets/stylesheets/views/_statistics_announcement.scss
+++ b/app/assets/stylesheets/views/_statistics_announcement.scss
@@ -1,5 +1,4 @@
 .statistics-announcement {
-  @include description;
   @include national-statistics-logo;
 
   .cancellation-notice {

--- a/app/assets/stylesheets/views/_take-part.scss
+++ b/app/assets/stylesheets/views/_take-part.scss
@@ -1,4 +1,3 @@
 .take-part {
-  @include description;
   @include sidebar-with-body;
 }

--- a/app/assets/stylesheets/views/_topical-event-about-page.scss
+++ b/app/assets/stylesheets/views/_topical-event-about-page.scss
@@ -1,4 +1,3 @@
 .topical-event-about-page {
-  @include description;
   @include sidebar-with-body;
 }

--- a/app/assets/stylesheets/views/_working-group.scss
+++ b/app/assets/stylesheets/views/_working-group.scss
@@ -1,4 +1,3 @@
 .working-group {
-  @include description;
   @include sidebar-with-body;
 }

--- a/app/assets/stylesheets/views/_world-location-news-article.scss
+++ b/app/assets/stylesheets/views/_world-location-news-article.scss
@@ -1,5 +1,4 @@
 .world-location-news-article {
-  @include description;
   @include sidebar-with-body;
   @include history-notice;
   @include withdrawal-notice;

--- a/app/views/components/_lead-paragraph.html.erb
+++ b/app/views/components/_lead-paragraph.html.erb
@@ -1,8 +1,8 @@
 <%
-  description ||= ""
+  text ||= ""
 %>
-<% if description.length > 0 %>
+<% if text.present? %>
   <p class="app-c-lead-paragraph">
-    <%= nbsp_between_last_two_words(description) %>
+    <%= nbsp_between_last_two_words(text) %>
   </p>
 <% end %>

--- a/app/views/components/_lead-paragraph.html.erb
+++ b/app/views/components/_lead-paragraph.html.erb
@@ -1,0 +1,8 @@
+<%
+  description ||= ""
+%>
+<% if description.length > 0 %>
+  <p class="app-c-lead-paragraph">
+    <%= nbsp_between_last_two_words(description) %>
+  </p>
+<% end %>

--- a/app/views/components/docs/lead-paragraph.yml
+++ b/app/views/components/docs/lead-paragraph.yml
@@ -5,4 +5,4 @@ accessibility_criteria: |
   - be visually distinct from other paragraphs
 fixtures:
   default:
-    description: 'UK Visas and Immigration is making changes to the Immigration Rules affecting various categories.'
+    text: 'UK Visas and Immigration is making changes to the Immigration Rules affecting various categories.'

--- a/app/views/components/docs/lead-paragraph.yml
+++ b/app/views/components/docs/lead-paragraph.yml
@@ -1,0 +1,8 @@
+name: Lead paragraph
+description: A paragraph of text
+accessibility_criteria: |
+  The lead paragraph must:
+  - be visually distinct from other paragraphs
+fixtures:
+  default:
+    description: 'UK Visas and Immigration is making changes to the Immigration Rules affecting various categories.'

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -3,6 +3,6 @@
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 <%= render 'shared/sidebar_image_with_body', content_item: @content_item %>
 <%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -3,6 +3,6 @@
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 <%= render 'shared/sidebar_image_with_body', content_item: @content_item %>
 <%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -118,7 +118,7 @@
     </div>
     <div class="column-two-thirds consultation-summary">
       <h2>Summary</h2>
-      <%= render 'shared/description', description: @content_item.description %>
+      <%= render 'components/lead-paragraph', description: @content_item.description %>
 
       <% if @content_item.held_on_another_website? %>
         <p><strong>This consultation <% if @content_item.closed? %>was<% else %>is being<% end %> held on <a href="<%= @content_item.held_on_another_website_url %>">another website</a>.</strong></p>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -118,7 +118,7 @@
     </div>
     <div class="column-two-thirds consultation-summary">
       <h2>Summary</h2>
-      <%= render 'components/lead-paragraph', description: @content_item.description %>
+      <%= render 'components/lead-paragraph', text: @content_item.description %>
 
       <% if @content_item.held_on_another_website? %>
         <p><strong>This consultation <% if @content_item.closed? %>was<% else %>is being<% end %> held on <a href="<%= @content_item.held_on_another_website_url %>">another website</a>.</strong></p>

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -7,7 +7,7 @@
     </div>
   </div>
   <%= render 'shared/title_and_translations', content_item: @content_item %>
-  <%= render 'components/lead-paragraph', description: @content_item.description %>
+  <%= render 'components/lead-paragraph', text: @content_item.description %>
 
   <% @additional_body = capture do %>
     <% if @content_item.corporate_information? %>

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -7,7 +7,7 @@
     </div>
   </div>
   <%= render 'shared/title_and_translations', content_item: @content_item %>
-  <%= render 'shared/description', description: @content_item.description %>
+  <%= render 'components/lead-paragraph', description: @content_item.description %>
 
   <% @additional_body = capture do %>
     <% if @content_item.corporate_information? %>

--- a/app/views/content_items/detailed_guide.html+new_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+new_navigation.erb
@@ -12,7 +12,7 @@
     <%= render 'shared/withdrawal_notice', content_item: @content_item %>
     <%= render 'shared/metadata', content_item: @content_item %>
     <%= render 'shared/history_notice', content_item: @content_item %>
-    <%= render 'components/lead-paragraph', description: @content_item.description %>
+    <%= render 'components/lead-paragraph', text: @content_item.description %>
 
     <div class="sidebar-with-body" id="contents">
       <% if @content_item.contents.any? %>

--- a/app/views/content_items/detailed_guide.html+new_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+new_navigation.erb
@@ -12,7 +12,7 @@
     <%= render 'shared/withdrawal_notice', content_item: @content_item %>
     <%= render 'shared/metadata', content_item: @content_item %>
     <%= render 'shared/history_notice', content_item: @content_item %>
-    <%= render 'shared/description', description: @content_item.description %>
+    <%= render 'components/lead-paragraph', description: @content_item.description %>
 
     <div class="sidebar-with-body" id="contents">
       <% if @content_item.contents.any? %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -19,7 +19,7 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 
 <div
   class="grid-row sidebar-with-body"

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -19,7 +19,7 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 
 <div
   class="grid-row sidebar-with-body"

--- a/app/views/content_items/document_collection.html+new_navigation.erb
+++ b/app/views/content_items/document_collection.html+new_navigation.erb
@@ -7,7 +7,7 @@
     <%= render 'shared/withdrawal_notice', content_item: @content_item %>
     <%= render 'shared/metadata', content_item: @content_item %>
     <%= render 'shared/history_notice', content_item: @content_item %>
-    <%= render 'components/lead-paragraph', description: @content_item.description %>
+    <%= render 'components/lead-paragraph', text: @content_item.description %>
     <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
 
     <%= render 'document_collection_body' %>

--- a/app/views/content_items/document_collection.html+new_navigation.erb
+++ b/app/views/content_items/document_collection.html+new_navigation.erb
@@ -7,7 +7,7 @@
     <%= render 'shared/withdrawal_notice', content_item: @content_item %>
     <%= render 'shared/metadata', content_item: @content_item %>
     <%= render 'shared/history_notice', content_item: @content_item %>
-    <%= render 'shared/description', description: @content_item.description %>
+    <%= render 'components/lead-paragraph', description: @content_item.description %>
     <%= render 'shared/sidebar_contents', contents: @content_item.contents %>
 
     <%= render 'document_collection_body' %>

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -4,7 +4,7 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 
 <div
   class="grid-row sidebar-with-body"

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -4,7 +4,7 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 
 <div
   class="grid-row sidebar-with-body"

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -3,6 +3,6 @@
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 <%= render 'shared/sidebar_image_with_body', content_item: @content_item %>
 <%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -3,6 +3,6 @@
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 <%= render 'shared/sidebar_image_with_body', content_item: @content_item %>
 <%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -4,7 +4,7 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 <%= render 'shared/sidebar_image_with_body', content_item: @content_item %>
 <%= render 'shared/share_buttons', share_urls: @content_item.share_urls %>
 <%= render 'govuk_component/document_footer', @content_item.document_footer %>

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -4,7 +4,7 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 <%= render 'shared/sidebar_image_with_body', content_item: @content_item %>
 <%= render 'shared/share_buttons', share_urls: @content_item.share_urls %>
 <%= render 'govuk_component/document_footer', @content_item.document_footer %>

--- a/app/views/content_items/publication.html+new_navigation.erb
+++ b/app/views/content_items/publication.html+new_navigation.erb
@@ -16,7 +16,7 @@
     <%= render 'shared/withdrawal_notice', content_item: @content_item %>
     <%= render 'shared/metadata', content_item: @content_item %>
     <%= render 'shared/history_notice', content_item: @content_item %>
-    <%= render 'components/lead-paragraph', description: @content_item.description %>
+    <%= render 'components/lead-paragraph', text: @content_item.description %>
 
     <h1 class="section-title" id="documents-title">
       <%= t("publications.documents", count: @content_item.documents_count) %>

--- a/app/views/content_items/publication.html+new_navigation.erb
+++ b/app/views/content_items/publication.html+new_navigation.erb
@@ -16,7 +16,7 @@
     <%= render 'shared/withdrawal_notice', content_item: @content_item %>
     <%= render 'shared/metadata', content_item: @content_item %>
     <%= render 'shared/history_notice', content_item: @content_item %>
-    <%= render 'shared/description', description: @content_item.description %>
+    <%= render 'components/lead-paragraph', description: @content_item.description %>
 
     <h1 class="section-title" id="documents-title">
       <%= t("publications.documents", count: @content_item.documents_count) %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -16,7 +16,7 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 
 <div class="grid-row sidebar-with-body">
   <div class="column-third">

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -16,7 +16,7 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 
 <div class="grid-row sidebar-with-body">
   <div class="column-third">

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -5,7 +5,7 @@
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 
 <div class="grid-row sidebar-with-body">
   <% if @content_item.nested_contents.any? %>

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -5,7 +5,7 @@
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 
 <div class="grid-row sidebar-with-body">
   <% if @content_item.nested_contents.any? %>

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -4,6 +4,6 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 <%= render 'shared/sidebar_image_with_body', content_item: @content_item %>
 <%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -4,6 +4,6 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 <%= render 'shared/sidebar_image_with_body', content_item: @content_item %>
 <%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -4,6 +4,6 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 <%= render 'shared/sidebar_contents_with_body', content_item: @content_item %>
 <%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -4,6 +4,6 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 <%= render 'shared/sidebar_contents_with_body', content_item: @content_item %>
 <%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -18,7 +18,7 @@
     <p><%= @content_item.cancellation_reason %></p>
   </div>
 <% end %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 
 <% if @content_item.release_date_changed? %>
 <div class="grid-row">

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -18,7 +18,7 @@
     <p><%= @content_item.cancellation_reason %></p>
   </div>
 <% end %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 
 <% if @content_item.release_date_changed? %>
 <div class="grid-row">

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :title, @content_item.title %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 <%= render 'shared/sidebar_image_with_body', content_item: @content_item %>

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :title, @content_item.title %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 <%= render 'shared/sidebar_image_with_body', content_item: @content_item %>

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :title, @content_item.title %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 <%= render 'shared/sidebar_contents_with_body', content_item: @content_item %>

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :title, @content_item.title %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 <%= render 'shared/sidebar_contents_with_body', content_item: @content_item %>

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :title, @content_item.title %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 
 <% @additional_body = capture do %>
   <% if @content_item.policies.any? %>

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :title, @content_item.title %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 
 <% @additional_body = capture do %>
   <% if @content_item.policies.any? %>

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -4,7 +4,7 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'shared/description', description: @content_item.description %>
+<%= render 'components/lead-paragraph', description: @content_item.description %>
 <%= render 'shared/sidebar_image_with_body', content_item: @content_item %>
 <%= render 'shared/share_buttons', share_urls: @content_item.share_urls %>
 <%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -4,7 +4,7 @@
 <%= render 'shared/withdrawal_notice', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'components/lead-paragraph', description: @content_item.description %>
+<%= render 'components/lead-paragraph', text: @content_item.description %>
 <%= render 'shared/sidebar_image_with_body', content_item: @content_item %>
 <%= render 'shared/share_buttons', share_urls: @content_item.share_urls %>
 <%= render 'shared/footer', @content_item.document_footer %>

--- a/app/views/shared/_description.html.erb
+++ b/app/views/shared/_description.html.erb
@@ -1,5 +1,0 @@
-<% if description.present? %>
-  <p class="description">
-    <%= nbsp_between_last_two_words(description) %>
-  </p>
-<% end %>

--- a/lib/generators/format/templates/format.html.erb
+++ b/lib/generators/format/templates/format.html.erb
@@ -8,4 +8,4 @@
   </div>
 </div>
 
-<%%= render 'components/lead-paragraph', description: @content_item.description %>
+<%%= render 'components/lead-paragraph', text: @content_item.description %>

--- a/lib/generators/format/templates/format.html.erb
+++ b/lib/generators/format/templates/format.html.erb
@@ -8,4 +8,4 @@
   </div>
 </div>
 
-<%%= render 'shared/description', description: @content_item.description %>
+<%%= render 'components/lead-paragraph', description: @content_item.description %>

--- a/test/component_test_helper.rb
+++ b/test/component_test_helper.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class ComponentTestCase < ActionView::TestCase
+  helper Rails.application.helpers
+
   def component_name
     raise NotImplementedError, "Override this method in your test class"
   end

--- a/test/components/lead_paragraph_test.rb
+++ b/test/components/lead_paragraph_test.rb
@@ -12,7 +12,7 @@ class LeadParagraphTest < ComponentTestCase
   test "renders a lead paragraph" do
     nbsp = HTMLEntities.new.decode('&nbsp;')
 
-    render_component(description: 'UK Visas and Immigration is making changes to the Immigration Rules affecting various categories.')
+    render_component(text: 'UK Visas and Immigration is making changes to the Immigration Rules affecting various categories.')
     assert_select ".app-c-lead-paragraph", text: "UK Visas and Immigration is making changes to the Immigration Rules affecting various#{nbsp}categories."
   end
 end

--- a/test/components/lead_paragraph_test.rb
+++ b/test/components/lead_paragraph_test.rb
@@ -1,6 +1,6 @@
 require 'component_test_helper'
 
-class PrintLinkTest < ComponentTestCase
+class LeadParagraphTest < ComponentTestCase
   def component_name
     "lead-paragraph"
   end
@@ -10,7 +10,9 @@ class PrintLinkTest < ComponentTestCase
   end
 
   test "renders a lead paragraph" do
+    nbsp = HTMLEntities.new.decode('&nbsp;')
+
     render_component(description: 'UK Visas and Immigration is making changes to the Immigration Rules affecting various categories.')
-    assert_select ".app-c-lead-paragraph", text: "UK Visas and Immigration is making changes to the Immigration Rules affecting various categories."
+    assert_select ".app-c-lead-paragraph", text: "UK Visas and Immigration is making changes to the Immigration Rules affecting various#{nbsp}categories."
   end
 end

--- a/test/components/lead_paragraph_test.rb
+++ b/test/components/lead_paragraph_test.rb
@@ -1,0 +1,16 @@
+require 'component_test_helper'
+
+class PrintLinkTest < ComponentTestCase
+  def component_name
+    "lead-paragraph"
+  end
+
+  test "renders nothing without a description" do
+    assert_empty render_component({})
+  end
+
+  test "renders a lead paragraph" do
+    render_component(description: 'UK Visas and Immigration is making changes to the Immigration Rules affecting various categories.')
+    assert_select ".app-c-lead-paragraph", text: "UK Visas and Immigration is making changes to the Immigration Rules affecting various categories."
+  end
+end

--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -42,7 +42,7 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
 
     assert_has_component_metadata_pair("see_updates_link", true)
 
-    within(".description") do
+    within(".app-c-lead-paragraph") do
       assert_text <<-DESCRIPTION
        It is with great sadness that the Ministry of Defence
        must confirm that Sir George Pomeroy Colley, died in battle


### PR DESCRIPTION
- Replaces existing lead paragraph in many many templates
- Accepts parameter for description i.e. text in paragraph
- Renders nothing if description not supplied

https://trello.com/c/ns76djkw/30-convert-lead-paragraph-lede-component

Currently marked as DO NOT MERGE because current component structure is unable to access required helper method nbsp_between_last_two_words, which is necessary for required functionality.

<img width="864" alt="screen shot 2017-07-21 at 11 08 15" src="https://user-images.githubusercontent.com/861310/28459339-f1170ed8-6e04-11e7-9bb1-dd051dfd7fd5.png">
