### PR TITLE
Statistics announcements to universal layout

### DIFF
--- a/app/assets/stylesheets/components/_important-metadata.scss
+++ b/app/assets/stylesheets/components/_important-metadata.scss
@@ -18,6 +18,11 @@
   @include responsive-bottom-margin;
 }
 
+.app-c-important-metadata__title {
+  font-weight: bold;
+  margin-bottom: 5px;
+}
+
 .app-c-important-metadata__term {
   float: left;
   padding-right: $gutter-one-third / 2;

--- a/app/assets/stylesheets/components/_important-metadata.scss
+++ b/app/assets/stylesheets/components/_important-metadata.scss
@@ -1,5 +1,4 @@
 .app-c-important-metadata {
-  @include responsive-bottom-margin;
   @include core-16;
   @include white-links;
   background: $govuk-blue;
@@ -10,6 +9,13 @@
     overflow: auto;
     padding: $gutter-two-thirds $gutter;
   }
+}
+
+// this will be moved and extended into a model for general component spacing
+// once this has been decided upon and other work completed, see:
+// https://trello.com/c/KEkNsxG3/142-3-implement-customisable-spacing-for-components
+.app-c-important-metadata--bottom-margin {
+  @include responsive-bottom-margin;
 }
 
 .app-c-important-metadata__term {

--- a/app/assets/stylesheets/components/_notice.scss
+++ b/app/assets/stylesheets/components/_notice.scss
@@ -1,6 +1,5 @@
 .app-c-notice {
   clear: both;
-  @include responsive-bottom-margin;
   padding: $gutter-two-thirds;
   border: 2px solid $govuk-blue;
 
@@ -13,6 +12,10 @@
       margin-bottom: 0;
     }
   }
+}
+
+.app-c-notice--bottom-margin {
+  @include responsive-bottom-margin;
 }
 
 .app-c-notice__title {

--- a/app/assets/stylesheets/views/_statistics_announcement.scss
+++ b/app/assets/stylesheets/views/_statistics_announcement.scss
@@ -1,21 +1,3 @@
 .statistics-announcement {
   @include add-title-margin;
-
-  .release-date-change-notice {
-    h2 {
-      font-weight: bold;
-      margin-bottom: $gutter-half;
-    }
-  }
-
-  .metadata-logo-wrapper {
-    position: relative;
-    padding: 0 $gutter-half;
-  }
-
-  .national-statistics-logo {
-    position: absolute;
-    top: $gutter-one-third;
-    right: $gutter;
-  }
 }

--- a/app/assets/stylesheets/views/_statistics_announcement.scss
+++ b/app/assets/stylesheets/views/_statistics_announcement.scss
@@ -7,4 +7,15 @@
       margin-bottom: $gutter-half;
     }
   }
+
+  .metadata-logo-wrapper {
+    position: relative;
+    padding: 0 $gutter-half;
+  }
+
+  .national-statistics-logo {
+    position: absolute;
+    top: $gutter-one-third;
+    right: $gutter;
+  }
 }

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -5,13 +5,6 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
 
   FORTHCOMING_NOTICE = "These statistics will be released".freeze
 
-  def publisher_metadata_and_release_date
-    publisher_metadata_and_release_date = publisher_metadata
-    publisher_metadata_and_release_date[:other].merge!(metadata[:other])
-
-    publisher_metadata_and_release_date
-  end
-
   def release_date
     content_item["details"]["display_date"]
   end

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -5,6 +5,13 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
 
   FORTHCOMING_NOTICE = "These statistics will be released".freeze
 
+  def publisher_metadata_and_release_date
+    publisher_metadata_and_release_date = publisher_metadata
+    publisher_metadata_and_release_date[:other].merge!(metadata[:other])
+
+    publisher_metadata_and_release_date
+  end
+
   def release_date
     content_item["details"]["display_date"]
   end

--- a/app/views/components/_important-metadata.html.erb
+++ b/app/views/components/_important-metadata.html.erb
@@ -1,4 +1,5 @@
 <%
