### PR TITLE
Add world locations to related nav component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8'
 
 gem 'govuk_app_config', '~> 0.3.0'
-gem 'govuk_navigation_helpers', '~> 7.1.0'
+gem 'govuk_navigation_helpers', '~> 7.2.0'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (7.1.0)
+    govuk_navigation_helpers (7.2.0)
       gds-api-adapters (>= 43.0)
     govuk_publishing_components (2.0.0)
       govspeak (>= 5.0.3)
@@ -327,8 +327,8 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 0.3.0)
   govuk_frontend_toolkit (= 5.1.0)
+  govuk_navigation_helpers (~> 7.2.0)
   govuk_publishing_components (~> 2.0.0)
-  govuk_navigation_helpers (~> 7.1.0)
   govuk_schemas
   htmlentities (= 4.3.4)
   jasmine-rails!

--- a/app/views/components/_related-navigation.html.erb
+++ b/app/views/components/_related-navigation.html.erb
@@ -1,11 +1,12 @@
 <%
-  defined_sections = ["topics", "publishers", "collections", "policies"]
+  defined_sections = ["topics", "publishers", "collections", "policies", "world_locations"]
   related_content = [
     {"related_items" => related_items ||= [] },
     {"topics" => topics ||= [] },
     {"publishers" => publishers ||= [] },
     {"collections" => collections ||= [] },
     {"policies" => policies ||= [] },
+    {"world_locations" => world_locations ||= [] }
   ]
   other ||= []
   format_data_for_related_navigation(related_content, other)

--- a/app/views/components/docs/related-navigation.yml
+++ b/app/views/components/docs/related-navigation.yml
@@ -44,13 +44,9 @@ examples:
           path: /careers-helpline-for-teenagers
       publishers:
         - text: Department for Education
-          path: /government/publications?keywords=&publication_filter_option=guidance&topics%5B%5D=all&departments%5B%5D=department-for-education&official_document_status=all&world_locations%5B%5D=all&from_date=&to_date=
-        - text: Minister of State for Apprenticeships and Skills
-          path: /government/ministers/minister-of-state--44
-        - text: The Rt Hon Anne Milton Mp
-          path: /government/people/anne-milton
-        - text: Kenya
-          path: /world/kenya
+          path: /government/department-for-education
+        - text: Department for Work and Pensions
+          path: /government/department-for-work-pensions
   with_collections:
     data:
       related_items:
@@ -77,6 +73,20 @@ examples:
       policies:
         - text: Further education and training
           path: /government/policies/further-education-and-training
+  with_world_locations:
+    data:
+      related_items:
+        - text: Find an apprenticeship
+          path: /apply-apprenticeship
+        - text: Training and study at work
+          path: /training-study-work-your-rights
+        - text: Careers helpline for teenagers
+          path: /careers-helpline-for-teenagers
+      world_locations:
+        - text: South Sudan
+          path: /world/south-sudan/news
+        - text: USA
+          path: /world/usa/news
   with_external_related_links:
     description: The component can accept other related links, such as external links or other contacts. In these cases, the component must also be passed a heading for that section
     data:
@@ -115,13 +125,7 @@ examples:
           path: /topic/further-education-skills/apprenticeships
       publishers:
         - text: Department for Education
-          path: /government/publications?keywords=&publication_filter_option=guidance&topics%5B%5D=all&departments%5B%5D=department-for-education&official_document_status=all&world_locations%5B%5D=all&from_date=&to_date=
-        - text: Minister of State for Apprenticeships and Skills
-          path: /government/ministers/minister-of-state--44
-        - text: The Rt Hon Anne Milton Mp
-          path: /government/people/anne-milton
-        - text: Kenya
-          path: /world/kenya
+          path: /government/department-for-education
       collections:
         - text: Recruit an apprentice (formerly apprenticeship vacancies)
           path: /government/collections/apprenticeship-vacancies
@@ -130,6 +134,11 @@ examples:
       policies:
         - text: Further education and training
           path: /government/policies/further-education-and-training
+      world_locations:
+        - text: South Sudan
+          path: /world/south-sudan/news
+        - text: USA
+          path: /world/usa/news
       other:
         -
           - title: "Elsewhere on the web"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,12 +28,13 @@ en:
     translations: "Translations"
   components:
     related_navigation:
-      collections: "Collections"
+      collections: "Collection"
       external_links: "Elsewhere on the web"
       policies: "Policy"
       publishers: "Detailed guidance from"
       related_content: "Related content"
       topics: "Explore the topic"
+      world_locations: 'Location'
     published_dates:
       full_page_history: "full page history"
       last_updated: "Last updated %{date}"

--- a/test/components/related_navigation_test.rb
+++ b/test/components/related_navigation_test.rb
@@ -37,6 +37,20 @@ class RelatedNavigationTest < ComponentTestCase
     assert_select ".app-c-related-navigation__section-link[href=\"/finding-a-job\"]", text: 'Finding a job'
   end
 
+  test "renders world locations section when passed world location items" do
+    render_component(
+      world_locations: [
+        {
+          text: "USA",
+          path: '/world/usa/news'
+        }
+      ]
+    )
+
+    assert_select ".app-c-related-navigation__sub-heading", text: 'Location'
+    assert_select ".app-c-related-navigation__section-link[href=\"/world/usa/news\"]", text: 'USA'
+  end
+
   test "renders publisher section when passed publisher items" do
     render_component(
       publishers: [
@@ -61,7 +75,7 @@ class RelatedNavigationTest < ComponentTestCase
       ]
     )
 
-    assert_select ".app-c-related-navigation__sub-heading", text: 'Collections'
+    assert_select ".app-c-related-navigation__sub-heading", text: 'Collection'
     assert_select ".app-c-related-navigation__section-link[href=\"/government/collections/the-future-of-jobs-and-skills\"]", text: 'The future of jobs and skills'
   end
 

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -28,6 +28,7 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
       topics: [],
       policies: [],
       publishers: [],
+      world_locations: [],
       other: [[], []]
     }
 


### PR DESCRIPTION
When testing the image formats universal layout, we noticed that speeches show related world locations  in the metadata [on the live page](https://www.gov.uk/government/speeches/2014-hillary-clinton-prize-for-women-peace-and-security), but [not on universal layout at all](https://government-frontend-pr-541.herokuapp.com/government/speeches/2014-hillary-clinton-prize-for-women-peace-and-security). We need to show these in the related navigation.

This PR uses the latest version of `govuk_navigation_helpers` which has been updated to return world locations https://github.com/alphagov/govuk_navigation_helpers/pull/88

<img width="927" alt="screen shot 2017-12-06 at 13 52 30" src="https://user-images.githubusercontent.com/29889908/33664842-e97753b4-da8c-11e7-8f90-936781149c1c.png">

Review app component guide:
https://government-frontend-pr-565.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-565.surge.sh/gallery.html
