### PR TITLE
Add a PR template with component guide and visual regression links

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE
+++ b/docs/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,5 @@
+Review app component guide:
+https://government-frontend-pr-XXX.herokuapp.com/component-guide
+
+Visual regression results:
+https://government-frontend-pr-XXX.surge.sh/gallery.html


### PR DESCRIPTION
Indicate where component guide and visual regression test results are available.
We can’t automatically generate the `XXX` part of the template

Following this guide:
https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/