### PR TITLE
Fix colour contrast in publication headers

### DIFF
--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -31,7 +31,7 @@
   .publication-header {
     @include core-19;
     color: $white;
-    background: $light-blue;
+    background: $govuk-blue;
     padding: ($gutter / 2) $gutter $gutter;
     margin-bottom: $gutter * 2;
 


### PR DESCRIPTION
HTML publication headers currently don't meet WCAG AA colour contrast ratio for normal text. Changing this from $light-blue to $govuk-blue fixes this.

**Before:**
<img width="976" alt="screen shot 2017-10-02 at 14 42 08" src="https://user-images.githubusercontent.com/29889908/31083420-9025de2e-a789-11e7-8483-03a4a2db83d3.png">

**After:**
<img width="983" alt="screen shot 2017-10-02 at 14 42 15" src="https://user-images.githubusercontent.com/29889908/31083445-97be62f0-a789-11e7-8f8a-5e62341b119b.png">

Previous ratio was 3.72:1, new ratio is 6.68:1 (need to meet 4.5:1)

Live page: https://government-frontend-pr-497.herokuapp.com/government/publications/budget-2016-documents/budget-2016

Review app component guide:
https://government-frontend-pr-497.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-497.surge.sh/gallery.html
