### PR TITLE
Add content metadata component

### DIFF
--- a/app/assets/stylesheets/components/_content-metadata.scss
+++ b/app/assets/stylesheets/components/_content-metadata.scss
@@ -1,0 +1,16 @@
+.app-c-content-metadata {
+  @include responsive-bottom-margin;
+  @include core-16;
+  padding-top: $gutter-half;
+  padding-bottom: $gutter-half;
+  border-top: 1px solid $border-colour;
+  border-bottom: 1px solid $border-colour;
+}
+
+.app-c-content-metadata__from {
+  margin-top: $gutter-half;
+}
+
+.app-c-content-metadata__from a {
+  font-weight: bold;
+}

--- a/app/views/components/_content-metadata.html.erb
+++ b/app/views/components/_content-metadata.html.erb
@@ -1,0 +1,21 @@
+<%
+  published ||= false
+  last_updated ||= false
+  from ||= false
+  link_to_history ||= false
+  metadata = [published, last_updated, from]
+%>
+<% if metadata.any? %>
+  <div class="app-c-content-metadata">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <%= render 'components/published-dates', published: published, last_updated: last_updated, link_to_history: link_to_history %>
+        <% if from %>
+          <div class="app-c-content-metadata__from">
+            <%= t("govuk_component.content-metadata.from", default: "From") %>: <%= from.to_sentence.html_safe %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/components/docs/content-metadata.yml
+++ b/app/views/components/docs/content-metadata.yml
@@ -1,0 +1,34 @@
+name: Content Metadata
+description: Lists publication dates and publishers.
+shared_accessibility_criteria:
+- link
+
+examples:
+  default:
+    data:
+      from:
+        - <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>
+      published: "31 July 2017"
+      last_updated: "20 September 2017"
+  with_history_link:
+    data:
+      from:
+        - <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>
+      published: "31 July 2017"
+      last_updated: "20 September 2017"
+      link_to_history: true
+  two_publishers:
+    data:
+      from:
+        - <a href='/government/organisations/department-for-education'>Department for Education</a>
+        - <a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>
+      published: "31 July 2017"
+      last_updated: "20 September 2017"
+  multiple_publishers_and_no_link_to_history:
+    data:
+      from:
+        - <a href='/government/organisations/department-for-education'>Department for Education</a>
+        - <a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>
+        - <a href='/government/organisations/department-for-work-pensions'>Department for Work and Pensions</a>
+      published: "31 July 2017"
+      last_updated: "20 September 2017"

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -9,7 +9,6 @@
     <% end %>
   </div>
 </div>
-
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 <%= render 'shared/metadata', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>

--- a/test/components/content_metadata_test.rb
+++ b/test/components/content_metadata_test.rb
@@ -1,0 +1,46 @@
+require 'component_test_helper'
+
+class ContentMetadataTest < ComponentTestCase
+  def component_name
+    "content-metadata"
+  end
+
+  test "does not render metadata when no data is given" do
+    assert_empty render_component({})
+  end
+
+  test "renders a from link when from data is given" do
+    render_component(from: ["<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"])
+    assert_select ".app-c-content-metadata__from a[href='/government/organisations/ministry-of-defence']", text: 'Ministry of Defence'
+    assert_select ".app-c-content-metadata__from", text: 'From: Ministry of Defence'
+  end
+
+
+  test "renders two from links when two publishers are given" do
+    render_component(from: ["<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>", "<a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>"])
+    assert_select ".app-c-content-metadata__from a[href='/government/organisations/ministry-of-defence']", text: 'Ministry of Defence'
+    assert_select ".app-c-content-metadata__from a[href='/government/organisations/education-funding-agency']", text: 'Education Funding Agency'
+  end
+
+  test "renders a sentence when multiple publishers are given" do
+    render_component(from: ["<a href='/government/organisations/department-for-education'>Department for Education</a>", "<a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>"])
+    assert_select ".app-c-content-metadata__from", text: 'From: Department for Education and Education Funding Agency'
+  end
+
+  test "renders published dates component when only published date is given" do
+    render_component(published: "31 July 2017")
+    assert_select ".app-c-published-dates"
+  end
+
+  test "renders published dates component when only last updated date is given" do
+    render_component(last_updated: "20 September 2017")
+    assert_select ".app-c-published-dates"
+  end
+
+  test "renders full metadata component when all parameters are given" do
+    render_component(from: ["<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"], published: "31 July 2017", last_updated: "20 September 2017", link_to_history: true)
+    assert_select ".app-c-published-dates"
+    assert_select ".app-c-content-metadata__from a[href='/government/organisations/ministry-of-defence']", text: 'Ministry of Defence'
+    assert_select ".app-c-content-metadata__from", text: 'From: Ministry of Defence'
+  end
+end


### PR DESCRIPTION
- Presents publisher metadata
- Passes params to published date component to display published and updated metadata

Review app component guide:
https://government-frontend-pr-534.herokuapp.com/component-guide
