### PR TITLE
Add right to left and HTML examples to component guide

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'dalli'
 gem 'gds-api-adapters', '~> 43.0'
 gem 'govuk_ab_testing', '~> 2.0'
 gem 'govuk_frontend_toolkit', '5.1.0'
-gem 'govuk_publishing_components', '~> 0.9.0', require: ENV['RAILS_ENV'] != "production" || ENV['HEROKU_APP_NAME'].to_s.length.positive?
+gem 'govuk_publishing_components', '~> 1.0.0', require: ENV['RAILS_ENV'] != "production" || ENV['HEROKU_APP_NAME'].to_s.length.positive?
 gem 'htmlentities', '4.3.4'
 gem 'logstasher', '0.6.1'
 gem 'plek', '1.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       sass (>= 3.2.0)
     govuk_navigation_helpers (6.3.0)
       gds-api-adapters (>= 43.0)
-    govuk_publishing_components (0.9.0)
+    govuk_publishing_components (1.0.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
@@ -326,7 +326,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.0)
   govuk_frontend_toolkit (= 5.1.0)
   govuk_navigation_helpers (~> 6.3)
-  govuk_publishing_components (~> 0.9.0)
+  govuk_publishing_components (~> 1.0.0)
   govuk_schemas
   htmlentities (= 4.3.4)
   jasmine-rails!

--- a/app/assets/stylesheets/components/_contents-list.scss
+++ b/app/assets/stylesheets/components/_contents-list.scss
@@ -40,6 +40,11 @@
   &:before {
     content: "— ";
     margin-left: -$contents-spacing;
+
+    .direction-rtl & {
+      margin-left: 0;
+      margin-right: -$contents-spacing;
+    }
   }
 
   // Focus styles on IE8 and older include the

--- a/app/views/components/docs/banner.yml
+++ b/app/views/components/docs/banner.yml
@@ -10,13 +10,16 @@ accessibility_criteria: |
   - be visually distinct from other content on the page
   - have an accessible name that describes the banner as a notice
   - have a text contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
-fixtures:
+examples:
   default:
-    text: 'This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government'
+    data:
+      text: 'This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government'
   banner_with_title:
-    title: 'Summary'
-    text: 'This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government'
+    data:
+      title: 'Summary'
+      text: 'This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government'
   banner_with_aside:
-    title: 'Summary'
-    text: 'This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government'
-    aside: 'This consultation ran from 9:30am on 30 January 2017 to 5pm on 28 February 2017'
+    data:
+      title: 'Summary'
+      text: 'This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government'
+      aside: 'This consultation ran from 9:30am on 30 January 2017 to 5pm on 28 February 2017'

--- a/app/views/components/docs/banner.yml
+++ b/app/views/components/docs/banner.yml
@@ -13,13 +13,21 @@ accessibility_criteria: |
 examples:
   default:
     data:
+      text: 'Text in a banner'
+  history_banner:
+    data:
       text: 'This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government'
   banner_with_title:
     data:
       title: 'Summary'
-      text: 'This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government'
+      text: 'We are seeking external users’ views on a series of options for either reducing the scope of the annual Defence Inflation Estimates publication or ceasing it completely.'
   banner_with_aside:
+    data:
+      title: 'Title'
+      text: 'Text'
+      aside: 'Aside'
+  consultation:
     data:
       title: 'Summary'
       text: 'This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government'
-      aside: 'This consultation ran from 9:30am on 30 January 2017 to 5pm on 28 February 2017'
+      aside: 'This consultation ran from<br><span class="consultation-date"><time datetime="2017-06-13T09:30:00.000+01:00">9:30am on 13 June 2017</time> to <time datetime="2017-07-11T23:45:00.000+01:00">11:45pm on 11 July 2017</time></span>'

--- a/app/views/components/docs/contents-list.yml
+++ b/app/views/components/docs/contents-list.yml
@@ -29,86 +29,92 @@ accessibility_criteria: |
   - have visible text
 
   Links with formatted numbers must separate the number and text with a space for correct screen reader pronunciation. This changes pronunciation from "1 dot Item" to "1 Item".
-fixtures:
+examples:
   default:
