### PR TITLE
Add right to left styles to detailed guides

### DIFF
--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -2,6 +2,11 @@
   @include sidebar-with-body;
   @include taxonomy-sidebar;
 
+  .direction-rtl & {
+    direction: rtl;
+    text-align: start;
+  }
+
   .related-mainstream-content {
     background: $panel-colour;
     padding: $gutter-half;


### PR DESCRIPTION
Fixes the mixture of rtl and ltr alignment currently showing.

https://trello.com/c/Rew0qb06/116-arabic-translation-template-issue-1

See:
https://www.gov.uk/guidance/mod-decisions-on-alleged-human-rights-breaches-during-operation-telic.ar
https://government-frontend-pr-464.herokuapp.com/guidance/mod-decisions-on-alleged-human-rights-breaches-during-operation-telic.ar

## Before
![screen shot 2017-08-25 at 17 20 04](https://user-images.githubusercontent.com/319055/29722716-bf1ad7ae-89b9-11e7-9948-23e9a204a716.png)

## After
![screen shot 2017-08-25 at 17 19 56](https://user-images.githubusercontent.com/319055/29722715-bf135e3e-89b9-11e7-85f3-02e5e1ce0160.png)