### PR TITLE
Improve translation navigation accessibility

### DIFF
--- a/app/assets/stylesheets/components/_translation-nav.scss
+++ b/app/assets/stylesheets/components/_translation-nav.scss
@@ -12,7 +12,7 @@
   margin-right: -$gutter-one-third;
 }
 
-.app-c-translation-nav__list__language {
+.app-c-translation-nav__list-item {
   float: left;
   padding-left: $gutter-one-third;
   padding-right: $gutter-one-third;
@@ -29,7 +29,7 @@
   }
 }
 
-.app-c-translation-nav__list__language:last-child {
+.app-c-translation-nav__list-item:last-child {
   border-right: 0;
   border-left: 0;
 }

--- a/app/views/components/_translation-nav.html.erb
+++ b/app/views/components/_translation-nav.html.erb
@@ -5,7 +5,7 @@
       <% translations.each.with_index do |translation, i| %>
         <li class="app-c-translation-nav__list-item">
           <% if translation[:active] %>
-            <%= translation[:text] %>
+            <span lang="<%= translation[:locale] %>"><%= translation[:text] %></span>
           <% else %>
             <%= link_to translation[:text], translation[:base_path], lang: translation[:locale], rel: "alternate" %>
           <% end %>

--- a/app/views/components/_translation-nav.html.erb
+++ b/app/views/components/_translation-nav.html.erb
@@ -7,7 +7,7 @@
           <% if translation[:active] %>
             <span lang="<%= translation[:locale] %>"><%= translation[:text] %></span>
           <% else %>
-            <%= link_to translation[:text], translation[:base_path], lang: translation[:locale], rel: "alternate" %>
+            <%= link_to translation[:text], translation[:base_path], hreflang: translation[:locale], lang: translation[:locale], rel: "alternate" %>
           <% end %>
         </li>
       <% end %>

--- a/app/views/components/_translation-nav.html.erb
+++ b/app/views/components/_translation-nav.html.erb
@@ -3,7 +3,7 @@
   <div class="app-c-translation-nav">
     <ul class="app-c-translation-nav__list">
       <% translations.each.with_index do |translation, i| %>
-        <li class="app-c-translation-nav__list__language">
+        <li class="app-c-translation-nav__list-item">
           <% if translation[:active] %>
             <%= translation[:text] %>
           <% else %>

--- a/app/views/components/_translation-nav.html.erb
+++ b/app/views/components/_translation-nav.html.erb
@@ -1,6 +1,6 @@
 <% translations ||= [] %>
 <% if translations.length > 1 %>
-  <div class="app-c-translation-nav">
+  <nav role="navigation" class="app-c-translation-nav">
     <ul class="app-c-translation-nav__list">
       <% translations.each.with_index do |translation, i| %>
         <li class="app-c-translation-nav__list-item">
@@ -12,5 +12,5 @@
         </li>
       <% end %>
     </ul>
-  </div>
+  </nav>
 <% end %>

--- a/app/views/components/_translation-nav.html.erb
+++ b/app/views/components/_translation-nav.html.erb
@@ -1,6 +1,6 @@
 <% translations ||= [] %>
 <% if translations.length > 1 %>
-  <nav role="navigation" class="app-c-translation-nav">
+  <nav role="navigation" class="app-c-translation-nav" aria-label="<%= t("common.translations") %>">
     <ul class="app-c-translation-nav__list">
       <% translations.each.with_index do |translation, i| %>
         <li class="app-c-translation-nav__list-item">

--- a/app/views/components/docs/translation-nav.yml
+++ b/app/views/components/docs/translation-nav.yml
@@ -2,6 +2,8 @@ name: Translation navigation
 description: A list of links to available translations
 body: The active property indicates the current language.
 accessibility_criteria: |
+  The component must be [a landmark with a navigation role](https://accessibility.blog.gov.uk/2016/05/27/using-navigation-landmarks/).
+
   The translation navigation links must:
 
   - identify the language of the link

--- a/app/views/components/docs/translation-nav.yml
+++ b/app/views/components/docs/translation-nav.yml
@@ -2,7 +2,10 @@ name: Translation navigation
 description: A list of links to available translations
 body: The active property indicates the current language.
 accessibility_criteria: |
-  The component must be [a landmark with a navigation role](https://accessibility.blog.gov.uk/2016/05/27/using-navigation-landmarks/).
+  The component must:
+
+  - be [a landmark with a navigation role](https://accessibility.blog.gov.uk/2016/05/27/using-navigation-landmarks/)
+  - have an accessible name in the current language, eg "Translations"
 
   The translation links must:
 
@@ -36,7 +39,7 @@ fixtures:
       active: true
     - locale: 'fr'
       base_path: '/fr'
-      text: 'French'
+      text: 'Français'
     - locale: 'hi'
       base_path: '/hi'
       text: 'हिंदी'

--- a/app/views/components/docs/translation-nav.yml
+++ b/app/views/components/docs/translation-nav.yml
@@ -4,9 +4,9 @@ body: The active property indicates the current language.
 accessibility_criteria: |
   The component must be [a landmark with a navigation role](https://accessibility.blog.gov.uk/2016/05/27/using-navigation-landmarks/).
 
-  The translation navigation links must:
+  The translation links must:
 
-  - identify the language of the link
+  - [identify the language of the text](https://www.w3.org/TR/UNDERSTANDING-WCAG20/meaning-other-lang-id.html#meaning-other-lang-id-examples-head)
   - accept focus
   - be focusable with a keyboard
   - indicate when it has focus

--- a/app/views/components/docs/translation-nav.yml
+++ b/app/views/components/docs/translation-nav.yml
@@ -10,6 +10,8 @@ accessibility_criteria: |
   The translation links must:
 
   - [identify the language of the text](https://www.w3.org/TR/UNDERSTANDING-WCAG20/meaning-other-lang-id.html#meaning-other-lang-id-examples-head)
+
+    [Watch a screen reader pronounce text differently based on lang attribute](https://bit.ly/screenreaderpronunciation)
   - accept focus
   - be focusable with a keyboard
   - indicate when it has focus

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
       short_ordinal: '%e %B %Y'
   common:
     last_updated: "Last updated"
+    translations: "Translations"
   language_names:
     ar: Arabic
     de: German

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,7 +88,6 @@ en:
       official:
         one: Official statistics announcement
         other: Official statistics announcements
-
       announcement:
         one: Announcement
         other: Announcements
@@ -267,6 +266,6 @@ en:
       avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to the whole country.
       avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all travel to the whole country.
   multi_page:
-      print_entire_guide: "Print entire guide"
-      previous_page: "Previous"
-      next_page: "Next"
+    print_entire_guide: "Print entire guide"
+    previous_page: "Previous"
+    next_page: "Next"

--- a/test/components/translation_nav_test.rb
+++ b/test/components/translation_nav_test.rb
@@ -5,6 +5,22 @@ class TranslationNavTest < ComponentTestCase
     "translation-nav"
   end
 
+  def multiple_translations
+    [
+      {
+        locale: 'en',
+        base_path: '/en',
+        text: 'English',
+        active: true
+      },
+      {
+        locale: 'hi',
+        base_path: '/hi',
+        text: 'हिंदी',
+      }
+    ]
+  end
+
   test "renders nothing when no translations are given" do
     assert_empty render_component({})
   end
@@ -23,52 +39,24 @@ class TranslationNavTest < ComponentTestCase
   end
 
   test "renders an active translation nav item with a text description" do
-    render_component(
-      translations: [
-        {
-          locale: 'en',
-          base_path: '/en',
-          text: 'English',
-          active: true
-        },
-        {
-          locale: 'hi',
-          base_path: '/hi',
-          text: 'हिंदी',
-        }
-      ]
-    )
+    render_component(translations: multiple_translations)
 
-    assert_select ".app-c-translation-nav__list__language", text: "English"
+    assert_select ".app-c-translation-nav__list-item", text: "English"
 
-    assert_select ".app-c-translation-nav__list__language a[lang=\"hi\"]", text: "हिंदी"
-    assert_select ".app-c-translation-nav__list__language a[href=\"/hi\"]"
+    assert_select ".app-c-translation-nav__list-item a[lang=\"hi\"]", text: "हिंदी"
+    assert_select ".app-c-translation-nav__list-item a[href=\"/hi\"]"
   end
 
   test "does not render an active translation item with a link" do
-    render_component(
-      translations: [
-        {
-          locale: 'en',
-          base_path: '/en',
-          text: 'English',
-          active: true
-        },
-        {
-          locale: 'hi',
-          base_path: '/hi',
-          text: 'हिंदी',
-        }
-      ]
-    )
+    render_component(translations: multiple_translations)
 
-    assert_select ".app-c-translation-nav__list__language", text: "English"
-    assert_select ".app-c-translation-nav__list__language a[href=\"/en\"]",
+    assert_select ".app-c-translation-nav__list-item", text: "English"
+    assert_select ".app-c-translation-nav__list-item a[href=\"/en\"]",
       false, "An active item should not link to a page translation"
 
 
-    assert_select ".app-c-translation-nav__list__language a[lang=\"hi\"]", text: "हिंदी"
-    assert_select ".app-c-translation-nav__list__language a[href=\"/hi\"]"
+    assert_select ".app-c-translation-nav__list-item a[lang=\"hi\"]", text: "हिंदी"
+    assert_select ".app-c-translation-nav__list-item a[href=\"/hi\"]"
   end
 
   test "renders an inactive translation nav item with locale, base path and text" do
@@ -93,14 +81,14 @@ class TranslationNavTest < ComponentTestCase
       ]
     )
 
-    assert_select ".app-c-translation-nav__list__language a[lang=\"fr\"]", text: "French"
-    assert_select ".app-c-translation-nav__list__language a[href=\"/fr\"]"
+    assert_select ".app-c-translation-nav__list-item a[lang=\"fr\"]", text: "French"
+    assert_select ".app-c-translation-nav__list-item a[href=\"/fr\"]"
 
-    assert_select ".app-c-translation-nav__list__language a[lang=\"zh\"]", text: "中文"
-    assert_select ".app-c-translation-nav__list__language a[href=\"/zh\"]"
+    assert_select ".app-c-translation-nav__list-item a[lang=\"zh\"]", text: "中文"
+    assert_select ".app-c-translation-nav__list-item a[href=\"/zh\"]"
 
-    assert_select ".app-c-translation-nav__list__language", text: "हिंदी"
-    assert_select ".app-c-translation-nav__list__language a[href=\"/hi\"]",
+    assert_select ".app-c-translation-nav__list-item", text: "हिंदी"
+    assert_select ".app-c-translation-nav__list-item a[href=\"/hi\"]",
       false, "An active item should not link to a page translation"
   end
 end

--- a/test/components/translation_nav_test.rb
+++ b/test/components/translation_nav_test.rb
@@ -64,4 +64,9 @@ class TranslationNavTest < ComponentTestCase
     render_component(translations: multiple_translations)
     assert_select "a[hreflang='hi']", text: "हिंदी"
   end
+
+  test "is labelled as translation navigation" do
+    render_component(translations: multiple_translations)
+    assert_select "nav[role='navigation'][aria-label='Translations']"
+  end
 end

--- a/test/components/translation_nav_test.rb
+++ b/test/components/translation_nav_test.rb
@@ -47,6 +47,12 @@ class TranslationNavTest < ComponentTestCase
     assert_select ".app-c-translation-nav__list-item a[href=\"/hi\"]"
   end
 
+  test "identifies the language of the text" do
+    render_component(translations: multiple_translations)
+    assert_select "span[lang='en']", text: "English"
+    assert_select "a[lang='hi']", text: "हिंदी"
+  end
+
   test "does not render an active translation item with a link" do
     render_component(translations: multiple_translations)
 

--- a/test/components/translation_nav_test.rb
+++ b/test/components/translation_nav_test.rb
@@ -59,4 +59,9 @@ class TranslationNavTest < ComponentTestCase
     assert_select "span[lang='en']", text: "English"
     assert_select "a[lang='hi']", text: "हिंदी"
   end
+
+  test "identifies the language of the target page" do
+    render_component(translations: multiple_translations)
+    assert_select "a[hreflang='hi']", text: "हिंदी"
+  end
 end

--- a/test/components/translation_nav_test.rb
+++ b/test/components/translation_nav_test.rb
@@ -38,63 +38,25 @@ class TranslationNavTest < ComponentTestCase
     )
   end
 
-  test "renders an active translation nav item with a text description" do
+  test "renders all items in a list" do
     render_component(translations: multiple_translations)
+    assert_select ".app-c-translation-nav__list-item", count: multiple_translations.length
+  end
 
-    assert_select ".app-c-translation-nav__list-item", text: "English"
+  test "renders an active item as text without a link" do
+    render_component(translations: multiple_translations)
+    assert_select ".app-c-translation-nav__list-item :not(a)", text: "English"
+    assert_select "a[href=\"/en\"]", false, "An active item should not be a link"
+  end
 
-    assert_select ".app-c-translation-nav__list-item a[lang=\"hi\"]", text: "हिंदी"
-    assert_select ".app-c-translation-nav__list-item a[href=\"/hi\"]"
+  test "renders inactive items as a link with locale, base path and text" do
+    render_component(translations: multiple_translations)
+    assert_select ".app-c-translation-nav__list-item a[lang='hi'][href='/hi']", text: "हिंदी"
   end
 
   test "identifies the language of the text" do
     render_component(translations: multiple_translations)
     assert_select "span[lang='en']", text: "English"
     assert_select "a[lang='hi']", text: "हिंदी"
-  end
-
-  test "does not render an active translation item with a link" do
-    render_component(translations: multiple_translations)
-
-    assert_select ".app-c-translation-nav__list-item", text: "English"
-    assert_select ".app-c-translation-nav__list-item a[href=\"/en\"]",
-      false, "An active item should not link to a page translation"
-
-
-    assert_select ".app-c-translation-nav__list-item a[lang=\"hi\"]", text: "हिंदी"
-    assert_select ".app-c-translation-nav__list-item a[href=\"/hi\"]"
-  end
-
-  test "renders an inactive translation nav item with locale, base path and text" do
-    render_component(
-      translations: [
-        {
-          locale: 'fr',
-          base_path: '/fr',
-          text: 'French',
-        },
-        {
-          locale: 'hi',
-          base_path: '/hi',
-          text: 'हिंदी',
-          active: true
-        },
-        {
-          locale: 'zh',
-          base_path: '/zh',
-          text: '中文'
-        }
-      ]
-    )
-
-    assert_select ".app-c-translation-nav__list-item a[lang=\"fr\"]", text: "French"
-    assert_select ".app-c-translation-nav__list-item a[href=\"/fr\"]"
-
-    assert_select ".app-c-translation-nav__list-item a[lang=\"zh\"]", text: "中文"
-    assert_select ".app-c-translation-nav__list-item a[href=\"/zh\"]"
-
-    assert_select ".app-c-translation-nav__list-item", text: "हिंदी"
-    assert_select ".app-c-translation-nav__list-item a[href=\"/hi\"]",
-      false, "An active item should not link to a page translation"
   end
 end

--- a/test/integration/news_article_test.rb
+++ b/test/integration/news_article_test.rb
@@ -34,8 +34,8 @@ class NewsArticleTest < ActionDispatch::IntegrationTest
   test "renders translation links when there is more than one translation" do
     setup_and_visit_content_item("news_article")
 
-    assert page.has_css?("div[class='app-c-translation-nav']")
-    assert page.has_css?("li[class='app-c-translation-nav__list__language']")
+    assert page.has_css?(".app-c-translation-nav")
+    assert page.has_css?(".app-c-translation-nav__list-item")
     assert page.has_link?("ردو", href: "/government/news/christmas-2016-prime-ministers-message.ur")
   end
 

--- a/test/integration/world_location_news_article_test.rb
+++ b/test/integration/world_location_news_article_test.rb
@@ -33,9 +33,8 @@ class WorldLocationNewsArticleTest < ActionDispatch::IntegrationTest
   test "renders translation links when there is more than one translation" do
     setup_and_visit_content_item("world_location_news_article_with_multiple_translations")
 
-    assert page.has_css?("div[class='app-c-translation-nav']")
-
-    assert page.has_css?("li[class='app-c-translation-nav__list__language']")
+    assert page.has_css?(".app-c-translation-nav")
+    assert page.has_css?(".app-c-translation-nav__list-item")
 
     assert page.has_content?("English हिंदी 日本語 中文 中文")
 


### PR DESCRIPTION
Best reviewed commit by commit.

https://government-frontend-pr-453.herokuapp.com/component-guide/translation-nav

* Switch to a nav element with an aria-label that can be translated (we don't have translations yet)
* Include the lang element on the currently active navigation element as a precaution
* Add links to WCAG for providing lang context and link to example video of pronunciation
* Include tests for each accessibility change to avoid regressions

Also includes some small cleanups:
* removes double double underscore from BEM
* simplifies tests
* whitespace in locale file
* tweak to fixture input (Français)

Fixes #443 