### PR TITLE
Add the TrafficSignsSummary A/B test

### DIFF
--- a/app/models/traffic_signs_summary_ab_test_request.rb
+++ b/app/models/traffic_signs_summary_ab_test_request.rb
@@ -1,0 +1,34 @@
+class TrafficSignsSummaryAbTestRequest
+  attr_accessor :requested_variant
+
+  delegate :analytics_meta_tag, to: :requested_variant
+
+  def initialize(request, content_item)
+    @content_item = content_item
+    @ab_test = GovukAbTesting::AbTest.new("TrafficSignsSummary", dimension: 81)
+    @requested_variant = @ab_test.requested_variant(request.headers)
+  end
+
+  def ab_test_applies?
+    @content_item["base_path"] == "/government/publications/know-your-traffic-signs"
+  end
+
+  def should_present_old_summary?
+    ab_test_applies? && @requested_variant.variant?("B")
+  end
+
+  def with_old_summary(content_item)
+    OldTrafficSignsContentItem.new(content_item)
+  end
+
+  def set_response_vary_header(response)
+    @requested_variant.configure_response response
+  end
+
+  class OldTrafficSignsContentItem < SimpleDelegator
+    def description
+      # From http://webarchive.nationalarchives.gov.uk/20170605215458/https://www.gov.uk/government/publications/know-your-traffic-signs
+      "Guidance on road traffic signage in Great Britain."
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,7 @@
   <% end %>
   <meta name="govuk:content-id" content="<%= @content_item.content_id %>" />
   <%= tasklist_variant.analytics_meta_tag.html_safe if tasklist_ab_test_applies? %>
+  <%= @traffic_signs_summary_ab_test.analytics_meta_tag.html_safe if @traffic_signs_summary_ab_test.ab_test_applies? %>
   <%= yield :extra_head_content %>
 </head>
 <body>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class ContentItemsControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::ContentStore
+  include GovukAbTesting::MinitestHelpers
 
   test 'routing handles paths with no format or locale' do
     assert_routing(
@@ -336,6 +337,57 @@ class ContentItemsControllerTest < ActionController::TestCase
     get :show, params: { path: 'foreign-travel-advice/albania', format: 'atom' }
 
     assert_equal response.headers["Access-Control-Allow-Origin"], "*"
+  end
+
+  test "updates Know your traffic signs description for B variant only" do
+    content_item = content_store_has_schema_example("publication", "publication")
+    path = "government/publications/know-your-traffic-signs"
+    content_item["base_path"] = "/#{path}"
+    content_item["description"] = "The current description"
+
+    content_store_has_item(content_item["base_path"], content_item)
+
+    with_variant TrafficSignsSummary: "A", dimension: 81 do
+      get :show, params: { path: path_for(content_item) }
+      assert_match(/The current description/, response.body)
+      refute_match(/Guidance on road traffic signage in Great Britain/, response.body)
+    end
+
+    with_variant TrafficSignsSummary: "B", dimension: 81 do
+      get :show, params: { path: path_for(content_item) }
+      refute_match(/The current description/, response.body)
+      assert_match(/Guidance on road traffic signage in Great Britain/, response.body)
+    end
+  end
+
+  test "Traffic signs summary test does not affect other pages in A" do
+    content_item = content_store_has_schema_example("publication", "publication")
+    path = "government/publications/some-other-publication"
+    content_item["base_path"] = "/#{path}"
+    content_item["description"] = "The current description"
+
+    content_store_has_item(content_item["base_path"], content_item)
+
+    setup_ab_variant("TrafficSignsSummary", "A")
+
+    get :show, params: { path: path_for(content_item) }
+    assert_match(/The current description/, response.body)
+    refute_match(/Guidance on road traffic signage in Great Britain/, response.body)
+  end
+
+  test "Traffic signs summary test does not affect other pages in B" do
+    content_item = content_store_has_schema_example("publication", "publication")
+    path = "government/publications/some-other-publication"
+    content_item["base_path"] = "/#{path}"
+    content_item["description"] = "The current description"
+
+    content_store_has_item(content_item["base_path"], content_item)
+
+    setup_ab_variant("TrafficSignsSummary", "B")
+
+    get :show, params: { path: path_for(content_item) }
+    assert_match(/The current description/, response.body)
+    refute_match(/Guidance on road traffic signage in Great Britain/, response.body)
   end
 
   def path_for(content_item, locale = nil)


### PR DESCRIPTION
The TrafficSignsSummary A/B test will test a content improvement to the
summary of the [Know your traffic signs][1] publication.

[1]: https://www.gov.uk/government/publications/know-your-traffic-signs

Visual regression results:
https://government-frontend-pr-515.surge.sh/gallery.html

## Dependencies:

- [x] https://github.com/alphagov/cdn-configs/pull/9
- [x] https://github.com/alphagov/fastly-configure/pull/44