### PR TITLE
[WIP] Add nav sidebar logic

### DIFF
--- a/app/helpers/navigation_sidebar_helper.rb
+++ b/app/helpers/navigation_sidebar_helper.rb
@@ -1,11 +1,11 @@
 module NavigationSidebarHelper
   def sidebar_link_to(link, section)
     if section === "related_items"
-      link_to link[:text], link[:href], class: "app-c-navigation-sidebar__related-link"
+      link_to link[:text], link[:path], class: "app-c-navigation-sidebar__related-link"
     elsif section === "external_links"
-      link_to link[:text], link[:href], class: "app-c-navigation-sidebar__external-related-link", rel: "external"
+      link_to link[:text], link[:path], class: "app-c-navigation-sidebar__external-related-link", rel: "external"
     else
-      link_to link[:text], link[:href], class: "app-c-navigation-sidebar__section-link"
+      link_to link[:text], link[:path], class: "app-c-navigation-sidebar__section-link"
     end
   end
 end

--- a/app/helpers/navigation_sidebar_helper.rb
+++ b/app/helpers/navigation_sidebar_helper.rb
@@ -1,11 +1,9 @@
 module NavigationSidebarHelper
   def sidebar_link_to(link, section)
     if section === "related_items"
-      link_to link[:text], link[:path], class: "app-c-navigation-sidebar__related-link"
-    elsif section === "external_links"
-      link_to link[:text], link[:path], class: "app-c-navigation-sidebar__external-related-link", rel: "external"
+      link_to link[:text], link[:path], class: "app-c-navigation-sidebar__related-link", rel: link[:type]
     else
-      link_to link[:text], link[:path], class: "app-c-navigation-sidebar__section-link"
+      link_to link[:text], link[:path], class: "app-c-navigation-sidebar__section-link", rel: link[:type]
     end
   end
 end

--- a/app/presenters/content_item/linkable.rb
+++ b/app/presenters/content_item/linkable.rb
@@ -18,11 +18,41 @@ module ContentItem
       })
     end
 
+    def related_whitehall_topics
+      links_for_navigation_sidebar('topics', 'whitehall')
+    end
+
+    def related_policies
+      links_for_navigation_sidebar('related_policies', 'policy')
+    end
+
+    def related_organisations
+      links_for_navigation_sidebar('organisations', 'organisation')
+    end
+
+    def related_collections
+      links_for_navigation_sidebar('document_collections', 'document_collection')
+    end
+
+    def related_ordered_items
+      links_for_navigation_sidebar('ordered_related_items', 'related')
+    end
+
   private
 
     def links(type)
       expanded_links_from_content_item(type).map do |link|
         link_for_type(type, link)
+      end
+    end
+
+    def links_for_navigation_sidebar(type, rendering_type)
+      expanded_links_from_content_item(type).map do |link|
+        {
+          path: link["base_path"],
+          text: link["title"],
+          type: rendering_type
+        }
       end
     end
 

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -62,6 +62,17 @@ class ContentItemPresenter
     @nav_helper.related_items
   end
 
+  def external_items
+    external_links = @content_item["details"]["external_related_links"] || []
+
+    external_links.map do |link|
+      {
+        path: link["url"],
+        text: link["title"]
+      }
+    end
+  end
+
   def tagged_to_a_taxon?
     content_item.dig("links", "taxons").present?
   end

--- a/app/views/components/_navigation-sidebar.html.erb
+++ b/app/views/components/_navigation-sidebar.html.erb
@@ -16,15 +16,13 @@
 %>
 <% if related_content.map(&:values).flatten.any? %>
   <aside class="app-c-navigation-sidebar" role="complementary">
+    <h2 id="nav-sidebar-related-content" class="app-c-navigation-sidebar__main-heading" >
+      <%= t('components.navigation_sidebar.related_content') %>
+    </h2>
     <% related_content.each do |section| %>
       <% section.each do |section_title, links| %>
-
-        <% if section_title === "related_items" %>
-          <h2 id="nav-sidebar-<%= section_title %>"
-              class="app-c-navigation-sidebar__main-heading" >
-            <%= t('components.navigation_sidebar.related_content') %>
-          </h2>
-          <nav role="navigation" class="app-c-navigation-sidebar__nav-section" aria-labelledby="nav-sidebar-<%= section_title %>" %>
+        <% if section_title === "related_items" && links.any? %>
+          <nav role="navigation" class="app-c-navigation-sidebar__nav-section" aria-labelledby="nav-sidebar-related-content" %>
             <ul class="app-c-navigation-sidebar__link-list">
               <% links.each do |link| %>
                 <li class="app-c-navigation-sidebar__link">

