### PR TITLE
Route radio buttons on choose sign in page

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -27,10 +27,15 @@ class ContentItemsController < ApplicationController
   end
 
   def service_sign_in_options
-    load_content_item
-    selected = @content_item.selected_option(params[:option])
+    if params[:option].blank?
+      redirect_path = root_path + params[:path]
+    else
+      load_content_item
+      selected = @content_item.selected_option(params[:option])
+      redirect_path = selected[:url]
+    end
 
-    redirect_to selected[:url]
+    redirect_to redirect_path
   end
 
 private

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -26,6 +26,13 @@ class ContentItemsController < ApplicationController
     render_template
   end
 
+  def service_sign_in_options
+    load_content_item
+    selected = @content_item.selected_option(params[:option])
+
+    redirect_to selected[:url]
+  end
+
 private
 
   # Allow guides to pass access token to each part to allow

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -33,6 +33,12 @@ module ServiceSignIn
       content_item['links']['parent'].first['base_path']
     end
 
+    def selected_option(selected_value)
+      symbolized_options.each do |option|
+        return option if option[:text].parameterize == selected_value
+      end
+    end
+
   private
 
     def choose_sign_in

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -13,19 +13,19 @@ module ServiceSignIn
     end
 
     def options
-      mapped_options = symbolized_options.map do |option|
+      radio_options = mapped_options.map do |option|
         {
           text: option[:text],
-          value: option[:text].parameterize,
+          value: option[:value],
           hint_text: option[:hint_text],
           bold: true
         }
       end
       # TODO: Move to decision of when or should be applied to schema
-      if mapped_options.length > 2
-        mapped_options.insert(-2, :or)
+      if radio_options.length > 2
+        radio_options.insert(-2, :or)
       else
-        mapped_options
+        radio_options
       end
     end
 
@@ -34,8 +34,8 @@ module ServiceSignIn
     end
 
     def selected_option(selected_value)
-      symbolized_options.each do |option|
-        return option if option[:text].parameterize == selected_value
+      mapped_options.each do |option|
+        return option if option[:value] == selected_value
       end
     end
 
@@ -43,6 +43,17 @@ module ServiceSignIn
 
     def choose_sign_in
       content_item["details"]["choose_sign_in"]
+    end
+
+    def mapped_options
+      symbolized_options.map do |option|
+        {
+          text: option[:text],
+          value: option[:text].parameterize,
+          hint_text: option[:hint_text],
+          url: option[:url],
+        }
+      end
     end
 
     def symbolized_options

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -1,6 +1,6 @@
 <%= render "components/back-link", href: @content_item.back_link %>
 
-<%= form_tag("/", method: "post", data: { module: 'track-radio-group' }) do %>
+<%= form_tag({controller: 'content_items', action: 'service_sign_in_options'}, method: "post", data: { module: 'track-radio-group' }) do %>
   <% legend_text = render 'govuk_component/title', title: @content_item.title %>
   <%= render "components/fieldset", legend_text: legend_text do %>
     <div class="grid-row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,6 @@ Rails.application.routes.draw do
         format: /atom/,
         locale: /\w{2}(-[\d\w]{2,3})?/,
       }
+
+  post '*path' => 'content_items#service_sign_in_options'
 end

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -362,6 +362,16 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_redirected_to link
   end
 
+  test "service_sign_in_options with no option param set displays choose_sign_in page" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
+
+    post :service_sign_in_options, params: { path: path }
+
+    assert_response :redirect
+    assert_redirected_to "/#{path}"
+  end
+
   def path_for(content_item, locale = nil)
     base_path = content_item['base_path'].sub(/^\//, '')
     base_path.gsub!(/\.#{locale}$/, '') if locale

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -346,6 +346,22 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_equal response.headers["Access-Control-Allow-Origin"], "*"
   end
 
+  test "service_sign_in_options with option param set" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
+
+    option = content_item['details']['choose_sign_in']['options'][0]
+    value = option['text'].parameterize
+    link = option['url']
+
+    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    post :service_sign_in_options, params: { path: path, option: value }
+
+    assert_response :redirect
+    assert_redirected_to link
+  end
+
   def path_for(content_item, locale = nil)
     base_path = content_item['base_path'].sub(/^\//, '')
     base_path.gsub!(/\.#{locale}$/, '') if locale


### PR DESCRIPTION
Trello card: https://trello.com/c/zsPE3IXV

Add routing to the radio buttons on the `choose sign in` page of the service_sign_in format.

The actual error handling, that displays an error message to the user, will be added in another PR. Reloading the `choose sign in` page if the user doesn't select an option just stops an exception from being raised.
