### PR TITLE
Run Publishing E2E Tests as part of a build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,5 @@ REPOSITORY = 'government-frontend'
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.buildProject()
+  govuk.buildProject(publishingE2ETests: true)
 }


### PR DESCRIPTION
This change will cause [Publishing End-to-end Tests][e2e-tests] to run
once the initial unit tests for this build has passed and will be
triggered as a dependent build.

These are used to test that none of the changes made in a commit to this
repo don't break the tech stack or break the end-to-end tests
environment.

The End-to-end tests take approximately 4/5 minutes to run and will make
it slower to get a passing build.

[e2e-tests]: https://github.com/alphagov/publishing-e2e-tests
