### PR TITLE
[Do not merge] Prototype removal of all navigation from content pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,3 +44,8 @@
 @import 'views/answer';
 @import 'views/help-page';
 @import "views/guide";
+
+.govuk-metadata,
+.govuk-document-footer {
+  display: none;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,7 +45,18 @@
 @import 'views/help-page';
 @import "views/guide";
 
-.govuk-metadata,
-.govuk-document-footer {
-  display: none;
+.pub-c-title {
+  margin-top: 30px;
+}
+
+.govuk-govspeak {
+  margin-top: 30px;
+}
+
+.govuk-metadata {
+  margin-top: 30px;
+}
+
+.pub-c-lead-paragraph {
+  margin-top: 30px;
 }

--- a/app/assets/stylesheets/mixins/_margins.scss
+++ b/app/assets/stylesheets/mixins/_margins.scss
@@ -18,3 +18,7 @@
   @include responsive-bottom-margin;
   @include responsive-top-margin;
 }
+
+@mixin add-page-bottom-margin {
+  margin-bottom: $gutter * 2;
+}

--- a/app/assets/stylesheets/views/_answer.scss
+++ b/app/assets/stylesheets/views/_answer.scss
@@ -1,5 +1,6 @@
 .answer {
   @include add-title-margin;
+  @include add-page-bottom-margin;
 
   .last-updated {
     padding-bottom: $gutter-half;

--- a/app/assets/stylesheets/views/_guide.scss
+++ b/app/assets/stylesheets/views/_guide.scss
@@ -1,6 +1,7 @@
 .guide {
   @include parts;
   @include add-title-margin;
+  @include add-page-bottom-margin;
 
   .part-navigation li {
     list-style: decimal;

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -1,6 +1,7 @@
 .travel-advice {
   @include parts;
   @include add-title-margin;
+  @include add-page-bottom-margin;
 
   .part-navigation {
     margin-bottom: $gutter * 1.5;

--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -1,0 +1,36 @@
+class EducationNavigationAbTestRequest
+  NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS =
+    %w{answer contact guide detailed_guide document_collection publication}.freeze
+
+  attr_accessor :requested_variant
+
+  delegate :analytics_meta_tag, to: :requested_variant
+
+  def initialize(request, content_item)
+    @content_item = content_item
+    @ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: 41)
+    @requested_variant = @ab_test.requested_variant(request.headers)
+  end
+
+  def ab_test_applies?
+    false
+  end
+
+  def should_present_new_navigation_view?
+    ab_test_applies? && @requested_variant.variant?("B")
+  end
+
+  def set_response_vary_header(response)
+    @requested_variant.configure_response response
+  end
+
+private
+
+  def content_is_tagged_to_a_taxon?
+    @content_item.dig("links", "taxons").present?
+  end
+
+  def content_schema_has_new_navigation?
+    NEW_NAVIGATION_CONTENT_ITEM_SCHEMAS.include? @content_item["schema_name"]
+  end
+end

--- a/app/views/content_items/publication.html+taxonomy_navigation.erb
+++ b/app/views/content_items/publication.html+taxonomy_navigation.erb
@@ -34,7 +34,6 @@
   </div>
 
   <div class="column-third add-title-margin">
-    <%= render partial: 'govuk_component/taxonomy_sidebar', locals: @content_item.taxonomy_sidebar %>
   </div>
 </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,13 +27,7 @@
   <%= yield :extra_head_content %>
 </head>
 <body>
-  <% unless content_for(:simple_header) %>
-    <%= render partial: 'govuk_component/government_navigation', locals: { active: active_proposition } %>
-  <% end %>
-
   <div id="wrapper" class="<%= wrapper_class %>">
-    <%= render_phase_label @content_item, content_for(:phase_message) %>
-    <%= render 'shared/breadcrumbs' %>
     <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">
       <%= yield %>
     </main>

--- a/app/views/shared/_related_items.html.erb
+++ b/app/views/shared/_related_items.html.erb
@@ -1,3 +1,2 @@
 <div class="column-third add-title-margin">
-  <%= render partial: 'govuk_component/related_items', locals: content_item.related_items %>
 </div>


### PR DESCRIPTION
We're considering removing all navigation patterns from as a test variant to see how each contributes to the way users navigate around the website.

Removes:
* Related links
* Metadata
* Document footer
* Breadcrumbs
* Government navigation

Examples:
https://government-frontend-pr-505.herokuapp.com/government/publications/recognising-the-terrorist-threat
https://government-frontend-pr-505.herokuapp.com/child-maintenance
https://government-frontend-pr-505.herokuapp.com/arranging-child-maintenance-yourself
https://government-frontend-pr-505.herokuapp.com/cma-cases/electro-rent-corporation-test-equipment-asset-management-and-microlease-merger-inquiry