### PR TITLE
Fix banner extra paragraph layout

### DIFF
--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -96,6 +96,7 @@
 <% consultation_desc = capture do %>
   <%= @content_item.description %>
   <% if @content_item.held_on_another_website? %>
+    <br/><br/>
     <strong>This consultation <% if @content_item.closed? %>was<% else %>is being<% end %> held on <a href="<%= @content_item.held_on_another_website_url %>">another website</a>.</strong>
   <% end %>
 <% end %>


### PR DESCRIPTION
- restore line break between summary text and consultation held on another website text

Wrong:

<img width="1014" alt="screen shot 2017-08-04 at 14 55 45" src="https://user-images.githubusercontent.com/861310/28971752-075122da-7925-11e7-9257-5d351bcdefee.png">

Better:

<img width="986" alt="screen shot 2017-08-04 at 14 56 19" src="https://user-images.githubusercontent.com/861310/28971765-1a02ed8c-7925-11e7-817b-0f27f5eb2f12.png">
