### PR TITLE
Don't show new nav for world wide mainstream pages

### DIFF
--- a/app/models/navigation_type.rb
+++ b/app/models/navigation_type.rb
@@ -7,19 +7,12 @@ class NavigationType
   end
 
   def should_present_taxonomy_navigation?
-    tagged_to_world_wide_taxonomy? ||
-      (!content_is_tagged_to_browse_pages? &&
+    !content_is_tagged_to_browse_pages? &&
       content_is_tagged_to_a_taxon? &&
-      content_schema_is_guidance?)
+      content_schema_is_guidance?
   end
 
 private
-
-  def tagged_to_world_wide_taxonomy?
-    @content_item.dig("links", "taxons").to_a.any? do |content_item|
-      content_item.fetch("base_path").starts_with?("/world")
-    end
-  end
 
   def content_is_tagged_to_a_taxon?
     @content_item.dig("links", "taxons").present?

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -268,31 +268,6 @@ class ContentItemsControllerTest < ActionController::TestCase
     refute_match(/A Taxon/, taxonomy_sidebar)
   end
 
-  test "show taxonomy-navigation when page is tagged to a world wide taxon" do
-    content_item = content_store_has_schema_example('document_collection', 'document_collection')
-    path = 'government/test/document_collection'
-    content_item['base_path'] = "/#{path}"
-    content_item['links'] = {
-      'mainstream_browse_pages' => [
-        {
-          'content_id' => 'something'
-        }
-      ],
-      'taxons' => [
-        {
-          'title' => 'A Taxon',
-          'base_path' => '/world/zanzibar',
-        }
-      ]
-    }
-
-    content_store_has_item(content_item['base_path'], content_item)
-
-    get :show, params: { path: path_for(content_item) }
-
-    assert_match(/A Taxon/, taxonomy_sidebar)
-  end
-
   test "shows the taxonomy-navigation if tagged to taxonomy" do
     content_item = content_store_has_schema_example("document_collection", "document_collection")
     path = "government/abtest/document_collection"


### PR DESCRIPTION
We now determine which navigation to show according to a complex decision tree:

![image](https://user-images.githubusercontent.com/233676/32623580-926bf5d4-c57e-11e7-8489-f359f55a9d8b.png)

When we rolled it out we thought that it would be good to always show the new navigation if the content is tagged to the world wide taxonomy (https://github.com/alphagov/government-frontend/pull/510), because it would be closest to what the B-variant was.

This had unintended effects of showing the world wide navigation on some mainstream pages, because they're tagged to the "generic" taxons in the world wide taxonomy.

## Before

![screen shot 2017-11-09 at 18 43 28](https://user-images.githubusercontent.com/233676/32623629-bd341a4e-c57e-11e7-9c9a-ae05cbee8c87.png)

## After

![screen shot 2017-11-09 at 18 42 55](https://user-images.githubusercontent.com/233676/32623639-c366074c-c57e-11e7-9478-c26b87d8403a.png)


https://trello.com/c/TqnWwFif