### PR TITLE
Add withdrawn notice to html publications

### DIFF
--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -20,7 +20,11 @@ class HtmlPublicationPresenter < ContentItemPresenter
   end
 
   def format_sub_type
-    parent["document_type"] if parent && parent["document_type"].present?
+    if parent && parent["document_type"].present?
+      parent["document_type"]
+    else
+      "publication"
+    end
   end
 
   def last_changed
@@ -55,5 +59,9 @@ private
 
   def public_timestamp
     content_item["details"]["public_timestamp"]
+  end
+
+  def withdrawal_notice_context
+    I18n.t("content_item.schema_name.#{format_sub_type}", count: 1)
   end
 end

--- a/app/presenters/withdrawable.rb
+++ b/app/presenters/withdrawable.rb
@@ -26,8 +26,11 @@ private
   end
 
   def withdrawal_notice_title
-    friendly_schema_name = I18n.t("content_item.schema_name.#{schema_name}", count: 1).downcase
-    "This #{friendly_schema_name} was withdrawn on #{withdrawal_notice_time}".html_safe
+    "This #{withdrawal_notice_context.downcase} was withdrawn on #{withdrawal_notice_time}".html_safe
+  end
+
+  def withdrawal_notice_context
+    I18n.t("content_item.schema_name.#{schema_name}", count: 1)
   end
 
   def withdrawal_notice_time

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -12,8 +12,6 @@
   </ol>
 </div>
 
-<%= render 'components/notice', @content_item.withdrawal_notice_component  %>
-
 <header class="publication-header" id="contents">
   <div class="html-publication-title">
     <% if @content_item.format_sub_type %>
@@ -23,6 +21,8 @@
   </div>
   <%= @content_item.last_changed %>
 </header>
+
+<%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 
 <div
   class="grid-row sidebar-with-body"

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -12,6 +12,8 @@
   </ol>
 </div>
 
+<%= render 'components/notice', @content_item.withdrawal_notice_component  %>
+
 <header class="publication-header" id="contents">
   <div class="html-publication-title">
     <% if @content_item.format_sub_type %>

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -90,4 +90,32 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       assert_equal brand, JSON.parse(page.text).fetch("organisation").fetch("brand")
     end
   end
+
+  test "withdrawn html publication" do
+    content_item = GovukSchemas::Example.find('html_publication', example_name: 'prime_ministers_office')
+    content_item['withdrawn_notice'] = {
+      'explanation': 'This is out of date',
+      'withdrawn_at': '2014-08-09T11:39:05Z'
+    }
+
+    content_store_has_item("/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration", content_item.to_json)
+    visit "/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration"
+
+    assert page.has_css?(".app-c-notice__title", text: "This policy paper was withdrawn on 9 August 2014")
+    assert page.has_css?(".app-c-notice", text: "This is out of date")
+  end
+
+  test "if document has no parent document_type 'publication' is shown" do
+    content_item = GovukSchemas::Example.find('html_publication', example_name: 'prime_ministers_office')
+    content_item['links']['parent'][0]['document_type'] = nil
+    content_item['withdrawn_notice'] = {
+      'explanation': 'This is out of date',
+      'withdrawn_at': '2014-08-09T11:39:05Z'
+    }
+
+    content_store_has_item("/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration", content_item.to_json)
+    visit "/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration"
+
+    assert page.has_css?(".app-c-notice__title", text: "This publication was withdrawn on 9 August 2014")
+  end
 end


### PR DESCRIPTION
- uses notice component
- requires update to translations, have copied the lines for 'publication' as 'html publication' wouldn't make sense to most people
- updated non-English language files as well, used the translation for 'publication' there as well

![screen shot 2017-09-07 at 09 28 48](https://user-images.githubusercontent.com/861310/30153574-0112a138-93af-11e7-920a-a4a18e9b2bfb.png)

https://trello.com/c/23VcfUo2/137-1-add-withdrawn-notice-to-html-publications

Examples:
- https://government-frontend-pr-474.herokuapp.com/government/publications/dependants-of-students-and-prospective-students-sty01/dependants-of-students-and-prospective-students-sty01
- https://government-frontend-pr-474.herokuapp.com/government/publications/fees-for-civil-and-family-courts/court-fees-for-the-high-court-county-court-and-family-court
- https://government-frontend-pr-474.herokuapp.com/government/publications/ex35-6ne-environmental-permit-application-advertisement/ex35-6ne-environmental-permit-application-advertisement
