### PR TITLE
Add error message component

### DIFF
--- a/app/assets/stylesheets/components/_error-message.scss
+++ b/app/assets/stylesheets/components/_error-message.scss
@@ -1,0 +1,15 @@
+$govuk-error-colour: $red;
+
+.app-c-error-message {
+  display: block;
+
+  margin: 0;
+  // TODO: use a var for padding
+  padding: 2px 0;
+
+  clear: both;
+
+  color: $govuk-error-colour;
+
+  @include bold-19;
+}

--- a/app/views/components/_error-message.html.erb
+++ b/app/views/components/_error-message.html.erb
@@ -1,0 +1,9 @@
+<% id ||= false %>
+<span
+  class="app-c-error-message"
+  <% if id %>
+    id="<%= id %>"
+  <% end %>
+>
+   <%= text %>
+</span>

--- a/app/views/components/docs/error-message.yml
+++ b/app/views/components/docs/error-message.yml
@@ -1,0 +1,13 @@
+name: Form error message
+description: Component to show a red error message - used for form validation. Use inside a label or legend.
+accessibility_criteria: |
+  - have a text contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+examples:
+  default:
+    data:
+      text: 'Descriptive error message'
+  outside_label_or_legend:
+    description: 'Used if the error message is not inside a label or legend, for example with `aria-describedby`'
+    data:
+      id: 'unique-error-id'
+      text: 'Descriptive error message'

--- a/test/components/error_message_test.rb
+++ b/test/components/error_message_test.rb
@@ -1,0 +1,23 @@
+require 'component_test_helper'
+
+class ErrorMessageTest < ComponentTestCase
+  def component_name
+    "error-message"
+  end
+
+  test "fails to render no data is given" do
+    assert_raise do
+      render_component({})
+    end
+  end
+
+  test "renders an error message correctly" do
+    render_component(text: 'Descriptive error message')
+    assert_select ".app-c-error-message", text: 'Descriptive error message'
+  end
+
+  test "renders an error message with an id" do
+    render_component(text: 'Descriptive error message with id', id: 'unique-error-id')
+    assert_select ".app-c-error-message[id='unique-error-id']", text: 'Descriptive error message with id'
+  end
+end


### PR DESCRIPTION
Used in labels and legends to show what the error is.

Forked from GOV.UK Frontend

Review app component guide:
https://government-frontend-pr-562.herokuapp.com/component-guide/error-message

https://trello.com/c/4p6T0Kbl/247-create-an-error-message-component-05
