### PR TITLE
Make title spacing consistent and remove unneeded CSS

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,10 +13,10 @@
 // helpers for common page elements
 @import 'helpers/back-to-content';
 @import 'helpers/sidebar-with-body';
-@import 'helpers/national_statistics_logo';
 @import 'helpers/organisation-links';
 @import 'helpers/taxonomy-sidebar';
 @import 'helpers/parts';
+@import 'helpers/add-title-margin';
 
 // components
 @import 'components/*';

--- a/app/assets/stylesheets/helpers/_add-title-margin.scss
+++ b/app/assets/stylesheets/helpers/_add-title-margin.scss
@@ -1,0 +1,5 @@
+@mixin add-title-margin {
+  .add-title-margin {
+    @include responsive-top-margin;
+  }
+}

--- a/app/assets/stylesheets/helpers/_national_statistics_logo.scss
+++ b/app/assets/stylesheets/helpers/_national_statistics_logo.scss
@@ -1,5 +1,0 @@
-@mixin national-statistics-logo {
-  .national-statistics-logo {
-    margin-top: $gutter * 1.5;
-  }
-}

--- a/app/assets/stylesheets/views/_answer.scss
+++ b/app/assets/stylesheets/views/_answer.scss
@@ -1,7 +1,5 @@
 .answer {
-  .add-title-margin {
-    @include responsive-top-margin;
-  }
+  @include add-title-margin;
 
   .last-updated {
     padding-bottom: $gutter-half;

--- a/app/assets/stylesheets/views/_contact.scss
+++ b/app/assets/stylesheets/views/_contact.scss
@@ -1,7 +1,5 @@
 .contact {
-  .add-title-margin {
-    @include responsive-top-margin;
-  }
+  @include add-title-margin;
 
   // FIXME: Overrides specific govspeak heading styles while h3s & h4s look similar
   // Govspeak component renders h3s and h4s at the same font size with different margins

--- a/app/assets/stylesheets/views/_guide.scss
+++ b/app/assets/stylesheets/views/_guide.scss
@@ -1,9 +1,6 @@
 .guide {
   @include parts;
-
-  .add-title-margin {
-    @include responsive-top-margin;
-  }
+  @include add-title-margin;
 
   .part-navigation li {
     list-style: decimal;

--- a/app/assets/stylesheets/views/_help-page.scss
+++ b/app/assets/stylesheets/views/_help-page.scss
@@ -1,7 +1,5 @@
 .help-page {
-  .add-title-margin {
-    @include responsive-top-margin;
-  }
+  @include add-title-margin;
 
   .last-updated {
     padding-bottom: $gutter-half;

--- a/app/assets/stylesheets/views/_publication.scss
+++ b/app/assets/stylesheets/views/_publication.scss
@@ -1,7 +1,7 @@
 .publication {
   @include sidebar-with-body;
-  @include national-statistics-logo;
   @include taxonomy-sidebar;
+  @include add-title-margin;
 
   .direction-rtl & {
     direction: rtl;

--- a/app/assets/stylesheets/views/_statistics_announcement.scss
+++ b/app/assets/stylesheets/views/_statistics_announcement.scss
@@ -1,5 +1,5 @@
 .statistics-announcement {
-  @include national-statistics-logo;
+  @include add-title-margin;
 
   .release-date-change-notice {
     h2 {

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -1,9 +1,6 @@
 .travel-advice {
   @include parts;
-
-  .add-title-margin {
-    @include responsive-top-margin;
-  }
+  @include add-title-margin;
 
   .part-navigation {
     margin-bottom: $gutter * 1.5;

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -6,11 +6,9 @@
     margin-bottom: $gutter * 1.5;
   }
 
+  // TODO: Remove this when components can accept variable unidirectional spacing,
+  // the component above should have a bigger margin-bottom.
   .map {
     margin-top: $gutter;
-
-    img {
-      max-width: 100%;
-    }
   }
 }

--- a/app/views/shared/_national_statistics_logo.html+new_navigation.erb
+++ b/app/views/shared/_national_statistics_logo.html+new_navigation.erb
@@ -1,3 +1,3 @@
-<div class="national-statistics-logo">
+<div class="add-title-margin">
   <%= image_tag 'national-statistics.png', alt: 'National Statistics' %>
 </div>

--- a/app/views/shared/_national_statistics_logo.html.erb
+++ b/app/views/shared/_national_statistics_logo.html.erb
@@ -1,5 +1,5 @@
 <div class="column-third">
-  <div class="national-statistics-logo">
+  <div class="add-title-margin">
     <%= image_tag 'national-statistics.png', alt: 'National Statistics' %>
   </div>
 </div>

--- a/app/views/shared/_withdrawal_notice.html.erb
+++ b/app/views/shared/_withdrawal_notice.html.erb
@@ -1,9 +1,0 @@
-<% if content_item.withdrawn? %>
-  <div class="withdrawal-notice">
-    <h2>
-      This <%= t("content_item.schema_name.#{content_item.schema_name}", count: 1).downcase %>
-      was withdrawn on <%= content_item.withdrawal_notice[:time] %>
-    </h2>
-    <%= render 'govuk_component/govspeak', content: content_item.withdrawal_notice[:explanation] %>
-  </div>
-<% end %>

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -61,7 +61,7 @@ class PublicationTest < ActionDispatch::IntegrationTest
 
   test "national statistics publication shows a logo" do
     setup_and_visit_content_item('statistics_publication')
-    assert page.has_css?(".national-statistics-logo img")
+    assert page.has_css?('img[alt="National Statistics"]')
   end
 
   test "renders 'Applies to' block in metadata when there are excluded nations" do

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -14,7 +14,7 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
 
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
-    assert page.has_css?('.national-statistics-logo img')
+    assert page.has_css?('img[alt="National Statistics"]')
     assert_has_component_metadata_pair("Release date", "January 2016 (provisional)")
   end
 


### PR DESCRIPTION
As part of auditing government-frontend I found these issues that seemed easier to fix at the time, can close and make into cards if needed.

National statistics:

Before:
![screen shot 2017-08-30 at 16 52 34](https://user-images.githubusercontent.com/2445413/29918458-75a4ec8a-8e3d-11e7-9fa5-f55c33902d51.png)
![screen shot 2017-08-30 at 16 52 26](https://user-images.githubusercontent.com/2445413/29918462-75af19a8-8e3d-11e7-94ff-621e16bccfeb.png)

After:
![screen shot 2017-08-30 at 16 52 40](https://user-images.githubusercontent.com/2445413/29918457-75a4f0a4-8e3d-11e7-8495-2dcf78423a53.png)
![screen shot 2017-08-30 at 16 52 30](https://user-images.githubusercontent.com/2445413/29918459-75a90446-8e3d-11e7-8c3a-ddaeb96e0699.png)

Maps:

- No change

Withdrawal Notice Partial:

- I think this was left around and we forgot to delete it