### PR TITLE
Create document list component

### DIFF
--- a/app/assets/stylesheets/components/_document-list.scss
+++ b/app/assets/stylesheets/components/_document-list.scss
@@ -1,0 +1,18 @@
+.app-c-document-list__item {
+  overflow: hidden;
+  margin-bottom: $gutter-one-third;
+  padding-bottom: $gutter-one-third;
+  border-bottom: 1px solid $border-colour;
+  list-style: none;
+}
+
+.app-c-document-list__item-title {
+  @include bold-19;
+}
+
+.app-c-document-list__attribute {
+  @include core-14;
+  float: left;
+  list-style: none;
+  padding-right: $gutter-two-thirds;
+}

--- a/app/assets/stylesheets/views/_document-collection.scss
+++ b/app/assets/stylesheets/views/_document-collection.scss
@@ -16,22 +16,4 @@
       margin-top: 0;
     }
   }
-
-  .group-document-list-item {
-    overflow: hidden;
-    margin-bottom: $gutter-one-third;
-    padding-bottom: $gutter-one-third;
-    border-bottom: 1px solid $border-colour;
-  }
-
-  .group-document-list-item-title {
-    @include bold-19;
-  }
-
-  .group-document-list-item-attributes li {
-    @include core-14;
-    float: left;
-    list-style: none;
-    padding-right: $gutter-two-thirds;
-  }
 }

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -14,7 +14,7 @@ class DocumentCollectionPresenter < ContentItemPresenter
 
   def groups
     groups = content_item["details"]["collection_groups"].reject { |group|
-      group_document_links(group).empty?
+      group_documents(group).empty?
     }
 
     groups.map { |group|
@@ -23,13 +23,26 @@ class DocumentCollectionPresenter < ContentItemPresenter
     }
   end
 
-  def group_document_links(group)
-    group_documents(group).map do |link|
+  def group_document_links(group, group_index)
+    group_documents(group).each_with_index.map do |link, link_index|
       {
-        public_updated_at: Time.zone.parse(link["public_updated_at"]),
-        document_type: link["document_type"],
-        title: link["title"],
-        base_path: link["base_path"]
+        link: {
+          text: link["title"],
+          path: link["base_path"],
+          data_attributes: {
+            track_category: 'navDocumentCollectionLinkClicked',
+            track_action: "#{group_index + 1}.#{link_index + 1}",
+            track_label: link["base_path"],
+            track_options: {
+              dimension28: group['documents'].count.to_s,
+              dimension29: link["title"]
+            }
+          }
+        },
+        metadata: {
+          public_updated_at: Time.zone.parse(link["public_updated_at"]),
+          document_type: link["document_type"],
+        },
       }
     end
   end

--- a/app/views/components/_document-list.html.erb
+++ b/app/views/components/_document-list.html.erb
@@ -1,0 +1,30 @@
+<%
+  items ||= []
+%>
+<% if items.any? %>
+  <ol class="app-c-document-list">
+    <% items.each do |item| %>
+      <li class="app-c-document-list__item">
+        <h3 class="app-c-document-list__item-title">
+          <%=
+            link_to(
+              item[:link][:text],
+              item[:link][:path],
+              data: item[:link][:data_attributes]
+            )
+          %>
+        </h3>
+        <ul>
+          <li class="app-c-document-list__attribute">
+            <time datetime="<%= item[:metadata][:public_updated_at].iso8601 %>">
+              <%= l(item[:metadata][:public_updated_at], format: :short_ordinal) %>
+            </time>
+          </li>
+          <li class="app-c-document-list__attribute">
+            <%= t("content_item.schema_name.#{item[:metadata][:document_type]}", count: 1) %>
+          </li>
+        </ul>
+      </li>
+    <% end %>
+  </ol>
+<% end %>

