### PR TITLE
Move page title to layout rather than individual views

### DIFF
--- a/app/presenters/case_study_presenter.rb
+++ b/app/presenters/case_study_presenter.rb
@@ -6,4 +6,8 @@ class CaseStudyPresenter < ContentItemPresenter
   def image
     content_item["details"]["image"]
   end
+
+  def page_title
+    "#{super} - #{I18n.t("content_item.schema_name.#{document_type}", count: 1)}"
+  end
 end

--- a/app/presenters/coming_soon_presenter.rb
+++ b/app/presenters/coming_soon_presenter.rb
@@ -18,6 +18,10 @@ class ComingSoonPresenter < ContentItemPresenter
     display_time(DateTime.parse(@publish_time))
   end
 
+  def page_title
+    "Coming soon"
+  end
+
 private
 
   def display_date(date)

--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -30,4 +30,8 @@ class FatalityNoticePresenter < ContentItemPresenter
       end
     end
   end
+
+  def page_title
+    "#{super} - #{I18n.t("content_item.schema_name.#{document_type}", count: 1)}"
+  end
 end

--- a/app/presenters/gone_presenter.rb
+++ b/app/presenters/gone_presenter.rb
@@ -6,4 +6,8 @@ class GonePresenter < ContentItemPresenter
     @explanation = content_item['details']['explanation']
     @alternative_path = content_item['details']['alternative_path']
   end
+
+  def page_title
+    "No longer available"
+  end
 end

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -51,6 +51,10 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
     content_item["details"]["latest_change_note"]
   end
 
+  def page_title
+    "#{super} - #{I18n.t("content_item.schema_name.#{document_type}", count: 1)}"
+  end
+
 private
 
   def state

--- a/app/presenters/unpublishing_presenter.rb
+++ b/app/presenters/unpublishing_presenter.rb
@@ -6,4 +6,8 @@ class UnpublishingPresenter < ContentItemPresenter
     @explanation = content_item['details']['explanation']
     @alternative_url = content_item['details']['alternative_url']
   end
+
+  def page_title
+    "No longer available"
+  end
 end

--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -1,5 +1,4 @@
 <% content_for :simple_header, true %>
-<%= content_for :title, @content_item.title %>
 
 <div class="grid-row sidebar-with-body">
   <div class="column-two-thirds">

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, "#{@content_item.page_title} - #{t("content_item.schema_name.#{@content_item.document_type}", count: 1)}" %>
-
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 <%= render 'shared/metadata', content_item: @content_item %>

--- a/app/views/content_items/coming_soon.html.erb
+++ b/app/views/content_items/coming_soon.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, "Coming soon - GOV.UK" %>
-
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', title: 'Coming soon' %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, @content_item.title %>
-
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 <%= render 'shared/metadata', content_item: @content_item %>

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -1,7 +1,4 @@
-<%
-  content_for :title, @content_item.title
-  content_for :simple_header, true
-%>
+<% content_for :simple_header, true %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, @content_item.page_title %>
-
 <div class="<%= @content_item.organisation_brand_class %>">
   <div class="grid-row">
     <div class="column-quarter">

--- a/app/views/content_items/detailed_guide.html+new_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+new_navigation.erb
@@ -1,4 +1,3 @@
-<%= content_for :title, @content_item.page_title %>
 <%= content_for :simple_header, true %>
 
 <div class="grid-row">

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,7 +1,3 @@
-<% # THIS IS PART OF EDUCATION NAVIGATION A/B TESTING - PLEASE KEEP IN SYNC WITH +new_navigation.erb %>
-
-<%= content_for :title, @content_item.page_title %>
-
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>

--- a/app/views/content_items/document_collection.html+new_navigation.erb
+++ b/app/views/content_items/document_collection.html+new_navigation.erb
@@ -1,4 +1,3 @@
-<%= content_for :title, @content_item.page_title %>
 <%= content_for :simple_header, true %>
 
 <div class="grid-row">

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, @content_item.page_title %>
-
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 <%= render 'shared/metadata', content_item: @content_item %>

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, "#{@content_item.page_title} - #{t("content_item.schema_name.#{@content_item.document_type}", count: 1)}" %>
-
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 <%= render 'shared/metadata', content_item: @content_item %>

