### PR TITLE
Published dates component

### DIFF
--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -1,8 +1,9 @@
 .app-c-published-dates {
+  margin-bottom: $gutter / 2;
   @include core-16;
 }
 
-.app-c-published-dates__page-history {
+.app-c-published-dates__change-history {
   margin: 20px 0;
 }
 

--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -1,0 +1,17 @@
+.app-c-published-dates {
+  @include core-16;
+}
+
+.app-c-published-dates__page-history {
+  margin: 20px 0;
+}
+
+.app-c-published-dates__change-item {
+  list-style-type: none;
+  margin-bottom: 10px;
+}
+
+.app-c-published-dates__change-date {
+  display: block;
+  @include bold-16;
+}

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -8,14 +8,14 @@
 <% if published || last_updated %>
 <div class="app-c-published-dates" <% if history%>id="history" data-module="toggle"<% end %>>
   <% if published %>
-    Published <%= published %>
+    <%= t('components.published_dates.published', date: published) %>
   <% end %>
   <% if last_updated %>
-    <% if published %><br /><% end %><%= t('common.last_updated', date: last_updated) %>
+    <% if published %><br /><% end %><%= t('components.published_dates.last_updated', date: last_updated) %>
     <% if link_to_history && history.empty? %>
-      &mdash; <a href="#history"><%= t('common.see_all_updates') %></a>
+      &mdash; <a href="#history"><%= t('components.published_dates.see_all_updates') %></a>
     <% elsif history.any? %>
-      <a href="#full-history" data-controls="full-history" data-expanded="false">&#43;&nbsp;<%= t('common.full_page_history') %></a>
+      <a href="#full-history" data-controls="full-history" data-expanded="false">&#43;&nbsp;<%= t('components.published_dates.full_page_history') %></a>
       <div class="app-c-published-dates__change-history js-hidden" id="full-history">
         <ol>
           <% history.each do |change| %>

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -6,7 +6,7 @@
   link_to_history ||= false
 %>
 
-<div class="app-c-published-dates" <% if history%>id="history"<% end %>>
+<div class="app-c-published-dates" <% if history%>id="history" data-module="toggle"<% end %>>
   Published <%= published %>
   <% if last_updated %>
     <% if published %><br /><% end %>
@@ -28,16 +28,3 @@
     <% end %>
   <% end %>
 </div>
-
-<% if history %>
-  <div class="app-c-published-dates__page-history" id="full-history">
-    <ol>
-      <% history.each do |change| %>
-        <li class="app-c-published-dates__change-item">
-          <time class="app-c-published-dates__change-date" datetime="<%= change[:timestamp] %>" class="timestamp"><%= change[:display_time] %></time>
-          <%= change[:note] %>
-        </li>
-      <% end %>
-    </ol>
-  </div>
-<% end %>

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -5,12 +5,13 @@
   last_updated ||= false
   link_to_history ||= false
 %>
-
+<% if published || last_updated %>
 <div class="app-c-published-dates" <% if history%>id="history" data-module="toggle"<% end %>>
-  Published <%= published %>
+  <% if published %>
+    Published <%= published %>
+  <% end %>
   <% if last_updated %>
-    <% if published %><br /><% end %>
-    <%= t('common.last_updated', date: last_updated) %>
+    <% if published %><br /><% end %><%= t('common.last_updated', date: last_updated) %>
     <% if link_to_history && history.empty? %>
       &mdash; <a href="#history"><%= t('common.see_all_updates') %></a>
     <% elsif history.any? %>
@@ -28,3 +29,4 @@
     <% end %>
   <% end %>
 </div>
+<% end %>

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -1,0 +1,43 @@
+<%
+  published ||= false
+  history ||= []
+  history = Array(history)
+  last_updated ||= false
+  link_to_history ||= false
+%>
+
+<div class="app-c-published-dates" <% if history%>id="history"<% end %>>
+  Published <%= published %>
+  <% if last_updated %>
+    <% if published %><br /><% end %>
+    <%= t('common.last_updated', date: last_updated) %>
+    <% if link_to_history && history.empty? %>
+      &mdash; <a href="#history"><%= t('common.see_all_updates') %></a>
+    <% elsif history.any? %>
+      <a href="#full-history" data-controls="full-history" data-expanded="false">&#43;&nbsp;<%= t('common.full_page_history') %></a>
+      <div class="app-c-published-dates__change-history js-hidden" id="full-history">
+        <ol>
+          <% history.each do |change| %>
+            <li class="app-c-published-dates__change-item">
+              <time class="app-c-published-dates__change-date" datetime="<%= change[:timestamp] %>" class="timestamp"><%= change[:display_time] %></time>
+              <%= change[:note] %>
+            </li>
+          <% end %>
+        </ol>
+      </div>
+    <% end %>
+  <% end %>
+</div>
+
+<% if history %>
+  <div class="app-c-published-dates__page-history" id="full-history">
+    <ol>
+      <% history.each do |change| %>
+        <li class="app-c-published-dates__change-item">
+          <time class="app-c-published-dates__change-date" datetime="<%= change[:timestamp] %>" class="timestamp"><%= change[:display_time] %></time>
+          <%= change[:note] %>
+        </li>
+      <% end %>
+    </ol>
+  </div>
+<% end %>

--- a/app/views/components/docs/published-dates.yml
+++ b/app/views/components/docs/published-dates.yml
@@ -1,5 +1,11 @@
 name: Published dates
 description: Dates to reflect when content was published and updated
+accessibility_criteria: |
+  The published dates component must:
+
+    - indicate to users that the full history section can be expanded and collapsed
+    - inform the user of the state of the full history section (expanded or collapsed)
+    - be usable with a keyboard
 shared_accessibility_criteria:
   - link
 examples:

--- a/app/views/components/docs/published-dates.yml
+++ b/app/views/components/docs/published-dates.yml
@@ -1,0 +1,36 @@
+name: Published dates
+description: Dates to reflect when content was published and updated
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      published: 1st January 1990
+  just_last_updated_date:
+    data:
+      last_updated: 20th October 2016
+  with_last_updated_date:
+    data:
+      published: 1st January 1990
+      last_updated: 20th October 2016
+  link_to_page_history:
+    description: This will set up a link to a '#history' anchor on the page. This can be used to link to another instance of this component, see [Display Page History example](/component-guide/published-dates/display_page_history)
+    data:
+      published: 1st January 1990
+      last_updated: 20th October 2016
+      link_to_history: true
+  display_page_history:
+    description: This will set up an expandable section on the page to let users toggle the display of the page history.
+    data:
+      published: 1st January 1990
+      last_updated: 20th October 2016
+      history:
+      - display_time: 1st January 1990
+        note: First published
+        timestamp: 1990-01-01T15:42:37.000+00:00
+      - display_time: 20th July 1995
+        note: Updated to include information for 1994
+        timestamp: 1995-07-20T15:42:37.000+00:00
+      - display_time: 14th October 2000
+        note: Updated information on pupil premium reviews and what information schools need to publish on their websites.
+        timestamp: 2000-10-14T15:42:37.000+00:00

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,12 @@ en:
   common:
     last_updated: "Last updated"
     translations: "Translations"
+  components:
+    published_dates:
+      full_page_history: "full page history"
+      last_updated: "Last updated %{date}"
+      published: "Published %{date}"
+      see_all_updates: "see all updates"
   language_names:
     ar: Arabic
     de: German

--- a/test/components/published_dates_test.rb
+++ b/test/components/published_dates_test.rb
@@ -1,0 +1,66 @@
+require 'component_test_helper'
+
+class PublishedDatesTest < ComponentTestCase
+  def component_name
+    "published-dates"
+  end
+
+  test "renders nothing when no dates are provided" do
+    assert_empty(render_component({}))
+  end
+
+  test "renders published date" do
+    render_component(published: "1st November 2000")
+    assert_select ".app-c-published-dates", text: "Published 1st November 2000"
+  end
+
+  test "renders published date and last updated date" do
+    render_component(published: "1st November 2000", last_updated: "15th July 2015")
+    assert_select ".app-c-published-dates", text: "Published 1st November 2000
+    Last updated 15th July 2015"
+  end
+
+  test "links to full page history" do
+    render_component(published: "1st November 2000", last_updated: "15th July 2015", link_to_history: true)
+    assert_select ".app-c-published-dates a[href=\"#history\"]"
+  end
+
+  test "renders full page history" do
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"]
+    )
+    assert_select ".app-c-published-dates__change-history#full-history"
+    assert_select ".app-c-published-dates .app-c-published-dates__change-date", text: "23 August 2013"
+  end
+
+  test "full page history is hidden on page load" do
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"]
+    )
+    assert_select ".app-c-published-dates__change-history.js-hidden"
+  end
+
+  test "renders link to full page history if history is provided" do
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"]
+    )
+    assert_select ".app-c-published-dates a[href=\"#full-history\"]"
+  end
+
+  test "includes data attributes for toggle behaviour" do
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"]
+    )
+    assert_select ".app-c-published-dates[data-module=\"toggle\"]"
+    assert_select ".app-c-published-dates a[href=\"#full-history\"][data-controls=\"full-history\"]"
+    assert_select ".app-c-published-dates a[href=\"#full-history\"][data-expanded=\"false\"]"
+  end
+end


### PR DESCRIPTION
Published dates component to be used within metadata block. 

<img width="997" alt="screen shot 2017-11-08 at 17 47 05" src="https://user-images.githubusercontent.com/29889908/32564656-dfbd69da-c4ac-11e7-937d-ca383be7e27a.png">

**Also links to expandable full page history**
<img width="795" alt="screen shot 2017-11-08 at 17 48 26" src="https://user-images.githubusercontent.com/29889908/32564714-0b0b318a-c4ad-11e7-8eb0-17cc6cd01cb4.png">

Trello Story: https://trello.com/c/UTBixmPW/85-convert-published-dates-into-a-component-for-universalnonav-variant

Review app component guide:
https://government-frontend-pr-529.herokuapp.com/component-guide/published-dates

Visual regression results:
https://government-frontend-pr-529.surge.sh/gallery.html
