### PR TITLE
Redirect to base_path/ for first part of guides

### DIFF
--- a/app/presenters/parts.rb
+++ b/app/presenters/parts.rb
@@ -17,7 +17,7 @@ module Parts
   end
 
   def has_valid_part?
-    !!current_part
+    !!current_part && current_part != parts.first
   end
 
   def current_part_title

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -72,6 +72,18 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_redirected_to content_item['base_path']
   end
 
+  test "redirects route for first path to base path" do
+    content_item = content_store_has_schema_example('guide', 'guide')
+    invalid_part_path = "#{path_for(content_item)}/#{content_item['details']['parts'].first['slug']}"
+
+    stub_request(:get, %r{#{invalid_part_path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    get :show, params: { path: invalid_part_path }
+
+    assert_response :redirect
+    assert_redirected_to content_item['base_path']
+  end
+
   test "returns HTML when an unspecific accepts header is requested (eg by IE8 and below)" do
     request.headers["Accept"] = "*/*"
     content_item = content_store_has_schema_example('travel_advice', 'full-country')

--- a/test/presenters/parts_test.rb
+++ b/test/presenters/parts_test.rb
@@ -125,6 +125,21 @@ class PartsTest < ActiveSupport::TestCase
     refute @parts.has_valid_part?
   end
 
+  test 'invalid when slug for first part is present in URL' do
+    class << @parts
+      def part_slug
+        'first-slug'
+      end
+
+      def requested_content_item_path
+        base_path + '/' + part_slug
+      end
+    end
+
+    assert @parts.requesting_a_part?
+    refute @parts.has_valid_part?
+  end
+
   test 'defaults to first part as current part when parts exist but no part requested' do
     presenting_first_part_in_content_item
 


### PR DESCRIPTION
[Trello](https://trello.com/c/ST5fkS0a/285-implement-redirect-from-default-chaptered-guides-pages)
- Internal links within a guide now point to the `base_path`, not to the `base_path` + `slug` of the first part. However, the longer URL is still accessible without redirecting to its shorter equivalent if entered manually into the address bar.
- This is not ideal for analytics, as we have to deal with two URLs for the same page.
- This PR solves this issue by redirecting the slug of the first part to /base_path.