--- a/app/views/components/_navigation-sidebar.html.erb
+++ b/app/views/components/_navigation-sidebar.html.erb
@@ -4,17 +4,16 @@
   publishers ||= []
   collections ||= []
   policies ||= []
-  external_links ||= []
+  other ||= []
   related_content = [
     {"related_items" => related_items},
     {"topics" => topics},
     {"publishers" => publishers},
     {"collections" => collections},
     {"policies" => policies},
-    {"external_links" => external_links}
   ]
 %>
-<% if related_content.map(&:values).flatten.any? %>
+<% if related_content.map(&:values).flatten.any? || external_links.any? %>
   <aside class="app-c-navigation-sidebar" role="complementary">
     <h2 id="nav-sidebar-related-content" class="app-c-navigation-sidebar__main-heading" >
       <%= t('components.navigation_sidebar.related_content') %>
@@ -51,5 +50,21 @@
         <% end %>
       <% end %>
     <% end %>
+
+    <% if other.any? %>
+      <h3 class="app-c-navigation-sidebar__sub-heading app-c-navigation-sidebar__external-heading">
+        <%= other["title"] %>
+      </h3>
+      <nav role="navigation" class="app-c-navigation-sidebar__nav-section">
+        <ul class="app-c-navigation-sidebar__link-list">
+          <% other["links"].each do |link| %>
+            <li class="app-c-navigation-sidebar__link">
+              <%= sidebar_link_to(link, "other") %>
+            </li>
+          <% end %>
+        </ul>
+      </nav>
+    <% end %>
+
   </aside>
 <% end %>

--- a/app/views/components/docs/navigation-sidebar.yml
+++ b/app/views/components/docs/navigation-sidebar.yml
@@ -10,121 +10,121 @@ examples:
     data:
       related_items:
         - text: Find an apprenticeship
-          href: /apply-apprenticeship
+          path: /apply-apprenticeship
         - text: Training and study at work
-          href: /training-study-work-your-rights
+          path: /training-study-work-your-rights
         - text: Careers helpline for teenagers
-          href: /careers-helpline-for-teenagers
+          path: /careers-helpline-for-teenagers
   with_curated_topics:
     data:
       related_items:
         - text: Find an apprenticeship
-          href: /apply-apprenticeship
+          path: /apply-apprenticeship
         - text: Training and study at work
-          href: /training-study-work-your-rights
+          path: /training-study-work-your-rights
         - text: Careers helpline for teenagers
-          href: /careers-helpline-for-teenagers
+          path: /careers-helpline-for-teenagers
       topics:
         - text: Apprenticeships, 14 to 19 education and training for work
-          href: /browse/education/find-course
+          path: /browse/education/find-course
         - text: Finding a job
-          href: /browse/working/finding-job
+          path: /browse/working/finding-job
         - text: Apprenticeships
-          href: /topic/further-education-skills/apprenticeships
+          path: /topic/further-education-skills/apprenticeships
   with_publishing_entities:
     data:
       related_items:
         - text: Find an apprenticeship
-          href: /apply-apprenticeship
+          path: /apply-apprenticeship
         - text: Training and study at work
-          href: /training-study-work-your-rights
+          path: /training-study-work-your-rights
         - text: Careers helpline for teenagers
-          href: /careers-helpline-for-teenagers
+          path: /careers-helpline-for-teenagers
       publishers:
         - text: Department for Education
-          href: /government/publications?keywords=&publication_filter_option=guidance&topics%5B%5D=all&departments%5B%5D=department-for-education&official_document_status=all&world_locations%5B%5D=all&from_date=&to_date=
+          path: /government/publications?keywords=&publication_filter_option=guidance&topics%5B%5D=all&departments%5B%5D=department-for-education&official_document_status=all&world_locations%5B%5D=all&from_date=&to_date=
         - text: Minister of State for Apprenticeships and Skills
-          href: /government/ministers/minister-of-state--44
+          path: /government/ministers/minister-of-state--44
         - text: The Rt Hon Anne Milton Mp
-          href: /government/people/anne-milton
+          path: /government/people/anne-milton
         - text: Kenya
-          href: /world/kenya
+          path: /world/kenya
   with_collections:
     data:
       related_items:
         - text: Find an apprenticeship
