### PR TITLE
Remove the beta banner from taxonomy navigation pages

### DIFF
--- a/app/views/shared/_breadcrumbs.html+taxonomy_navigation.erb
+++ b/app/views/shared/_breadcrumbs.html+taxonomy_navigation.erb
@@ -1,20 +1,4 @@
 <% if @content_item.taxon_breadcrumbs.any? %>
-  <%=
-    render(
-      partial: 'govuk_component/beta_label',
-      locals: {
-        message: <<-MESSAGE
-        This is a test version of the layout of this page.
-        <a id=taxonomy-survey
-           href='https://www.smartsurvey.co.uk/s/betasurvey2017?c=#{current_path_without_query_string}'
-           target='_blank'
-           rel='noopener noreferrer'>
-          Take the survey to help us improve it
-        </a>
-        MESSAGE
-      }
-    )
-  %>
   <%= render 'govuk_component/breadcrumbs',
     breadcrumbs: @content_item.taxon_breadcrumbs,
     collapse_on_mobile: true %>


### PR DESCRIPTION
* We are rolling out taxonomy navigation as the live variant on certain
pages, meaning it’s no longer a test version
* The survey in it’s current form on these pages isn’t required. A new
survey will be used on newer test variants
* The AB test has been disabled

Compare live, integration and this branch:
https://www.gov.uk/government/publications/national-apprenticeship-awards-apprentice-categories?ABTest-EducationNavigation=B
https://www-origin.integration.publishing.service.gov.uk/government/publications/national-apprenticeship-awards-apprentice-categories
https://government-frontend-pr-517.herokuapp.com/government/publications/national-apprenticeship-awards-apprentice-categories

https://trello.com/c/zuBOPznV/74-remove-ab-test-from-government-frontend

cc @vanitabarrett 