### PR TITLE
Use the same metadata for all pages

### DIFF
--- a/app/presenters/content_item/metadata.rb
+++ b/app/presenters/content_item/metadata.rb
@@ -15,12 +15,6 @@ module ContentItem
       }
     end
 
-    def metadata_for_taxonomy_navigation
-      data = metadata
-      data.delete(:part_of)
-      data
-    end
-
     def document_footer
       {
         from: from,
@@ -31,12 +25,6 @@ module ContentItem
         direction: text_direction,
         other: {}
       }
-    end
-
-    def document_footer_for_taxonomy_navigation
-      data = document_footer
-      data.delete(:part_of)
-      data
     end
   end
 end

--- a/app/views/shared/_footer.html+taxonomy_navigation.erb
+++ b/app/views/shared/_footer.html+taxonomy_navigation.erb
@@ -1,1 +1,0 @@
-<%= render 'govuk_component/document_footer', @content_item.document_footer_for_taxonomy_navigation %>

--- a/app/views/shared/_metadata.html+taxonomy_navigation.erb
+++ b/app/views/shared/_metadata.html+taxonomy_navigation.erb
@@ -1,1 +1,1 @@
-<%= render 'govuk_component/metadata', @content_item.metadata_for_taxonomy_navigation %>
+<%= render 'govuk_component/metadata', @content_item.metadata %>


### PR DESCRIPTION
* Don’t hide the `part of` bits of metadata on new taxonomy pages
* We will be iterating what nav is shown in future multivariate tests
* Part of includes both trivially related things and important related
things – we need to do better in distinguishing them

Review app vs live:
https://government-frontend-pr-516.herokuapp.com/government/publications/national-apprenticeship-awards-apprentice-categories
https://www.gov.uk/government/publications/national-apprenticeship-awards-apprentice-categories?ABTest-EducationNavigation=B

https://trello.com/c/zuBOPznV/74-remove-ab-test-from-government-frontend