### PR TITLE
Upgrade govuk_navigation_helpers to v7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8'
 
 gem 'govuk_app_config', '~> 0.3.0'
-gem 'govuk_navigation_helpers', '~> 6.3'
+gem 'govuk_navigation_helpers', '~> 7.0'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (6.3.0)
+    govuk_navigation_helpers (7.0.0)
       gds-api-adapters (>= 43.0)
     govuk_publishing_components (1.11.0)
       govspeak (>= 5.0.3)
@@ -325,7 +325,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 0.3.0)
   govuk_frontend_toolkit (= 5.1.0)
-  govuk_navigation_helpers (~> 6.3)
+  govuk_navigation_helpers (~> 7.0)
   govuk_publishing_components (~> 1.11.0)
   govuk_schemas
   htmlentities (= 4.3.4)

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -270,6 +270,10 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
   test "shows the taxonomy-navigation if tagged to taxonomy" do
+    GovukNavigationHelpers::ContentItem
+      .stubs(:whitelisted_root_taxon_content_ids)
+      .returns(["aaaa-bbbb"])
+
     content_item = content_store_has_schema_example("document_collection", "document_collection")
     path = "government/abtest/document_collection"
     content_item['base_path'] = "/#{path}"

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class ContentItemsControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::ContentStore
+  include GdsApi::TestHelpers::Rummager
   include GovukAbTesting::MinitestHelpers
 
   test 'routing handles paths with no format or locale' do
@@ -277,9 +278,14 @@ class ContentItemsControllerTest < ActionController::TestCase
         {
           'title' => 'A Taxon',
           'base_path' => '/a-taxon',
+          'content_id' => 'aaaa-bbbb',
         }
       ]
     }
+
+    # GovukNavigationHelpers::NavigationHelper.taxonomy_sidebar makes requests
+    # to Rummager for related content for given taxons
+    stub_any_rummager_search
 
     content_store_has_item(content_item['base_path'], content_item)
 

--- a/test/support/govuk_content_schema_examples.rb
+++ b/test/support/govuk_content_schema_examples.rb
@@ -1,4 +1,5 @@
 require 'gds_api/test_helpers/content_store'
+require 'gds_api/test_helpers/rummager'
 
 # Include this module to get access to the GOVUK Content Schema examples in the
 # tests.


### PR DESCRIPTION
This update ensures that only taxons from the three published taxon branches (education, childcare-parenting and world) get shown for breadcrumbs and the side bar taxon links. 

This solves the specific problem that draft taxons were showing up on the draft stack when publishers were previewing their content. That was not a good user experience for them, as when published, those taxons and breadcrumbs would not be on the live site.

See https://github.com/alphagov/govuk_navigation_helpers/pull/82 for more details.

## Screenshots:

### Before:

The 'About the route', 'Welfare Reform' and 'Work' taxons are draft taxons and show up in the left side bar and breadcrumbs (when previewing this on the draft stack). Only 'Educations in prisons' is a published taxon.

![screen shot 2017-11-17 at 14 42 11](https://user-images.githubusercontent.com/5112255/32953938-a34db820-cba9-11e7-90b9-cf9affb70588.png)

### After:

Only the published taxon 'Educations in prisons' shows up in the side bar. The draft taxons do not appear in the links and side bar anymore.

![screen shot 2017-11-17 at 14 42 18](https://user-images.githubusercontent.com/5112255/32953937-a3372c36-cba9-11e7-8ee8-87a313f4fb14.png)