+  title ||= false
   items = local_assigns[:items] || {}
   items = items.reject { |k,v| v.nil? }
   items = items.merge(items) { |k,v| Array(v).join(",").html_safe }
@@ -7,6 +8,9 @@
 -%>
 <% if items.any? -%>
   <div class="app-c-important-metadata <%= margin_bottom_class %>">
+    <% if title %>
+      <h2 class="app-c-important-metadata__title"><%= title %></h2>
+    <% end %>
     <dl data-module="track-click">
     <% items.each do |title, definition| -%>
       <dt class="app-c-important-metadata__term"><%= title %>: </dt>

--- a/app/views/components/_important-metadata.html.erb
+++ b/app/views/components/_important-metadata.html.erb
@@ -1,13 +1,12 @@
 <%
-  title ||= false
+  title = local_assigns[:title]
   items = local_assigns[:items] || {}
   items = items.reject { |k,v| v.nil? }
   items = items.merge(items) { |k,v| Array(v).join(",").html_safe }
-  margin_bottom ||= 1
-  margin_bottom_class = "app-c-important-metadata--bottom-margin" if margin_bottom == 1
+  margin_bottom_class = " app-c-important-metadata--bottom-margin" unless local_assigns[:margin_bottom]
 -%>
 <% if items.any? -%>
-  <div class="app-c-important-metadata <%= margin_bottom_class %>">
+  <div class="app-c-important-metadata<%= margin_bottom_class %>">
     <% if title %>
       <h2 class="app-c-important-metadata__title"><%= title %></h2>
     <% end %>

--- a/app/views/components/_important-metadata.html.erb
+++ b/app/views/components/_important-metadata.html.erb
@@ -2,9 +2,11 @@
   items = local_assigns[:items] || {}
   items = items.reject { |k,v| v.nil? }
   items = items.merge(items) { |k,v| Array(v).join(",").html_safe }
+  margin_bottom ||= 1
+  margin_bottom_class = "app-c-important-metadata--bottom-margin" if margin_bottom == 1
 -%>
 <% if items.any? -%>
-  <div class="app-c-important-metadata">
+  <div class="app-c-important-metadata <%= margin_bottom_class %>">
     <dl data-module="track-click">
     <% items.each do |title, definition| -%>
       <dt class="app-c-important-metadata__term"><%= title %>: </dt>

--- a/app/views/components/_notice.html.erb
+++ b/app/views/components/_notice.html.erb
@@ -2,10 +2,9 @@
   <%
     description_text ||= false
     description_govspeak ||= false
-    margin_bottom ||= 1
-    margin_bottom_class = "app-c-notice--bottom-margin" if margin_bottom == 1
+    margin_bottom_class = " app-c-notice--bottom-margin" unless local_assigns[:margin_bottom]
   %>
-  <section class="app-c-notice <%= margin_bottom_class %>" aria-label="Notice">
+  <section class="app-c-notice<%= margin_bottom_class %>" aria-label="Notice">
     <% if description_text || description_govspeak %>
       <h2 class="app-c-notice__title"><%= title %></h2>
     <% else %>

--- a/app/views/components/_notice.html.erb
+++ b/app/views/components/_notice.html.erb
@@ -2,8 +2,10 @@
   <%
     description_text ||= false
     description_govspeak ||= false
+    margin_bottom ||= 1
+    margin_bottom_class = "app-c-notice--bottom-margin" if margin_bottom == 1
   %>
-  <section class="app-c-notice" aria-label="Notice">
+  <section class="app-c-notice <%= margin_bottom_class %>" aria-label="Notice">
     <% if description_text || description_govspeak %>
       <h2 class="app-c-notice__title"><%= title %></h2>
     <% else %>

--- a/app/views/components/docs/important-metadata.yml
+++ b/app/views/components/docs/important-metadata.yml
@@ -20,3 +20,10 @@ examples:
         Date of occurrence: 29 November 2013
         Aircraft category: <a href="https://www.gov.uk/aaib-reports?aircraft_category%5B%5D=general-aviation">General Aviation</a>
         Report type: <a href="https://www.gov.uk/aaib-reports?report-type%5B%5D=%5B%5D=formal-report">Formal Report</a>
