### PR TITLE
Change path for world locations

### DIFF
--- a/app/services/world_location_base_path.rb
+++ b/app/services/world_location_base_path.rb
@@ -3,7 +3,7 @@
 #following problems have arisen that this approach temporarily solves:
 #
 # * we require world locations to be associated with content in Whitehall
-#   for email subscriptionas to work so we can't just get rid of them
+#   for email subscriptions to work so we can't just get rid of them
 # * we also need them as not all content will be part of the taxonomy
 #   (e.g. news about the country)
 # * the taxon will take the base path (/world/<country-slug>) and so the
@@ -15,10 +15,10 @@
 #
 #A slightly better solution will be for Whitehall to retrieve the taxon path from
 #publishing API and send that with the world location link as an additional field
-#in the links. We'll need the taxonomy to exist in order to implement this. Thiw
+#in the links. We'll need the taxonomy to exist in order to implement this. This
 #will still require frontend code to know about the links but will be similar
 #to prior art we have for some links to be affected by elements with `detail`.
-#
+
 class WorldLocationBasePath
   EXCEPTIONAL_CASES = {
     "Democratic Republic of Congo" => "democratic-republic-of-congo",
@@ -32,10 +32,9 @@ class WorldLocationBasePath
       title = world_location_link["title"]
       return base_path if base_path.present?
 
-      slug = EXCEPTIONAL_CASES[title] ||
-        title.parameterize
+      slug = EXCEPTIONAL_CASES[title] || title.parameterize
 
-      "/world/#{slug}"
+      "/world/#{slug}/news"
     end
   end
 end

--- a/test/integration/case_study_test.rb
+++ b/test/integration/case_study_test.rb
@@ -30,7 +30,7 @@ class CaseStudyTest < ActionDispatch::IntegrationTest
   test "world location part of link" do
     setup_and_visit_content_item('translated')
 
-    part_of = "<a href=\"/world/spain\">Spain</a>"
+    part_of = "<a href=\"/world/spain/news\">Spain</a>"
 
     assert_has_component_metadata_pair("part_of", [part_of])
     assert_has_component_document_footer_pair("part_of", [part_of])

--- a/test/integration/world_location_news_article_test.rb
+++ b/test/integration/world_location_news_article_test.rb
@@ -18,7 +18,7 @@ class WorldLocationNewsArticleTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('world_location_news_article')
 
     from = "<a href=\"/government/world/organisations/british-high-commission-nairobi\">British High Commission Nairobi</a>"
-    part_of = "<a href=\"/world/kenya\">Kenya</a>"
+    part_of = "<a href=\"/world/kenya/news\">Kenya</a>"
 
     assert_has_component_metadata_pair("first_published", "24 November 2015")
     assert_has_component_document_footer_pair("published", "24 November 2015")

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -62,7 +62,7 @@ class CaseStudyPresenterTest < PresenterTestCase
     expected_part_of_links = [
       link_to('Work Programme real life stories', '/government/collections/work-programme-real-life-stories'),
       link_to('Cheese', '/policy/cheese'),
-      link_to('Pakistan', '/world/pakistan'),
+      link_to('Pakistan', '/world/pakistan/news'),
     ]
     assert_equal expected_part_of_links, presented_item(schema_name, with_extras).part_of
   end

--- a/test/services/world_location_base_path_test.rb
+++ b/test/services/world_location_base_path_test.rb
@@ -11,11 +11,11 @@ class WorldLocationBasePathWhenPathExists < ActiveSupport::TestCase
 end
 
 class WorldLocationBasePathWithoutBasePath < ActiveSupport::TestCase
-  test "returns /world/usa" do
+  test "returns /world/usa/news" do
     link = {
       "title" => "USA"
     }
-    assert_equal "/world/usa", WorldLocationBasePath.for(link)
+    assert_equal "/world/usa/news", WorldLocationBasePath.for(link)
   end
 end
 
@@ -25,11 +25,11 @@ class WorldLocationBasePathForExceptionalCase < ActiveSupport::TestCase
    "South Georgia and the South Sandwich Islands" => "south-georgia-and-the-south-sandwich-islands",
    "St Pierre & Miquelon" => "st-pierre-miquelon"
   }.each do |title, expected_slug|
-    test "returns /government/world/#{expected_slug}" do
+    test "returns /world/#{expected_slug}/news" do
       link = {
         "title" => title
       }
-      assert_equal "/world/#{expected_slug}", WorldLocationBasePath.for(link)
+      assert_equal "/world/#{expected_slug}/news", WorldLocationBasePath.for(link)
     end
   end
 end


### PR DESCRIPTION
This commit changes the generated path for world locations to point to `/world/location/news` since most things tagged to a world location and rendered by government-frontend are things that would appear on the world location news page.

Trello: https://trello.com/c/9RRoTUXO/128-change-world-location-path-in-government-frontend-to-world-location-news