### PR TITLE
Add logic to link up with govuk_navigation_helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8'
 
 gem 'govuk_app_config', '~> 0.3.0'
-gem 'govuk_navigation_helpers', '~> 7.0'
+gem 'govuk_navigation_helpers', '~> 7.1.0'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (7.0.0)
+    govuk_navigation_helpers (7.1.0)
       gds-api-adapters (>= 43.0)
     govuk_publishing_components (2.0.0)
       govspeak (>= 5.0.3)
@@ -327,8 +327,8 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 0.3.0)
   govuk_frontend_toolkit (= 5.1.0)
-  govuk_navigation_helpers (~> 7.0)
   govuk_publishing_components (~> 2.0.0)
+  govuk_navigation_helpers (~> 7.1.0)
   govuk_schemas
   htmlentities (= 4.3.4)
   jasmine-rails!

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -58,6 +58,10 @@ class ContentItemPresenter
     @nav_helper.taxonomy_sidebar
   end
 
+  def related_navigation
+    @nav_helper.related_navigation_sidebar
+  end
+
   def related_items
     @nav_helper.related_items
   end

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -21,6 +21,19 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     assert_equal "Type", ContentItemPresenter.new("document_type" => "Type").document_type
   end
 
+  test "#related_navigation retrieves content for related navigation component" do
+    expected = {
+      related_items: [],
+      collections: [],
+      topics: [],
+      policies: [],
+      publishers: [],
+      other: [[], []]
+    }
+
+    assert_equal expected, ContentItemPresenter.new("schema_name" => "Schema name").related_navigation
+  end
+
   test "available_translations sorts languages by locale with English first" do
     translated = govuk_content_schema_example('case_study', 'translated')
     locales = ContentItemPresenter.new(translated).available_translations


### PR DESCRIPTION
Wraps the govuk_navigation_helpers related_navigation_sidebar method in the content item presenter so that it is accessible within views. This will allow us to simply pass `@content_item.related_navigation_sidebar` to the sidebar component when we want to render it on content pages (full example below):

`<%= render 'components/related-navigation-sidebar', @content_item.related_navigation_sidebar %>`

**Note: the above code will only work once https://github.com/alphagov/government-frontend/pull/556 has been merged, as this renames the component and allows it to display external and contact links. Otherwise, use `render 'components/navigation-sidebar'`**

To-Do:

- [x]  Bump govuk_navigation_helpers gem once the logic has been merged and gem versioned.

Dependent on: https://github.com/alphagov/govuk_navigation_helpers/pull/85
