### PR TITLE
Set environment vars for Rummager

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,6 +14,9 @@
     "PLEK_SERVICE_CONTENT_STORE_URI": {
       "value": "https://www.gov.uk/api"
     },
+    "PLEK_SERVICE_RUMMAGER_URI": {
+      "value": "https://www.gov.uk/api"
+    },
     "PLEK_SERVICE_STATIC_URI": {
       "value": "assets.digital.cabinet-office.gov.uk"
     },

--- a/startup.sh
+++ b/startup.sh
@@ -7,6 +7,7 @@ if [[ $1 == "--live" ]] ; then
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
+  PLEK_SERVICE_RUMMAGER_URI=${PLEK_SERVICE_RUMMAGER_URI-https://www.gov.uk/api} \
   bundle exec rails s -p 3090
 else
   bundle exec rails s -p 3090


### PR DESCRIPTION
Rummager/search is a dependency of the navigation helpers (it uses it to show related content). We normally don't notice this because the govuk_navigation_helpers gem is designed to fail gracefully when rummager isn't available.