### PR TITLE
Move the breadcrumb outside of the main element

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,9 +27,9 @@
   <% end %>
 
   <div id="wrapper" class="<%= wrapper_class %>">
+    <%= render_phase_label @content_item, content_for(:phase_message) %>
+    <%= render 'shared/breadcrumbs' %>
     <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">
-      <%= render_phase_label @content_item, content_for(:phase_message) %>
-      <%= render 'shared/breadcrumbs' %>
       <%= yield %>
     </main>
   </div>


### PR DESCRIPTION
- skip to content link now bypasses the breadcrumb
- change made to keep us consistent following the same change to Elements

https://trello.com/c/IsxWIQXQ/21-2-investigate-work-needed-to-have-breadcrumbs-consistent-with-govuk-elements
