### PR TITLE
Bump govuk_publishing_components gem to 1.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'dalli'
 gem 'gds-api-adapters', '~> 43.0'
 gem 'govuk_ab_testing', '~> 2.0'
 gem 'govuk_frontend_toolkit', '5.1.0'
-gem 'govuk_publishing_components', '~> 1.2.0', require: ENV['RAILS_ENV'] != "production" || ENV['HEROKU_APP_NAME'].to_s.length.positive?
+gem 'govuk_publishing_components', '~> 1.5.0', require: ENV['RAILS_ENV'] != "production" || ENV['HEROKU_APP_NAME'].to_s.length.positive?
 gem 'htmlentities', '4.3.4'
 gem 'logstasher', '0.6.1'
 gem 'plek', '1.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       sass (>= 3.2.0)
     govuk_navigation_helpers (6.3.0)
       gds-api-adapters (>= 43.0)
-    govuk_publishing_components (1.2.0)
+    govuk_publishing_components (1.5.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
@@ -326,7 +326,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.0)
   govuk_frontend_toolkit (= 5.1.0)
   govuk_navigation_helpers (~> 6.3)
-  govuk_publishing_components (~> 1.2.0)
+  govuk_publishing_components (~> 1.5.0)
   govuk_schemas
   htmlentities (= 4.3.4)
   jasmine-rails!


### PR DESCRIPTION
- Add links to component guide homepage
- Add dark_background context to examples
- Add optional descriptions to examples