--- a/app/views/components/docs/document-list.yml
+++ b/app/views/components/docs/document-list.yml
@@ -1,0 +1,78 @@
+name: Document list
+description: An ordered list of links to documents including document type and when updated.
+body: |
+  Outputs a list of links to documents, based on an array of document data. This must include:
+
+  * link text
+  * link href
+  * last updated date object
+  * document type
+
+  Tracking can be added to the links by supplying optional data attributes for each.
+
+  Documents are presented in an ordered list as the component expects that the ordering of the documents is relevant.
+accessibility_criteria: |
+  The component must:
+
+  * inform the user how many items are in the list
+
+  Links in the component must:
+
+  * accept focus
+  * be focusable with a keyboard
+  * be usable with a keyboard
+  * indicate when it has focus
+  * change in appearance when touched (in the touch-down state)
+  * change in appearance when hovered
+  * be usable with touch
+  * be usable with speech
+  * have visible text
+fixtures:
+  default:
+    items:
+    - link:
+        text: 'Alternative provision'
+        path: '/government/publications/alternative-provision'
+      metadata:
+        public_updated_at: 2016-06-27 10:29:44
+        document_type: 'statutory_guidance'
+    - link:
+        text: 'Behaviour and discipline in schools: guide for governing bodies'
+        path: '/government/publications/behaviour-and-discipline-in-schools-guidance-for-governing-bodies'
+      metadata:
+        public_updated_at: 2015-09-24 16:42:48
+        document_type: 'statutory_guidance'
+    - link:
+        text: 'Children missing education'
+        path: '/government/publications/children-missing-education'
+      metadata:
+        public_updated_at: 2016-09-05 16:48:27
+        document_type: 'statutory_guidance'
+  with_data_attributes_on_links:
+    items:
+    - link:
+        text: 'School behaviour and attendance: parental responsibility measures'
+        path: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+        data_attributes:
+          track_category: 'navDocumentCollectionLinkClicked'
+          track_action: 1.1
+          track_label: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+          track_options:
+            dimension28: 2
+            dimension29: 'School behaviour and attendance: parental responsibility measures'
+      metadata:
+        public_updated_at: 2017-01-05 14:50:33
+        document_type: 'statutory_guidance'
+    - link:
+        text: 'School exclusion'
+        path: '/government/publications/school-exclusion'
+        data_attributes:
+          track_category: 'navDocumentCollectionLinkClicked'
+          track_action: 1.2
+          track_label: '/government/publications/school-exclusion'
+          track_options:
+            dimension28: 2
+            dimension29: 'School exclusion'
+      metadata:
+        public_updated_at: 2017-07-19 15:01:48
+        document_type: 'statutory_guidance'

--- a/app/views/content_items/_document_collection_body.html.erb
+++ b/app/views/content_items/_document_collection_body.html.erb
@@ -9,35 +9,8 @@
         content: group["body"],
         direction: page_text_direction %>
   <% end %>
-  <ol class="group-document-list" data-module="track-click">
-    <% @content_item.group_document_links(group).each_with_index do |link, link_index| %>
-      <li class="group-document-list-item">
-        <h3 class="group-document-list-item-title">
-          <%=
-            link_to(
-              link[:title],
-              link[:base_path],
-              data: {
-                track_category: 'navDocumentCollectionLinkClicked',
-                track_action: "#{group_index + 1}.#{link_index + 1}",
-                track_label: link[:base_path],
-                track_options: {
-                  dimension28: @content_item.group_document_links(group).count.to_s,
-                  dimension29: link[:title]
-                }
-              }
-            )
-          %>
-        </h3>
-        <ul class="group-document-list-item-attributes">
-          <li>
-            <time datetime="<%= link[:public_updated_at].iso8601 %>">
-              <%= l(link[:public_updated_at], format: :short_ordinal) %>
-            </time>
-          </li>
-          <li><%= t("content_item.schema_name.#{link[:document_type]}", count: 1) %></li>
-        </ul>
-      </li>
-    <% end %>
-  </ol>
+
+  <div data-module="track-click">
+    <%= render 'components/document-list', items: @content_item.group_document_links(group, group_index) %>
+  </div>
 <% end %>