-    contents:
-      - href: "#first-thing"
-        text: First thing
-      - href: "#second-thing"
-        text: Second thing
-      - href: "#third-thing"
-        text: Third thing
+    data:
+      contents:
+        - href: "#first-thing"
+          text: First thing
+        - href: "#second-thing"
+          text: Second thing
+        - href: "#third-thing"
+          text: Third thing
   long_text:
-    contents:
-      - href: "#first-thing"
-        text: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-      - href: "#second-thing"
-        text: Another pretty long contents list entry, not as long as the first, but still a little.
-      - href: "#third-thing"
-        text: Third thing
+    data:
+      contents:
+        - href: "#first-thing"
+          text: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        - href: "#second-thing"
+          text: Another pretty long contents list entry, not as long as the first, but still a little.
+        - href: "#third-thing"
+          text: Third thing
   nested_contents_lists:
-    contents:
-      - href: "#first-thing"
-        text: First thing
-      - href: "#second-thing"
-        text: Second thing
-      - href: "#third-thing"
-        text: Third thing
-        items:
-          - href: "#sub-third-thing"
-            text: Sub third thing
-          - href: "#another-third-thing"
-            text: Another third thing
-      - href: "#fourth-thing"
-        text: Fourth thing
+    data:
+      contents:
+        - href: "#first-thing"
+          text: First thing
+        - href: "#second-thing"
+          text: Second thing
+        - href: "#third-thing"
+          text: Third thing
+          items:
+            - href: "#sub-third-thing"
+              text: Sub third thing
+            - href: "#another-third-thing"
+              text: Another third thing
+        - href: "#fourth-thing"
+          text: Fourth thing
   formats_numbers:
-    format_numbers: true
-    contents:
-      - href: "#first-thing"
-        text: 1. First thing
-      - href: "#second-thing"
-        text: 2. Second thing
-      - href: "#third-thing"
-        text: 3. Third thing
+    data:
+      format_numbers: true
+      contents:
+        - href: "#first-thing"
+          text: 1. First thing
+        - href: "#second-thing"
+          text: 2. Second thing
+        - href: "#third-thing"
+          text: 3. Third thing
   formats_complex_numbers:
-    format_numbers: true
-    contents:
-      - href: "#"
-        text: 1. Item
-      - href: "#"
-        text: 1.1 Sub item
-      - href: "#"
-        text: 1.2 Sub item
-      - href: "#"
-        text: "1.02 longer decimals allowed"
-      - href: "#"
-        text: "1.021 even longer decimals ignored"
-      - href: "#"
-        text: 1 Number without period
-      - href: "#"
-        text: 10. Two digit numbers
-      - href: "#"
-        text: 99. Two digit numbers
-      - href: "#"
-        text: 100. Three digit numbers
-      - href: "#"
-        text: 2017 four digit numbers ignored
-      - href: "#"
-        text: "2001: A space odyssey"
+    data:
+      format_numbers: true
+      contents:
+        - href: "#"
+          text: 1. Item
+        - href: "#"
+          text: 1.1 Sub item
+        - href: "#"
+          text: 1.2 Sub item
+        - href: "#"
+          text: "1.02 longer decimals allowed"
+        - href: "#"
+          text: "1.021 even longer decimals ignored"
+        - href: "#"
+          text: 1 Number without period
+        - href: "#"
+          text: 10. Two digit numbers
+        - href: "#"
+          text: 99. Two digit numbers
+        - href: "#"
+          text: 100. Three digit numbers
+        - href: "#"
+          text: 2017 four digit numbers ignored
+        - href: "#"
+          text: "2001: A space odyssey"
   nested_with_formatted_numbers:
-    format_numbers: true
-    contents:
-      - href: "#first-thing"
-        text: 1. First thing
-        items:
-        - href: "#second-thing"
-          text: 2. Numbers not parsed
-        - href: "#third-thing"
-          text: 3. Numbers are just text
-      - href: "#first-thing"
-        text: 2. Next thing
-        items:
-        - href: "#second-thing"
-          text: No numbers here
-        - href: "#third-thing"
-          text: None here either
+    data:
+      format_numbers: true
+      contents:
+        - href: "#first-thing"
+          text: 1. First thing
+          items:
+          - href: "#second-thing"
+            text: 2. Numbers not parsed
+          - href: "#third-thing"
+            text: 3. Numbers are just text
+        - href: "#first-thing"
+          text: 2. Next thing
+          items:
+          - href: "#second-thing"
+            text: No numbers here
+          - href: "#third-thing"
+            text: None here either