-          href: /apply-apprenticeship
+          path: /apply-apprenticeship
         - text: Training and study at work
-          href: /training-study-work-your-rights
+          path: /training-study-work-your-rights
         - text: Careers helpline for teenagers
-          href: /careers-helpline-for-teenagers
+          path: /careers-helpline-for-teenagers
       collections:
         - text: Recruit an apprentice (formerly apprenticeship vacancies)
-          href: /government/collections/apprenticeship-vacancies
+          path: /government/collections/apprenticeship-vacancies
         - text: The future of jobs and skills
-          href: /government/collections/the-future-of-jobs-and-skills
+          path: /government/collections/the-future-of-jobs-and-skills
   with_policies:
     data:
       related_items:
         - text: Find an apprenticeship
-          href: /apply-apprenticeship
+          path: /apply-apprenticeship
         - text: Training and study at work
-          href: /training-study-work-your-rights
+          path: /training-study-work-your-rights
         - text: Careers helpline for teenagers
-          href: /careers-helpline-for-teenagers
+          path: /careers-helpline-for-teenagers
       policies:
         - text: Further education and training
-          href: /government/policies/further-education-and-training
+          path: /government/policies/further-education-and-training
   with_external_related_links:
     data:
       related_items:
         - text: Find an apprenticeship
-          href: /apply-apprenticeship
+          path: /apply-apprenticeship
         - text: Training and study at work
-          href: /training-study-work-your-rights
+          path: /training-study-work-your-rights
         - text: Careers helpline for teenagers
-          href: /careers-helpline-for-teenagers
+          path: /careers-helpline-for-teenagers
       external_links:
         - text: The Student Room repaying your student loan
-          href: https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan
+          path: https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan
         - text: Student finance data protection statements
-          href: http://www.sfengland.slc.co.uk/dataprotection.aspx
+          path: http://www.sfengland.slc.co.uk/dataprotection.aspx
   with_all_related-content:
     data:
       related_items:
         - text: Find an apprenticeship
-          href: /apply-apprenticeship
+          path: /apply-apprenticeship
         - text: Training and study at work
-          href: /training-study-work-your-rights
+          path: /training-study-work-your-rights
         - text: Careers helpline for teenagers
-          href: /careers-helpline-for-teenagers
+          path: /careers-helpline-for-teenagers
       topics:
         - text: Apprenticeships, 14 to 19 education and training for work
-          href: /browse/education/find-course
+          path: /browse/education/find-course
         - text: Finding a job
-          href: /browse/working/finding-job
+          path: /browse/working/finding-job
         - text: Apprenticeships
-          href: /topic/further-education-skills/apprenticeships
+          path: /topic/further-education-skills/apprenticeships
       publishers:
         - text: Department for Education
-          href: /government/publications?keywords=&publication_filter_option=guidance&topics%5B%5D=all&departments%5B%5D=department-for-education&official_document_status=all&world_locations%5B%5D=all&from_date=&to_date=
+          path: /government/publications?keywords=&publication_filter_option=guidance&topics%5B%5D=all&departments%5B%5D=department-for-education&official_document_status=all&world_locations%5B%5D=all&from_date=&to_date=
         - text: Minister of State for Apprenticeships and Skills
-          href: /government/ministers/minister-of-state--44
+          path: /government/ministers/minister-of-state--44
         - text: The Rt Hon Anne Milton Mp
-          href: /government/people/anne-milton
+          path: /government/people/anne-milton
         - text: Kenya
-          href: /world/kenya
+          path: /world/kenya
       collections:
         - text: Recruit an apprentice (formerly apprenticeship vacancies)
-          href: /government/collections/apprenticeship-vacancies
+          path: /government/collections/apprenticeship-vacancies
         - text: The future of jobs and skills
-          href: /government/collections/the-future-of-jobs-and-skills
+          path: /government/collections/the-future-of-jobs-and-skills
       policies:
         - text: Further education and training
-          href: /government/policies/further-education-and-training
+          path: /government/policies/further-education-and-training
       external_links:
         - text: The Student Room repaying your student loan
-          href: https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan
+          path: https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan
         - text: Student finance data protection statements
-          href: http://www.sfengland.slc.co.uk/dataprotection.aspx
+          path: http://www.sfengland.slc.co.uk/dataprotection.aspx
 

