### PR TITLE
Add pass-plus chapters and sync tasklist pages with list in frontend

### DIFF
--- a/app/controllers/concerns/tasklist_ab_testable.rb
+++ b/app/controllers/concerns/tasklist_ab_testable.rb
@@ -2,32 +2,51 @@ module TasklistABTestable
   TASKLIST_DIMENSION = 66
 
   TASKLIST_PRIMARY_PAGES = %w(
-    /legal-obligations-drivers-riders
+    /apply-first-provisional-driving-licence
+    /book-driving-test
+    /book-theory-test
+    /cancel-driving-test
+    /cancel-theory-test
+    /change-driving-test
+    /change-theory-test
+    /check-driving-test
+    /check-theory-test
+    /driving-eyesight-rules
     /driving-lessons-learning-to-drive
+    /driving-test/what-to-take
+    /find-driving-schools-and-lessons
     /government/publications/car-show-me-tell-me-vehicle-safety-questions
+    /guidance/the-highway-code
+    /legal-obligations-drivers-riders
+    /pass-plus
+    /take-practice-theory-test
     /theory-test/revision-and-practice
     /theory-test/what-to-take
-    /pass-plus
+    /vehicles-can-drive
   ).freeze
 
   TASKLIST_SECONDARY_PAGES = %w(
-    /driving-eyesight-rules
-    /complain-about-a-driving-instructor
-    /driving-test-cost
-    /government/publications/driving-instructor-grades-explained
-    /guidance/rules-for-observing-driving-tests
-    /speed-limits
-    /seat-belts-law
-    /vehicle-insurance
-    /report-an-illegal-driving-instructor
-    /government/publications/know-your-traffic-signs
     /apply-for-your-full-driving-licence
-    /driving-licence-fees
-    /report-driving-test-impersonation
-    /government/publications/application-for-refunding-out-of-pocket-expenses
-    /government/publications/l-plate-size-rules
     /automatic-driving-licence-to-manual
+    /complain-about-a-driving-instructor
+    /driving-licence-fees
+    /driving-test-cost
+    /dvlaforms
+    /find-theory-test-pass-number
+    /government/publications/application-for-refunding-out-of-pocket-expenses
     /government/publications/drivers-record-for-learner-drivers
+    /government/publications/driving-instructor-grades-explained
+    /government/publications/know-your-traffic-signs
+    /government/publications/l-plate-size-rules
+    /guidance/rules-for-observing-driving-tests
+    /report-an-illegal-driving-instructor
+    /report-driving-medical-condition
+    /report-driving-test-impersonation
+    /seat-belts-law
+    /speed-limits
+    /track-your-driving-licence-application
+    /vehicle-insurance
+    /view-driving-licence
   ).freeze
 
   MATCHING_PAGES = %w(

--- a/app/controllers/concerns/tasklist_ab_testable.rb
+++ b/app/controllers/concerns/tasklist_ab_testable.rb
@@ -60,6 +60,11 @@ module TasklistABTestable
     /driving-test/test-cancelled-bad-weather
     /driving-test/using-your-own-car
     /driving-test/what-happens-during-test
+    /pass-plus/apply-for-a-pass-plus-certificate
+    /pass-plus/booking-pass-plus
+    /pass-plus/car-insurance-discounts
+    /pass-plus/local-councils-offering-discounts
+    /pass-plus/how-pass-plus-training-works
     /theory-test
     /theory-test/hazard-perception-test
     /theory-test/if-you-have-safe-road-user-award


### PR DESCRIPTION
We want to keep these lists in sync so that it's easy to tell if either is out
of date.  These lists are used to determine which pages should show a learn-to-drive-a-car
task list. 

By doing this sync, we add `driving-test/what-to-take` which was missing (and
is rendered by govt-frontend) and sort them so it's easier to what's there.

We also add the chapters for `/pass-plus` so they get a task list rendered too.

The corresponding pass-plus PR in Frontend is https://github.com/alphagov/frontend/pull/1300