### PR TITLE
Create universal layout with no navigation variant

### DIFF
--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -1,5 +1,4 @@
 .app-c-published-dates {
-  margin-bottom: $gutter / 2;
   @include core-16;
 }
 

--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -4,6 +4,7 @@
     margin-bottom: $gutter;
 
     @include media(tablet) {
+      margin-top: 0;
       margin-bottom: $gutter * 1.5;
     }
 

--- a/app/assets/stylesheets/mixins/_margins.scss
+++ b/app/assets/stylesheets/mixins/_margins.scss
@@ -18,3 +18,7 @@
   @include responsive-bottom-margin;
   @include responsive-top-margin;
 }
+
+.responsive-bottom-margin {
+  @include responsive-bottom-margin;
+}

--- a/app/presenters/content_item/linkable.rb
+++ b/app/presenters/content_item/linkable.rb
@@ -18,6 +18,12 @@ module ContentItem
       })
     end
 
+    def organisations_ordered_by_importance
+      organisations_with_emphasised_first.map do |link|
+        link_to(link["title"], link["base_path"])
+      end
+    end
+
   private
 
     def links(type)
@@ -33,12 +39,6 @@ module ContentItem
 
     def links_group(types)
       types.flat_map { |type| links(type) }.uniq
-    end
-
-    def organisations_ordered_by_importance
-      organisations_with_emphasised_first.map do |link|
-        link_to(link["title"], link["base_path"])
-      end
     end
 
     def organisations_with_emphasised_first

--- a/app/views/components/docs/content-metadata.yml
+++ b/app/views/components/docs/content-metadata.yml
@@ -1,5 +1,9 @@
-name: Content Metadata
+name: Content metadata
 description: Lists publication dates and publishers.
