### PR TITLE
Remove bespoke taxonomy sidebar component styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,7 +13,6 @@
 // helpers for common page elements
 @import 'helpers/sidebar-with-body';
 @import 'helpers/organisation-links';
-@import 'helpers/taxonomy-sidebar';
 @import 'helpers/parts';
 @import 'helpers/add-title-margin';
 

--- a/app/assets/stylesheets/helpers/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/helpers/_taxonomy-sidebar.scss
@@ -1,5 +1,0 @@
-@mixin taxonomy-sidebar {
-  .govuk-taxonomy-sidebar {
-    margin-top: 50px;
-  }
-}

--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -1,6 +1,5 @@
 .detailed-guide {
   @include sidebar-with-body;
-  @include taxonomy-sidebar;
 
   .direction-rtl & {
     direction: rtl;

--- a/app/assets/stylesheets/views/_document-collection.scss
+++ b/app/assets/stylesheets/views/_document-collection.scss
@@ -1,6 +1,5 @@
 .document-collection {
   @include sidebar-with-body;
-  @include taxonomy-sidebar;
 
   .group-title {
     @include bold-27;

--- a/app/assets/stylesheets/views/_publication.scss
+++ b/app/assets/stylesheets/views/_publication.scss
@@ -1,6 +1,5 @@
 .publication {
   @include sidebar-with-body;
-  @include taxonomy-sidebar;
   @include add-title-margin;
 
   .direction-rtl & {

--- a/app/views/content_items/detailed_guide.html+new_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+new_navigation.erb
@@ -32,7 +32,7 @@
     <%= render 'shared/footer', @content_item.document_footer %>
   </div>
 
-  <div class="column-third">
+  <div class="column-third add-title-margin">
     <%= render partial: 'govuk_component/taxonomy_sidebar', locals: @content_item.taxonomy_sidebar %>
   </div>
 </div>

--- a/app/views/content_items/document_collection.html+new_navigation.erb
+++ b/app/views/content_items/document_collection.html+new_navigation.erb
@@ -12,7 +12,7 @@
     <%= render 'document_collection_body' %>
   </div>
 
-  <div class="column-third">
+  <div class="column-third add-title-margin">
     <%= render partial: 'govuk_component/taxonomy_sidebar', locals: @content_item.taxonomy_sidebar %>
   </div>
 </div>

--- a/app/views/content_items/publication.html+new_navigation.erb
+++ b/app/views/content_items/publication.html+new_navigation.erb
@@ -33,7 +33,7 @@
     </div>
   </div>
 
-  <div class="column-third">
+  <div class="column-third add-title-margin">
     <%= render partial: 'govuk_component/taxonomy_sidebar', locals: @content_item.taxonomy_sidebar %>
   </div>
 </div>


### PR DESCRIPTION
* Use the `add-title-margin` class
* Avoid styling components, this breaks their isolation
* Makes taxonomy component spacing behave in the same way as related links component

Part of:
https://trello.com/c/FN3ppmn2/60-update-taxonomy-related-links-in-right-column-to-match-the-design-used-by-mainstream-browse-related-links