### PR TITLE
Allow component guide to render on Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'gds-api-adapters', '~> 43.0'
 gem 'govuk_ab_testing', '~> 2.0'
 gem 'govuk_elements_rails', '3.0.1'
 gem 'govuk_frontend_toolkit', '5.1.0'
+gem 'govuk_publishing_components', '~> 0.3.1', require: ENV['RAILS_ENV'] != "production" || ENV['HEROKU_APP_NAME'].to_s.length.positive?
 gem 'htmlentities', '4.3.4'
 gem 'logstasher', '0.6.1'
 gem 'plek', '1.11'
@@ -29,7 +30,6 @@ gem 'govuk_navigation_helpers', '~> 6.3'
 
 group :development, :test do
   gem 'govuk-lint'
-  gem 'govuk_publishing_components', '~> 0.3.0'
   gem 'govuk_schemas'
   gem 'jasmine-rails', '~> 0.14.0'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       sass (>= 3.2.0)
     govuk_navigation_helpers (6.3.0)
       gds-api-adapters (>= 43.0)
-    govuk_publishing_components (0.3.0)
+    govuk_publishing_components (0.3.1)
       govspeak (~> 5.0.3)
       govuk_frontend_toolkit
       rails (~> 5.0.0, >= 5.0.0.1)
@@ -320,7 +320,7 @@ DEPENDENCIES
   govuk_elements_rails (= 3.0.1)
   govuk_frontend_toolkit (= 5.1.0)
   govuk_navigation_helpers (~> 6.3)
-  govuk_publishing_components (~> 0.3.0)
+  govuk_publishing_components (~> 0.3.1)
   govuk_schemas
   htmlentities (= 4.3.4)
   jasmine-rails (~> 0.14.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,9 @@ Rails.application.routes.draw do
     # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
     mount JasmineRails::Engine => "/specs" if defined?(JasmineRails)
     get 'random/:schema' => 'randomly_generated_content_item#show'
-
-    mount GovukPublishingComponents::Engine, at: "/component-guide" if defined?(GovukPublishingComponents)
   end
+
+  mount GovukPublishingComponents::Engine, at: "/component-guide" if defined?(GovukPublishingComponents)
 
   get 'healthcheck', to: proc { [200, {}, ['']] }
   get '*path/:variant' => 'content_items#show',


### PR DESCRIPTION
We need the component guide to be available in Heroku preview apps to check components in pull requests and to link to versions of the guide.

* We don't want the component guide to render in production mode
* Heroku review apps have the production environment set
* Make a special case for including the guide when a HEROKU env
  variable has been set
* This allows us to link users to a PR's component guide or master’s

https://government-frontend-pr-416.herokuapp.com/component-guide