### PR TITLE
Don't render translations when only one available

### DIFF
--- a/app/views/components/_translation-nav.html.erb
+++ b/app/views/components/_translation-nav.html.erb
@@ -1,13 +1,16 @@
-<div class="app-c-translation-nav">
-  <ul class="app-c-translation-nav__list">
-    <% translations.each.with_index do |translation, i| %>
-      <li class="app-c-translation-nav__list__language">
-        <% if translation[:active] %>
-          <%= translation[:text] %>
-        <% else %>
-          <%= link_to translation[:text], translation[:base_path], lang: translation[:locale], rel: "alternate" %>
-        <% end %>
-      </li>
-    <% end %>
-  </ul>
-</div>
+<% translations ||= [] %>
+<% if translations.length > 1 %>
+  <div class="app-c-translation-nav">
+    <ul class="app-c-translation-nav__list">
+      <% translations.each.with_index do |translation, i| %>
+        <li class="app-c-translation-nav__list__language">
+          <% if translation[:active] %>
+            <%= translation[:text] %>
+          <% else %>
+            <%= link_to translation[:text], translation[:base_path], lang: translation[:locale], rel: "alternate" %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/test/components/translation_nav_test.rb
+++ b/test/components/translation_nav_test.rb
@@ -5,10 +5,21 @@ class TranslationNavTest < ComponentTestCase
     "translation-nav"
   end
 
-  test "fails to render a translation nav when no translations are given" do
-    assert_raise do
-      render_component({})
-    end
+  test "renders nothing when no translations are given" do
+    assert_empty render_component({})
+  end
+
+  test "renders nothing when only one translation given" do
+    assert_empty render_component(
+      translations: [
+        {
+          locale: 'en',
+          base_path: '/en',
+          text: 'English',
+          active: true
+        }
+      ]
+    )
   end
 
   test "renders an active translation nav item with a text description" do


### PR DESCRIPTION
Fix issue where “English” is showing by itself on all English detailed guides.

Update translation nav component to only output navigation if there’s
more than one available translation. If there's only one then it's
the current page and the text is redundant.

Fixes:
![screen shot 2017-08-07 at 17 16 42](https://user-images.githubusercontent.com/319055/29035632-370a44a4-7b94-11e7-9480-8e4264971046.png)