### PR TITLE
Ensure Withdrawn is included on all withdrawn content

### DIFF
--- a/app/presenters/corporate_information_page_presenter.rb
+++ b/app/presenters/corporate_information_page_presenter.rb
@@ -6,7 +6,7 @@ class CorporateInformationPagePresenter < ContentItemPresenter
   include CorporateInformationGroups
 
   def page_title
-    page_title = title.to_s
+    page_title = super
     page_title += " - #{default_organisation['title']}" if default_organisation
     page_title
   end

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -5,9 +5,9 @@ class GuidePresenter < ContentItemPresenter
 
   def page_title
     if @part_slug
-      "#{title}: #{current_part_title}"
+      "#{super}: #{current_part_title}"
     else
-      title
+      super
     end
   end
 

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -4,9 +4,9 @@ class TravelAdvicePresenter < ContentItemPresenter
 
   def page_title
     if is_summary?
-      title
+      super
     else
-      "#{current_part_title} - #{title}"
+      "#{current_part_title} - #{super}"
     end
   end
 

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -19,6 +19,11 @@ class CorporateInformationPagePresenterTest
       assert_equal "About us", presented_item.page_title
     end
 
+    test 'presents withdrawn in the title for withdrawn content' do
+      presented_item = presented_item(schema_name, "withdrawn_notice" => { "explanation": "Withdrawn", "withdrawn_at": "2014-08-22T10:29:02+01:00" })
+      assert_equal "[Withdrawn] About us - Department of Health", presented_item.page_title
+    end
+
     test 'has contents list' do
       assert presented_item.is_a?(ContentsList)
     end

--- a/test/presenters/guide_presenter_test.rb
+++ b/test/presenters/guide_presenter_test.rb
@@ -22,6 +22,11 @@ class GuidePresenterTest
       assert_equal presented_item.current_part_title_with_index, "1. #{first_part_title}"
     end
 
+    test 'presents withdrawn in the title for withdrawn content' do
+      presented_item = presented_item(schema_name, nil, "withdrawn_notice" => { "explanation": "Withdrawn", "withdrawn_at": "2014-08-22T10:29:02+01:00" })
+      assert_equal "[Withdrawn] The national curriculum", presented_item.page_title
+    end
+
     test "presents a print link" do
       assert_equal "#{schema_item['base_path']}/print", presented_item.print_link
     end

--- a/test/presenters/travel_advice_presenter_test.rb
+++ b/test/presenters/travel_advice_presenter_test.rb
@@ -43,6 +43,11 @@ class TravelAdvicePresenterTest
       assert_equal "#{first_part['title']} - #{example['title']}", presented_part.page_title
     end
 
+    test 'presents withdrawn in the title for withdrawn content' do
+      presented_item = presented_item("full-country", nil, "withdrawn_notice" => { "explanation": "Withdrawn", "withdrawn_at": "2014-08-22T10:29:02+01:00" })
+      assert_equal "[Withdrawn] Albania travel advice", presented_item.page_title
+    end
+
     test "presents summary as the current part when no part slug provided" do
       example = schema_item("full-country")
       presented = presented_item("full-country")


### PR DESCRIPTION
This cover a few edge cases where custom page_titles
where being generated

https://trello.com/c/Mn8Yk9Z6/278-add-withdrawn-to-page-title