--- a/app/views/components/docs/contents-list.yml
+++ b/app/views/components/docs/contents-list.yml
@@ -118,3 +118,44 @@ examples:
             text: No numbers here
           - href: "#third-thing"
             text: None here either
+  right_to_left:
+    data:
+      contents:
+        - href: "#section"
+          text: "هل يمكنك تقديم"
+        - href: "#section-1"
+          text: "أعد مستند"
+        - href: "#section-2"
+          text: "تقديم الطلب"
+    context:
+      right_to_left: true
+  right_to_left_with_formatted_numbers:
+    data:
+      format_numbers: true
+      contents:
+        - href: "#section"
+          text: "هل يمكنك تقديم"
+        - href: "#section-1"
+          text: "أعد مستند"
+        - href: "#section-2"
+          text: "تقديم الطلب"
+    context:
+      right_to_left: true
+  right_to_left_with_nested_contents_lists:
+    data:
+      contents:
+        - href: "#section"
+          text: "هل يمكنك تقديم"
+        - href: "#section-1"
+          text: "أعد مستند"
+        - href: "#section-2"
+          text: "تقديم الطلب"
+          items:
+            - href: "#section"
+              text: "هل يمكنك تقديم"
+            - href: "#section-1"
+              text: "أعد مستند"
+            - href: "#section-2"
+              text: "تقديم الطلب"
+    context:
+      right_to_left: true

--- a/app/views/components/docs/document-list.yml
+++ b/app/views/components/docs/document-list.yml
@@ -27,52 +27,54 @@ accessibility_criteria: |
   * be usable with touch
   * be usable with speech
   * have visible text
-fixtures:
+examples:
   default:
-    items:
-    - link:
-        text: 'Alternative provision'
-        path: '/government/publications/alternative-provision'
-      metadata:
-        public_updated_at: 2016-06-27 10:29:44
-        document_type: 'statutory_guidance'
-    - link:
-        text: 'Behaviour and discipline in schools: guide for governing bodies'
-        path: '/government/publications/behaviour-and-discipline-in-schools-guidance-for-governing-bodies'
-      metadata:
-        public_updated_at: 2015-09-24 16:42:48
-        document_type: 'statutory_guidance'
-    - link:
-        text: 'Children missing education'
-        path: '/government/publications/children-missing-education'
-      metadata:
-        public_updated_at: 2016-09-05 16:48:27
-        document_type: 'statutory_guidance'
+    data:
+      items:
+      - link:
+          text: 'Alternative provision'
+          path: '/government/publications/alternative-provision'
+        metadata:
+          public_updated_at: 2016-06-27 10:29:44
+          document_type: 'statutory_guidance'
+      - link:
+          text: 'Behaviour and discipline in schools: guide for governing bodies'
+          path: '/government/publications/behaviour-and-discipline-in-schools-guidance-for-governing-bodies'
+        metadata:
+          public_updated_at: 2015-09-24 16:42:48
+          document_type: 'statutory_guidance'
+      - link:
+          text: 'Children missing education'
+          path: '/government/publications/children-missing-education'
+        metadata:
+          public_updated_at: 2016-09-05 16:48:27
+          document_type: 'statutory_guidance'
   with_data_attributes_on_links:
