### PR TITLE
Check GovukPublishingComponents exists before init

### DIFF
--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,3 +1,5 @@
-GovukPublishingComponents.configure do |c|
-  c.component_guide_title = "Government Frontend Component Guide"
+if defined?(GovukPublishingComponents)
+  GovukPublishingComponents.configure do |c|
+    c.component_guide_title = "Government Frontend Component Guide"
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     mount JasmineRails::Engine => "/specs" if defined?(JasmineRails)
     get 'random/:schema' => 'randomly_generated_content_item#show'
 
-    mount GovukPublishingComponents::Engine, at: "/component-guide"
+    mount GovukPublishingComponents::Engine, at: "/component-guide" if defined?(GovukPublishingComponents)
   end
 
   get 'healthcheck', to: proc { [200, {}, ['']] }


### PR DESCRIPTION
- govuk publishing components is only included when in dev and test environments
- the initialiser doesn't therefore work in production
- only run the initialiser if the module is defined
