### PR TITLE
Add forthcoming notice to statistics announcements

### DIFF
--- a/app/helpers/typography_helper.rb
+++ b/app/helpers/typography_helper.rb
@@ -2,7 +2,7 @@ module TypographyHelper
   def nbsp_between_last_two_words(text)
     return text if text.nil?
     escaped_text = html_escape_once(text.strip)
-    escaped_text.sub(/\s([\w\.\?\!]+)$/, '&nbsp;\1').html_safe
+    escaped_text.sub(/\s([\w\.\?\!\:]+)$/, '&nbsp;\1').html_safe
   end
 
   def strip_trailing_colons(text)

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -2,6 +2,8 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
   include ContentItem::Metadata
   include ContentItem::TitleAndContext
 
+  FORTHCOMING_NOTICE = "These statistics will be available".freeze
+
   def release_date
     content_item["details"]["display_date"]
   end
@@ -53,6 +55,14 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
 
   def page_title
     "#{super} - #{I18n.t("content_item.schema_name.#{document_type}", count: 1)}"
+  end
+
+  def forthcoming_notice_title
+    "#{FORTHCOMING_NOTICE} #{release_date}"
+  end
+
+  def forthcoming_publication?
+    !cancelled?
   end
 
 private

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -14,6 +14,11 @@
 <% if @content_item.cancelled? %>
   <%= render 'components/notice', title: 'Statistics release cancelled', description_text: @content_item.cancellation_reason %>
 <% end %>
+
+<% if @content_item.forthcoming_publication? %>
+  <%= render 'components/notice', title: @content_item.forthcoming_notice_title %>
+<% end %>
+
 <%= render 'components/lead-paragraph', text: @content_item.description %>
 
 <% if @content_item.release_date_changed? %>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -16,7 +16,7 @@
 <% end %>
 
 <% if @content_item.forthcoming_publication? %>
-  <%= render 'components/notice', title: @content_item.forthcoming_notice_title %>
+  <%= render 'components/notice', title: nbsp_between_last_two_words(@content_item.forthcoming_notice_title) %>
 <% end %>
 
 <%= render 'components/lead-paragraph', text: @content_item.description %>

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -48,4 +48,18 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
       assert_has_component_metadata_pair("Reason for change", @content_item["details"]["latest_change_note"])
     end
   end
+
+  test "statistics announcement that are not cancelled display forthcoming notice" do
+    setup_and_visit_content_item('official_statistics')
+
+    within(".app-c-notice") do
+      assert_text "#{StatisticsAnnouncementPresenter::FORTHCOMING_NOTICE} #{@content_item['details']['display_date']}"
+    end
+  end
+
+  test "cancelled statistics announcements do not display the forthcoming notice" do
+    setup_and_visit_content_item('cancelled_official_statistics')
+
+    refute page.has_text?(StatisticsAnnouncementPresenter::FORTHCOMING_NOTICE)
+  end
 end

--- a/test/presenters/statistics_announcement_presenter_test.rb
+++ b/test/presenters/statistics_announcement_presenter_test.rb
@@ -64,6 +64,14 @@ class StatisticsAnnouncementPresenterTest < PresenterTestCase
     refute statistics_announcement_national.release_date_changed?
   end
 
+  test 'an announcement is forthcoming if it is not cancelled' do
+    assert statistics_announcement.forthcoming_publication?
+  end
+
+  test 'a cancelled announcement takes precedence over a forthcoming announcement' do
+    refute statistics_announcement_cancelled.forthcoming_publication?
+  end
+
   def statistics_announcement_cancelled
     presented_item('cancelled_official_statistics')
   end


### PR DESCRIPTION
When viewing statistical announcements that have a `display_date` in the future, users think they are looking at an actual released statistic and find it confusing that there is nothing there. Add a notice to the page to inform the users that the announcement is forthcoming.

Some examples:
https://government-frontend-pr-498.herokuapp.com/government/statistics/announcements/construction-output-in-great-britain-aug-2017

https://government-frontend-pr-498.herokuapp.com/government/statistics/announcements/business-population-estimates-2017

## Before
<img width="807" alt="screen shot 2017-10-06 at 09 36 08" src="https://user-images.githubusercontent.com/647311/31269901-267dcb5a-aa7a-11e7-803c-230fe58d4617.png">

## After
<img width="1001" alt="screen shot 2017-10-06 at 09 33 40" src="https://user-images.githubusercontent.com/647311/31269919-31b3d3de-aa7a-11e7-8a06-fed4f9af4285.png">


[Trello](https://trello.com/c/prArYYxS/153-were-sending-emails-about-stats-announcements-and-we-shouldnt-be)