### PR TITLE
Create figure component

### DIFF
--- a/app/assets/stylesheets/components/_figure.scss
+++ b/app/assets/stylesheets/components/_figure.scss
@@ -1,0 +1,11 @@
+.app-c-figure {
+  @include responsive-bottom-margin;
+}
+
+.app-c-figure__image {
+  max-width: 100%;
+}
+
+.app-c-figure__figcaption {
+  @include core-16;
+}

--- a/app/assets/stylesheets/helpers/_sidebar-with-body.scss
+++ b/app/assets/stylesheets/helpers/_sidebar-with-body.scss
@@ -4,18 +4,6 @@
     margin-bottom: $gutter * 1.5;
   }
 
-  .sidebar-image {
-    @include responsive-bottom-margin;
-
-    img {
-      max-width: 100%;
-    }
-
-    figcaption {
-      @include core-16;
-    }
-  }
-
   .offset-one-third {
     @include media(tablet) {
       margin-left: percentage(1 / 3);

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -11,7 +11,6 @@
 
   .map {
     margin-top: $gutter;
-    margin-bottom: $gutter;
 
     img {
       max-width: 100%;

--- a/app/views/components/_figure.html.erb
+++ b/app/views/components/_figure.html.erb
@@ -1,0 +1,8 @@
+<%
+  alt ||= false
+  caption ||= false
+%>
+<figure class="app-c-figure">
+  <img class="app-c-figure__image" src="<%= src %>" <% if alt %>alt="<%= alt %>"<% end %>>
+  <% if caption %><figcaption class="app-c-figure__figcaption"><%= caption %></figcaption><% end %>
+</figure>

--- a/app/views/components/docs/figure.yml
+++ b/app/views/components/docs/figure.yml
@@ -1,0 +1,24 @@
+name: Figure
+description: A figure containing an image that never exceeds the component’s width
+body: |
+  A figure should be used for images that are referenced within a page, but which can be moved around without affecting the flow of the page [(see guidance here)](https://developer.mozilla.org/en/docs/Web/HTML/Element/figure)
+
+  Examples:
+
+  - [Case Study containing an image](/government/case-studies/2013-elections-in-swaziland)
+  - [Travel Advice containing a map (image)](/foreign-travel-advice/nepal)
+accessibility_criteria: |
+  The figure must:
+
+  - provide an informative text description, as alt text or caption
+
+fixtures:
+  default:
+    src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
+  figure_with_alt_text:
+    src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
+    alt: 'An image of the lords chamber'
+  figure_with_caption:
+    src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
+    alt: 'An image of the lords chamber'
+    caption: 'The Lords Chamber'

--- a/app/views/shared/_sidebar_image.html.erb
+++ b/app/views/shared/_sidebar_image.html.erb
@@ -1,6 +1,3 @@
 <% if image %>
-  <figure class="sidebar-image">
-    <img src="<%= image["url"] %>" alt="<%= image["alt_text"] %>">
-    <% if image["caption"].present? %><figcaption><%= image["caption"] %></figcaption><% end %>
-  </figure>
+  <%= render 'components/figure', src: image["url"], alt: image["alt_text"], caption: image["caption"] %>
 <% end %>

--- a/app/views/shared/_travel_advice_summary.html.erb
+++ b/app/views/shared/_travel_advice_summary.html.erb
@@ -10,13 +10,14 @@
 <% end %>
 
 <%= render 'govuk_component/metadata', content_item.metadata %>
+
+<div class="map">
 <% if content_item.map %>
-  <figure class="map">
-    <img src="<%= content_item.map["url"] %>" alt="<%= content_item.map["alt_text"] %>">
+  <% download_caption = capture do %>
     <% if content_item.map_download_url %>
-      <figcaption>
         <%= render 'components/download-link', href: content_item.map_download_url, link_text: "Download map (PDF)" %>
-      </figcaption>
     <% end %>
-  </figure>
+  <% end %>
+  <%= render 'components/figure', src: content_item.map["url"], alt: content_item.map["alt_text"], caption: download_caption %>
 <% end %>
+</div>

--- a/test/components/figure_test.rb
+++ b/test/components/figure_test.rb
@@ -1,0 +1,26 @@
+require 'component_test_helper'
+
+class FigureTest < ComponentTestCase
+  def component_name
+    "figure"
+  end
+
+  test "fails to render a figure when no data is given" do
+    assert_raise do
+      render_component({})
+    end
+  end
+
+  test "renders a figure correctly" do
+    render_component(src: '/image', alt: 'image alt text')
+    assert_select ".app-c-figure__image[src=\"/image\"]"
+    assert_select ".app-c-figure__image[alt=\"image alt text\"]"
+  end
+
+  test "renders a figure with caption correctly" do
+    render_component(src: '/image', alt: 'image alt text', caption: 'This is a caption')
+    assert_select ".app-c-figure__image[src=\"/image\"]"
+    assert_select ".app-c-figure__image[alt=\"image alt text\"]"
+    assert_select ".app-c-figure__figcaption", text: 'This is a caption'
+  end
+end


### PR DESCRIPTION
The image component:
* Replaces existing responsive sidebar images
* Takes parameters for href, alt text and caption
* Deliberately errors if no href or alt text is given
* Is documented in the component guide (shown below)

Note: rendering of this component in the component guide currently uses an image URL from a GOV.UK page - if there are any other suggestions for images to use as an example in the guide, feel free to suggest.

<img width="1011" alt="screen shot 2017-08-15 at 11 20 31" src="https://user-images.githubusercontent.com/29889908/29312098-e7c0364c-81ab-11e7-9bdc-b043948bfe37.png">
<img width="996" alt="screen shot 2017-08-15 at 11 20 42" src="https://user-images.githubusercontent.com/29889908/29312103-ea838492-81ab-11e7-96d4-a530d4601fca.png">

Examples:
* [Case Study](https://government-frontend-pr-448.herokuapp.com/government/case-studies/2013-elections-in-swaziland)
* [News Article](https://government-frontend-pr-448.herokuapp.com/government/news/the-personal-independence-payment-amendment-regulations-2017-statement-by-paul-gray)
* [Travel Advice](https://government-frontend-pr-448.herokuapp.com/foreign-travel-advice/nepal)
