### PR TITLE
Create download link component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,3 +54,4 @@
 
 // components
 @import 'components/print-link';
+@import 'components/download-link';

--- a/app/assets/stylesheets/components/_download-link.scss
+++ b/app/assets/stylesheets/components/_download-link.scss
@@ -1,0 +1,21 @@
+.app-c-download-link {
+  display: inline-block;
+  @include bold-19;
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-top: $gutter;
+  }
+}
+
+
+// scss-lint:disable SelectorFormat
+.app-c-download-link__icon {
+  margin-right: 0.5em;
+  height: 1.31578947368em; // 25 / 19
+  width: 1.31578947368em;
+  vertical-align: middle;
+}
+// scss-lint:enable SelectorFormat
+

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -57,26 +57,5 @@
     img {
       max-width: 100%;
     }
-
-    .map-download {
-      margin-top: $gutter-half;
-
-      @include media(tablet) {
-        margin-top: $gutter;
-      }
-
-      a {
-        display: block;
-        @include bold-19;
-        min-height: 2.5em;
-        padding-left: 2.5em;
-        background: image-url("icon-file-download.png") no-repeat scroll 0 0;
-
-        @include device-pixel-ratio() {
-          background-image: image-url("icon-file-download-2x.png");
-          background-size: 25px 25px;
-        }
-      }
-    }
   }
 }

--- a/app/views/components/_download-link.html.erb
+++ b/app/views/components/_download-link.html.erb
@@ -1,0 +1,17 @@
+<%
+  link_text ||= "Download File"
+%>
+
+<a class="app-c-download-link" href="<%= href %>">
+  <svg class="app-c-download-link__icon"
+        aria-hidden="true"
+        viewBox="0 0 25 25"
+        height="25"
+        width="25"
+        xmlns="http://www.w3.org/2000/svg">
+    <g>
+      <path d="M23 5h2v20H5v-2h18V5z"/>
+      <path d="M0 0h20v20H0z"/>
+    </g>
+  </svg><%= link_text %>
+</a>

--- a/app/views/components/docs/download-link.yml
+++ b/app/views/components/docs/download-link.yml
@@ -1,0 +1,16 @@
+name: Download link
+description: A link with a file download icon
+accessibility_criteria: |
+  The download link must:
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - indicate when it has focus
+  The download icon must:
+  - be presentational and ignored by screen readers
+fixtures:
+  default:
+    href: '/download-this'
+  custom_link_text:
+    href: '/download-map'
+    link_text: 'Download Map (PDF)'

--- a/app/views/shared/_travel_advice_summary.html.erb
+++ b/app/views/shared/_travel_advice_summary.html.erb
@@ -14,8 +14,8 @@
   <figure class="map">
     <img src="<%= content_item.map["url"] %>" alt="<%= content_item.map["alt_text"] %>">
     <% if content_item.map_download_url %>
-      <figcaption class="map-download">
-        <a href="<%= content_item.map_download_url %>">Download map (PDF)</a>
+      <figcaption>
+        <%= render 'components/download-link', href: content_item.map_download_url, link_text: "Download map (PDF)" %>
       </figcaption>
     <% end %>
   </figure>

--- a/test/components/download_link_test.rb
+++ b/test/components/download_link_test.rb
@@ -1,0 +1,23 @@
+require 'component_test_helper'
+
+class DownloadLinkTest < ComponentTestCase
+  def component_name
+    "download-link"
+  end
+
+  test "fails to render a download link when no href is given" do
+    assert_raise do
+      render_component({})
+    end
+  end
+
+  test "renders a download link correctly" do
+    render_component(href: '/download-me')
+    assert_select ".app-c-download-link[href=\"/download-me\"]"
+  end
+
+  test "renders a download link with custom link text correctly" do
+    render_component(href: '/download-map', link_text: 'Download this file')
+    assert_select ".app-c-download-link[href=\"/download-map\"]", text: "Download this file"
+  end
+end


### PR DESCRIPTION
- Replaces the existing download map link in travel advice pages.
- Takes parameters for href and link text
- Deliberately errors if no href is provided
- Documented in the component guide (shown below):

<img width="1008" alt="screen shot 2017-07-21 at 15 32 42" src="https://user-images.githubusercontent.com/29889908/28468089-df3e1236-6e29-11e7-9f1c-e839993fb940.png">
<img width="996" alt="screen shot 2017-07-21 at 15 33 08" src="https://user-images.githubusercontent.com/29889908/28468104-ea02303a-6e29-11e7-99f8-378d38348b1c.png">