+  with_title:
+    description: Used on statistics announcements to display release date changed information, [see example](https://gov.uk/government/statistics/announcements/museums-and-galleries-monthly-visits--8)
+    data:
+      title: "The release date has been changed"
+      items:
+        Previous Date: 4 February 2016 9:00pm
+        Reason for change: Incorrectly input as 2015 instead of 2016

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -5,14 +5,11 @@
   </div>
 </div>
 
-<div class="grid-row">
-  <div class="column-full metadata-logo-wrapper">
-    <%= render "components/publisher-metadata", @content_item.publisher_metadata_and_release_date %>
-    <% if @content_item.national_statistics? %>
-      <%= image_tag 'national-statistics.png', alt: 'National Statistics', class: 'national-statistics-logo' %>
-    <% end %>
-  </div>
-</div>
+<% if @content_item.national_statistics? %>
+  <%= render 'shared/publisher_metadata_with_logo', metadata: @content_item.publisher_metadata_and_release_date %>
+<% else %>
+  <%= render "components/publisher-metadata", @content_item.publisher_metadata_and_release_date %>
+<% end %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -1,25 +1,34 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>
+    <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
   </div>
-  <% if @content_item.national_statistics? %>
-    <%= render 'shared/national_statistics_logo' %>
-  <% end %>
 </div>
 
-<div class="primary-metadata">
-  <%= render 'shared/metadata', content_item: @content_item %>
+<div class="grid-row">
+  <div class="column-full metadata-logo-wrapper">
+    <%= render "components/publisher-metadata", @content_item.publisher_metadata_and_release_date %>
+    <% if @content_item.national_statistics? %>
+      <%= image_tag 'national-statistics.png', alt: 'National Statistics', class: 'national-statistics-logo' %>
+    <% end %>
+  </div>
 </div>
 
-<% if @content_item.cancelled? %>
-  <%= render 'components/notice', title: 'Statistics release cancelled', description_text: @content_item.cancellation_reason %>
-<% end %>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <% if @content_item.cancelled? %>
+      <%= render 'components/notice', title: 'Statistics release cancelled', description_text: @content_item.cancellation_reason %>
+    <% end %>
+    <% if @content_item.forthcoming_publication? %>
+      <%= render 'components/notice', title: nbsp_between_last_two_words(@content_item.forthcoming_notice_title) %>
+    <% end %>
+  </div>
 
-<% if @content_item.forthcoming_publication? %>
-  <%= render 'components/notice', title: nbsp_between_last_two_words(@content_item.forthcoming_notice_title) %>
-<% end %>
+  <div class="column-one-third">
+    <%= render 'components/related-navigation', @content_item.related_navigation %>
+  </div>
+</div>
 
-<%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
 
 <% if @content_item.release_date_changed? %>
 <div class="grid-row">

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -5,14 +5,11 @@
   </div>
 </div>
 
-<% if @content_item.national_statistics? %>
-  <%= render 'shared/publisher_metadata_with_logo', metadata: @content_item.publisher_metadata_and_release_date %>
-<% else %>
-  <%= render "components/publisher-metadata", @content_item.publisher_metadata_and_release_date %>
-<% end %>
+<%= render 'shared/publisher_metadata_with_logo' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">
+    <%= render "components/important-metadata", items: @content_item.metadata[:other] %>
     <% if @content_item.cancelled? %>
       <%= render 'components/notice', title: 'Statistics release cancelled', description_text: @content_item.cancellation_reason %>
     <% end %>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -9,7 +9,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render "components/important-metadata", items: @content_item.metadata[:other] %>
+    <%= render "components/important-metadata", items: @content_item.metadata[:other], margin_bottom: 0 %>
     <% if @content_item.cancelled? %>
       <%= render 'components/notice', title: 'Statistics release cancelled', description_text: @content_item.cancellation_reason %>
     <% end %>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -9,12 +9,25 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render "components/important-metadata", items: @content_item.metadata[:other], margin_bottom: 0 %>
     <% if @content_item.cancelled? %>
-      <%= render 'components/notice', title: 'Statistics release cancelled', description_text: @content_item.cancellation_reason %>
+      <%= render 'components/notice', title: 'Statistics release cancelled', description_text: @content_item.cancellation_reason, margin_bottom: true %>
     <% end %>
     <% if @content_item.forthcoming_publication? %>
-      <%= render 'components/notice', title: nbsp_between_last_two_words(@content_item.forthcoming_notice_title) %>
+      <%= render 'components/notice', title: nbsp_between_last_two_words(@content_item.forthcoming_notice_title), margin_bottom: true %>
+    <% end %>
+
+    <%= render "components/important-metadata", items: @content_item.metadata[:other], margin_bottom: @content_item.release_date_changed? %>
+
+    <% if @content_item.release_date_changed? %>
+      <div class="release-date-changed">
+        <%= render "components/important-metadata",
+          title: "The release date has been changed",
+          items: {
+            "Previous date" => @content_item.previous_release_date,
+            "Reason for change" => @content_item.release_date_change_reason,
+          }
+        %>
+      </div>
     <% end %>
   </div>
 
@@ -22,18 +35,3 @@
     <%= render 'components/related-navigation', @content_item.related_navigation %>
   </div>
 </div>
-
-
-<% if @content_item.release_date_changed? %>
-<div class="grid-row">
-  <div class="column-two-thirds release-date-change-notice">
-    <h2>The release date has been changed</h2>
-    <%= render 'govuk_component/metadata',
-        other: {
-          "Previous date" => @content_item.previous_release_date,
-          "Reason for change" => @content_item.release_date_change_reason,
-        }
-    %>
-  </div>
-</div>
-<% end %>

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -1,8 +1,10 @@
+<% metadata ||= @content_item.publisher_metadata %>
+
 <% render_logo = @content_item.try(:national_statistics?) -%>
 <div class="grid-row">
   <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if render_logo %>">
     <div class="column-two-thirds metadata-column">
-      <%= render "components/publisher-metadata", @content_item.publisher_metadata %>
+      <%= render "components/publisher-metadata", metadata %>
     </div>
     <div class="column-one-third">
       <% if render_logo %>

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -4,7 +4,7 @@
 <div class="grid-row">
   <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if render_logo %>">
     <div class="column-two-thirds metadata-column">
-      <%= render "components/publisher-metadata", metadata %>
+      <%= render "components/publisher-metadata", @content_item.publisher_metadata %>
     </div>
     <div class="column-one-third">
       <% if render_logo %>

--- a/test/components/important_metadata_test.rb
+++ b/test/components/important_metadata_test.rb
@@ -14,6 +14,17 @@ class ImportantMetadataTest < ComponentTestCase
     assert_empty render_component(other: { a: false, b: "", c: [], d: {}, e: nil })
   end
 
+  test "renders a title when a title is provided" do
+    render_component(
+      title: 'The release date has been changed',
+      items: {
+      "Release Date": "14 October 2016"
+      }
+    )
+
+    assert_select ".app-c-important-metadata__title", text: "The release date has been changed"
+  end
+
   test "renders metadata link pairs from data it is given" do
     render_component(items: {
       "Opened": "14 October 2016",

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -7,7 +7,7 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
 
-    within '.app-c-publisher-metadata' do
+    within '.app-c-important-metadata' do
       assert page.has_text?("Release date: 20 January 2016 9:30am (confirmed)")
     end
   end
@@ -19,7 +19,7 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
     assert page.has_text?(@content_item["description"])
     assert page.has_css?('img[alt="National Statistics"]')
 
-    within '.app-c-publisher-metadata' do
+    within '.app-c-important-metadata' do
       assert page.has_text?("Release date: January 2016 (provisional)")
     end
   end
@@ -34,7 +34,7 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
       assert page.has_text?(@content_item["details"]["cancellation_reason"]), "displays cancelleation reason"
     end
 
-    within '.app-c-publisher-metadata' do
+    within '.app-c-important-metadata' do
       assert page.has_text?("Proposed release: 20 January 2016 9:30am")
       assert page.has_text?("Cancellation date: 17 January 2016 2:19pm")
     end
@@ -46,7 +46,7 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
 
-    within '.app-c-publisher-metadata' do
+    within '.app-c-important-metadata' do
       assert page.has_text?("Release date: 20 January 2016 9:30am (confirmed)")
     end
 

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -6,7 +6,10 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
 
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
-    assert_has_component_metadata_pair("Release date", "20 January 2016 9:30am (confirmed)")
+
+    within '.app-c-publisher-metadata' do
+      assert page.has_text?("Release date: 20 January 2016 9:30am (confirmed)")
+    end
   end
 
   test "national statistics" do
@@ -15,7 +18,10 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
     assert page.has_css?('img[alt="National Statistics"]')
-    assert_has_component_metadata_pair("Release date", "January 2016 (provisional)")
+
+    within '.app-c-publisher-metadata' do
+      assert page.has_text?("Release date: January 2016 (provisional)")
+    end
   end
 
   test "cancelled statistics" do
@@ -28,8 +34,10 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
       assert page.has_text?(@content_item["details"]["cancellation_reason"]), "displays cancelleation reason"
     end
 
-    assert_has_component_metadata_pair("Proposed release", "20 January 2016 9:30am")
-    assert_has_component_metadata_pair("Cancellation date", "17 January 2016 2:19pm")
+    within '.app-c-publisher-metadata' do
+      assert page.has_text?("Proposed release: 20 January 2016 9:30am")
+      assert page.has_text?("Cancellation date: 17 January 2016 2:19pm")
+    end
   end
 
   test "statistics with a changed release date" do
@@ -38,8 +46,8 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
 
-    within '.primary-metadata' do
-      assert_has_component_metadata_pair("Release date", "20 January 2016 9:30am (confirmed)")
+    within '.app-c-publisher-metadata' do
+      assert page.has_text?("Release date: 20 January 2016 9:30am (confirmed)")
     end
 
     within '.release-date-change-notice' do

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -45,15 +45,12 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
 
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
+    assert page.has_text?("Release date: 20 January 2016 9:30am (confirmed)")
 
-    within '.app-c-important-metadata' do
-      assert page.has_text?("Release date: 20 January 2016 9:30am (confirmed)")
-    end
-
-    within '.release-date-change-notice' do
+    within '.release-date-changed .app-c-important-metadata' do
       assert page.has_text?("The release date has been changed")
-      assert_has_component_metadata_pair("Previous date", "19 January 2016 9:30am")
-      assert_has_component_metadata_pair("Reason for change", @content_item["details"]["latest_change_note"])
+      assert page.has_text?("Previous date", "19 January 2016 9:30am")
+      assert page.has_text?("Reason for change", @content_item["details"]["latest_change_note"])
     end
   end
 


### PR DESCRIPTION
Moving statistics announcements over to universal layout.
<img width="1011" alt="screen shot 2017-12-18 at 17 25 44" src="https://user-images.githubusercontent.com/29889908/34119102-de8cc994-e418-11e7-9cc4-e6416f7195bf.png">

<img width="989" alt="screen shot 2017-12-18 at 17 26 53" src="https://user-images.githubusercontent.com/29889908/34119106-e38a60dc-e418-11e7-82fc-4f6425f1de34.png">

Example pages: 

- [Official Statistics Announcement](https://government-frontend-pr-602.herokuapp.com/government/statistics/announcements/ni-tourism-statistics-oct-13-to-sep-14)
- [Statistics Announcement](https://government-frontend-pr-602.herokuapp.com/government/statistics/announcements/vat-factsheet-2014-15)
- [Cancelled Statistics Announcement](https://government-frontend-pr-602.herokuapp.com/government/statistics/announcements/delayed-transfers-of-care-for-october-2015)
- [Statistics Announcement with changed release date](https://government-frontend-pr-602.herokuapp.com/government/statistics/announcements/museums-and-galleries-monthly-visits--8)
