### PR TITLE
Add missing ID from consultations

### DIFF
--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -74,7 +74,7 @@
 <% if @content_item.final_outcome? %>
   <section class="original-consultation">
     <header>
-      <%= render 'components/heading', text: "Original consultation", heading_level: 2 %>
+      <%= render 'components/heading', text: "Original consultation", id: "original-consultation-title", heading_level: 2 %>
     </header>
 <% end %>
 


### PR DESCRIPTION
Make it possible to link to this part of a consultation (eg where the banner is)