### PR TITLE
[DO NOT MERGE] Update guide gem to 1.8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'dalli'
 gem 'gds-api-adapters', '~> 43.0'
 gem 'govuk_ab_testing', '~> 2.0'
 gem 'govuk_frontend_toolkit', '5.1.0'
-gem 'govuk_publishing_components', '~> 1.8.0', require: false
+gem 'govuk_publishing_components', '~> 1.8.1', require: false
 gem 'htmlentities', '4.3.4'
 gem 'logstasher', '0.6.1'
 gem 'plek', '1.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,10 +125,11 @@ GEM
       sass (>= 3.2.0)
     govuk_navigation_helpers (6.3.0)
       gds-api-adapters (>= 43.0)
-    govuk_publishing_components (1.8.0)
+    govuk_publishing_components (1.8.1)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
+      rouge
       sass-rails (>= 5.0.4)
       slimmer
     govuk_schemas (2.2.0)
@@ -241,6 +242,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     robotex (1.0.0)
+    rouge (2.2.1)
     rubocop (0.49.1)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
@@ -326,7 +328,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.0)
   govuk_frontend_toolkit (= 5.1.0)
   govuk_navigation_helpers (~> 6.3)
-  govuk_publishing_components (~> 1.8.0)
+  govuk_publishing_components (~> 1.8.1)
   govuk_schemas
   htmlentities (= 4.3.4)
   jasmine-rails!


### PR DESCRIPTION
Update govuk_publishing_components gem to 1.8.1 to:
* hide cookie and survey banners in the government-frontend component guide
* fix syntax highlighting in the government-frontend component guide

Review app component guide:
https://government-frontend-pr-487.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-487.surge.sh/gallery.html
