### PR TITLE
Move description above documents

### DIFF
--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -131,6 +131,17 @@
   </section>
 <% end %>
 
+<div class="grid-row sidebar-with-body">
+  <div class="column-third">
+    <h1 class="section-title" id="description-title">
+      Consultation description
+    </h1>
+  </div>
+  <div class="column-two-thirds" aria-labelledby="description-title">
+    <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
+  </div>
+</div>
+
 <% if @content_item.documents? %>
   <div class="grid-row sidebar-with-body">
     <div class="column-third">
@@ -145,17 +156,6 @@
     </div>
   </div>
 <% end %>
-
-<div class="grid-row sidebar-with-body">
-  <div class="column-third">
-    <h1 class="section-title" id="description-title">
-      Consultation description
-    </h1>
-  </div>
-  <div class="column-two-thirds" aria-labelledby="description-title">
-    <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
-  </div>
-</div>
 
 <% if @content_item.ways_to_respond? %>
   <div class="grid-row sidebar-with-body">


### PR DESCRIPTION
When a consultation has many attachments, the description is below the
documents and users may miss important information.

This was brought up in the Snook discovery into Consultations.

## Before
<img width="1024" alt="consultations-before" src="https://user-images.githubusercontent.com/523014/28623345-96552036-720d-11e7-83d7-1eccb1f7482f.png">

## After
<img width="1024" alt="consultations-after" src="https://user-images.githubusercontent.com/523014/28623348-9b36d6bc-720d-11e7-93b8-35740b622ecf.png">
