### PR TITLE
Removes a duplicate method added when integrating the navigation sidebar

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -70,10 +70,6 @@ class ContentItemPresenter
     content_item.dig("links", "taxons").present?
   end
 
-  def related_navigation_sidebar
-    @nav_helper.related_navigation_sidebar
-  end
-
 private
 
   def display_date(timestamp, format = "%-d %B %Y")


### PR DESCRIPTION
This method isn't used and is a duplicate of `related_navigation`.

Review app component guide:
https://government-frontend-pr-XXX.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-XXX.surge.sh/gallery.html
