### PR TITLE
Fix link to history behaviour

### DIFF
--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -6,7 +6,7 @@
   link_to_history ||= false
 %>
 <% if published || last_updated %>
-<div class="app-c-published-dates" <% if history%>id="history" data-module="toggle"<% end %>>
+<div class="app-c-published-dates" <% if history.any? %>id="history" data-module="toggle"<% end %>>
   <% if published %>
     <%= t('components.published_dates.published', date: published) %>
   <% end %>

--- a/test/components/published_dates_test.rb
+++ b/test/components/published_dates_test.rb
@@ -35,6 +35,18 @@ class PublishedDatesTest < ComponentTestCase
     assert_select ".app-c-published-dates .app-c-published-dates__change-date", text: "23 August 2013"
   end
 
+  test "only adds history id when passed page history" do
+    render_component(published: "1st November 2000")
+    assert_select "#history", false, "should only render history id if passed history item"
+
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"]
+    )
+    assert_select "#history"
+  end
+
   test "full page history is hidden on page load" do
     render_component(
       published: "1st November 2000",


### PR DESCRIPTION
Component was incorrectly applying the history id to the component each time, as the check for history should have been checking for history.any?

Updated to include this check, component now only contains history id if a history item has been passed to it.

Review app component guide:
https://government-frontend-pr-537.herokuapp.com/component-guide/published-dates

Visual regression results:
https://government-frontend-pr-537.surge.sh/gallery.html
