### PR TITLE
Create publication header component

### DIFF
--- a/app/assets/stylesheets/components/_publication-header.scss
+++ b/app/assets/stylesheets/components/_publication-header.scss
@@ -1,0 +1,11 @@
+.app-c-publication-header {
+  @include core-19;
+  color: $white;
+  background: $govuk-blue;
+  padding: ($gutter / 2) $gutter $gutter;
+  margin-bottom: $gutter * 2;
+}
+
+.app-c-publication-header__last-changed {
+  margin-top: $gutter / 2;
+}

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -28,18 +28,6 @@
     }
   }
 
-  .publication-header {
-    @include core-19;
-    color: $white;
-    background: $govuk-blue;
-    padding: ($gutter / 2) $gutter $gutter;
-    margin-bottom: $gutter * 2;
-
-    .last-changed {
-      margin-top: $gutter / 2;
-    }
-  }
-
   .column-quarter-desktop-only {
     @include grid-column( 1 / 4, $full-width: desktop );
 

--- a/app/views/components/_publication-header.html.erb
+++ b/app/views/components/_publication-header.html.erb
@@ -1,0 +1,9 @@
+<header class="app-c-publication-header">
+  <%= render partial: 'govuk_component/title', locals: {
+    title: title,
+    context: context,
+    inverse: true,
+    margin_bottom: 0
+  } %>
+  <p class="app-c-publication-header__last-changed"><%= last_changed %></p>
+</header>

--- a/app/views/components/docs/publication-header.yml
+++ b/app/views/components/docs/publication-header.yml
@@ -1,0 +1,15 @@
+name: Publication Header
+description: A page header, currently used on HTML Publication pages.
+body: |
+  Real world example: [HTML Publication with header](/government/publications/budget-2016-documents/budget-2016)
+accessibility_criteria: |
+  The header must:
+
+  - be visually distinct from other content on the page
+  - have a text contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+examples:
+  default:
+    data:
+      title: 'Budget 2016'
+      context: 'Policy Paper'
+      last_changed: 'Updated 16 March 2016'

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -12,21 +12,14 @@
   </ol>
 </div>
 
-<header class="publication-header" id="contents">
-  <%= render partial: 'govuk_component/title', locals: {
-    title: @content_item.title,
-    context: I18n.t("content_item.schema_name.#{@content_item.format_sub_type}", count: 1),
-    inverse: true,
-    margin_bottom: 0
-  } %>
-  <p class="last-changed"><%= @content_item.last_changed %></p>
-</header>
+<%= render 'components/publication-header', title: @content_item.title, context: I18n.t("content_item.schema_name.#{@content_item.format_sub_type}", count: 1), last_changed: @content_item.last_changed %>
 
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 
 <div
   class="grid-row sidebar-with-body"
   data-module="sticky-element-container"
+  id="contents"
 >
   <% if @content_item.contents.any? %>
     <div class="column-quarter-desktop-only">

--- a/test/components/publication_header_test.rb
+++ b/test/components/publication_header_test.rb
@@ -1,0 +1,43 @@
+require 'component_test_helper'
+
+class PublicationHeaderTest < ComponentTestCase
+  def component_name
+    "publication-header"
+  end
+
+  test "fails to render a publication-header when no properties are supplied" do
+    assert_raise do
+      render_component({})
+    end
+  end
+end
+
+# This component renders some content using the static title component, which cannot currently be tested using the approach above.
+# To cover this gap, below is an integration test that loads the publication header page in the component guide in order to test
+# that the remaining aspects of the component are being rendered correctly.
+
+class PublicationHeaderTitleTest < ActionDispatch::IntegrationTest
+  test "renders a publication header" do
+    visit '/component-guide/publication-header/default'
+
+    within '.component-guide-preview' do
+      assert page.has_selector?(".app-c-publication-header")
+    end
+  end
+
+  test "renders a publication header with a title" do
+    visit '/component-guide/publication-header/default'
+
+    within '.component-guide-preview' do
+      assert_has_component_title("Budget 2016")
+    end
+  end
+
+  test "renders a publication header with last changed date" do
+    visit '/component-guide/publication-header/default'
+
+    within '.component-guide-preview' do
+      assert page.has_selector?(".app-c-publication-header__last-changed", text: "Updated 16 March 2016")
+    end
+  end
+end

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -10,7 +10,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   test "html publications" do
     setup_and_visit_content_item('published')
 
-    within ".publication-header" do
+    within ".app-c-publication-header" do
       assert page.has_text?(@content_item["details"]["format_sub_type"])
       assert page.has_text?(@content_item["title"])
 
@@ -69,7 +69,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   test "no contents are shown when headings are an empty list" do
     setup_and_visit_content_item("prime_ministers_office")
 
-    within ".publication-header" do
+    within ".app-c-publication-header" do
       refute page.has_text?("Contents")
     end
   end


### PR DESCRIPTION
Replace the existing html publication header with a component which makes use of govuk-title component.

In component guide:


Review app component guide:
https://government-frontend-pr-499.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-499.surge.sh/gallery.html
