### PR TITLE
Link to component guide when starting app in dev mode

### DIFF
--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -2,4 +2,12 @@ if defined?(GovukPublishingComponents)
   GovukPublishingComponents.configure do |c|
     c.component_guide_title = "Government Frontend Component Guide"
   end
+
+  if Rails.env.development?
+    startup_message = "=> government-frontend component guide available at: /component-guide"
+    color_blue = 36
+
+    # https://stackoverflow.com/questions/1489183/colorized-ruby-output
+    puts "\e[#{color_blue}m#{startup_message}\e[0m"
+  end
 end


### PR DESCRIPTION
Make the component guide visible to developers working on the application.

https://trello.com/c/kXABQ1vo/61-1-echo-the-link-from-application-boot

![screen shot 2017-08-01 at 17 15 25](https://user-images.githubusercontent.com/319055/28835537-9047764c-76dd-11e7-8ebf-92b561ebb7bd.png)