### PR TITLE
Force "guidance" context in detailed guides title

### DIFF
--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -6,8 +6,10 @@ class DetailedGuidePresenter < ContentItemPresenter
   include Political
   include TitleAndContext
 
-  def context
-    parent["title"]
+  def title_and_context
+    super.tap do |t|
+      t[:context] = I18n.t("content_item.schema_name.guidance", count: 1)
+    end
   end
 
   def related_guides

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -84,4 +84,10 @@ class DetailedGuidePresenterTest < PresenterTestCase
     assert example['details'].include?('national_applicability')
     assert_equal presented.applies_to, 'England, Scotland, and Wales (see guidance for <a rel="external" href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for">Northern Ireland</a>)'
   end
+
+  test 'context in title is overridden to display as guidance' do
+    I18n.with_locale("fr") do
+      assert_equal I18n.t("content_item.schema_name.guidance", count: 1), presented_item.title_and_context[:context]
+    end
+  end
 end


### PR DESCRIPTION
User reported incorrect translation in Arabic in zendesk ticket
https://govuk.zendesk.com/agent/tickets/2319144

This led to us noticing a discrepency between English and all
other languages. This is remedied by using the "guidance"
context in the title for all detailed guides as English had
been updated to say "Guidance" already.