### PR TITLE
Hebrew is a right-to-left language

### DIFF
--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1,4 +1,6 @@
 he:
+  i18n:
+    direction: rtl
   language_names:
     he: "עברית"
   content_item:


### PR DESCRIPTION
This commit adds `rtl` to the he.yml locale as Hebrew should read right
to left.

Fixes [Zendesk](https://govuk.zendesk.com/agent/tickets/2496478)

Example with the issue: 

https://www.gov.uk/government/news/foreign-secretary-article-on-the-balfour-declaration

![image](https://user-images.githubusercontent.com/5216/32184195-6aba7ee0-bd93-11e7-956f-5dbff4892b1e.png)

After: 

![image](https://user-images.githubusercontent.com/5216/32184250-9ee9644c-bd93-11e7-8a03-e5e1c7610558.png)

