### PR TITLE
Don't wrap numbers without a period

### DIFF
--- a/app/helpers/contents_list_helper.rb
+++ b/app/helpers/contents_list_helper.rb
@@ -7,7 +7,7 @@ module ContentsListHelper
     # Must be followed by a space
     # May contain a period `1.`
     # May be a decimal `1.2`
-    number = /^\d{1,3}(\.?|\.\d{1,2})(?=\s)/.match(content_item_text)
+    number = /^\d{1,3}(\.|\.\d{1,2})(?=\s)/.match(content_item_text)
 
     if number
       words = content_item_text.sub(number.to_s, '').strip #remove the number from the text

--- a/test/helpers/contents_list_helper_test.rb
+++ b/test/helpers/contents_list_helper_test.rb
@@ -17,8 +17,10 @@ class ContentsListHelperTest < ActionView::TestCase
     assert_equal text, strip_tags(wrapped_html)
   end
 
-  test "it wraps a number and text in span elements if it's a number without a period" do
-    assert_split_number_and_text('1 Thing', '1', 'Thing')
+  test "it does not wrap a number and text in span elements if it's a number without a period" do
+    input = '<a href="#thing">1 Thing</a>'
+    expected = '<a href="#thing">1 Thing</a>'
+    assert_equal expected, wrap_numbers_with_spans(input)
   end
 
   test "it wraps a number in the form X.Y" do


### PR DESCRIPTION
We've had a ticket come in where someone was writing dates in the headings (e.g. 2 April 2017) and this was being parsed as a numbered list. Since the guidance for govspeak is to include the period after numbers you want to be recognised as numbers, I don't think it makes sense for numbers without a period to be accepted.

It's also unclear why numbers without periods are currently being accepted.