### PR TITLE
Only use heading in notice if description present

### DIFF
--- a/app/views/components/_notice.html.erb
+++ b/app/views/components/_notice.html.erb
@@ -1,14 +1,20 @@
 <% if defined?(title) %>
   <%
-    description_text ||= ""
-    description_govspeak ||= ""
+    description_text ||= false
+    description_govspeak ||= false
   %>
   <section class="app-c-notice" aria-label="Notice">
-    <h2 class="app-c-notice__title"><%= title %></h2>
-    <% if description_text.present? %>
+    <% if description_text || description_govspeak %>
+      <h2 class="app-c-notice__title"><%= title %></h2>
+    <% else %>
+      <span class="app-c-notice__title"><%= title %></span>
+    <% end %>
+
+    <% if description_text %>
       <p class="app-c-notice__description"><%= description_text %></p>
     <% end %>
-    <% if description_govspeak.present? %>
+
+    <% if description_govspeak %>
       <%= render 'govuk_component/govspeak', content: description_govspeak %>
     <% end %>
   </section>

--- a/app/views/components/docs/notice.yml
+++ b/app/views/components/docs/notice.yml
@@ -5,7 +5,10 @@ body: |
 
   The component accepts either a simple string description_text parameter that it wraps in a paragraph, or a description_govspeak parameter that is rendered through govspeak for more complex HTML layout.
 accessibility_criteria: |
-  The notice border colour must have a contrast ratio of more than 4.5:1 with its background to be visually distinct.
+  The notice must:
+
+  - have a border colour contrast ratio of more than 4.5:1 with its background to be visually distinct.
+  - always render headings with associated description content, so there are no isolated heading elements inside the component
 fixtures:
   default:
     title: 'Statistics release cancelled'

--- a/test/components/notice_test.rb
+++ b/test/components/notice_test.rb
@@ -46,4 +46,22 @@ class NoticeGovspeakTest < ActionDispatch::IntegrationTest
       assert_has_component_govspeak("<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel=\"external\" href=\"https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/\">www.ogauthority.co.uk</a></p>")
     end
   end
+
+  test "renders title as heading only if description present" do
+    visit '/component-guide/notice/with_description_text'
+
+    within '.component-guide-preview' do
+      assert page.has_selector?("h2.app-c-notice__title", text: "Statistics release cancelled")
+      assert page.has_selector?("p.app-c-notice__description", text: "Duplicate, added in error")
+    end
+  end
+
+  test "render title as paragraph if no description present" do
+    visit '/component-guide/notice/default'
+
+    within '.component-guide-preview' do
+      assert page.has_selector?("span.app-c-notice__title", text: "Statistics release cancelled")
+      assert page.has_no_selector?(".app-c-notice__description")
+    end
+  end
 end


### PR DESCRIPTION
The notice component was not accessible as headings were being used without any content following.
A check is now done to see if description is present before placing the title in a heading or paragraph.

Fixes issue #442