### PR TITLE
Raise errors for missing translations in dev and test

### DIFF
--- a/app/views/content_items/publication.html+new_navigation.erb
+++ b/app/views/content_items/publication.html+new_navigation.erb
@@ -18,14 +18,14 @@
     <%= render 'shared/history_notice', content_item: @content_item %>
     <%= render 'components/lead-paragraph', text: @content_item.description %>
 
-    <%= render 'components/heading', text: t("publications.documents", count: @content_item.documents_count), id: "documents-title" %>
+    <%= render 'components/heading', text: t("publication.documents", count: @content_item.documents_count), id: "documents-title" %>
     <div aria-labelledby="documents-title">
       <%= render 'govuk_component/govspeak',
                  content: @content_item.documents,
                  direction: page_text_direction %>
     </div>
 
-    <%= render 'components/heading', text: t("publications.details"), id: "details-title" %>
+    <%= render 'components/heading', text: t("publication.details"), id: "details-title" %>
 
     <div aria-labelledby="details-title">
       <%= render 'govuk_component/govspeak',

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -20,7 +20,7 @@
 
 <div class="grid-row sidebar-with-body">
   <div class="column-third">
-    <%= render 'components/heading', text: t("publications.documents", count: @content_item.documents_count), id: "documents-title" %>
+    <%= render 'components/heading', text: t("publication.documents", count: @content_item.documents_count), id: "documents-title" %>
   </div>
   <div class="column-two-thirds" aria-labelledby="documents-title">
     <%= render 'govuk_component/govspeak',
@@ -31,7 +31,7 @@
 
 <div class="grid-row sidebar-with-body">
   <div class="column-third">
-    <%= render 'components/heading', text: t("publications.details"), id: "details-title" %>
+    <%= render 'components/heading', text: t("publication.details"), id: "details-title" %>
   </div>
   <div class="column-two-thirds" aria-labelledby="details-title">
     <%= render 'govuk_component/govspeak',

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,5 +38,5 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
Raise errors for missing translations in dev and test

* Catch missing translations
* Fix incorrect reference to translation: Change `publication` to `publications`