### PR TITLE
[DO NOT MERGE] Fix preview layout for no whitelisted taxons

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -110,7 +110,7 @@ private
     if should_present_universal_navigation?
       request.variant = :universal_navigation
     else
-      @navigation = NavigationType.new(@content_item.content_item)
+      @navigation = NavigationType.new(@content_item)
       if @navigation.should_present_taxonomy_navigation?
         request.variant = :taxonomy_navigation
       end

--- a/app/models/navigation_type.rb
+++ b/app/models/navigation_type.rb
@@ -2,27 +2,19 @@ class NavigationType
   GUIDANCE_SCHEMAS =
     %w{answer contact guide detailed_guide document_collection publication}.freeze
 
-  def initialize(content_item)
-    @content_item = content_item
+  def initialize(presented_content_item)
+    @content_item = presented_content_item
   end
 
   def should_present_taxonomy_navigation?
-    !content_is_tagged_to_browse_pages? &&
-      content_is_tagged_to_a_taxon? &&
+    !@content_item.tagged_to_browse_pages? &&
+      @content_item.tagged_to_a_taxon? &&
       content_schema_is_guidance?
   end
 
 private
 
-  def content_is_tagged_to_a_taxon?
-    @content_item.dig("links", "taxons").present?
-  end
-
-  def content_is_tagged_to_browse_pages?
-    @content_item.dig("links", "mainstream_browse_pages").present?
-  end
-
   def content_schema_is_guidance?
-    GUIDANCE_SCHEMAS.include? @content_item["schema_name"]
+    GUIDANCE_SCHEMAS.include? @content_item.schema_name
   end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -23,6 +23,7 @@ class ContentItemPresenter
     @phase = content_item["phase"]
     @document_type = content_item["document_type"]
     @nav_helper = GovukNavigationHelpers::NavigationHelper.new(content_item)
+    @nav_helper_content_item = GovukNavigationHelpers::ContentItem.new(content_item)
     @part_slug = requesting_a_part? ? requested_content_item_path.split('/').last : nil
   end
 
@@ -63,7 +64,7 @@ class ContentItemPresenter
   end
 
   def tagged_to_a_taxon?
-    content_item.dig("links", "taxons").present?
+    @nav_helper_content_item.parent_taxons.any?
   end
 
   def tagged_to_browse_pages?

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -66,6 +66,10 @@ class ContentItemPresenter
     content_item.dig("links", "taxons").present?
   end
 
+  def tagged_to_browse_pages?
+    content_item.dig("links", "mainstream_browse_pages").present?
+  end
+
 private
 
   def display_date(timestamp, format = "%-d %B %Y")


### PR DESCRIPTION
Use `GovukNavigationHelpers::ContentItem` to get the taxons for a content item. This enables us to check if the linked taxons belongs to the whitelisted root taxons from https://github.com/alphagov/govuk_navigation_helpers/pull/82.

Specifically this should fix an issue when Publisher would see a different layout between draft and live content, as well as different breadcrumbs.

## Screenshots

### Live page:

![screen shot 2017-11-22 at 16 58 34](https://user-images.githubusercontent.com/5112255/33139908-77b583a4-cfa6-11e7-97ce-eaeccc8836d1.png)

### Page on Draft Stack - Before

![screen shot 2017-11-22 at 16 58 45](https://user-images.githubusercontent.com/5112255/33139907-77a004ca-cfa6-11e7-953e-fb58d8f476d2.png)

### Page on Draft Stack - After

![screen shot 2017-11-22 at 16 58 25](https://user-images.githubusercontent.com/5112255/33139909-77cdcc16-cfa6-11e7-8f7d-9d835aeca039.png)
