### PR TITLE
Add shared accessibility criteria to components

### DIFF
--- a/app/views/components/docs/back-to-top.yml
+++ b/app/views/components/docs/back-to-top.yml
@@ -1,17 +1,7 @@
 name: Back to top link
 description: An anchor link intended to allow users to return to the top of the content.
-accessibility_criteria: |
-  The link must:
-
-  - accept focus
-  - be focusable with a keyboard
-  - be usable with a keyboard
-  - indicate when it has focus
-  - change in appearance when touched (in the touch-down state)
-  - change in appearance when hovered
-  - be usable with touch
-  - be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
-  - have visible text
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:

--- a/app/views/components/docs/contents-list.yml
+++ b/app/views/components/docs/contents-list.yml
@@ -16,19 +16,9 @@ accessibility_criteria: |
   - inform the user how many items are in the list
   - convey the content structure
 
-  The contents item links must:
-
-  - accept focus
-  - be focusable with a keyboard
-  - be usable with a keyboard
-  - indicate when it has focus
-  - change in appearance when touched (in the touch-down state)
-  - change in appearance when hovered
-  - be usable with touch
-  - be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
-  - have visible text
-
   Links with formatted numbers must separate the number and text with a space for correct screen reader pronunciation. This changes pronunciation from "1 dot Item" to "1 Item".
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:

--- a/app/views/components/docs/document-list.yml
+++ b/app/views/components/docs/document-list.yml
@@ -15,18 +15,8 @@ accessibility_criteria: |
   The component must:
 
   * inform the user how many items are in the list
-
-  Links in the component must:
-
-  * accept focus
-  * be focusable with a keyboard
-  * be usable with a keyboard
-  * indicate when it has focus
-  * change in appearance when touched (in the touch-down state)
-  * change in appearance when hovered
-  * be usable with touch
-  * be usable with speech
-  * have visible text
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:

--- a/app/views/components/docs/download-link.yml
+++ b/app/views/components/docs/download-link.yml
@@ -3,21 +3,11 @@ description: A link with a file download icon
 body: |
   For usability the provided link text should indicate the file type and size of the download.
 accessibility_criteria: |
-  The download link must:
-
-  - accept focus
-  - be focusable with a keyboard
-  - be usable with a keyboard
-  - indicate when it has focus
-  - change in appearance when touched (in the touch-down state)
-  - change in appearance when hovered
-  - be usable with touch
-  - be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
-  - have visible text
-
   The download icon must:
 
   - be presentational and ignored by screen readers
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:

--- a/app/views/components/docs/print-link.yml
+++ b/app/views/components/docs/print-link.yml
@@ -1,19 +1,9 @@
 name: Print link
 description: A link with a print icon
 accessibility_criteria: |
-  The print link must:
-
-  - accept focus
-  - be focusable with a keyboard
-  - be usable with a keyboard
-  - indicate when it has focus
-  - change in appearance when touched (in the touch-down state)
-  - change in appearance when hovered
-  - be usable with touch
-  - be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
-  - have visible text
-
   The print icon must be presentational and ignored by screen readers.
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:

--- a/app/views/components/docs/share-links.yml
+++ b/app/views/components/docs/share-links.yml
@@ -14,14 +14,9 @@ body: |
     - [Right to left](/government/news/uk-sets-out-long-term-support-for-stable-secure-and-prosperous-afghanistan-to-2020.ur)
 
 accessibility_criteria: |
-  The share link must:
-
-  - accept focus
-  - be focusable with a keyboard
-  - be usable with a keyboard
-  - indicate when it has focus
-
   The share link icons must be presentational and ignored by screen readers.
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:

--- a/app/views/components/docs/subscription-links.yml
+++ b/app/views/components/docs/subscription-links.yml
@@ -1,19 +1,9 @@
 name: Subscription links
 description: Links to ‘Get email alerts’ and ‘Subscribe to feed’
 accessibility_criteria: |
-  The subscription links must:
-
-  - accept focus
-  - be focusable with a keyboard
-  - be usable with a keyboard
-  - indicate when they have focus
-  - change in appearance when touched (in the touch-down state)
-  - change in appearance when hovered
-  - be usable with touch
-  - be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
-  - have visible text
-
   Icons in subscription links must be presentational and ignored by screen readers.
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:

--- a/app/views/components/docs/translation-nav.yml
+++ b/app/views/components/docs/translation-nav.yml
@@ -12,15 +12,8 @@ accessibility_criteria: |
   - [identify the language of the text](https://www.w3.org/TR/UNDERSTANDING-WCAG20/meaning-other-lang-id.html#meaning-other-lang-id-examples-head)
 
     [Watch a screen reader pronounce text differently based on lang attribute](https://bit.ly/screenreaderpronunciation)
-  - accept focus
-  - be focusable with a keyboard
-  - indicate when it has focus
-  - be usable with a keyboard
-  - change in appearance when touched (in the touch-down state)
-  - change in appearance when hovered
-  - be usable with touch
-  - be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
-  - have visible text
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:


### PR DESCRIPTION
- replaces all instances of link accessibility criteria with the shared version pulled from the gem
- all other existing component specific accessibility criteria should remain

![screen shot 2017-09-13 at 17 16 25](https://user-images.githubusercontent.com/861310/30388345-55a8068c-98a7-11e7-842e-118c2334cdff.png)

https://trello.com/c/qS1pfVle/132-2-accessibility-criteria-universal-criteria-for-all-components

https://government-frontend-pr-482.herokuapp.com/component-guide
