### PR TITLE
Add national applicability to universal navigation variant

### DIFF
--- a/app/assets/stylesheets/components/_content-metadata.scss
+++ b/app/assets/stylesheets/components/_content-metadata.scss
@@ -7,10 +7,10 @@
   border-bottom: 1px solid $border-colour;
 }
 
-.app-c-content-metadata__from {
+.app-c-content-metadata__other {
   margin-top: $gutter-half;
 }
 
-.app-c-content-metadata__from a {
+.app-c-content-metadata__other a {
   font-weight: bold;
 }

--- a/app/assets/stylesheets/components/_content-metadata.scss
+++ b/app/assets/stylesheets/components/_content-metadata.scss
@@ -9,6 +9,11 @@
 
 .app-c-content-metadata__other {
   margin-top: $gutter-half;
+
+  // Don't include a margin if there’s no published dates above
+  &:first-child {
+    margin-top: 0;
+  }
 }
 
 .app-c-content-metadata__other a {

--- a/app/presenters/content_item/linkable.rb
+++ b/app/presenters/content_item/linkable.rb
@@ -18,12 +18,6 @@ module ContentItem
       })
     end
 
-    def organisations_ordered_by_importance
-      organisations_with_emphasised_first.map do |link|
-        link_to(link["title"], link["base_path"])
-      end
-    end
-
   private
 
     def links(type)
@@ -39,6 +33,12 @@ module ContentItem
 
     def links_group(types)
       types.flat_map { |type| links(type) }.uniq
+    end
+
+    def organisations_ordered_by_importance
+      organisations_with_emphasised_first.map do |link|
+        link_to(link["title"], link["base_path"])
+      end
     end
 
     def organisations_with_emphasised_first

--- a/app/presenters/content_item/metadata.rb
+++ b/app/presenters/content_item/metadata.rb
@@ -15,6 +15,17 @@ module ContentItem
       }
     end
 
