### PR TITLE
Add placeholder env-vars for S3 credentials

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,6 +25,12 @@
     },
     "HEROKU_APP_NAME": {
       "required": true
+    },
+    "S3_AWS_ACCESS_KEY_ID": {
+      "required": true
+    },
+    "S3_SECRET_ACCESS_KEY": {
+      "required": true
     }
   },
   "image": "heroku/ruby",


### PR DESCRIPTION
We want to keep the S3 bucket credentials secret. To do this we can require their existence in app.json and define their values in the 'parent' (i.e. master build) of the app in the heroku dashboard.