### PR TITLE
Some tweaks to the type on the banners.

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -20,26 +20,8 @@
   }
 }
 
-.app-c-banner__main {
-  @include grid-column( 2 / 3, $full-width: tablet, $float: right );
-
-  @include media(tablet) {
-    padding-right: 0;
-    border-left: 1px solid $white;
-  }
-}
-
-.app-c-banner__aside {
-  margin-top: $gutter-half;
-
-  @include media(tablet) {
-    margin-top: 0;
-    padding-right: $gutter / 2;
-  }
-}
-
 .app-c-banner__text {
-  @include bold-36;
+  @include core-24;
 }
 
 .app-c-banner__title {
@@ -48,7 +30,8 @@
 }
 
 .app-c-banner__desc {
-  @include core-24;
+  @include core-19;
   // Ensure the text has a line-length of around 60 characters
   max-width: 30em;
+  padding-top: $gutter-one-third;
 }

--- a/app/assets/stylesheets/views/_consultation.scss
+++ b/app/assets/stylesheets/views/_consultation.scss
@@ -2,7 +2,7 @@
   @include sidebar-with-body;
 
   .consultation-date {
-    @include core-24;
+    @include bold-19;
   }
 
   .original-consultation {

--- a/app/views/components/_banner.html.erb
+++ b/app/views/components/_banner.html.erb
@@ -12,18 +12,8 @@
   </p>
 <% end %>
 <section class="app-c-banner<% if aside %> app-c-banner--grid<% end %>" aria-label="Notice">
+  <%= content_block %>
   <% if aside %>
-    <div class="grid-row">
-      <div class="app-c-banner__main">
-        <%= content_block %>
-      </div>
-      <div class="column-third">
-        <div class="app-c-banner__aside">
-          <p><%= aside %></p>
-        </div>
-      </div>
-    </div>
-  <% else %>
-    <%= content_block %>
+    <p class="app-c-banner__desc"><%= aside %></p>
   <% end %>
 </section>

--- a/app/views/components/docs/banner.yml
+++ b/app/views/components/docs/banner.yml
@@ -30,4 +30,4 @@ examples:
     data:
       title: 'Summary'
       text: 'This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government'
-      aside: 'This consultation ran from<br><span class="consultation-date"><time datetime="2017-06-13T09:30:00.000+01:00">9:30am on 13 June 2017</time> to <time datetime="2017-07-11T23:45:00.000+01:00">11:45pm on 11 July 2017</time></span>'
+      aside: 'This consultation ran from: <span class="consultation-date"><time datetime="2017-06-13T09:30:00.000+01:00">9:30am on 13 June 2017</time> to <time datetime="2017-07-11T23:45:00.000+01:00">11:45pm on 11 July 2017</time></span>'

--- a/test/components/banner_test.rb
+++ b/test/components/banner_test.rb
@@ -39,6 +39,6 @@ class BannerTest < ComponentTestCase
     assert_select ".app-c-banner--grid"
     assert_select ".app-c-banner__title", text: 'Summary'
     assert_select ".app-c-banner__desc", text: 'This was published under the 2010 to 2015 Conservative government'
-    assert_select ".app-c-banner__aside p", text: 'This consultation ran from 9:30am on 30 January 2017 to 5pm on 28 February 2017'
+    assert_select ".app-c-banner__desc", text: 'This consultation ran from 9:30am on 30 January 2017 to 5pm on 28 February 2017'
   end
 end


### PR DESCRIPTION
Part of https://trello.com/c/q0PNOZkj/117-move-formats-with-images-to-universal-layout

Deleted the 1/3rd column for the aside. Made consultation date range
bold.

Review app component guide:
https://government-frontend-pr-XXX.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-XXX.surge.sh/gallery.html
