### PR TITLE
Enable skipped integration tests

### DIFF
--- a/app/views/components/_publisher-metadata.html.erb
+++ b/app/views/components/_publisher-metadata.html.erb
@@ -19,7 +19,7 @@
           %>
           <% if values.any? %>
             <dt class="app-c-publisher-metadata__term"><%= title %>: </dt>
-            <dd class="app-c-publisher-metadata_definition"><%= values.to_sentence.html_safe %></dd>
+            <dd class="app-c-publisher-metadata__definition"><%= values.to_sentence.html_safe %></dd>
           <% end %>
         <% end %>
         </dl>

--- a/test/integration/case_study_test.rb
+++ b/test/integration/case_study_test.rb
@@ -27,14 +27,12 @@ class CaseStudyTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "world location part of link" do
-    # FIXME: 'Part of' links are moving
-    skip
+  test "world location link" do
     setup_and_visit_content_item('translated')
 
-    part_of = "<a href=\"/world/spain/news\">Spain</a>"
-
-    assert_has_component_metadata_pair("part_of", [part_of])
-    assert_has_component_document_footer_pair("part_of", [part_of])
+    within(".app-c-related-navigation__nav-section[aria-labelledby='related-nav-world_locations']") do
+      assert page.has_css?(".app-c-related-navigation__section-link", text: "Spain")
+      assert page.has_link?("Spain", href: "/world/spain/news")
+    end
   end
 end

--- a/test/integration/news_article_test.rb
+++ b/test/integration/news_article_test.rb
@@ -30,14 +30,13 @@ class NewsArticleTest < ActionDispatch::IntegrationTest
   end
 
 
-  test "renders 'part of' in metadata and document footer" do
-    # FIXME: 'Part of' links are moving
-    skip
+  test "renders policy links" do
     setup_and_visit_content_item('news_article_government_response')
 
-    part_of = "<a href=\"/government/policies/marine-environment\">Marine environment</a>"
-    assert_has_component_metadata_pair("part_of", [part_of])
-    assert_has_component_document_footer_pair("part_of", [part_of])
+    within(".app-c-related-navigation__nav-section[aria-labelledby='related-nav-policies']") do
+      assert page.has_css?(".app-c-related-navigation__section-link", text: "Marine environment")
+      assert page.has_link?("Marine environment", href: "/government/policies/marine-environment")
+    end
   end
 
   test "renders translation links when there is more than one translation" do

--- a/test/integration/speech_test.rb
+++ b/test/integration/speech_test.rb
@@ -44,15 +44,14 @@ class SpeechTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders part of in metadata and document footer" do
-    # FIXME: These links are moving
-    skip
+  test "renders related policy links" do
     setup_and_visit_content_item('speech-transcript')
 
-    link1 = "<a href=\"/government/policies/government-transparency-and-accountability\">Government transparency and accountability</a>"
-    link2 = "<a href=\"/government/policies/tax-evasion-and-avoidance\">Tax evasion and avoidance</a>"
-    link3 = "<a href=\"/government/topical-events/anti-corruption-summit-london-2016\">Anti-Corruption Summit: London 2016</a>"
-    assert_has_component_metadata_pair("part_of", [link1, link2, link3])
-    assert_has_component_document_footer_pair("part_of", [link1, link2, link3])
+    within(".app-c-related-navigation__nav-section[aria-labelledby='related-nav-policies']") do
+      assert page.has_css?(".app-c-related-navigation__section-link", text: "Government transparency and accountability")
+      assert page.has_link?("Government transparency and accountability", href: "/government/policies/government-transparency-and-accountability")
+      assert page.has_css?(".app-c-related-navigation__section-link", text: "Tax evasion and avoidance")
+      assert page.has_link?("Tax evasion and avoidance", href: "/government/policies/tax-evasion-and-avoidance")
+    end
   end
 end

--- a/test/integration/world_location_news_article_test.rb
+++ b/test/integration/world_location_news_article_test.rb
@@ -26,18 +26,19 @@ class WorldLocationNewsArticleTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders 'from' and 'part of' links" do
-    # FIXME: These are moving to sidebar.
-    skip
+  test "renders organisation and location links" do
+    setup_and_visit_content_item('world_location_news_article')
 
-    from = "<a href=\"/government/world/organisations/british-high-commission-nairobi\">British High Commission Nairobi</a>"
-    part_of = "<a href=\"/world/kenya/news\">Kenya</a>"
+    within(".app-c-publisher-metadata__other") do
+      assert page.has_css?(".app-c-publisher-metadata__term", text: "From:")
+      assert page.has_css?(".app-c-publisher-metadata__definition", text: "British High Commission Nairobi")
+      assert page.has_link?("British High Commission Nairobi", href: "/government/world/organisations/british-high-commission-nairobi")
+    end
 
-    assert_has_component_metadata_pair("from", [from])
-    assert_has_component_document_footer_pair("from", [from])
-
-    assert_has_component_metadata_pair("part_of", [part_of])
-    assert_has_component_document_footer_pair("part_of", [part_of])
+    within(".app-c-related-navigation__nav-section[aria-labelledby='related-nav-world_locations']") do
+      assert page.has_css?(".app-c-related-navigation__section-link", text: "Kenya")
+      assert page.has_link?("Kenya", href: "/world/kenya/news")
+    end
   end
 
   test "renders translation links when there is more than one translation" do


### PR DESCRIPTION
Depends on https://github.com/alphagov/govuk-content-schemas/pull/682

Refactors and re-enables some integration tests for formats which have been redesigned and links moved to the navigation sidebar.