--- a/test/components/document_list_test.rb
+++ b/test/components/document_list_test.rb
@@ -1,0 +1,109 @@
+require 'component_test_helper'
+
+class DocumentListTest < ComponentTestCase
+  def component_name
+    "document-list"
+  end
+
+  test "renders nothing when no parameters are given" do
+    assert_empty render_component({})
+  end
+
+  test "renders nothing when an empty array is passed in" do
+    assert_empty render_component(items: [])
+  end
+
+  test "renders a document list correctly" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "School behaviour and attendance: parental responsibility measures",
+            path: "/government/publications/parental-responsibility-measures-for-behaviour-and-attendance"
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+            document_type: "statutory_guidance"
+          }
+        },
+        {
+          link: {
+            text: "School exclusion",
+            path: "/government/publications/school-exclusion"
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-07-19 15:01:48 +0000"),
+            document_type: "statutory_guidance"
+          }
+        }
+      ]
+    )
+    li = ".app-c-document-list__item-title"
+    attribute = ".app-c-document-list__attribute"
+
+    assert_select "#{li} a[href='/government/publications/parental-responsibility-measures-for-behaviour-and-attendance']", text: "School behaviour and attendance: parental responsibility measures"
+    assert_select "#{attribute} time[datetime='2017-01-05T14:50:33+00:00']", text: "5 January 2017"
+    assert_select attribute.to_s, text: "Statutory guidance"
+
+    assert_select "#{li} a[href='/government/publications/school-exclusion']", text: "School exclusion"
+    assert_select "#{attribute} time[datetime='2017-07-19T16:01:48+01:00']", text: "19 July 2017"
+  end
+
+  test "renders a document list with link tracking" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Link 1",
+            path: "/link1",
+            data_attributes: {
+              track_category: "navDocumentCollectionLinkClicked",
+              track_action: "1.1",
+              track_label: "/link1",
+              track_options: {
+                dimension28: "2",
+                dimension29: "Link 1"
+              }
+            }
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+            document_type: "statutory_guidance"
+          }
+        },
+        {
+          link: {
+            text: "Link 2",
+            path: "/link2",
+            data_attributes: {
+              track_category: "navDocumentCollectionLinkClicked",
+              track_action: "1.2",
+              track_label: "/link2",
+              track_options: {
+                dimension28: "2",
+                dimension29: "Link 2"
+              }
+            }
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-07-19 15:01:48 +0000"),
+            document_type: "statutory_guidance"
+          }
+        }
+      ]
+    )
+    li = ".app-c-document-list__item-title"
+
+    assert_select "#{li} a[href='/link1']", text: "Link 1"
+    assert_select "#{li} a[data-track-category='navDocumentCollectionLinkClicked']", text: "Link 1"
+    assert_select "#{li} a[data-track-action='1.1']", text: "Link 1"
+    assert_select "#{li} a[data-track-label='/link1']", text: "Link 1"
+    assert_select "#{li} a[data-track-options='{\"dimension28\":\"2\",\"dimension29\":\"Link 1\"}']", text: "Link 1"
+
+    assert_select "#{li} a[href='/link2']", text: "Link 2"
+    assert_select "#{li} a[data-track-category='navDocumentCollectionLinkClicked']", text: "Link 2"
+    assert_select "#{li} a[data-track-action='1.2']", text: "Link 2"
+    assert_select "#{li} a[data-track-label='/link2']", text: "Link 2"
+    assert_select "#{li} a[data-track-options='{\"dimension28\":\"2\",\"dimension29\":\"Link 2\"}']", text: "Link 2"
+  end
+end

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -39,7 +39,7 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
 
     within ".sidebar-with-body" do
       assert page.has_css?(shared_component_selector("govspeak"), count: group_count)
-      assert page.has_css?('.group-document-list', count: group_count)
+      assert page.has_css?('.app-c-document-list', count: group_count)
     end
   end
 
@@ -48,31 +48,29 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
     documents = @content_item["links"]["documents"]
 
     documents.each do |doc|
-      assert page.has_css?('.group-document-list-item-title a', text: doc["title"])
+      assert page.has_css?('.app-c-document-list__item-title a', text: doc["title"])
     end
 
-    assert page.has_css?('.group-document-list .group-document-list-item', count: documents.count)
+    assert page.has_css?('.app-c-document-list .app-c-document-list__item', count: documents.count)
 
