### PR TITLE
Show tasklist sidebar on publication content

### DIFF
--- a/app/controllers/concerns/tasklist_ab_testable.rb
+++ b/app/controllers/concerns/tasklist_ab_testable.rb
@@ -1,5 +1,6 @@
 module TasklistABTestable
   TASKLIST_DIMENSION = 66
+  PUBLICATION_PAGE = "/government/publications/car-show-me-tell-me-vehicle-safety-questions".freeze
 
   def self.included(base)
     base.helper_method(
@@ -25,6 +26,15 @@ module TasklistABTestable
 
   def should_show_tasklist_sidebar?
     tasklist_ab_test_applies? && tasklist_variant.variant?('B')
+  end
+
+  def publication_with_sidebar?
+    should_show_tasklist_sidebar? &&
+      request.path == PUBLICATION_PAGE
+  end
+
+  def publication_with_sidebar_template_name
+    "publication_with_tasklist_sidebar"
   end
 
   def tasklist_variant

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -59,7 +59,11 @@ private
   end
 
   def content_item_template
-    @content_item.schema_name
+    if publication_with_sidebar?
+      publication_with_sidebar_template_name
+    else
+      @content_item.schema_name
+    end
   end
 
   def render_template

--- a/app/views/content_items/publication_with_tasklist_sidebar.html.erb
+++ b/app/views/content_items/publication_with_tasklist_sidebar.html.erb
@@ -1,0 +1,37 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+        context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
+        title: @content_item.title,
+        average_title_length: "long" %>
+
+    <%= render 'shared/translations' %>
+    <% if @content_item.national_statistics? %>
+      <%= render 'shared/national_statistics_logo' %>
+    <% end %>
+
+    <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
+    <%= render 'shared/metadata', content_item: @content_item %>
+    <%= render 'shared/history_notice', content_item: @content_item %>
+    <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
+
+    <%= render 'components/heading', text: t("publication.documents", count: @content_item.documents_count), id: "documents-title" %>
+    <div aria-labelledby="documents-title">
+      <%= render 'govuk_component/govspeak',
+          content: @content_item.documents,
+          direction: page_text_direction %>
+    </div>
+
+    <%= render 'components/heading', text: t("publication.details"), id: "details-title" %>
+
+    <div aria-labelledby="details-title">
+      <%= render 'govuk_component/govspeak',
+          content: @content_item.details,
+          direction: page_text_direction %>
+    </div>
+
+    <%= render 'shared/footer', @content_item.document_footer %>
+  </div>
+
+  <%= render 'shared/sidebar_tasklist', tasklist: tasklist %>
+</div>


### PR DESCRIPTION
This will show the tasklist sidebar on a specific publication page that
is part of learn to drive.

Trello: https://trello.com/c/WWZn2kNO/

## Before

![before](https://user-images.githubusercontent.com/136777/33025624-65fd8f4a-ce06-11e7-9184-2188f3d5c6f5.png)


## After

![show me tell me questions car driving test gov uk](https://user-images.githubusercontent.com/136777/33025630-69dc8148-ce06-11e7-8183-3c49c381aa2a.png)