-    items:
-    - link:
-        text: 'School behaviour and attendance: parental responsibility measures'
-        path: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
-        data_attributes:
-          track_category: 'navDocumentCollectionLinkClicked'
-          track_action: 1.1
-          track_label: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
-          track_options:
-            dimension28: 2
-            dimension29: 'School behaviour and attendance: parental responsibility measures'
-      metadata:
-        public_updated_at: 2017-01-05 14:50:33
-        document_type: 'statutory_guidance'
-    - link:
-        text: 'School exclusion'
-        path: '/government/publications/school-exclusion'
-        data_attributes:
-          track_category: 'navDocumentCollectionLinkClicked'
-          track_action: 1.2
-          track_label: '/government/publications/school-exclusion'
-          track_options:
-            dimension28: 2
-            dimension29: 'School exclusion'
-      metadata:
-        public_updated_at: 2017-07-19 15:01:48
-        document_type: 'statutory_guidance'
+    data:
+      items:
+      - link:
+          text: 'School behaviour and attendance: parental responsibility measures'
+          path: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+          data_attributes:
+            track_category: 'navDocumentCollectionLinkClicked'
+            track_action: 1.1
+            track_label: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+            track_options:
+              dimension28: 2
+              dimension29: 'School behaviour and attendance: parental responsibility measures'
+        metadata:
+          public_updated_at: 2017-01-05 14:50:33
+          document_type: 'statutory_guidance'
+      - link:
+          text: 'School exclusion'
+          path: '/government/publications/school-exclusion'
+          data_attributes:
+            track_category: 'navDocumentCollectionLinkClicked'
+            track_action: 1.2
+            track_label: '/government/publications/school-exclusion'
+            track_options:
+              dimension28: 2
+              dimension29: 'School exclusion'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'statutory_guidance'

--- a/app/views/components/docs/download-link.yml
+++ b/app/views/components/docs/download-link.yml
@@ -18,9 +18,11 @@ accessibility_criteria: |
   The download icon must:
 
   - be presentational and ignored by screen readers
-fixtures:
+examples:
   default:
-    href: '/download-this'
+    data:
+      href: '/download-this'
   custom_link_text:
-    href: '/download-map'
-    link_text: 'Download Map (PDF)'
+    data:
+      href: '/download-map'
+      link_text: 'Download Map (PDF)'

--- a/app/views/components/docs/figure.yml
+++ b/app/views/components/docs/figure.yml
@@ -25,3 +25,10 @@ examples:
       src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
       alt: 'An image of the lords chamber'
       caption: 'The Lords Chamber'
+  right_to_left_with_caption:
+    data:
+      src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/31637/s300_Visas_-_Website.jpg'
+      alt: 'تأشيرات'
+      caption: 'تأشيرات'
+    context:
+      right_to_left: true

--- a/app/views/components/docs/figure.yml
+++ b/app/views/components/docs/figure.yml
@@ -12,13 +12,16 @@ accessibility_criteria: |
 
   - provide an informative text description, as alt text or caption
 
-fixtures:
+examples:
   default:
-    src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
+    data:
+      src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
   figure_with_alt_text:
-    src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
-    alt: 'An image of the lords chamber'
+    data:
+      src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
+      alt: 'An image of the lords chamber'
   figure_with_caption:
-    src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
-    alt: 'An image of the lords chamber'
-    caption: 'The Lords Chamber'
+    data:
+      src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/54374/s630_the_lords_chamber.jpg'
+      alt: 'An image of the lords chamber'
+      caption: 'The Lords Chamber'

--- a/app/views/components/docs/heading.yml
+++ b/app/views/components/docs/heading.yml
@@ -17,6 +17,11 @@ examples:
   default:
     data:
       text: 'Download the full outcome'
+  right_to_left:
+    data:
+      text: 'مستندات'
+    context:
+      right_to_left: true
   with_id_attribute:
     data:
       text: 'Detail of outcome'

--- a/app/views/components/docs/heading.yml
+++ b/app/views/components/docs/heading.yml
@@ -13,12 +13,15 @@ accessibility_criteria: |
   - be part of a correct heading structure for a page
   - be semantically represented as a heading
   - convey the heading level
-fixtures:
+examples:
   default:
-    text: 'Download the full outcome'
+    data:
+      text: 'Download the full outcome'
   with_id_attribute:
-    text: 'Detail of outcome'
-    id: 'detail_of_outcome'
+    data:
+      text: 'Detail of outcome'
+      id: 'detail_of_outcome'
   specific_heading_level:
-    text: 'Original consultation'
-    heading_level: 3
+    data:
+      text: 'Original consultation'
+      heading_level: 3

