### PR TITLE
Add a homepage for developers

### DIFF
--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -1,0 +1,15 @@
+class DevelopmentController < ApplicationController
+  layout false
+
+  def index
+    @schema_names = %w[answer case_study coming_soon consultation contact
+                       corporate_information_page detailed_guide document_collection
+                       fatality_notice guide help_page html_publication news_article
+                       placeholder_corporate_information_page publication specialist_document
+                       speech statistical_data_set statistics_announcement take_part
+                       topical_event_about_page travel_advice working_group
+                       world_location_news_article]
+
+    @paths = YAML.load_file("test/wraith/config.yaml")["paths"]
+  end
+end

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>
+    government-frontend development page
+  </title>
+</head>
+<body>
+  <div id="wrapper">
+    <main class="govspeak">
+      <%= render 'govuk_component/title', title: 'government-frontend' %>
+
+      <% html = capture do %>
+        <p>
+          Hi, this is the root of the <%= link_to 'government-frontend', 'https://github.com/alphagov/government-frontend' %> application.
+          This page is intended to be shown in development and on Heroku review apps. It
+          won't be shown to users on GOV.UK because there are no routes to it.
+        </p>
+
+        <h2>Component guide</h2>
+
+        <p>
+          To see the available components, take a look at the <%= link_to 'component guide', '/component-guide' %>.
+        </p>
+
+        <h2>Configuration</h2>
+
+        <table>
+          <tr>
+            <td>Content store</td>
+            <td><%= link_to Plek.find('content-store'), Plek.find('content-store') %></td>
+          </tr>
+          <tr>
+            <td>Static</td>
+            <td><%= link_to Plek.find('static'), Plek.find('static') %></td>
+          </tr>
+          <tr>
+            <td>Rummager (search)</td>
+            <td><%= link_to Plek.find('rummager'), Plek.find('rummager') %></td>
+          </tr>
+        </table>
+
+        <h2>Examples</h2>
+
+        <p>
+          The content schemas contain <%= link_to 'handmade examples', 'https://github.com/alphagov/govuk-content-schemas/tree/master/examples' %>
+          for each schema rendered by this app. These are used in tests.
+        </p>
+
+        <p>
+          If this application is pointed at the <%= link_to 'dummy content store', 'https://github.com/alphagov/govuk-content-schemas/blob/master/docs/running-frontend-against-examples.md' %>
+          you can use the links below to view pages using the examples. For a
+          full list of examples, see <%= link_to 'govspeak-examples guide', 'https://govuk-content-store-examples.herokuapp.com' %>.
+        </p>
+        <table>
+          <% @schema_names.each do |schema_name| %>
+            <tr>
+              <td>
+                <%= schema_name %>
+              </td>
+              <td>
+                <%= link_to "Canonical example", "/examples/#{schema_name}/#{schema_name}" %>*
+              </td>
+              <td>
+                <%= link_to "Random example", "/examples/#{schema_name}/random" %>*
+              </td>
+            </tr>
+          <% end %>
+        </table>
+
+        * Will only work if this app is pointed at the <%= link_to 'dummy content store', 'https://github.com/alphagov/govuk-content-schemas/blob/master/docs/running-frontend-against-examples.md' %>.
+
+        <h2>Examples from GOV.UK</h2>
+
+        <p>These pages are used to run visual regression tests. They're good examples
+          of the types of pages rendered by this application.</p>
+        <table>
+          <% @paths.each do |name, path| %>
+            <tr>
+              <td>
+                <%= name %>
+              </td>
+              <td>
+                <%= link_to path, path %>
+              </td>
+            </tr>
+          <% end %>
+        </table>
+      <% end %>
+
+      <%= render 'govuk_component/govspeak', content: html %>
+    </main>
+  </div>
+</body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
     get 'random/:schema' => 'randomly_generated_content_item#show'
   end
 
+  root to: 'development#index'
+
   mount GovukPublishingComponents::Engine, at: "/component-guide" if defined?(GovukPublishingComponents)
 
   get 'healthcheck', to: proc { [200, {}, ['']] }


### PR DESCRIPTION
This adds a page at the root of the site that will be visible in development and on Heroku review apps.

It has the following things that would be useful in development:

- Links to the component guide
- The URLs of the content store, rummager, static, so it's clear which version we are using
- Link to the canonical example of a template (the one named after the schema)*
- Link to a random version of the template*
- List of links to pages rendered by government-frontend. I've reused the wraith config for this, it seemed like a nice representative list of different pages.

https://trello.com/c/IoHKyhoX

`*` will work after https://github.com/alphagov/govuk-content-schemas/pull/665 is merged and we point the Heroku review apps to the [example content store Heroku app](https://govuk-content-store-examples.herokuapp.com). 