### PR TITLE
Include title margin styles on detailed guides & collections

### DIFF
--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -1,4 +1,5 @@
 .detailed-guide {
+  @include add-title-margin;
   @include sidebar-with-body;
 
   .direction-rtl & {

--- a/app/assets/stylesheets/views/_document-collection.scss
+++ b/app/assets/stylesheets/views/_document-collection.scss
@@ -1,4 +1,5 @@
 .document-collection {
+  @include add-title-margin;
   @include sidebar-with-body;
 
   .group-title {


### PR DESCRIPTION
`govuk-taxonomy-sidebar` styles were removed in https://github.com/alphagov/government-frontend/pull/507 but the styles for `add-title-margin` were not being included on detailed guides and collections.

https://www.gov.uk/government/collections/national-curriculum
https://government-frontend-pr-514.herokuapp.com/government/collections/national-curriculum

https://www.gov.uk/guidance/student-bursary-support-service-demonstration-videos-for-education-institutions
https://government-frontend-pr-514.herokuapp.com/guidance/student-bursary-support-service-demonstration-videos-for-education-institutions