--- a/app/views/components/docs/lead-paragraph.yml
+++ b/app/views/components/docs/lead-paragraph.yml
@@ -2,6 +2,7 @@ name: Lead paragraph
 description: The opening paragraph of content. Typically a content item’s description field.
 accessibility_criteria: |
   The lead paragraph must be visually distinct from other paragraphs.
-fixtures:
+examples:
   default:
-    text: 'UK Visas and Immigration is making changes to the Immigration Rules affecting various categories.'
+    data:
+      text: 'UK Visas and Immigration is making changes to the Immigration Rules affecting various categories.'

--- a/app/views/components/docs/lead-paragraph.yml
+++ b/app/views/components/docs/lead-paragraph.yml
@@ -6,3 +6,8 @@ examples:
   default:
     data:
       text: 'UK Visas and Immigration is making changes to the Immigration Rules affecting various categories.'
+  right_to_left:
+    data:
+      text: 'قرارات تحقيقات وزارة الدفاع في الانتهاكات المزعومة للمادة ٢ والمادة ٣ من المعاهدة الاوروبية لحقوق الانسان خلال العمليات العسكرية في العراق.'
+    context:
+      right_to_left: true

--- a/app/views/components/docs/notice.yml
+++ b/app/views/components/docs/notice.yml
@@ -9,12 +9,15 @@ accessibility_criteria: |
 
   - have a border colour contrast ratio of more than 4.5:1 with its background to be visually distinct.
   - always render headings with associated description content, so there are no isolated heading elements inside the component
-fixtures:
+examples:
   default:
-    title: 'Statistics release cancelled'
+    data:
+      title: 'Statistics release cancelled'
   with_description_text:
-    title: 'Statistics release cancelled'
-    description_text: 'Duplicate, added in error'
+    data:
+      title: 'Statistics release cancelled'
+      description_text: 'Duplicate, added in error'
   with_description_govspeak:
-    title: 'Statistics release update'
-    description_govspeak: '<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel="external" href="https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/">www.ogauthority.co.uk</a></p>'
+    data:
+      title: 'Statistics release update'
+      description_govspeak: '<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel="external" href="https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/">www.ogauthority.co.uk</a></p>'

--- a/app/views/components/docs/print-link.yml
+++ b/app/views/components/docs/print-link.yml
@@ -14,9 +14,11 @@ accessibility_criteria: |
   - have visible text
 
   The print icon must be presentational and ignored by screen readers.
-fixtures:
+examples:
   default:
-    href: '/print-this'
+    data:
+      href: '/print-this'
   custom_link_text:
-    link_text: 'Print me'
-    href: '/print-me'
+    data:
+      link_text: 'Print me'
+      href: '/print-me'

--- a/app/views/components/docs/share-links.yml
+++ b/app/views/components/docs/share-links.yml
@@ -35,3 +35,9 @@ examples:
   with_only_one_link_provided:
     data:
       facebook_href: '/only-facebook-link'
+  right_to_left:
+    data:
+      facebook_href: '/facebook-link'
+      twitter_href: '/twitter-link'
+    context:
+      right_to_left: true

--- a/app/views/components/docs/share-links.yml
+++ b/app/views/components/docs/share-links.yml
@@ -22,13 +22,16 @@ accessibility_criteria: |
   - indicate when it has focus
 
   The share link icons must be presentational and ignored by screen readers.
-fixtures:
+examples:
   default:
-    facebook_href: '/facebook-link'
-    twitter_href: '/twitter-link'
+    data:
+      facebook_href: '/facebook-link'
+      twitter_href: '/twitter-link'
   with_custom_text:
-    title: 'Share this news article'
-    facebook_href: '/facebook-share-link'
-    twitter_href: '/twitter-share-link'
+    data:
+      title: 'Share this news article'
+      facebook_href: '/facebook-share-link'
+      twitter_href: '/twitter-share-link'
   with_only_one_link_provided:
-    facebook_href: '/only-facebook-link'
+    data:
+      facebook_href: '/only-facebook-link'

--- a/app/views/components/docs/subscription-links.yml
+++ b/app/views/components/docs/subscription-links.yml
@@ -14,11 +14,14 @@ accessibility_criteria: |
   - have visible text
 
   Icons in subscription links must be presentational and ignored by screen readers.
