### PR TITLE
Add track radio group module

### DIFF
--- a/app/assets/javascripts/modules/track-radio-group.js
+++ b/app/assets/javascripts/modules/track-radio-group.js
@@ -1,0 +1,28 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (global, GOVUK) {
+  'use strict'
+
+  var $ = global.jQuery
+
+  GOVUK.Modules.TrackRadioGroup = function () {
+    this.start = function (element) {
+      element.on('submit', function (event) {
+        var options = { transport: 'beacon' }
+
+        var $submittedForm = $(event.target)
+
+        var $checkedOption = $submittedForm.find('input:checked')
+
+        var checkedValue = $checkedOption.val()
+
+        if (typeof checkedValue === 'undefined') {
+          checkedValue = 'submitted-without-choosing'
+        }
+
+        GOVUK.analytics.trackEvent('Radio button chosen', checkedValue, options)
+      })
+    }
+  }
+})(window, window.GOVUK)

--- a/spec/javascripts/track-radio-group.spec.js
+++ b/spec/javascripts/track-radio-group.spec.js
@@ -1,0 +1,58 @@
+/* global describe beforeEach it spyOn expect */
+
+var $ = window.jQuery
+
+describe('A radio group tracker', function () {
+  'use strict'
+
+  var GOVUK = window.GOVUK
+  var tracker
+  var element
+
+  GOVUK.analytics = GOVUK.analytics || {}
+  GOVUK.analytics.trackEvent = function () {}
+
+  beforeEach(function () {
+    spyOn(GOVUK.analytics, 'trackEvent')
+
+    element = $(
+      '<div>' +
+        '<form onsubmit="event.preventDefault()">' +
+          '<input type="radio" name="sign-in-option" value="government-gateway">' +
+          '<input type="radio" name="sign-in-option" value="govuk-verify">' +
+          '<input type="radio" name="sign-in-option" value="lost-account-details">' +
+          '<button>Submit</button>' +
+        '</form>' +
+      '</div>'
+    )
+
+    tracker = new GOVUK.Modules.TrackRadioGroup()
+    tracker.start(element)
+  })
+
+  it('tracks government-gateway checked radio when clicking submit', function () {
+    element.find('input[value="government-gateway"]').trigger('click')
+    element.find('form').trigger('submit')
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'Radio button chosen', 'government-gateway', { transport: 'beacon' }
+    )
+  })
+
+  it('tracks govuk-verify checked radio when clicking submit', function () {
+    element.find('input[value="govuk-verify"]').trigger('click')
+    element.find('form').trigger('submit')
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'Radio button chosen', 'govuk-verify', { transport: 'beacon' }
+    )
+  })
+
+  it('tracks no choice when clicking submit and checked nothing', function () {
+    element.find('form').trigger('submit')
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'Radio button chosen', 'submitted-without-choosing', { transport: 'beacon' }
+    )
+  })
+})


### PR DESCRIPTION
We want to see what users are selecting when going through the sign in option journey.

This module allows us to do so by firing an event when they submit the form.

This is based on something we used for the A/B test but refactored to use the module format.

- https://github.com/alphagov/government-frontend/pull/544/files#diff-d9e8d7c7a844d60076e6152e0911dbb2
- https://github.com/alphagov/government-frontend/pull/544/files#diff-3952895e8eee3e0496e344cded23e0d3

Tested this in a page (since we're not using it just yet) with the following results:

<img width="973" alt="screen shot 2017-12-07 at 14 52 36" src="https://user-images.githubusercontent.com/2445413/33721446-f2899336-db5e-11e7-883f-bbc4fa4751ce.png">

<img width="723" alt="screen shot 2017-12-07 at 14 58 40" src="https://user-images.githubusercontent.com/2445413/33721546-42f02042-db5f-11e7-91a5-74ba676c80c1.png">


Part of https://trello.com/c/ApvFOYTk/263-add-analytics-tracking-to-page-to-track-radio-button-selection-3