+    def content_metadata
+      {
+        published: published,
+        last_updated: updated,
+        link_to_history: !!updated,
+        other: {
+          'From': organisations_ordered_by_importance
+        }
+      }
+    end
+
     def document_footer
       {
         from: from,

--- a/app/presenters/content_item/national_applicability.rb
+++ b/app/presenters/content_item/national_applicability.rb
@@ -30,6 +30,12 @@ module ContentItem
       end
     end
 
+    def content_metadata
+      super.tap do |m|
+        m[:other] = { 'Applies to': applies_to }.merge(m[:other])
+      end
+    end
+
   private
 
     def translated_schema_name(count)

--- a/app/views/components/_content-metadata.html.erb
+++ b/app/views/components/_content-metadata.html.erb
@@ -1,18 +1,27 @@
 <%
   published ||= false
   last_updated ||= false
-  from ||= false
   link_to_history ||= false
-  metadata = [published, last_updated, from]
+  other ||= {}
+  other_has_values = other.values.compact.reject(&:blank?).any?
+  metadata = [published, last_updated]
 %>
-<% if metadata.any? %>
+<% if metadata.any? || other_has_values %>
   <div class="app-c-content-metadata">
     <div class="grid-row">
       <div class="column-two-thirds">
         <%= render 'components/published-dates', published: published, last_updated: last_updated, link_to_history: link_to_history %>
-        <% if from %>
-          <div class="app-c-content-metadata__from">
-            <%= t("govuk_component.content-metadata.from", default: "From") %>: <%= from.to_sentence.html_safe %>
+        <% if other_has_values %>
+          <div class="app-c-content-metadata__other">
+            <% other.each do |title, values| %>
+              <%
+                values ||= []
+                values = Array(values)
+              %>
+              <% if values.any? %>
+                <p><%= title %>: <%= values.to_sentence.html_safe %></p>
+              <% end %>
+            <% end %>
           </div>
         <% end %>
       </div>

--- a/app/views/components/docs/content-metadata.yml
+++ b/app/views/components/docs/content-metadata.yml
@@ -57,3 +57,7 @@ examples:
         Another: []
         "Empty thing": false
         "Also empty": {}
+  national_applicability:
+    data:
+      other:
+        Applies to: "England, Scotland, and Wales (see detailed guidance for <a href=\"http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for\" rel=\"external\">Northern Ireland</a>)"

--- a/app/views/components/docs/content-metadata.yml
+++ b/app/views/components/docs/content-metadata.yml
@@ -10,17 +10,19 @@ shared_accessibility_criteria:
 examples:
   default:
     data:
-      from:
-        - <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>
       published: 31 July 2017
       last_updated: 20 September 2017
+      other:
+        From:
+          - <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>
   with_history_link:
     data:
-      from:
-        - <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>
       published: 31 July 2017
       last_updated: 20 September 2017
       link_to_history: true
+      other:
+        From:
+          - <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>
   no_last_updated:
     data:
       published: 31 July 2017
@@ -31,16 +33,27 @@ examples:
       link_to_history: true
   two_publishers:
     data:
-      from:
-        - <a href='/government/organisations/department-for-education'>Department for Education</a>
-        - <a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>
       published: 31 July 2017
       last_updated: 20 September 2017
+      other:
+        From:
+          - <a href='/government/organisations/department-for-education'>Department for Education</a>
+          - <a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>
   multiple_publishers_and_no_link_to_history:
     data:
-      from:
-        - <a href='/government/organisations/department-for-education'>Department for Education</a>
-        - <a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>
-        - <a href='/government/organisations/department-for-work-pensions'>Department for Work and Pensions</a>
       published: 31 July 2017
       last_updated: 20 September 2017
+      other:
+        From:
+          - <a href='/government/organisations/department-for-education'>Department for Education</a>
+          - <a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>
+          - <a href='/government/organisations/department-for-work-pensions'>Department for Work and Pensions</a>
+  nothing:
+    description: |
+      If an `other` object is provided with keys that have no values the component does not render.
+    data:
+      other:
+        From:
+        Another: []
+        "Empty thing": false
+        "Also empty": {}

--- a/app/views/content_items/detailed_guide.html+universal_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+universal_navigation.erb
@@ -12,15 +12,7 @@
   </div>
 </div>
 
-<%= render 'components/content-metadata', {
-      published: @content_item.published,
-      last_updated: @content_item.updated,
-      link_to_history: !!@content_item.updated,
-      other: {
-        From: @content_item.organisations_ordered_by_importance
-      }
-    } %>
-
+<%= render 'components/content-metadata', @content_item.content_metadata %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 

--- a/app/views/content_items/detailed_guide.html+universal_navigation.erb
+++ b/app/views/content_items/detailed_guide.html+universal_navigation.erb
@@ -16,7 +16,9 @@
       published: @content_item.published,
       last_updated: @content_item.updated,
       link_to_history: !!@content_item.updated,
-      from: @content_item.organisations_ordered_by_importance
+      other: {
+        From: @content_item.organisations_ordered_by_importance
+      }
     } %>
 
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>

--- a/app/views/content_items/publication.html+universal_navigation.erb
+++ b/app/views/content_items/publication.html+universal_navigation.erb
@@ -20,15 +20,7 @@
   </div>
 </div>
 
-<%= render 'components/content-metadata', {
-      published: @content_item.published,
-      last_updated: @content_item.updated,
-      link_to_history: !!@content_item.updated,
-      other: {
-        From: @content_item.organisations_ordered_by_importance
-      }
-    } %>
-
+<%= render 'components/content-metadata', @content_item.content_metadata %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 

--- a/app/views/content_items/publication.html+universal_navigation.erb
+++ b/app/views/content_items/publication.html+universal_navigation.erb
@@ -24,7 +24,9 @@
       published: @content_item.published,
       last_updated: @content_item.updated,
       link_to_history: !!@content_item.updated,
-      from: @content_item.organisations_ordered_by_importance
+      other: {
+        From: @content_item.organisations_ordered_by_importance
+      }
     } %>
 
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>

