### PR TITLE
Suppress first published date for  bulk published specialist documents

### DIFF
--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -112,6 +112,22 @@ class SpecialistDocumentPresenterTest
         'on the Big Issue Invest website'
       )
     end
+
+    test 'removes first published dates for bulk published documents' do
+      example = schema_item('aaib-reports')
+      example["details"]["metadata"]["bulk_published"] = true
+
+      refute present_example(example).metadata[:first_published]
+      refute present_example(example).document_footer[:published]
+
+      example["details"]["metadata"]["bulk_published"] = false
+      assert present_example(example).metadata[:first_published]
+      assert present_example(example).document_footer[:published]
+
+      example["details"]["metadata"] = {}
+      assert present_example(example).metadata[:first_published]
+      assert present_example(example).document_footer[:published]
+    end
   end
 
   class PresentedSpecialistDocumentWithFinderFacets < SpecialistDocumentTestCase


### PR DESCRIPTION
For certain AAIB reports the publish date is the date the site was scraped rather than the date the report was first published. Ideally the data in the content item would be correct.

https://trello.com/c/FhAbqDhg/
https://govuk.zendesk.com/agent/tickets/2293473

Example:
https://www.gov.uk/aaib-reports/lockheed-l1011-385-1-15-g-bhbr-19-december-1989

Also memoize the result of first_public_at to avoid repetitive sorting of the change history, which could be timely if long.

## Before
![screen shot 2017-08-10 at 15 08 35](https://user-images.githubusercontent.com/319055/29174945-b4d38344-7ddf-11e7-83b6-ac6cda3d31cb.png)

## After
![screen shot 2017-08-10 at 15 08 47](https://user-images.githubusercontent.com/319055/29174944-b4c65296-7ddf-11e7-9303-af7f23e81d0c.png)
