### PR TITLE
Update guide gem to 1.11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'dalli'
 gem 'gds-api-adapters', '~> 48.0'
 gem 'govuk_ab_testing', '~> 2.0'
 gem 'govuk_frontend_toolkit', '5.1.0'
-gem 'govuk_publishing_components', '~> 1.10.0', require: false
+gem 'govuk_publishing_components', '~> 1.11.0', require: false
 gem 'htmlentities', '4.3.4'
 gem 'logstasher', '0.6.1'
 gem 'plek', '1.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       sass (>= 3.2.0)
     govuk_navigation_helpers (6.3.0)
       gds-api-adapters (>= 43.0)
-    govuk_publishing_components (1.10.0)
+    govuk_publishing_components (1.11.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
@@ -237,7 +237,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     robotex (1.0.0)
-    rouge (2.2.1)
+    rouge (3.0.0)
     rubocop (0.49.1)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
@@ -326,7 +326,7 @@ DEPENDENCIES
   govuk_app_config (~> 0.3.0)
   govuk_frontend_toolkit (= 5.1.0)
   govuk_navigation_helpers (~> 6.3)
-  govuk_publishing_components (~> 1.10.0)
+  govuk_publishing_components (~> 1.11.0)
   govuk_schemas
   htmlentities (= 4.3.4)
   jasmine-rails!


### PR DESCRIPTION
Includes the following:

* Render accessibility violations in component guide
* Remove hover styles in component guide
* Include check for components without documentation (when running `bundle exec rake` )

Review app component guide:
https://government-frontend-pr-496.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-496.surge.sh/gallery.html