-    within ".group-document-list:first-of-type .group-document-list-item:first-of-type .group-document-list-item-attributes" do
-      assert page.has_text?('16 March 2007'), "has properly formatted date"
-      assert page.has_css?('[datetime="2007-03-16T15:00:02+00:00"]'), "has iso8601 datetime attribute"
-      assert page.has_text?('Guidance'), "has formatted document_type"
+    document_lists = page.all('.app-c-document-list')
+
+    within document_lists[0] do
+      list_items = page.all(".app-c-document-list__item")
+      within list_items[0] do
+        assert page.has_text?('16 March 2007'), "has properly formatted date"
+        assert page.has_css?('[datetime="2007-03-16T15:00:02+00:00"]'), "has iso8601 datetime attribute"
+        assert page.has_text?('Guidance'), "has formatted document_type"
+      end
     end
   end
 
   test 'includes tracking data on all collection documents' do
     setup_and_visit_content_item('document_collection')
-    groups = page.all('.group-document-list')
+    groups = page.all('.app-c-document-list')
+    assert page.has_css?('[data-module="track-click"]'), count: groups.length
 
-    groups.each do |group|
-      assert_equal(
-        "track-click",
-        group['data-module'],
-        "Expected the module 'track-click' to be set in the group #{group.inspect}"
-      )
-    end
-
-    first_section_links = groups.first.all('.group-document-list-item-title a')
+    first_section_links = groups.first.all('.app-c-document-list__item-title a')
     first_link = first_section_links.first
 
     assert_equal(
@@ -92,7 +90,6 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
       first_link[:href],
       'Expected the content item base path to be set in the data attributes'
     )
-
     assert first_link['data-track-options'].present?
 
     data_options = JSON.parse(first_link['data-track-options'])

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -50,15 +50,28 @@ class DocumentCollectionPresenterTest
     test 'presents an ordered list of group documents' do
       documents = [
         {
-          public_updated_at: Time.zone.parse("2007-03-16 15:00:02 +0000"),
-          document_type: "guidance",
-          title: "National standard for driving cars and light vans",
-          base_path: "/government/publications/national-standard-for-driving-cars-and-light-vans"
+          link: {
+            text: "National standard for driving cars and light vans",
+            path: "/government/publications/national-standard-for-driving-cars-and-light-vans",
+            data_attributes: {
+              track_category: "navDocumentCollectionLinkClicked",
+              track_action: "1.1",
+              track_label: "/government/publications/national-standard-for-driving-cars-and-light-vans",
+              track_options: {
+                dimension28: "1",
+                dimension29: "National standard for driving cars and light vans"
+              }
+            }
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2007-03-16 15:00:02 +0000"),
+            document_type: "guidance"
+          }
         }
       ]
       document_ids = schema_item["details"]["collection_groups"].first["documents"]
 
-      assert_equal documents, presented_item.group_document_links("documents" => [document_ids.first])
+      assert_equal documents, presented_item.group_document_links({ "documents" => [document_ids.first] }, 0)
     end
   end
 
@@ -72,8 +85,8 @@ class DocumentCollectionPresenterTest
           .select { |g| g["title"] == "One document missing from links" }
           .first
 
-      presented_links = presenter.group_document_links(group_with_missing_document)
-      presented_links_base_paths = presented_links.collect { |link| link[:base_path] }
+      presented_links = presenter.group_document_links(group_with_missing_document, 0)
+      presented_links_base_paths = presented_links.collect { |link| link[:link][:path] }
 
       assert_equal(
         ["/government/publications/national-standard-for-developed-driving-competence"],


### PR DESCRIPTION
- accepts a content item and outputs a list of lists and information from it
- accepts an optional parameter to add tracking to the links
- possible point of contention: for the date object had to add a check/convert to date object part in order to get component guide to render. Open to better solution if one can be found.

(was called collection list component until part way through development when it became clear the name wasn't clear enough)

https://trello.com/c/JlNtwQ5G/75-2-convert-collection-list-to-document-list-component

<img width="941" alt="screen shot 2017-08-14 at 08 59 19" src="https://user-images.githubusercontent.com/861310/29262994-e36c69a4-80ce-11e7-8a03-27e03f175b70.png">
