### PR TITLE
Enable right-to-left text direction for Farsi content

### DIFF
--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1,4 +1,6 @@
 fa:
+  i18n:
+    direction: rtl
   language_names:
     fa: "فارسی"
   content_item:


### PR DESCRIPTION
We've received a [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/2512759) informing us that our Farsi/Persian content is currently left-aligned, however it is a language that reads right-to-left and so should be right-aligned.  This is already in place for other "right-to-left" languages such as Hebrew (see [example](https://www.gov.uk/government/speeches/ambassador-quarreys-speech-for-international-holocaust-remembrance-day.he)).

This PR sets the direction of Farsi content to `rtl` in its locale YAML file to
enable correct alignment.

### Before

![screen shot 2017-11-13 at 16 37 03](https://user-images.githubusercontent.com/13434452/32737050-ee4f7e2e-c890-11e7-9e21-c0daba1230bb.png)

### After

![screen shot 2017-11-13 at 16 36 46](https://user-images.githubusercontent.com/13434452/32737064-f734e060-c890-11e7-9edf-35f0a7ed78fe.png)

