### PR TITLE
Point to example content store

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
       "value": "https://www.gov.uk"
     },
     "PLEK_SERVICE_CONTENT_STORE_URI": {
-      "value": "https://www.gov.uk/api"
+      "value": "https://govuk-content-store-examples.herokuapp.com/api"
     },
     "PLEK_SERVICE_RUMMAGER_URI": {
       "value": "https://www.gov.uk/api"


### PR DESCRIPTION
This points Heroku apps to the example content store, so that we can use the examples and random content. For all other pages the app will keep working in the same way because it forwards to the real content store (https://github.com/alphagov/govuk-content-schemas/pull/665).

https://trello.com/c/IoHKyhoX