### PR TITLE
Reduce timeout from 10s to 5s for Webchat availability polling

### DIFF
--- a/app/assets/javascripts/webchat/library.js
+++ b/app/assets/javascripts/webchat/library.js
@@ -7,7 +7,7 @@
 
 
   function Webchat (options) {
-    var POLL_INTERVAL = 10 * 1000
+    var POLL_INTERVAL = 5 * 1000
     var AJAX_TIMEOUT  = 5 * 1000
     var API_STATES = [
       "BUSY",

--- a/spec/javascripts/webchat.spec.js
+++ b/spec/javascripts/webchat.spec.js
@@ -1,7 +1,7 @@
 /* global describe beforeEach setFixtures it spyOn expect jasmine */
 
 var $ = window.jQuery
-var POLL_INTERVAL = '11' // Offset by one
+var POLL_INTERVAL = '6' // Offset by one
 
 describe('Webchat', function () {
   var GOVUK = window.GOVUK


### PR DESCRIPTION
Graham Orr from HMRC:
"We have previously requested that all webchat links have their update time reduced from 15 to 10 seconds as an experiment.

The experiment was a success and we would now like the webchat update time to be lowered from 10 seconds down to 5 seconds."

Do not merge until Monday 07/08/17