### PR TITLE
Include static title component in html publication

### DIFF
--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -32,22 +32,11 @@
     @include core-19;
     color: $white;
     background: $light-blue;
-    padding: ($gutter * 2) $gutter $gutter;
+    padding: ($gutter / 2) $gutter $gutter;
     margin-bottom: $gutter * 2;
-  }
 
-  // Based on the govuk-title component
-  .html-publication-title {
-    margin-bottom: $gutter / 2;
-
-    .context {
-      @include core-27;
-      color: $white;
-      margin-bottom: $gutter-one-third;
-    }
-
-    h1 {
-      @include bold-48;
+    .last-changed {
+      margin-top: $gutter / 2;
     }
   }
 

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -13,13 +13,13 @@
 </div>
 
 <header class="publication-header" id="contents">
-  <div class="html-publication-title">
-    <% if @content_item.format_sub_type %>
-      <p class="context"><%= I18n.t("content_item.schema_name.#{@content_item.format_sub_type}", count: 1) %></p>
-    <% end %>
-    <h1><%= @content_item.title %></h1>
-  </div>
-  <%= @content_item.last_changed %>
+  <%= render partial: 'govuk_component/title', locals: {
+    title: @content_item.title,
+    context: I18n.t("content_item.schema_name.#{@content_item.format_sub_type}", count: 1),
+    inverse: true,
+    margin_bottom: 0
+  } %>
+  <p class="last-changed"><%= @content_item.last_changed %></p>
 </header>
 
 <div


### PR DESCRIPTION
Replaces the html-publication-title with the static title component (pub-c-title).

**Before:**
<img width="980" alt="screen shot 2017-09-05 at 16 55 15" src="https://user-images.githubusercontent.com/29889908/30070327-032c8790-925b-11e7-8172-2b0e5c44ae92.png">

**After:**
<img width="993" alt="screen shot 2017-09-05 at 16 54 46" src="https://user-images.githubusercontent.com/29889908/30070304-f2313e36-925a-11e7-8eef-060ff99c58f9.png">

**Note: can only be merged and deployed after static title spacing changes have been deployed** 