-fixtures:
+examples:
   default:
-    email_signup_link: '/foreign-travel-advice/singapore/email-signup'
-    feed_link: '/foreign-travel-advice/singapore.atom'
+    data:
+      email_signup_link: '/foreign-travel-advice/singapore/email-signup'
+      feed_link: '/foreign-travel-advice/singapore.atom'
   with_only_email_signup_link:
-    email_signup_link: '/foreign-travel-advice/singapore/email-signup'
+    data:
+      email_signup_link: '/foreign-travel-advice/singapore/email-signup'
   with_only_feed_link:
-    feed_link: '/foreign-travel-advice/singapore.atom'
+    data:
+      feed_link: '/foreign-travel-advice/singapore.atom'

--- a/app/views/components/docs/translation-nav.yml
+++ b/app/views/components/docs/translation-nav.yml
@@ -56,3 +56,15 @@ examples:
       - locale: 'zh'
         base_path: '/zh'
         text: '中文'
+  right_to_left:
+    data:
+      translations:
+        - locale: 'en'
+          base_path: '/en'
+          text: 'English'
+        - locale: 'ar'
+          base_path: '/ar'
+          text: 'العربية'
+          active: true
+    context:
+      right_to_left: true

--- a/app/views/components/docs/translation-nav.yml
+++ b/app/views/components/docs/translation-nav.yml
@@ -21,36 +21,38 @@ accessibility_criteria: |
   - be usable with touch
   - be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
   - have visible text
-fixtures:
+examples:
   # TODO: We need to add a fixture to show component rendering right-to-left.
   # This is dependant on being able to provide context to fixtures.
   default:
-    translations:
-    - locale: 'en'
-      base_path: '/en'
-      text: 'English'
-      active: true
-    - locale: 'hi'
-      base_path: '/hi'
-      text: 'हिंदी'
+    data:
+      translations:
+      - locale: 'en'
+        base_path: '/en'
+        text: 'English'
+        active: true
+      - locale: 'hi'
+        base_path: '/hi'
+        text: 'हिंदी'
   multiple_translations:
-    translations:
-    - locale: 'en'
-      base_path: '/en'
-      text: 'English'
-      active: true
-    - locale: 'fr'
-      base_path: '/fr'
-      text: 'Français'
-    - locale: 'hi'
-      base_path: '/hi'
-      text: 'हिंदी'
-    - locale: 'ja'
-      base_path: '/ja'
-      text: '日本語'
-    - locale: 'ur'
-      base_path: '/ur'
-      text: 'اردو'
-    - locale: 'zh'
-      base_path: '/zh'
-      text: '中文'
+    data:
+      translations:
+      - locale: 'en'
+        base_path: '/en'
+        text: 'English'
+        active: true
+      - locale: 'fr'
+        base_path: '/fr'
+        text: 'Français'
+      - locale: 'hi'
+        base_path: '/hi'
+        text: 'हिंदी'
+      - locale: 'ja'
+        base_path: '/ja'
+        text: '日本語'
+      - locale: 'ur'
+        base_path: '/ur'
+        text: 'اردو'
+      - locale: 'zh'
+        base_path: '/zh'
+        text: '中文'

--- a/app/views/components/docs/translation-nav.yml
+++ b/app/views/components/docs/translation-nav.yml
@@ -22,8 +22,6 @@ accessibility_criteria: |
   - be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
   - have visible text
 examples:
-  # TODO: We need to add a fixture to show component rendering right-to-left.
-  # This is dependant on being able to provide context to fixtures.
   default:
     data:
       translations:


### PR DESCRIPTION
Best reviewed with `?w=1` or commit by commit

* Update example documentation to new format (see https://github.com/alphagov/govuk_publishing_components/pull/37)
* Add right to left examples
* Add HTML examples to banner
* Fix bug with right to left contents lists

https://government-frontend-pr-465.herokuapp.com/component-guide

![screen shot 2017-08-29 at 13 05 37](https://user-images.githubusercontent.com/319055/29819980-cc12f258-8cba-11e7-8d5b-25ed092716a6.png)