+body: |
+  A replacement for the [metadata component](https://govuk-static.herokuapp.com/component-guide/metadata) with only the important details. Dates are rendered by the [published dates component](/component-guide/published-dates).
+
+  Part of the universal navigation design and only used as part of a multivariate test.
 shared_accessibility_criteria:
 - link
 
@@ -8,27 +12,35 @@ examples:
     data:
       from:
         - <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>
-      published: "31 July 2017"
-      last_updated: "20 September 2017"
+      published: 31 July 2017
+      last_updated: 20 September 2017
   with_history_link:
     data:
       from:
         - <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>
-      published: "31 July 2017"
-      last_updated: "20 September 2017"
+      published: 31 July 2017
+      last_updated: 20 September 2017
+      link_to_history: true
+  no_last_updated:
+    data:
+      published: 31 July 2017
+  no_publishers:
+    data:
+      published: 31 July 2017
+      last_updated: 20 September 2017
       link_to_history: true
   two_publishers:
     data:
       from:
         - <a href='/government/organisations/department-for-education'>Department for Education</a>
         - <a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>
-      published: "31 July 2017"
-      last_updated: "20 September 2017"
+      published: 31 July 2017
+      last_updated: 20 September 2017
   multiple_publishers_and_no_link_to_history:
     data:
       from:
         - <a href='/government/organisations/department-for-education'>Department for Education</a>
         - <a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>
         - <a href='/government/organisations/department-for-work-pensions'>Department for Work and Pensions</a>
-      published: "31 July 2017"
-      last_updated: "20 September 2017"
+      published: 31 July 2017
+      last_updated: 20 September 2017

--- a/app/views/content_items/_body_with_related_links.html+universal_navigation.erb
+++ b/app/views/content_items/_body_with_related_links.html+universal_navigation.erb
@@ -1,0 +1,11 @@
+<% content_for :simple_header, true %>
+<%= render 'govuk_component/title', title: @content_item.title %>
+<div class="grid-row sidebar-with-body">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/govspeak',
+        content: @content_item.body,
+        direction: page_text_direction,
+        disable_youtube_expansions: true,
+        rich_govspeak: true %>
+  </div>
+</div>

--- a/app/views/content_items/_guide_body.html.erb
+++ b/app/views/content_items/_guide_body.html.erb
@@ -1,0 +1,25 @@
+<% if @content_item.multi_page_guide? %>
+  <aside class="part-navigation-container" role="complementary">
+    <%= render 'shared/parts_navigation', content_item: @content_item, navigation_label: 'Pages in this guide' %>
+  </aside>
+<% end %>
+
+<% if @content_item.has_parts? %>
+  <% if @content_item.multi_page_guide? %>
+    <h1 class="part-title">
+      <%= @content_item.current_part_title_with_index %>
+    </h1>
+  <% end %>
+
+  <%= render 'govuk_component/govspeak',
+      content: @content_item.current_part_body,
+      direction: page_text_direction,
+      disable_youtube_expansions: true,
+      rich_govspeak: true %>
+
+  <%= render 'govuk_component/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
+
+  <% if @content_item.multi_page_guide? %>
+    <%= render 'components/print-link', href: @content_item.print_link, link_text: t("multi_page.print_entire_guide") %>
+  <% end %>
+<% end %>

--- a/app/views/content_items/_publication_inline_body.html.erb
+++ b/app/views/content_items/_publication_inline_body.html.erb
@@ -1,0 +1,15 @@
+<%= render 'components/heading', text: t("publication.documents", count: @content_item.documents_count), id: "documents-title" %>
+
+<div aria-labelledby="documents-title">
+  <%= render 'govuk_component/govspeak',
+             content: @content_item.documents,
+             direction: page_text_direction %>
+</div>
+
+<%= render 'components/heading', text: t("publication.details"), id: "details-title" %>
+
+<div aria-labelledby="details-title">
+  <%= render 'govuk_component/govspeak',
+             content: @content_item.details,
+             direction: page_text_direction %>
+</div>

--- a/app/views/content_items/detailed_guide.html+universal_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+universal_navigation.erb
@@ -12,6 +12,13 @@
   </div>
 </div>
 
+<%= render 'components/content-metadata', {
+      published: @content_item.published,
+      last_updated: @content_item.updated,
+      link_to_history: !!@content_item.updated,
+      from: @content_item.organisations_ordered_by_importance
+    } %>
+
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 
@@ -25,10 +32,12 @@
     <div class="responsive-bottom-margin">
       <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
     </div>
-    <%= render 'components/published-dates', {
-          published: @content_item.published,
-          last_updated: @content_item.updated,
-          history: @content_item.history
-        } %>
+    <div class="responsive-bottom-margin">
+      <%= render 'components/published-dates', {
+            published: @content_item.published,
+            last_updated: @content_item.updated,
+            history: @content_item.history
+          } %>
+    </div>
   </div>
 </div>

--- a/app/views/content_items/detailed_guide.html+universal_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+universal_navigation.erb
@@ -1,0 +1,29 @@
+<%= content_for :simple_header, true %>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title', @content_item.title_and_context %>
+    <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
+  </div>
+  <div class="column-third">
+    <%= render 'components/translation-nav', translations: @content_item.available_translations %>
+    <% if @content_item.image.present? %>
+      <%= image_tag @content_item.image, class: "logo-image" %>
+    <% end %>
+  </div>
+</div>
+
+<%= render 'components/notice', @content_item.withdrawal_notice_component  %>
+<%= render 'shared/history_notice', content_item: @content_item %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <% if @content_item.contents.any? %>
+      <div class="responsive-bottom-margin">
+        <%= render 'components/contents-list', contents: @content_item.contents %>
+      </div>
+    <% end %>
+    <div class="responsive-bottom-margin">
+      <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
+    </div>
+  </div>
+</div>

--- a/app/views/content_items/detailed_guide.html+universal_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+universal_navigation.erb
@@ -25,5 +25,10 @@
     <div class="responsive-bottom-margin">
       <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
     </div>
+    <%= render 'components/published-dates', {
+          published: @content_item.published,
+          last_updated: @content_item.updated,
+          history: @content_item.history
+        } %>
   </div>
 </div>

--- a/app/views/content_items/guide.html+universal_navigation.erb
+++ b/app/views/content_items/guide.html+universal_navigation.erb
@@ -1,0 +1,7 @@
+<% content_for :simple_header, true %>
+<%= render 'govuk_component/title', title: @content_item.title %>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'guide_body' %>
+  </div>
+</div>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -1,33 +1,8 @@
 <% content_for :simple_header, true %>
-
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', { title: @content_item.title } %>
-    <% if @content_item.multi_page_guide? %>
-      <aside class="part-navigation-container" role="complementary">
-        <%= render 'shared/parts_navigation', content_item: @content_item, navigation_label: 'Pages in this guide' %>
-      </aside>
-    <% end %>
-
-    <% if @content_item.has_parts? %>
-      <% if @content_item.multi_page_guide? %>
-        <h1 class="part-title">
-          <%= @content_item.current_part_title_with_index %>
-        </h1>
-      <% end %>
-
-      <%= render 'govuk_component/govspeak',
-          content: @content_item.current_part_body,
-          direction: page_text_direction,
-          disable_youtube_expansions: true,
-          rich_govspeak: true %>
-
-      <%= render 'govuk_component/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
-
-      <% if @content_item.multi_page_guide? %>
-        <%= render 'components/print-link', href: @content_item.print_link, link_text: t("multi_page.print_entire_guide") %>
-      <% end %>
-    <% end %>
+    <%= render 'guide_body' %>
   </div>
   <% if local_assigns.has_key?(:tasklist) && show_tasklist_sidebar? %>
     <%= render 'shared/sidebar_tasklist', tasklist: tasklist %>

--- a/app/views/content_items/publication.html+taxonomy_navigation.erb
+++ b/app/views/content_items/publication.html+taxonomy_navigation.erb
@@ -16,21 +16,7 @@
     <%= render 'shared/metadata', content_item: @content_item %>
     <%= render 'shared/history_notice', content_item: @content_item %>
     <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
-
-    <%= render 'components/heading', text: t("publication.documents", count: @content_item.documents_count), id: "documents-title" %>
-    <div aria-labelledby="documents-title">
-      <%= render 'govuk_component/govspeak',
-                 content: @content_item.documents,
-                 direction: page_text_direction %>
-    </div>
-
-    <%= render 'components/heading', text: t("publication.details"), id: "details-title" %>
-
-    <div aria-labelledby="details-title">
-      <%= render 'govuk_component/govspeak',
-                 content: @content_item.details,
-                 direction: page_text_direction %>
-    </div>
+    <%= render 'publication_inline_body' %>
   </div>
 
   <div class="column-third add-title-margin">

--- a/app/views/content_items/publication.html+universal_navigation.erb
+++ b/app/views/content_items/publication.html+universal_navigation.erb
@@ -20,6 +20,13 @@
   </div>
 </div>
 
+<%= render 'components/content-metadata', {
+      published: @content_item.published,
+      last_updated: @content_item.updated,
+      link_to_history: !!@content_item.updated,
+      from: @content_item.organisations_ordered_by_importance
+    } %>
+
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 
@@ -28,10 +35,12 @@
     <div class="responsive-bottom-margin">
       <%= render 'publication_inline_body' %>
     </div>
-    <%= render 'components/published-dates', {
-          published: @content_item.published,
-          last_updated: @content_item.updated,
-          history: @content_item.history
-        } %>
+    <div class="responsive-bottom-margin">
+      <%= render 'components/published-dates', {
+            published: @content_item.published,
+            last_updated: @content_item.updated,
+            history: @content_item.history
+          } %>
+    </div>
   </div>
 </div>

--- a/app/views/content_items/publication.html+universal_navigation.erb
+++ b/app/views/content_items/publication.html+universal_navigation.erb
@@ -1,0 +1,30 @@
+<%= content_for :simple_header, true %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+               context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
+               title: @content_item.title,
+               average_title_length: "long" %>
+  </div>
+  <div class="column-third">
+    <% if @content_item.national_statistics? %>
+      <%= image_tag 'national-statistics.png', alt: 'National Statistics' %>
+    <% end %>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
+  </div>
+</div>
+
+<%= render 'components/notice', @content_item.withdrawal_notice_component  %>
+<%= render 'shared/history_notice', content_item: @content_item %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'publication_inline_body' %>
+  </div>
+</div>

--- a/app/views/content_items/publication.html+universal_navigation.erb
+++ b/app/views/content_items/publication.html+universal_navigation.erb
@@ -25,6 +25,13 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'publication_inline_body' %>
+    <div class="responsive-bottom-margin">
+      <%= render 'publication_inline_body' %>
+    </div>
+    <%= render 'components/published-dates', {
+          published: @content_item.published,
+          last_updated: @content_item.updated,
+          history: @content_item.history
+        } %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,7 +41,7 @@
     <% if show_tasklist_header? %>
       <%= render 'shared/tasklist_header' %>
     <% else %>
-      <% unless content_for(:no_breadcrumbs) %>
+      <% if !content_for(:no_breadcrumbs) && !universal_navigation_without_nav? %>
         <%= render 'shared/breadcrumbs' %>
       <% end %>
     <% end %>

--- a/test/controllers/content_navigation_ab_testing_content_items_controller_test.rb
+++ b/test/controllers/content_navigation_ab_testing_content_items_controller_test.rb
@@ -76,7 +76,8 @@ class ContentItemsControllerTest < ActionController::TestCase
         refute_partial('govuk_component/document_footer')
 
         if document_type.in? %w{detailed_guide statutory_guidance}
-          assert_template 'components/_published-dates'
+          assert_template partial: 'components/_published-dates', count: 2
+          assert_template 'components/_content-metadata'
         end
       end
     end

--- a/test/controllers/content_navigation_ab_testing_content_items_controller_test.rb
+++ b/test/controllers/content_navigation_ab_testing_content_items_controller_test.rb
@@ -74,6 +74,10 @@ class ContentItemsControllerTest < ActionController::TestCase
         refute_partial('shared/_related_items')
         refute_partial('govuk_component/metadata')
         refute_partial('govuk_component/document_footer')
+
+        if document_type.in? %w{detailed_guide statutory_guidance}
+          assert_template 'components/_published-dates'
+        end
       end
     end
   end

--- a/test/controllers/content_navigation_ab_testing_content_items_controller_test.rb
+++ b/test/controllers/content_navigation_ab_testing_content_items_controller_test.rb
@@ -63,6 +63,19 @@ class ContentItemsControllerTest < ActionController::TestCase
         refute @controller.universal_navigation_with_mainstream_nav?
       end
     end
+
+    test "#{document_type} shows no navigation elements for universal no navigation variant" do
+      path = "government/abtest/#{schema_name}"
+      content_item_inside_of_test(document_type, schema_name, path)
+
+      with_variant ContentNavigation: ContentItemsController::CONTENT_NAVIGATION_UNIVERSAL_NO_NAVIGATION do
+        get :show, params: { path: path }
+        refute_partial('shared/_breadcrumbs')
+        refute_partial('shared/_related_items')
+        refute_partial('govuk_component/metadata')
+        refute_partial('govuk_component/document_footer')
+      end
+    end
   end
 
   def content_item_inside_of_test(document_type, schema_name, path)
@@ -89,5 +102,9 @@ class ContentItemsControllerTest < ActionController::TestCase
     content_item['document_type'] = document_type
     content_item['base_path'] = "/#{path}"
     content_item
+  end
+
+  def refute_partial(partial)
+    assert_template partial: partial, count: 0
   end
 end

--- a/test/integration/answer_test.rb
+++ b/test/integration/answer_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class AnswerTest < ActionDispatch::IntegrationTest
+  test "random but valid items do not error" do
+    setup_and_visit_random_content_item
+  end
+
   test "renders title and body" do
     setup_and_visit_content_item('answer')
     assert page.has_text?(@content_item["title"])

--- a/test/integration/contact_test.rb
+++ b/test/integration/contact_test.rb
@@ -2,9 +2,7 @@ require 'test_helper'
 
 class ContactTest < ActionDispatch::IntegrationTest
   test "random but valid items do not error" do
-    10.times do
-      setup_and_visit_random_content_item
-    end
+    setup_and_visit_random_content_item
   end
 
   test "online forms are rendered" do

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class DetailedGuideTest < ActionDispatch::IntegrationTest
+  test "random but valid items do not error" do
+    setup_and_visit_random_content_item
+  end
+
   test "detailed guide" do
     setup_and_visit_content_item('detailed_guide')
 

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -2,9 +2,7 @@ require 'test_helper'
 
 class HtmlPublicationTest < ActionDispatch::IntegrationTest
   test "random but valid items do not error" do
-    10.times do
-      setup_and_visit_random_content_item
-    end
+    setup_and_visit_random_content_item
   end
 
   test "html publications" do

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -2,9 +2,7 @@ require 'test_helper'
 
 class PublicationTest < ActionDispatch::IntegrationTest
   test "random but valid items do not error" do
-    10.times do
-      setup_and_visit_random_content_item(document_type: 'notice')
-    end
+    setup_and_visit_random_content_item(document_type: 'notice')
   end
 
   test "publication" do

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class PublicationTest < ActionDispatch::IntegrationTest
   test "random but valid items do not error" do
-    setup_and_visit_random_content_item(document_type: 'notice')
+    setup_and_visit_random_content_item(document_type: 'statutory_guidance')
   end
 
   test "publication" do


### PR DESCRIPTION
Raising this PR in case I need to handover the work at short notice.

Creates a universal layout for:
* guides
* answers
* publications (statutory guidance only)
* detailed guides

Tests are applied to these pages based on logic in #526 
https://gist.github.com/fofr/cbf398e868ac2e3052be5a666635ee6a

When the "UniversalNoNav" variant is set:
* no breadcrumbs display
* no related links or taxonomy sidebar displays
* no metadata or document footer components display
* all content is inline in a left column, with an empty column to the right

Still to do:
* [x] Incorporate metadata component #534 

To test on Heroku:
* Use the ModHeader extension and set:
   Header: `GOVUK-ABTest-ContentNavigation`
   Value: `UniversalNoNav`
* Use slugs from gist and visit the review app, eg:
   https://government-frontend-pr-535.herokuapp.com/guidance/schools-financial-efficiency-effective-procurement

Part of:
https://trello.com/c/1caGTIJn/77-create-no-navigation-test-variant-based-on-first-universal-design
Follows on from #526 

## Screenshots

| Type | Screen |
| -- | -- |
| Mobile guidance | ![government-frontend-pr-535 herokuapp com-guidance-schools-financial-efficiency-effective-procurement iphone 6](https://user-images.githubusercontent.com/319055/32728416-2ce328a2-c878-11e7-879c-fb015ea8520b.png) |
| Desktop guidance | ![government-frontend-pr-535 herokuapp com-guidance-schools-financial-efficiency-effective-procurement](https://user-images.githubusercontent.com/319055/32728417-2d024250-c878-11e7-9af4-f1d8d722ded1.png) |
| Desktop guide | ![government-frontend-pr-535 herokuapp com-apprenticeships-guide 1](https://user-images.githubusercontent.com/319055/32728623-eba3ef2e-c878-11e7-840a-c964c5453ba8.png) |
| Desktop publication | ![government-frontend-pr-535 herokuapp com-government-publications-send-code-of-practice-0-to-25](https://user-images.githubusercontent.com/319055/32728585-c3a35d02-c878-11e7-8f02-22661a3d1513.png) |

