### PR TITLE
Include withdrawn notice on corporate info pages

### DIFF
--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -7,6 +7,7 @@
     </div>
   </div>
   <%= render 'shared/title_and_translations', content_item: @content_item %>
+  <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
   <%= render 'components/lead-paragraph', text: @content_item.description %>
 
   <% @additional_body = capture do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,9 @@ en:
       consultation_outcome:
         one: Consultation outcome
         other: Consultation outcomes
+      corporate_information_page:
+        one: Information page
+        other: Information pages
       corporate_report:
         one: Corporate report
         other: Corporate reports

--- a/test/integration/corporate_information_page_test.rb
+++ b/test/integration/corporate_information_page_test.rb
@@ -86,4 +86,18 @@ class CorporateInformationPageTest < ActionDispatch::IntegrationTest
       }
     )
   end
+
+  test 'renders a withdrawal notice on withdrawn page' do
+    content_item = GovukSchemas::Example.find('corporate_information_page', example_name: 'corporate_information_page')
+    content_item['withdrawn_notice'] = {
+      'explanation': 'This is out of date',
+      'withdrawn_at': '2014-08-09T11:39:05Z'
+    }
+    content_store_has_item("/government/organisations/department-of-health/about", content_item.to_json)
+
+    visit "/government/organisations/department-of-health/about"
+
+    assert page.has_css?(".app-c-notice__title", text: "This information page was withdrawn on 9 August 2014")
+    assert page.has_css?(".app-c-notice", text: "This is out of date")
+  end
 end


### PR DESCRIPTION
Withdrawal notices are now included on corporate information pages when the content_item includes withdrawn_notice data.

**Before:**
![screen shot 2017-08-22 at 11 47 13](https://user-images.githubusercontent.com/29889908/29562077-d01fb2b8-872f-11e7-83c2-4113107cc01d.png)

**After:**
![screen shot 2017-08-22 at 11 47 25](https://user-images.githubusercontent.com/29889908/29562090-d9cee8b0-872f-11e7-9a5f-5b5bf7105961.png)

Examples of withdrawn corporate information pages:

- [Monitor Media Enquiries](https://www.gov.uk/government/organisations/monitor/about/media-enquiries)
- [Highways Agency About Page](https://www.gov.uk/government/organisations/highways-agency/about)
- [DSA Statistics](https://www.gov.uk/government/organisations/driving-standards-agency/about/statistics)