--- a/app/views/content_items/gone.html.erb
+++ b/app/views/content_items/gone.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, "No longer available - GOV.UK" %>
-
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', title: 'The page you\'re looking for is no longer available' %>

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -1,5 +1,5 @@
 <%
-  content_for :title, "Print #{@content_item.title}"
+  content_for :title, "Print #{@content_item.page_title}"
   content_for :simple_header, true
   content_for :extra_head_content do %>
   <meta name="robots" content="noindex, nofollow">

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -1,7 +1,4 @@
-<%
-  content_for :simple_header, true
-  content_for :title, @content_item.page_title
-%>
+<% content_for :simple_header, true %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -1,5 +1,4 @@
 <%
-  content_for :title, @content_item.title
   content_for :simple_header, true
 %>
 

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, @content_item.page_title %>
-
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 <%= render 'shared/metadata', content_item: @content_item %>

--- a/app/views/content_items/publication.html+new_navigation.erb
+++ b/app/views/content_items/publication.html+new_navigation.erb
@@ -1,4 +1,3 @@
-<%= content_for :title, @content_item.page_title %>
 <%= content_for :simple_header, true %>
 
 <div class="grid-row">

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, @content_item.page_title %>
-
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -1,7 +1,4 @@
-<%
-  content_for :simple_header, true
-  content_for :title, @content_item.page_title
-%>
+<% content_for :simple_header, true %>
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'shared/metadata', content_item: @content_item %>

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, @content_item.page_title %>
-
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 <%= render 'shared/metadata', content_item: @content_item %>

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, @content_item.page_title %>
-
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 <%= render 'shared/metadata', content_item: @content_item %>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, "#{@content_item.title} - #{t("content_item.schema_name.#{@content_item.document_type}", count: 1)}" %>
-
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, @content_item.title %>
-
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'components/lead-paragraph', text: @content_item.description %>
 <%= render 'shared/sidebar_image_with_body', content_item: @content_item %>

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, @content_item.title %>
-
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'components/lead-paragraph', text: @content_item.description %>
 <%= render 'shared/sidebar_contents_with_body', content_item: @content_item %>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -1,5 +1,4 @@
 <%
-  content_for :title, @content_item.page_title
   content_for :simple_header, true
   content_for :extra_head_content do %>
   <%= auto_discovery_link_tag :atom, @content_item.feed_link,

--- a/app/views/content_items/unpublishing.html.erb
+++ b/app/views/content_items/unpublishing.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, "No longer available - GOV.UK" %>
-
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', title: 'The page you\'re looking for is no longer available' %>

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, @content_item.title %>
-
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'components/lead-paragraph', text: @content_item.description %>
 

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :title, @content_item.page_title %>
-
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 <%= render 'shared/metadata', content_item: @content_item %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title><%= yield :title %> - GOV.UK</title>
+  <title>
+    <%if content_for?(:page) %>
+      <%= yield :page %> - GOV.UK
+    <% else %>
+      <%= @content_item.page_title %> - GOV.UK
+    <% end %>
+  </title>
   <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %><!--<![endif]-->
   <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><script>var ieVersion = 6;</script><![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><script>var ieVersion = 7;</script><![endif]-->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>
-    <%if content_for?(:page) %>
-      <%= yield :page %> - GOV.UK
+    <%if content_for?(:title) %>
+      <%= yield :title %> - GOV.UK
     <% else %>
       <%= @content_item.page_title %> - GOV.UK
     <% end %>

--- a/lib/generators/format/templates/format.html.erb
+++ b/lib/generators/format/templates/format.html.erb
@@ -1,5 +1,3 @@
-<%%= content_for :title, @content_item.title %>
-
 <div class="grid-row">
   <div class="column-two-thirds">
     <%%= render 'govuk_component/title',


### PR DESCRIPTION
This allows us to have a more consistent approach for
page titles.

This work corrects `html_publications` which previously
missed the `[withdrawn]` notice when they had been withdrawn.

https://trello.com/c/Mn8Yk9Z6/278-add-withdrawn-to-page-title