### PR TITLE
Downgrade Airbrake and use standard config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,7 @@ source 'https://rubygems.org'
 
 ruby File.read(".ruby-version").strip
 
-gem 'airbrake', '~> 5.5'
-gem 'airbrake-ruby', '1.5'
-
+gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
 gem 'asset_bom_removal-rails', '~> 1.0.0'
 gem 'dalli'
 gem 'gds-api-adapters', '~> 43.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/alphagov/airbrake.git
+  revision: ad9c926a56535c48f95c33824a76e10bc8f91179
+  branch: silence-dep-warnings-for-rails-5
+  specs:
+    airbrake (4.3.8)
+      builder
+      multi_json
+      rails (>= 5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -40,9 +50,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (5.5.0)
-      airbrake-ruby (~> 1.5)
-    airbrake-ruby (1.5.0)
     anemone (0.7.2)
       nokogiri (>= 1.3.0)
       robotex (>= 1.0.0)
@@ -155,6 +162,7 @@ GEM
       metaclass (~> 0.0.1)
     money (6.9.0)
       i18n (>= 0.6.4, < 0.9)
+    multi_json (1.12.1)
     netrc (0.11.0)
     nio4r (1.2.1)
     nokogiri (1.6.8)
@@ -303,8 +311,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (~> 5.5)
-  airbrake-ruby (= 1.5)
+  airbrake!
   asset_bom_removal-rails (~> 1.0.0)
   better_errors
   binding_of_caller

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,10 +1,10 @@
 if ENV['ERRBIT_API_KEY'].present?
-  errbit_uri = Plek.find('errbit')
+  errbit_uri = Plek.find_uri('errbit')
 
   Airbrake.configure do |config|
-    config.project_key = ENV['ERRBIT_API_KEY']
-    config.project_id = 1 # dummy, not used in Errbit
-    config.host = errbit_uri
-    config.environment = ENV['ERRBIT_ENVIRONMENT_NAME']
+    config.api_key = ENV['ERRBIT_API_KEY']
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == 'https'
+    config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
   end
 end


### PR DESCRIPTION
We’re seeing some errors with Airbrake 5:
`Airbrake: falling back to sync delivery because there are no running async workers`
`Airbrake: unexpected code (200). Body: {“notice”: … }`

Also fixes other incompatibilities outlined in
https://docs.publishing.service.gov.uk/manual/upgrade-rails.html#airbrake

Downgrades to version 4 with custom branch we are using along with default config:
https://github.com/alphagov/govuk-rails-app-template/blob/master/templates/config/initializers/airbrake.rb

See also:
https://github.com/errbit/errbit/issues/1087#issuecomment-227627038