### PR TITLE
Improve banner accessibility

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,3 +1,5 @@
+@import "grid_layout";
+
 .app-c-banner {
   @include responsive-bottom-margin;
   @include core-19;
@@ -19,18 +21,19 @@
 }
 
 .app-c-banner__main {
-  margin-top: $gutter-half;
+  @include grid-column( 2 / 3, $full-width: tablet, $float: right );
 
   @include media(tablet) {
-    margin-top: 0;
-    margin-left: -$gutter-one-third;
     padding-right: 0;
     border-left: 1px solid $white;
   }
 }
 
 .app-c-banner__aside {
+  margin-top: $gutter-half;
+
   @include media(tablet) {
+    margin-top: 0;
     padding-right: $gutter / 2;
   }
 }

--- a/app/views/components/_banner.html.erb
+++ b/app/views/components/_banner.html.erb
@@ -14,13 +14,13 @@
 <section class="app-c-banner<% if aside %> app-c-banner--grid<% end %>" aria-label="Notice">
   <% if aside %>
     <div class="grid-row">
+      <div class="app-c-banner__main">
+        <%= content_block %>
+      </div>
       <div class="column-third">
         <div class="app-c-banner__aside">
           <p><%= aside %></p>
         </div>
-      </div>
-      <div class="column-two-thirds app-c-banner__main">
-        <%= content_block %>
       </div>
     </div>
   <% else %>


### PR DESCRIPTION
- ordering of aside and main banner content changed so aside occurs in the dom after the main content, so screen readers should read the heading first (unless you're using VoiceOver in Chrome, which has weird issues that we've decided to ignore as they're out of our control)
- changed aside element to an aside
- appearance of component should not have changed at all

https://government-frontend-pr-470.herokuapp.com/component-guide/banner

![screen shot 2017-09-01 at 11 15 27](https://user-images.githubusercontent.com/861310/29965767-ebd729e4-8f06-11e7-8bea-d964fd3555ab.png)

https://trello.com/c/J6907ojp/93-2-banner-component-is-inaccessible-to-screen-reader-users
