### PR TITLE
Add progressive disclosure to long related nav

### DIFF
--- a/app/helpers/related_navigation_helper.rb
+++ b/app/helpers/related_navigation_helper.rb
@@ -23,4 +23,8 @@ module RelatedNavigationHelper
       "--other"
     end
   end
+
+  def remaining_links(links, max_section_length)
+    links.length - max_section_length
+  end
 end

--- a/app/views/components/_related-navigation.html.erb
+++ b/app/views/components/_related-navigation.html.erb
@@ -1,4 +1,5 @@
 <%
+  max_section_length = 5
   defined_sections = ["topics", "publishers", "collections", "policies", "world_locations"]
   related_content = [
     {"related_items" => related_items ||= [] },
@@ -18,7 +19,7 @@
     </h2>
     <% related_content.each do |section| %>
       <% section.each do |section_title, links| %>
-        <% if links.any?%>
+        <% if links.any? %>
           <% unless section_title === "related_items" %>
             <h3 id="related-nav-<%= section_title %>" class="
               app-c-related-navigation__sub-heading
@@ -27,12 +28,46 @@
               <%= construct_section_heading(section_title) %>
             </h3>
           <% end %>
-          <nav role="navigation" class="app-c-related-navigation__nav-section" aria-labelledby="related-nav-<%= section_title %>">
+          <nav role="navigation" class="app-c-related-navigation__nav-section" aria-labelledby="related-nav-<%= section_title %>" data-module="toggle">
             <ul class="app-c-related-navigation_link-list" data-module="track-click">
-              <% links.each do |link| %>
-                <li class="app-c-related-navigation__link">
-                  <%= link_to link[:text], link[:path], class: "app-c-related-navigation__section-link" + construct_section_styling(section_title, defined_sections), rel: link[:rel] %>
-                </li>
+              <% constructed_link_array = [] %>
+              <% links.each.with_index(1) do |link, index| %>
+                <% if index <= max_section_length %>
+                  <li class="app-c-related-navigation__link">
+                    <%=
+                      link_to(
+                        link[:text],
+                        link[:path],
+                        class: "app-c-related-navigation__section-link" + construct_section_styling(section_title, defined_sections),
+                        rel: link[:rel]
+                      )
+                    %>
+                  </li>
+                <% else %>
+                  <%
+                    constructed_link_array.push(
+                      link_to(
+                        link[:text],
+                        link[:path],
+                        class: "app-c-related-navigation__section-link" + construct_section_styling(section_title, defined_sections),
+                        rel: link[:rel]
+                      )
+                    )
+                  %>
+                <% end %>
+              <% end %>
+              <% if links.length > max_section_length %>
+              <li class="app-c-related-navigation__link toggle-wrap">
+                <a href="#"
+                  data-controls="toggle_<%= section_title %>"
+                  data-expanded="false"
+                  data-toggled-text="<%= t("govuk_component.metadata.toggle_less", default: "Show fewer") %>">
+                    <%= t("govuk_component.metadata.toggle_more", number: remaining_links(links, max_section_length), default: "+ #{remaining_links(links, max_section_length)} more") %>
+                </a>
+              </li>
+              <li class="app-c-related-navigation__link">
+                <span id="toggle_<%= section_title %>" class="js-hidden"><%= constructed_link_array.to_sentence.html_safe %></span>
+              </li>
               <% end %>
             </ul>
           </nav>

--- a/app/views/components/docs/related-navigation.yml
+++ b/app/views/components/docs/related-navigation.yml
@@ -107,6 +107,54 @@ examples:
               - path: "https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan"
                 rel: external
                 text: "The Student Room: repaying your student loan"
+  with_extensive_world_locations:
+    description: The component handles having a long list of content passed to it, by only showing the first few items and hiding the rest behind a Show More toggle.
+    data:
+      world_locations:
+        - text: Algeria
+          path: /world/algeria/news
+        - text: Austria
+          path: /world/austria/news
+        - text: Belarus
+          path: /world/belarus/news
+        - text: Belgium
+          path: /world/belgium/news
+        - text: Bolivia
+          path: /world/bolivia/news
+        - text: Brazil
+          path: /world/brazil/news
+        - text: Canada
+          path: /world/canada/news
+        - text: Chile
+          path: /world/chile/news
+        - text: China
+          path: /world/China/news
+        - text: Cuba
+          path: /world/cuba/news
+        - text: Denmark
+          path: /world/denmark/news
+        - text: Egypt
+          path: /world/egypt/news
+        - text: Fiji
+          path: /world/fiji/news
+        - text: Finland
+          path: /world/finland/news
+        - text: France
+          path: /world/france/news
+        - text: Germany
+          path: /world/germany/news
+        - text: Greece
+          path: /world/greece/news
+        - text: Norway
+          path: /world/norway/news
+        - text: Russia
+          path: /world/russia/news
+        - text: Sweden
+          path: /world/sweden/news
+        - text: United Kingdom
+          path: /world/united-kingdom/news
+        - text: USA
+          path: /world/usa/news
   with_all_related-content:
     data:
       related_items:

--- a/test/components/related_navigation_test.rb
+++ b/test/components/related_navigation_test.rb
@@ -139,6 +139,41 @@ class RelatedNavigationTest < ComponentTestCase
     assert_select ".app-c-related-navigation__nav-section[aria-labelledby]"
   end
 
+  test "adds a show more toggle link to long sections" do
+    render_component(
+      world_locations: [
+        {
+          text: 'USA',
+          path: '/usa'
+        },
+        {
+          text: 'Wales',
+          path: '/wales'
+        },
+        {
+          text: 'Fiji',
+          path: '/fiji'
+        },
+        {
+          text: 'Iceland',
+          path: '/iceland'
+        },
+        {
+          text: 'Sweden',
+          path: '/sweden'
+        },
+        {
+          text: 'Mauritius',
+          path: '/mauritius'
+        }
+      ]
+    )
+
+    assert_select ".app-c-related-navigation__section-link[href=\"/wales\"]", text: 'Wales'
+    assert_select ".app-c-related-navigation__link.toggle-wrap", text: '+ 1 more'
+    assert_select "#toggle_world_locations .app-c-related-navigation__section-link[href=\"/mauritius\"]", text: 'Mauritius'
+  end
+
   test "renders multiple items when passed data for multiple sections" do
     render_component(
       related_items: [


### PR DESCRIPTION
Adding Show More/Show Fewer button for long sections of the related navigation component.

<img width="902" alt="screen shot 2017-12-08 at 11 49 08" src="https://user-images.githubusercontent.com/29889908/33764758-d2e82a10-dc0d-11e7-84ae-354c02c3f329.png">

Review app component guide:
https://government-frontend-pr-575.herokuapp.com/component-guide/related-navigation/with_extensive_world_locations

**Note: the link above makes it look like the list is indented. This is an issue with the component guide rather than the component itself, on live pages the component will not be indented.**

Example page: https://government-frontend-pr-575.herokuapp.com/government/news/chevening-scholarship-places-in-developing-countries-tripled-for-201516

Visual regression results:
https://government-frontend-pr-575.surge.sh/gallery.html
