### PR TITLE
Add error summary component

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,1 +1,2 @@
 //= require_tree ./modules
+//= require_tree ./components

--- a/app/assets/javascripts/components/error-summary.js
+++ b/app/assets/javascripts/components/error-summary.js
@@ -1,0 +1,20 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (global, GOVUK) {
+  'use strict'
+
+  var $ = global.jQuery
+
+  GOVUK.Modules.ErrorSummary = function () {
+    this.start = function (element) {
+      element.focus()
+      // Focus on inputs with errors, so they're easier to discover
+      element.on('click', '.js-error-summary__link', function (event) {
+        event.preventDefault()
+        var href = $(this).attr('href')
+        $(href).focus()
+      })
+    }
+  }
+})(window, window.GOVUK)

--- a/app/assets/stylesheets/components/_error-summary.scss
+++ b/app/assets/stylesheets/components/_error-summary.scss
@@ -1,0 +1,75 @@
+@import "helpers/contents-list-helper";
+
+.app-c-error-summary {
+  color: $app-text-colour;
+  padding: $app-spacing-scale-3;
+
+  border: $app-border-width-mobile solid $app-error-colour;
+
+  @include media(tablet) {
+
+    padding: $app-spacing-scale-4;
+
+    border: $app-border-width-tablet solid $app-error-colour;
+  }
+}
+
+.app-c-error-summary:focus {
+  outline: $app-focus-width solid $app-focus-colour;
+}
+
+.app-c-error-summary__title {
+  margin-top: 0;
+  margin-bottom: $app-spacing-scale-3;
+
+  @include media(tablet) {
+    margin-bottom: $app-spacing-scale-4;
+  }
+
+  @include bold-24;
+}
+
+.app-c-error-summary__body {
+  @include core-19;
+}
+
+.app-c-error-summary__text {
+  margin-top: 0;
+  margin-bottom: $app-spacing-scale-3;
+
+  @include media(tablet) {
+    margin-bottom: $app-spacing-scale-4;
+  }
+}
+
+.app-c-error-summary__list {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.app-c-error-summary__list__item {
+  margin-bottom: $app-spacing-scale-2;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.app-c-error-summary__link {
+  &:link,
+  &:link:focus,
+  &:focus,
+  &:visited,
+  &:hover,
+  &:active {
+    color: $app-error-colour;
+    font-weight: bold;
+    text-decoration: underline;
+  }
+
+  &:hover {
+    color: darken($app-error-colour, 10%);
+  }
+}

--- a/app/assets/stylesheets/components/helpers/_variables.scss
+++ b/app/assets/stylesheets/components/helpers/_variables.scss
@@ -13,7 +13,13 @@ $app-spacing-scale-8: 60px;
 $app-text-colour: $text-colour;
 $app-secondary-text-colour: $grey-1;
 
+// Border widths
+$app-border-width-mobile: 4px;
+$app-border-width-tablet: 5px;
 $app-border-width-form-element: 2px;
+
+// Focus
+$app-focus-width: 3px;
 $app-focus-colour: $focus-colour;
 
 $app-error-colour: $red;

--- a/app/views/components/_error-summary.html.erb
+++ b/app/views/components/_error-summary.html.erb
@@ -1,0 +1,33 @@
+<%
+  description ||= false
+  items ||= []
+  title_id ||= "error-summary-title-#{SecureRandom.hex(4)}"
+%>
+<div
+  class="app-c-error-summary"
+  data-module="error-summary"
+  aria-labelledby="<%= title_id %>"
+  role="alert"
+  tabindex="-1"
+>
+  <h2 class="app-c-error-summary__title" id="<%= title_id %>">
+    <%= title %>
+  </h2>
+  <div class="app-c-error-summary__body">
+    <% if description %>
+      <p class="app-c-error-summary__text"><%= description %></p>
+    <% end %>
+    <% if items.present? %>
+      <ul class="app-c-error-summary__list">
+        <% items.each_with_index do |item, index| %>
+          <li class="app-c-error-summary__list__item">
+            <a
+              class="js-error-summary__link app-c-error-summary__link"
+              href="<%= item[:href] %>"
+            ><%= item[:text] %></a>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+</div>

--- a/app/views/components/docs/error-summary.yml
+++ b/app/views/components/docs/error-summary.yml
@@ -1,0 +1,26 @@
+name: Form error summary
+description: Used at the top of the page, to summarise validation errors.
+accessibility_criteria: |
+  - should be focused on page load, to ensure this error is noticed by assistive tech
+  - list of errors should be clickable and focus the inputs with errors
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      title: Message to alert the user to a problem goes here
+      description: Optional description of the errors and how to correct them
+      items:
+      - text: Descriptive link to the question with an error
+        href: '#example-error-1'
+  with_many_errors:
+    data:
+      title: Message to alert the user to a problem goes here
+      description: Optional description of the errors and how to correct them
+      items:
+      - text: Descriptive link to the question with an error 1
+        href: '#example-error-1'
+      - text: Descriptive link to the question with an error 2
+        href: '#example-error-2'
+      - text: Descriptive link to the question with an error 3
+        href: '#example-error-3'

--- a/spec/javascripts/error-summary.spec.js
+++ b/spec/javascripts/error-summary.spec.js
@@ -1,0 +1,72 @@
+/* global describe afterEach beforeEach it expect */
+
+var $ = window.jQuery
+
+function isFocused (element) {
+  return $(element)[0] === $(element)[0].ownerDocument.activeElement
+}
+
+describe('An error summary component', function () {
+  'use strict'
+
+  var GOVUK = window.GOVUK
+  var module
+  var element
+
+  beforeEach(function () {
+    element = $(
+      '<div ' +
+        'class="app-c-error-summary" ' +
+        'data-module="error-summary" ' +
+        'aria-labelledby="error-summary-title-id" ' +
+        'role="alert" ' +
+        'tabindex="-1" ' +
+      '> ' +
+        '<h2 class="app-c-error-summary__title" id="error-summary-title-id"> ' +
+          'Message to alert the user to a problem goes here ' +
+        '</h2> ' +
+        '<div class="app-c-error-summary__body"> ' +
+          '<p class="app-c-error-summary__text"> ' +
+            'Optional description of the errors and how to correct them ' +
+          '</p> ' +
+          '<ul class="app-c-error-summary__list"> ' +
+            '<li class="app-c-error-summary__list__item"> ' +
+              '<a ' +
+                'class="js-error-summary__link app-c-error-summary__link" ' +
+                'href="#example-error-1" ' +
+              '>Descriptive link to the question with an error</a> ' +
+            '</li> ' +
+          '</ul> ' +
+        '</div> ' +
+      '</div>'
+    )
+    $(document.body).append(element)
+    document.body.focus()
+    module = new GOVUK.Modules.ErrorSummary()
+  })
+
+  afterEach(function () {
+    // clean up the test element after each test
+    element.remove()
+    element = undefined
+  })
+
+  it('is focused on load', function () {
+    module.start(element)
+
+    expect(isFocused(element)).toBe(true)
+  })
+
+  it('focuses inputs with no location change when clicking error links', function () {
+    var originalHref = window.location.href
+    var inputElement = $('<input type="text" id="example-error-1" name="example-error-1" />')
+    $(document.body).append(inputElement)
+
+    module.start(element)
+
+    element.find('.js-error-summary__link').trigger('click')
+
+    expect(isFocused(inputElement)).toBe(true)
+    expect(originalHref).toBe(window.location.href)
+  })
+})

--- a/test/components/error_summary_test.rb
+++ b/test/components/error_summary_test.rb
@@ -1,0 +1,84 @@
+require 'component_test_helper'
+
+class ErrorSummaryTest < ComponentTestCase
+  def component_name
+    "error-summary"
+  end
+
+  test "fails to render when no data is given" do
+    assert_raise do
+      render_component({})
+    end
+  end
+
+  test "renders an error summary with title and aria-labelledby set correctly" do
+    render_component(
+      title: 'Message to alert the user to a problem goes here'
+    )
+
+    aria_labelledby_id = ''
+    assert_select(".app-c-error-summary") do |element|
+      aria_labelledby_id = element.css('.app-c-error-summary').first.attributes["aria-labelledby"].value
+    end
+
+    assert_select ".app-c-error-summary__title[id='#{aria_labelledby_id}']", text: 'Message to alert the user to a problem goes here'
+    assert_select ".app-c-error-summary__text", count: 0
+    assert_select ".app-c-error-summary__list", count: 0
+  end
+
+  test "renders an error summary with items" do
+    render_component(
+      title: 'Message to alert the user to a problem goes here',
+      description: 'Optional description of the errors and how to correct them',
+      items: [
+        {
+          text: 'Descriptive link to the question with an error',
+          href: '#example-error-1'
+        }
+      ]
+    )
+    assert_select ".app-c-error-summary__title", text: 'Message to alert the user to a problem goes here'
+    assert_select ".app-c-error-summary__text", text: 'Optional description of the errors and how to correct them'
+    assert_select(
+      "ul li a.app-c-error-summary__link:first-of-type[href='#example-error-1']",
+      text: 'Descriptive link to the question with an error'
+    )
+  end
+
+  test "renders an error summary with multiple links" do
+    render_component(
+      title: 'Message to alert the user to a problem goes here',
+      description: 'Optional description of the errors and how to correct them',
+      items: [
+        {
+          text: 'Descriptive link to the question with an error 1',
+          href: '#example-error-1'
+        },
+        {
+          text: 'Descriptive link to the question with an error 2',
+          href: '#example-error-2'
+        },
+        {
+          text: 'Descriptive link to the question with an error 3',
+          href: '#example-error-3'
+        }
+      ]
+    )
+
+    assert_select ".app-c-error-summary__title", text: 'Message to alert the user to a problem goes here'
+    assert_select ".app-c-error-summary__text", text: 'Optional description of the errors and how to correct them'
+
+    assert_select(
+      "ul li a.app-c-error-summary__link:first-of-type[href='#example-error-1']",
+      text: 'Descriptive link to the question with an error 1'
+    )
+    assert_select(
+      "ul li a.app-c-error-summary__link:nth-of-type(1)[href='#example-error-2']",
+      text: 'Descriptive link to the question with an error 2'
+    )
+    assert_select(
+      "ul li a.app-c-error-summary__link:last-of-type[href='#example-error-3']",
+      text: 'Descriptive link to the question with an error 3'
+    )
+  end
+end


### PR DESCRIPTION
Review app component guide:
https://government-frontend-pr-589.herokuapp.com/component-guide/error-summary

Part of https://trello.com/c/1ckIbeBr/246-create-an-error-summary-component-1

- [x] Tested cross browser
- [x] Tested in VoiceOver, hard to test this properly out of context, we'll want to do a better test when it is in the page. (Should the component guide allow you to side load components when they rely on them?)
- [x]  Add integration tests