### PR TITLE
Return 406 status for unsupported formats

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -5,6 +5,7 @@ class ContentItemsController < ApplicationController
   rescue_from GdsApi::HTTPNotFound, with: :error_notfound
   rescue_from GdsApi::InvalidUrl, with: :error_notfound
   rescue_from ActionView::MissingTemplate, with: :error_406
+  rescue_from ActionController::UnknownFormat, with: :error_406
 
   attr_accessor :content_item
 
@@ -49,6 +50,11 @@ private
     end
 
     request.variant = :print if params[:variant] == "print"
+
+    respond_to do |format|
+      format.html
+      format.atom
+    end
 
     with_locale do
       render content_item_template

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -72,6 +72,41 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_redirected_to content_item['base_path']
   end
 
+  test "returns HTML when an unspecific accepts header is requested (eg by IE8 and below)" do
+    request.headers["Accept"] = "*/*"
+    content_item = content_store_has_schema_example('travel_advice', 'full-country')
+
+    get :show, params: {
+      path: path_for(content_item)
+    }
+
+    assert_match(/text\/html/, response.headers['Content-Type'])
+    assert_response :success
+    assert_select '#wrapper'
+  end
+
+  test "returns a 406 for XMLHttpRequests" do
+    request.headers["X-Requested-With"] = "XMLHttpRequest"
+    content_item = content_store_has_schema_example('case_study', 'case_study')
+
+    get :show, params: {
+      path: path_for(content_item)
+    }
+
+    assert_response :not_acceptable
+  end
+
+  test "returns a 406 for unsupported format requests, eg text/javascript" do
+    request.headers["Accept"] = "text/javascript"
+    content_item = content_store_has_schema_example('case_study', 'case_study')
+
+    get :show, params: {
+      path: path_for(content_item)
+    }
+
+    assert_response :not_acceptable
+  end
+
   test "gets item from content store" do
     content_item = content_store_has_schema_example('case_study', 'case_study')
 


### PR DESCRIPTION
When a request is made for an unsupported format, eg text/javascript, the lack of a respond_to block meant we attempted to render it without a layout.

This led to a body being sent to slimmer without a #wrapper element,
causing the error:
`> undefined method 'to_html' for nil:NilClass`
in the BodyInserter processor

* Add a respond_to block to respond only to known formats
* Catch unknown format errors and return 406 (not acceptable)

This matches: https://github.com/alphagov/finder-frontend/pull/271

`format.html` must come before `format.atom` in the block. If a browser sends an unspecific accepts header, eg `*/*`, Rails falls through to the first format/variant declared in `respond_to`.

See also: https://github.com/gds-attic/multipage-frontend/pull/23