### PR TITLE
Add content navigation multivariate test

### DIFF
--- a/app/controllers/concerns/content_navigation_ab_testable.rb
+++ b/app/controllers/concerns/content_navigation_ab_testable.rb
@@ -37,7 +37,8 @@ module ContentNavigationABTestable
       GovukAbTesting::AbTest.new(
         "ContentNavigation",
         dimension: CONTENT_NAVIGATION_DIMENSION,
-        allowed_variants: CONTENT_NAVIGATION_ALLOWED_VARIANTS
+        allowed_variants: CONTENT_NAVIGATION_ALLOWED_VARIANTS,
+        control_variant: CONTENT_NAVIGATION_ORIGINAL
       )
   end
 

--- a/app/controllers/concerns/content_navigation_ab_testable.rb
+++ b/app/controllers/concerns/content_navigation_ab_testable.rb
@@ -1,0 +1,86 @@
+module ContentNavigationABTestable
+  CONTENT_NAVIGATION_DIMENSION = 67
+  CONTENT_NAVIGATION_ORIGINAL = "Original".freeze
+  CONTENT_NAVIGATION_UNIVERSAL_NO_NAVIGATION = "UniversalNoNav".freeze
+  CONTENT_NAVIGATION_UNIVERSAL_MAINSTREAM_NAVIGATION = "UniversalMainstreamNav".freeze
+  CONTENT_NAVIGATION_UNIVERSAL_TAXON_NAVIGATION = "UniversalTaxonNav".freeze
+
+  CONTENT_NAVIGATION_ALLOWED_VARIANTS = [
+    CONTENT_NAVIGATION_ORIGINAL,
+    CONTENT_NAVIGATION_UNIVERSAL_NO_NAVIGATION,
+    CONTENT_NAVIGATION_UNIVERSAL_MAINSTREAM_NAVIGATION,
+    CONTENT_NAVIGATION_UNIVERSAL_TAXON_NAVIGATION
+  ].freeze
+
+  GUIDANCE_DOCUMENT_TYPES = %w(
+    answer
+    guide
+    detailed_guide
+    statutory_guidance
+  ).freeze
+
+  def self.included(base)
+    base.helper_method(
+      :content_navigation_variant,
+      :content_navigation_ab_test_applies?,
+      :content_navigation_test_original_variant?,
+      :universal_navigation_without_nav?,
+      :universal_navigation_with_taxon_nav?,
+      :universal_navigation_with_mainstream_nav?
+    )
+
+    base.after_action :set_content_navigation_response_header
+  end
+
+  def content_navigation_ab_test
+    @content_navigation_ab_test ||=
+      GovukAbTesting::AbTest.new(
+        "ContentNavigation",
+        dimension: CONTENT_NAVIGATION_DIMENSION,
+        allowed_variants: CONTENT_NAVIGATION_ALLOWED_VARIANTS
+      )
+  end
+
+  # Universal navigation:
+  # https://gov-uk.atlassian.net/wiki/spaces/GFED/pages/186351726/Sprint+1+designs
+  #
+  # Universal navigation must only be shown when:
+  # * in the multivariate test
+  # * not showing the original variant
+  def should_present_universal_navigation?
+    content_navigation_ab_test_applies? && !content_navigation_test_original_variant?
+  end
+
+  def content_navigation_ab_test_applies?
+    @content_item && @content_item.tagged_to_a_taxon? && content_document_type_is_guidance?
+  end
+
+  def content_document_type_is_guidance?
+    GUIDANCE_DOCUMENT_TYPES.include? @content_item.document_type
+  end
+
+  def content_navigation_test_original_variant?
+    content_navigation_variant.variant?(CONTENT_NAVIGATION_ORIGINAL)
+  end
+
+  def universal_navigation_without_nav?
+    content_navigation_variant.variant?(CONTENT_NAVIGATION_UNIVERSAL_NO_NAVIGATION)
+  end
+
+  def universal_navigation_with_taxon_nav?
+    content_navigation_variant.variant?(CONTENT_NAVIGATION_UNIVERSAL_TAXON_NAVIGATION)
+  end
+
+  def universal_navigation_with_mainstream_nav?
+    content_navigation_variant.variant?(CONTENT_NAVIGATION_UNIVERSAL_MAINSTREAM_NAVIGATION)
+  end
+
+  def content_navigation_variant
+    @content_navigation_variant ||=
+      content_navigation_ab_test.requested_variant(request.headers)
+  end
+
+  def set_content_navigation_response_header
+    content_navigation_variant.configure_response(response) if content_navigation_ab_test_applies?
+  end
+end