--- a/test/components/content_metadata_test.rb
+++ b/test/components/content_metadata_test.rb
@@ -9,22 +9,27 @@ class ContentMetadataTest < ComponentTestCase
     assert_empty render_component({})
   end
 
+  test "does not render when an 'other' object is provided without any values" do
+    assert_empty render_component(other: { From: [] })
+    assert_empty render_component(other: { a: false, b: "", c: [], d: {}, e: nil })
+  end
+
   test "renders a from link when from data is given" do
-    render_component(from: ["<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"])
-    assert_select ".app-c-content-metadata__from a[href='/government/organisations/ministry-of-defence']", text: 'Ministry of Defence'
-    assert_select ".app-c-content-metadata__from", text: 'From: Ministry of Defence'
+    render_component(other: { From: ["<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"] })
+    assert_select ".app-c-content-metadata__other a[href='/government/organisations/ministry-of-defence']", text: 'Ministry of Defence'
+    assert_select ".app-c-content-metadata__other", text: 'From: Ministry of Defence'
   end
 
 
   test "renders two from links when two publishers are given" do
-    render_component(from: ["<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>", "<a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>"])
-    assert_select ".app-c-content-metadata__from a[href='/government/organisations/ministry-of-defence']", text: 'Ministry of Defence'
-    assert_select ".app-c-content-metadata__from a[href='/government/organisations/education-funding-agency']", text: 'Education Funding Agency'
+    render_component(other: { From: ["<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>", "<a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>"] })
+    assert_select ".app-c-content-metadata__other a[href='/government/organisations/ministry-of-defence']", text: 'Ministry of Defence'
+    assert_select ".app-c-content-metadata__other a[href='/government/organisations/education-funding-agency']", text: 'Education Funding Agency'
   end
 
   test "renders a sentence when multiple publishers are given" do
-    render_component(from: ["<a href='/government/organisations/department-for-education'>Department for Education</a>", "<a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>"])
-    assert_select ".app-c-content-metadata__from", text: 'From: Department for Education and Education Funding Agency'
+    render_component(other: { From: ["<a href='/government/organisations/department-for-education'>Department for Education</a>", "<a href='/government/organisations/education-funding-agency'>Education Funding Agency</a>"] })
+    assert_select ".app-c-content-metadata__other", text: 'From: Department for Education and Education Funding Agency'
   end
 
   test "renders published dates component when only published date is given" do
@@ -38,9 +43,9 @@ class ContentMetadataTest < ComponentTestCase
   end
 
   test "renders full metadata component when all parameters are given" do
-    render_component(from: ["<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"], published: "31 July 2017", last_updated: "20 September 2017", link_to_history: true)
+    render_component(other: { From: ["<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"] }, published: "31 July 2017", last_updated: "20 September 2017", link_to_history: true)
     assert_select ".app-c-published-dates"
-    assert_select ".app-c-content-metadata__from a[href='/government/organisations/ministry-of-defence']", text: 'Ministry of Defence'
-    assert_select ".app-c-content-metadata__from", text: 'From: Ministry of Defence'
+    assert_select ".app-c-content-metadata__other a[href='/government/organisations/ministry-of-defence']", text: 'Ministry of Defence'
+    assert_select ".app-c-content-metadata__other", text: 'From: Ministry of Defence'
   end
 end


### PR DESCRIPTION
Allow content metadata to render any metadata types
* Use pattern from static metadata component:
https://govuk-static.herokuapp.com/component-guide/metadata
* Allow further metadata to be added easily as design is iterated
* This allows us to easily add national applicability

Add national applicability to content metadata
* Move content_metadata params into metadata presenter module
* Decorate with “Applies to” when National Applicability applies
* Add “Applies to” to the beginning of the hash to appear before “From”
* Use existing methods for generating “Applies to” from content item
* Improve rendering of component when no dates provided

Review app component guide:
https://government-frontend-pr-539.herokuapp.com/component-guide/content-metadata

![screen shot 2017-11-15 at 09 52 29](https://user-images.githubusercontent.com/319055/32829693-bbd3b536-c9ea-11e7-84cf-516f34d7cb4f.png)