--- a/app/views/components/docs/navigation-sidebar.yml
+++ b/app/views/components/docs/navigation-sidebar.yml
@@ -84,11 +84,15 @@ examples:
           path: /training-study-work-your-rights
         - text: Careers helpline for teenagers
           path: /careers-helpline-for-teenagers
-      external_links:
-        - text: The Student Room repaying your student loan
-          path: https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan
-        - text: Student finance data protection statements
-          path: http://www.sfengland.slc.co.uk/dataprotection.aspx
+      other:
+        title: "Elsewhere on the web"
+        links:
+          - text: The Student Room repaying your student loan
+            path: https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan
+            rel: external
+          - text: Student finance data protection statements
+            path: http://www.sfengland.slc.co.uk/dataprotection.aspx
+            rel: external
   with_all_related-content:
     data:
       related_items:
@@ -122,9 +126,13 @@ examples:
       policies:
         - text: Further education and training
           path: /government/policies/further-education-and-training
-      external_links:
-        - text: The Student Room repaying your student loan
-          path: https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan
-        - text: Student finance data protection statements
-          path: http://www.sfengland.slc.co.uk/dataprotection.aspx
+      other:
+        title: "Elsewhere on the web"
+        links:
+          - text: The Student Room repaying your student loan
+            path: https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan
+            rel: external
+          - text: Student finance data protection statements
+            path: http://www.sfengland.slc.co.uk/dataprotection.aspx
+            rel: external
 

--- a/test/components/navigation_sidebar_test.rb
+++ b/test/components/navigation_sidebar_test.rb
@@ -14,7 +14,7 @@ class NavigationSidebarTest < ComponentTestCase
       related_items: [
         {
           text: "Apprenticeships",
-          href: '/apprenticeships'
+          path: '/apprenticeships'
         }
       ]
     )
@@ -28,7 +28,7 @@ class NavigationSidebarTest < ComponentTestCase
       topics: [
         {
           text: "Finding a job",
-          href: '/finding-a-job'
+          path: '/finding-a-job'
         }
       ]
     )
@@ -42,7 +42,7 @@ class NavigationSidebarTest < ComponentTestCase
       publishers: [
         {
           text: "Department for Education",
-          href: '/government/organisation/department-for-education'
+          path: '/government/organisation/department-for-education'
         }
       ]
     )
@@ -56,7 +56,7 @@ class NavigationSidebarTest < ComponentTestCase
       collections: [
         {
           text: "The future of jobs and skills",
-          href: '/government/collections/the-future-of-jobs-and-skills'
+          path: '/government/collections/the-future-of-jobs-and-skills'
         }
       ]
     )
@@ -70,7 +70,7 @@ class NavigationSidebarTest < ComponentTestCase
       policies: [
         {
           text: "Further education and training",
-          href: '/government/policies/further-education-and-training'
+          path: '/government/policies/further-education-and-training'
         }
       ]
     )
@@ -84,7 +84,7 @@ class NavigationSidebarTest < ComponentTestCase
       external_links: [
         {
           text: "The Student Room repaying your student loan",
-          href: 'https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan'
+          path: 'https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan'
         }
       ]
     )
@@ -98,7 +98,7 @@ class NavigationSidebarTest < ComponentTestCase
       external_links: [
         {
           text: "The Student Room repaying your student loan",
-          href: 'https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan'
+          path: 'https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan'
         }
       ]
     )
@@ -111,7 +111,7 @@ class NavigationSidebarTest < ComponentTestCase
       topics: [
         {
           text: "Apprenticeships",
-          href: '/apprenticeships'
+          path: '/apprenticeships'
         }
       ]
     )
@@ -124,13 +124,13 @@ class NavigationSidebarTest < ComponentTestCase
       related_items: [
         {
           text: "Apprenticeships",
-          href: '/apprenticeships'
+          path: '/apprenticeships'
         }
       ],
       policies: [
         {
           text: "Further education and training",
-          href: '/government/policies/further-education-and-training'
+          path: '/government/policies/further-education-and-training'
         }
       ]
     )


### PR DESCRIPTION
**WIP!!** 

Need to add the logic to retrieve data for the different sections in the navigation sidebar.

Probably worth reviewing commit by commit as the first few commits just involve renaming component arguments from `href` to `path`. Logic added in [this commit](https://github.com/alphagov/government-frontend/pull/554/commits/e7699498a5fa9d6f5eb6985acc03e633a0e88db9).

Review app component guide:
https://government-frontend-pr-554.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-554.surge.sh/gallery.html
