### PR TITLE
Add current_path to the survey link in the beta banner

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,6 +14,10 @@ module ApplicationHelper
     active_proposition_mapping.fetch(active, active)
   end
 
+  def current_path_without_query_string
+    request.original_fullpath.split("?", 2).first
+  end
+
 private
 
   def active_proposition_mapping

--- a/app/views/shared/_breadcrumbs.html+new_navigation.erb
+++ b/app/views/shared/_breadcrumbs.html+new_navigation.erb
@@ -6,7 +6,7 @@
         message: <<-MESSAGE
         This is a test version of the layout of this page.
         <a id=taxonomy-survey
-           href='https://www.smartsurvey.co.uk/s/betasurvey2017'
+           href='https://www.smartsurvey.co.uk/s/betasurvey2017?c=#{current_path_without_query_string}'
            target='_blank'
            rel='noopener noreferrer'>
           Take the survey to help us improve it

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  tests ApplicationHelper
+
+  test "#current_path_without_query_string returns the path of the current request" do
+    self.stubs(:request).returns(ActionDispatch::TestRequest.create("PATH_INFO" => '/foo/bar'))
+    assert_equal '/foo/bar', current_path_without_query_string
+  end
+
+  test "#current_path_without_query_string returns the path of the current request stripping off any query string parameters" do
+    self.stubs(:request).returns(ActionDispatch::TestRequest.create("PATH_INFO" => '/foo/bar', "QUERY_STRING" => 'ham=jam&spam=gram'))
+    assert_equal '/foo/bar', current_path_without_query_string
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/Bo5SQrIm/215-add-page-tracking-custom-dimension-into-education-beta-survey-banner

This lets the survey team know where each response has come from and
allows them to filter by section of the site.