### PR TITLE
Add clarity to stats announcement forthcoming notice

### DIFF
--- a/app/helpers/statistics_announcement_helper.rb
+++ b/app/helpers/statistics_announcement_helper.rb
@@ -1,0 +1,27 @@
+module StatisticsAnnouncementHelper
+  def on_in_between_for_release_date(date)
+    return "on #{date}" if date_is_exact_format?(date)
+    return "in #{date}" if date_is_one_month_format?(date)
+    return "between #{replace_on_with_and(date)}" if date_is_two_month_format?(date)
+    date
+  end
+
+private
+
+  def replace_on_with_and(date_in_two_month_format)
+    re = /\s(to)\s/
+    date_in_two_month_format.sub(re, " and ")
+  end
+
+  def date_is_two_month_format?(date)
+    date =~ /\A(\w+)\s(to)\s(\w+)/
+  end
+
+  def date_is_one_month_format?(date)
+    date =~ /\A(\w+)\s(\d{1,4})/
+  end
+
+  def date_is_exact_format?(date)
+    date.downcase =~ /\A(\d{1,2})\s(\w+)\s(\d{4})\s(\d{1,2}:\d{1,2})(am|pm)/
+  end
+end

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -1,8 +1,9 @@
 class StatisticsAnnouncementPresenter < ContentItemPresenter
   include ContentItem::Metadata
   include ContentItem::TitleAndContext
+  include StatisticsAnnouncementHelper
 
-  FORTHCOMING_NOTICE = "These statistics will be available".freeze
+  FORTHCOMING_NOTICE = "These statistics will be released".freeze
 
   def release_date
     content_item["details"]["display_date"]
@@ -58,7 +59,7 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
   end
 
   def forthcoming_notice_title
-    "#{FORTHCOMING_NOTICE} #{release_date}"
+    "#{FORTHCOMING_NOTICE} #{on_in_between_for_release_date(release_date)}"
   end
 
   def forthcoming_publication?

--- a/test/helpers/statistics_announcement_helper_test.rb
+++ b/test/helpers/statistics_announcement_helper_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class StatisticsAnnouncementHelperTest < ActionView::TestCase
+  test "returns 'on' if the date is an exact format" do
+    assert_equal "on 10 January 2017 9:30am", on_in_between_for_release_date("10 January 2017 9:30am")
+    assert_equal "on 1 December 2010 11:30pm", on_in_between_for_release_date("1 December 2010 11:30pm")
+    assert_equal "on 18 March 2020 1:30PM", on_in_between_for_release_date("18 March 2020 1:30PM")
+  end
+
+  test "returns 'in' if the date is a one month format" do
+    assert_equal "in January 2018", on_in_between_for_release_date("January 2018")
+  end
+
+  test "returns 'between' and replaces 'to' with 'and' if the date is a two month format" do
+    assert_equal "between March and April 2018", on_in_between_for_release_date("March to April 2018")
+  end
+
+  test "returns the passed in string if it doesn't match any format" do
+    assert_equal "some or other unexpected date format", on_in_between_for_release_date("some or other unexpected date format")
+  end
+end

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -53,7 +53,7 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('official_statistics')
 
     within(".app-c-notice") do
-      assert_text "#{StatisticsAnnouncementPresenter::FORTHCOMING_NOTICE} #{@content_item['details']['display_date']}"
+      assert_text "#{StatisticsAnnouncementPresenter::FORTHCOMING_NOTICE} on #{@content_item['details']['display_date']}"
     end
   end
 


### PR DESCRIPTION
Add a helper to improve the clarity of the forthcoming notification on Statistical Announcements.

Statistical Announcements can have three different date formats:

* Exact e.g. `10th January 2018 9:30am (provisional)`
* One month e.g. `January 2018 (provisional)`
* Two month e.g. `January to February 2018 (provisional)`

To improve the clarity of the notice, we want to add `on`, `in` or `between` before the date component. In addition, when we are working with a two month date range, we want to substitute `and` for the `to` (`...between January and February...`) so we do not imply that the publication is only available between the two months.

Example of an exact date:
https://government-frontend-pr-502.herokuapp.com/government/statistics/announcements/12-week-maternal-assessment-for-q4-201617-and-annual-data-201617--3

Example of a one month date:
https://government-frontend-pr-502.herokuapp.com/government/statistics/announcements/nhs-outcomes-framework-indicators-nov-2018-release

Example of a two month range:
https://government-frontend-pr-502.herokuapp.com/government/statistics/announcements/housing-statistics-1-april-2017-to-30-september-2017

[Trello](https://trello.com/c/vRY4O6vp/208-clarify-statistical-announcement-forthcoming-notice)