--- a/app/controllers/concerns/content_navigation_ab_testable.rb
+++ b/app/controllers/concerns/content_navigation_ab_testable.rb
@@ -1,4 +1,5 @@
 module ContentNavigationABTestable
+  CONTENT_NAVIGATION_TEST_NAME = "ContentNavigation".freeze
   CONTENT_NAVIGATION_DIMENSION = 67
   CONTENT_NAVIGATION_ORIGINAL = "Original".freeze
   CONTENT_NAVIGATION_UNIVERSAL_NO_NAVIGATION = "UniversalNoNav".freeze
@@ -23,7 +24,6 @@ module ContentNavigationABTestable
     base.helper_method(
       :content_navigation_variant,
       :content_navigation_ab_test_applies?,
-      :content_navigation_test_original_variant?,
       :universal_navigation_without_nav?,
       :universal_navigation_with_taxon_nav?,
       :universal_navigation_with_mainstream_nav?
@@ -35,7 +35,7 @@ module ContentNavigationABTestable
   def content_navigation_ab_test
     @content_navigation_ab_test ||=
       GovukAbTesting::AbTest.new(
-        "ContentNavigation",
+        CONTENT_NAVIGATION_TEST_NAME,
         dimension: CONTENT_NAVIGATION_DIMENSION,
         allowed_variants: CONTENT_NAVIGATION_ALLOWED_VARIANTS,
         control_variant: CONTENT_NAVIGATION_ORIGINAL
@@ -49,7 +49,7 @@ module ContentNavigationABTestable
   # * in the multivariate test
   # * not showing the original variant
   def should_present_universal_navigation?
-    content_navigation_ab_test_applies? && !content_navigation_test_original_variant?
+    content_navigation_ab_test_applies? && !content_navigation_variant.variant?(CONTENT_NAVIGATION_ORIGINAL)
   end
 
   def content_navigation_ab_test_applies?
@@ -60,20 +60,19 @@ module ContentNavigationABTestable
     GUIDANCE_DOCUMENT_TYPES.include? @content_item.document_type
   end
 
-  def content_navigation_test_original_variant?
-    content_navigation_variant.variant?(CONTENT_NAVIGATION_ORIGINAL)
-  end
-
   def universal_navigation_without_nav?
-    content_navigation_variant.variant?(CONTENT_NAVIGATION_UNIVERSAL_NO_NAVIGATION)
+    content_navigation_ab_test_applies? &&
+      content_navigation_variant.variant?(CONTENT_NAVIGATION_UNIVERSAL_NO_NAVIGATION)
   end
 
   def universal_navigation_with_taxon_nav?
-    content_navigation_variant.variant?(CONTENT_NAVIGATION_UNIVERSAL_TAXON_NAVIGATION)
+    content_navigation_ab_test_applies? &&
+      content_navigation_variant.variant?(CONTENT_NAVIGATION_UNIVERSAL_TAXON_NAVIGATION)
   end
 
   def universal_navigation_with_mainstream_nav?
-    content_navigation_variant.variant?(CONTENT_NAVIGATION_UNIVERSAL_MAINSTREAM_NAVIGATION)
+    content_navigation_ab_test_applies? &&
+      content_navigation_variant.variant?(CONTENT_NAVIGATION_UNIVERSAL_MAINSTREAM_NAVIGATION)
   end
 
   def content_navigation_variant

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -62,6 +62,10 @@ class ContentItemPresenter
     @nav_helper.related_items
   end
 
+  def tagged_to_a_taxon?
+    content_item.dig("links", "taxons").present?
+  end
+
 private
 
   def display_date(timestamp, format = "%-d %B %Y")

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,7 @@
   <%= tasklist_variant.analytics_meta_tag.html_safe if tasklist_ab_test_applies? %>
   <%= @traffic_signs_summary_ab_test.analytics_meta_tag.html_safe if @traffic_signs_summary_ab_test.ab_test_applies? %>
   <%= tasklist_header_variant.analytics_meta_tag.html_safe if tasklist_header_ab_test_applies? %>
+  <%= content_navigation_variant.analytics_meta_tag.html_safe if content_navigation_ab_test_applies? %>
   <%= yield :extra_head_content %>
   <%= @self_assessment_requested_variant.analytics_meta_tag.html_safe %>
 </head>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -231,7 +231,7 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
   test "does not show taxonomy-navigation when no taxons are tagged to Detailed Guides" do
-    content_item = content_store_has_schema_example('detailed_guide', 'detailed_guide')
+    content_item = content_store_has_schema_example('document_collection', 'document_collection')
     path = 'government/test/detailed-guide'
     content_item['base_path'] = "/#{path}"
     content_item['links'] = {}
@@ -244,8 +244,8 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
   test "does not show taxonomy-navigation when page is tagged to mainstream browse" do
-    content_item = content_store_has_schema_example('detailed_guide', 'detailed_guide')
-    path = 'government/test/detailed-guide'
+    content_item = content_store_has_schema_example('document_collection', 'document_collection')
+    path = 'government/test/document_collection'
     content_item['base_path'] = "/#{path}"
     content_item['links'] = {
       'mainstream_browse_pages' => [
@@ -269,8 +269,8 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
   test "show taxonomy-navigation when page is tagged to a world wide taxon" do
-    content_item = content_store_has_schema_example('detailed_guide', 'detailed_guide')
-    path = 'government/test/detailed-guide'
+    content_item = content_store_has_schema_example('document_collection', 'document_collection')
+    path = 'government/test/document_collection'
     content_item['base_path'] = "/#{path}"
     content_item['links'] = {
       'mainstream_browse_pages' => [
@@ -294,8 +294,8 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
   test "shows the taxonomy-navigation if tagged to taxonomy" do
-    content_item = content_store_has_schema_example("guide", "guide")
-    path = "government/abtest/guide"
+    content_item = content_store_has_schema_example("document_collection", "document_collection")
+    path = "government/abtest/document_collection"
     content_item['base_path'] = "/#{path}"
     content_item['links'] = {
       'taxons' => [

--- a/test/controllers/content_navigation_ab_testing_content_items_controller_test.rb
+++ b/test/controllers/content_navigation_ab_testing_content_items_controller_test.rb
@@ -58,13 +58,20 @@ class ContentItemsControllerTest < ActionController::TestCase
       path = "government/abtest/#{schema_name}"
       content_item['document_type'] = document_type
       content_item['base_path'] = "/#{path}"
-      content_item['links'] = {}
+      content_item['links'] = {
+        'taxons' => [
+          {
+            'title' => 'A Taxon',
+            'base_path' => '/a-taxon',
+          }
+        ]
+      }
       content_store_has_item(content_item['base_path'], content_item)
 
       get :show, params: { path: path }
       requested_variant_name = @controller.content_navigation_ab_test.requested_variant(request.headers).variant_name
       assert_response 200
-      assert_equal [], @request.variant
+      assert_equal [:taxonomy_navigation], @request.variant
       assert_equal ContentItemsController::CONTENT_NAVIGATION_ORIGINAL, requested_variant_name
     end
 

--- a/test/controllers/content_navigation_ab_testing_content_items_controller_test.rb
+++ b/test/controllers/content_navigation_ab_testing_content_items_controller_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class ContentItemsControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::ContentStore
+  include GovukAbTesting::MinitestHelpers
+
+  ContentItemsController::GUIDANCE_DOCUMENT_TYPES.each do |document_type|
+    schema_name = document_type == 'statutory_guidance' ? 'publication' : document_type
+
+    test "does not show universal navigation when no taxons are tagged to #{document_type}" do
+      content_item = content_store_has_schema_example(schema_name, schema_name)
+      path = "government/abtest/#{schema_name}"
+      content_item['base_path'] = "/#{path}"
+      content_item['links'] = {}
+
+      content_store_has_item(content_item['base_path'], content_item)
+
+      setup_ab_variant('ContentNavigation', ContentItemsController::CONTENT_NAVIGATION_ORIGINAL)
+      get :show, params: { path: path }
+      assert_equal [], @request.variant
+      assert_response_not_modified_for_ab_test('ContentNavigation')
+    end
+
+    test "#{document_type} honours content navigation AB Testing cookie" do
+      content_item = content_store_has_schema_example(schema_name, schema_name)
+      path = "government/abtest/#{schema_name}"
+      content_item['document_type'] = document_type
+      content_item['base_path'] = "/#{path}"
+      content_item['links'] = {
+        'taxons' => [
+          {
+            'title' => 'A Taxon',
+            'base_path' => '/a-taxon',
+          }
+        ]
+      }
+
+      content_store_has_item(content_item['base_path'], content_item)
+
+      ContentItemsController::CONTENT_NAVIGATION_ALLOWED_VARIANTS.each do |variant|
+        with_variant ContentNavigation: variant do
+          get :show, params: { path: path }
+          requested = @controller.content_navigation_ab_test.requested_variant(request.headers)
+          assert_response 200
+          assert requested.variant?(variant)
+
+          if variant == ContentItemsController::CONTENT_NAVIGATION_ORIGINAL
+            assert_equal [:taxonomy_navigation], @request.variant
+          else
+            assert_equal [:universal_navigation], @request.variant
+          end
+        end
+      end
+    end
+
+    test "defaults to original view without AB testing cookie for #{document_type}" do
+      content_item = content_store_has_schema_example(schema_name, schema_name)
+      path = "government/abtest/#{schema_name}"
+      content_item['document_type'] = document_type
+      content_item['base_path'] = "/#{path}"
+      content_item['links'] = {}
+      content_store_has_item(content_item['base_path'], content_item)
+
+      get :show, params: { path: path }
+      assert_response 200
+      assert_equal [], @request.variant
+    end
+  end
+end

--- a/test/controllers/content_navigation_ab_testing_content_items_controller_test.rb
+++ b/test/controllers/content_navigation_ab_testing_content_items_controller_test.rb
@@ -62,8 +62,10 @@ class ContentItemsControllerTest < ActionController::TestCase
       content_store_has_item(content_item['base_path'], content_item)
 
       get :show, params: { path: path }
+      requested_variant_name = @controller.content_navigation_ab_test.requested_variant(request.headers).variant_name
       assert_response 200
       assert_equal [], @request.variant
+      assert_equal ContentItemsController::CONTENT_NAVIGATION_ORIGINAL, requested_variant_name
     end
   end
 end


### PR DESCRIPTION
First pass at adding the content navigation multivariate test. This adds the logic to respond to test bucket, without any of the markup changes or variations.

Start with 4 variants matching https://github.com/alphagov/cdn-configs/pull/17
original, no nav, taxonomy nav, mainstream nav

* Follow “concern” pattern setup in #513 for task list AB test
* Only content with the document types listed are part of the test
* The content must also be tagged to a taxon
* Use a “universal_navigation” variant for all multivariate tests
except original – they are largely the same, significant differences
with original shouldn’t be repeated

Part of:
https://trello.com/c/sVQSGE2e/16-create-multivariant-test-for-content-pages
https://trello.com/c/1caGTIJn/77-create-no-navigation-test-variant-based-on-first-universal-design