### PR TITLE
Test component guide

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'dalli'
 gem 'gds-api-adapters', '~> 43.0'
 gem 'govuk_ab_testing', '~> 2.0'
 gem 'govuk_frontend_toolkit', '5.1.0'
-gem 'govuk_publishing_components', '~> 0.7.0', require: ENV['RAILS_ENV'] != "production" || ENV['HEROKU_APP_NAME'].to_s.length.positive?
+gem 'govuk_publishing_components', '~> 0.9.0', require: ENV['RAILS_ENV'] != "production" || ENV['HEROKU_APP_NAME'].to_s.length.positive?
 gem 'htmlentities', '4.3.4'
 gem 'logstasher', '0.6.1'
 gem 'plek', '1.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       sass (>= 3.2.0)
     govuk_navigation_helpers (6.3.0)
       gds-api-adapters (>= 43.0)
-    govuk_publishing_components (0.7.0)
+    govuk_publishing_components (0.9.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
@@ -326,7 +326,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.0)
   govuk_frontend_toolkit (= 5.1.0)
   govuk_navigation_helpers (~> 6.3)
-  govuk_publishing_components (~> 0.7.0)
+  govuk_publishing_components (~> 0.9.0)
   govuk_schemas
   htmlentities (= 4.3.4)
   jasmine-rails!

--- a/app/views/components/_figure.html.erb
+++ b/app/views/components/_figure.html.erb
@@ -1,8 +1,8 @@
 <%
-  alt ||= false
+  alt ||= ''
   caption ||= false
 %>
 <figure class="app-c-figure">
-  <img class="app-c-figure__image" src="<%= src %>" <% if alt %>alt="<%= alt %>"<% end %>>
+  <img class="app-c-figure__image" src="<%= src %>" alt="<%= alt %>">
   <% if caption %><figcaption class="app-c-figure__figcaption"><%= caption %></figcaption><% end %>
 </figure>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,11 @@ Rails.application.configure do
 
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
+
+  # TODO: Re-enable tests to run against compiled assets with digests
+  #       Add a performant assets compilation step before tests run
+  # Don't depend on precompiled JS assets. We are not currently precompiling
+  # javascript before tests run. Meaning failing JS will not be detected
+  # in integration tests.
+  config.assets.digest = false
 end

--- a/test/components/all_components.rb
+++ b/test/components/all_components.rb
@@ -1,4 +1,4 @@
-require 'component_test_helper'
+require 'test_helper'
 
 # TODO: Move this logic to the GOVUK Publishing Components gem
 # and have the tests visit each component.

--- a/test/components/all_components.rb
+++ b/test/components/all_components.rb
@@ -6,13 +6,10 @@ class AllComponentsTest < ActionDispatch::IntegrationTest
   test "renders all component guide pages without erroring" do
     visit '/component-guide'
     components = all(:css, '.component-list a').map do |el|
-      {
-        text: el[:text],
-        href: el[:href]
-      }
+      "#{el[:href]}/preview"
     end
     components.each do |component|
-      visit component[:href] + '/preview'
+      visit component
     end
   end
 end

--- a/test/components/all_components.rb
+++ b/test/components/all_components.rb
@@ -1,0 +1,18 @@
+require 'component_test_helper'
+
+# TODO: Move this logic to the GOVUK Publishing Components gem
+# and have the tests visit each component.
+class AllComponentsTest < ActionDispatch::IntegrationTest
+  test "renders all component guide pages without erroring" do
+    visit '/component-guide'
+    components = all(:css, '.component-list a').map do |el|
+      {
+        text: el[:text],
+        href: el[:href]
+      }
+    end
+    components.each do |component|
+      visit component[:href] + '/preview'
+    end
+  end
+end


### PR DESCRIPTION
This PR prepares government-frontend to be able to pick up throw accessibility errors from the component guide.

Related PR: https://github.com/alphagov/govuk_publishing_components/pull/33