### PR TITLE
Feature/choose sign in add error handling

### DIFF
--- a/app/assets/stylesheets/components/_error-message.scss
+++ b/app/assets/stylesheets/components/_error-message.scss
@@ -3,9 +3,7 @@
 .app-c-error-message {
   display: block;
 
-  margin: 0;
-  // TODO: use a var for padding
-  padding: 2px 0;
+  margin-bottom: $app-spacing-scale-3;
 
   clear: both;
 

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -28,14 +28,13 @@ class ContentItemsController < ApplicationController
 
   def service_sign_in_options
     if params[:option].blank?
-      redirect_path = root_path + params[:path]
+      @error = true
+      show
     else
       load_content_item
       selected = @content_item.selected_option(params[:option])
-      redirect_path = selected[:url]
+      redirect_to selected[:url]
     end
-
-    redirect_to redirect_path
   end
 
 private

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -27,10 +27,15 @@ class ContentItemsController < ApplicationController
   end
 
   def service_sign_in_options
-    load_content_item
-    selected = @content_item.selected_option(params[:option])
+    if params[:option].blank?
+      redirect_path = root_path + params[:path]
+    else
+      load_content_item
+      selected = @content_item.selected_option(params[:option])
+      redirect_path = selected[:url]
+    end
 
-    redirect_to selected[:url]
+    redirect_to redirect_path
   end
 
 private

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -26,6 +26,13 @@ class ContentItemsController < ApplicationController
     render_template
   end
 
+  def service_sign_in_options
+    load_content_item
+    selected = @content_item.selected_option(params[:option])
+
+    redirect_to selected[:url]
+  end
+
 private
 
   # Allow guides to pass access token to each part to allow

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -45,7 +45,11 @@ private
   end
 
   def present(content_item)
-    presenter_name = content_item['schema_name'].classify + 'Presenter'
+    presenter_name = if service_sign_in_format?(content_item["schema_name"])
+                       service_sign_in_presenter_name(content_item)
+                     else
+                       content_item['schema_name'].classify + 'Presenter'
+                     end
     presenter_class = Object.const_get(presenter_name)
     presenter_class.new(content_item, content_item_path)
   rescue NameError
@@ -112,6 +116,20 @@ private
 
   def with_locale
     I18n.with_locale(@content_item.locale || I18n.default_locale) { yield }
+  end
+
+  def service_sign_in_format?(schema_name)
+    schema_name == "service_sign_in"
+  end
+
+  def service_sign_in_presenter_name(content_item)
+    slug = content_item_path.split("/").last
+
+    content_item["details"].each do |key, value|
+      if value["slug"] == slug
+        return "ServiceSignIn::#{key.classify}Presenter"
+      end
+    end
   end
 
   def setup_tasklist_header_ab_testing

--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -5,7 +5,7 @@ class DevelopmentController < ApplicationController
     @schema_names = %w[answer case_study coming_soon consultation contact
                        corporate_information_page detailed_guide document_collection
                        fatality_notice guide help_page html_publication news_article
-                       placeholder_corporate_information_page publication specialist_document
+                       placeholder_corporate_information_page publication service_sign_in specialist_document
                        speech statistical_data_set statistics_announcement take_part
                        topical_event_about_page travel_advice working_group
                        world_location_news_article]

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -33,6 +33,12 @@ module ServiceSignIn
       content_item['links']['parent'].first['base_path']
     end
 
+    def selected_option(selected_value)
+      symbolized_options.each do |option|
+        return option if option[:text].parameterize == selected_value
+      end
+    end
+
   private
 
     def choose_sign_in

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -1,4 +1,7 @@
 module ServiceSignIn
   class ChooseSignInPresenter < ContentItemPresenter
+    def page_type
+      "choose_sign_in"
+    end
   end
 end

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -13,19 +13,19 @@ module ServiceSignIn
     end
 
     def options
-      mapped_options = symbolized_options.map do |option|
+      radio_options = mapped_options.map do |option|
         {
           text: option[:text],
-          value: option[:text].parameterize,
+          value: option[:value],
           hint_text: option[:hint_text],
           bold: true
         }
       end
       # TODO: Move to decision of when or should be applied to schema
-      if mapped_options.length > 2
-        mapped_options.insert(-2, :or)
+      if radio_options.length > 2
+        radio_options.insert(-2, :or)
       else
-        mapped_options
+        radio_options
       end
     end
 
@@ -34,8 +34,8 @@ module ServiceSignIn
     end
 
     def selected_option(selected_value)
-      symbolized_options.each do |option|
-        return option if option[:text].parameterize == selected_value
+      mapped_options.each do |option|
+        return option if option[:value] == selected_value
       end
     end
 
@@ -43,6 +43,17 @@ module ServiceSignIn
 
     def choose_sign_in
       content_item["details"]["choose_sign_in"]
+    end
+
+    def mapped_options
+      symbolized_options.map do |option|
+        {
+          text: option[:text],
+          value: option[:text].parameterize,
+          hint_text: option[:hint_text],
+          url: option[:url],
+        }
+      end
     end
 
     def symbolized_options

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -8,6 +8,9 @@ module ServiceSignIn
       choose_sign_in["title"]
     end
 
+    def description
+      choose_sign_in["description"]
+    end
   private
 
     def choose_sign_in

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -13,13 +13,19 @@ module ServiceSignIn
     end
 
     def options
-      symbolized_options.map do |option|
+      mapped_options = symbolized_options.map do |option|
         {
           text: option[:text],
           value: option[:text].parameterize,
           hint_text: option[:hint_text],
           bold: true
         }
+      end
+      # TODO: Move to decision of when or should be applied to schema
+      if mapped_options.length > 2
+        mapped_options.insert(-2, :or)
+      else
+        mapped_options
       end
     end
 

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -3,5 +3,15 @@ module ServiceSignIn
     def page_type
       "choose_sign_in"
     end
+
+    def title
+      choose_sign_in["title"]
+    end
+
+  private
+
+    def choose_sign_in
+      content_item["details"]["choose_sign_in"]
+    end
   end
 end

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -11,10 +11,32 @@ module ServiceSignIn
     def description
       choose_sign_in["description"]
     end
+
+    def options
+      symbolized_options.map do |option|
+        {
+          text: option[:text],
+          value: option[:text].parameterize,
+          hint_text: option[:hint_text],
+          bold: true
+        }
+      end
+    end
+
   private
 
     def choose_sign_in
       content_item["details"]["choose_sign_in"]
+    end
+
+    def symbolized_options
+      options_with_text.map(&:symbolize_keys)
+    end
+
+    def options_with_text
+      # Sometimes the dummy store can produce options without text, may be a bug since
+      # the content schemas [specify these as required](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/service_sign_in.jsonnet#L39-L45)
+      choose_sign_in["options"].select { |option| option['text'].present? }
     end
   end
 end

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -1,0 +1,4 @@
+module ServiceSignIn
+  class ChooseSignInPresenter < ContentItemPresenter
+  end
+end

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -23,6 +23,10 @@ module ServiceSignIn
       end
     end
 
+    def back_link
+      content_item['links']['parent'].first['base_path']
+    end
+
   private
 
     def choose_sign_in

--- a/app/presenters/service_sign_in/create_new_account_presenter.rb
+++ b/app/presenters/service_sign_in/create_new_account_presenter.rb
@@ -8,7 +8,15 @@ module ServiceSignIn
       create_new_account["title"]
     end
 
+    def back_link
+      "#{content_item['base_path']}/#{parent_slug}"
+    end
+
   private
+
+    def parent_slug
+      content_item["details"]["choose_sign_in"]["slug"]
+    end
 
     def create_new_account
       content_item["details"]["create_new_account"]

--- a/app/presenters/service_sign_in/create_new_account_presenter.rb
+++ b/app/presenters/service_sign_in/create_new_account_presenter.rb
@@ -1,0 +1,7 @@
+module ServiceSignIn
+  class CreateNewAccountPresenter < ContentItemPresenter
+    def page_type
+      "create_new_account"
+    end
+  end
+end

--- a/app/presenters/service_sign_in/create_new_account_presenter.rb
+++ b/app/presenters/service_sign_in/create_new_account_presenter.rb
@@ -8,6 +8,10 @@ module ServiceSignIn
       create_new_account["title"]
     end
 
+    def body
+      create_new_account["body"]
+    end
+
     def back_link
       "#{content_item['base_path']}/#{parent_slug}"
     end

--- a/app/presenters/service_sign_in/create_new_account_presenter.rb
+++ b/app/presenters/service_sign_in/create_new_account_presenter.rb
@@ -3,5 +3,15 @@ module ServiceSignIn
     def page_type
       "create_new_account"
     end
+
+    def title
+      create_new_account["title"]
+    end
+
+  private
+
+    def create_new_account
+      content_item["details"]["create_new_account"]
+    end
   end
 end

--- a/app/views/content_items/service_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in.html.erb
@@ -1,4 +1,8 @@
 <% content_for :no_breadcrumbs, true %>
 <% content_for :simple_header, true %>
+<% content_for :extra_head_content do %>
+  <% # prevent search engines from indexing this page %>
+  <meta name="robots" content="noindex, nofollow">
+<% end %>
 
 <%= render partial: "content_items/service_sign_in/#{@content_item.page_type}" %>

--- a/app/views/content_items/service_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "content_items/service_sign_in/choose_sign_in" %>

--- a/app/views/content_items/service_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in.html.erb
@@ -1,1 +1,4 @@
+<% content_for :no_breadcrumbs, true %>
+<% content_for :simple_header, true %>
+
 <%= render partial: "content_items/service_sign_in/#{@content_item.page_type}" %>

--- a/app/views/content_items/service_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: "content_items/service_sign_in/choose_sign_in" %>
+<%= render partial: "content_items/service_sign_in/#{@content_item.page_type}" %>

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -1,6 +1,6 @@
 <%= render "components/back-link", href: @content_item.back_link %>
 
-<%= form_tag("/", method: "post", data: { module: 'track-radio-group' }) do %>
+<%= form_tag({controller: 'content_items', action: 'service_sign_in_options'}, method: "post", data: { module: 'track-radio-group' }) do %>
   <% legend_text = render 'govuk_component/title', title: @content_item.title %>
   <%= render "components/fieldset", legend_text: legend_text do %>
     <div class="grid-row">

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -3,5 +3,6 @@
     <legend>
       <%= render 'govuk_component/title', title: @content_item.title %>
     </legend>
+    <%= render 'govuk_component/govspeak', content: @content_item.description %>
   </fieldset>
 <% end %>

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -1,9 +1,7 @@
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_component/title',
-        context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
-        title: @content_item.title %>
-  </div>
-</div>
-
-<%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
+<%= form_tag("/", method: "post") do %>
+  <fieldset>
+    <legend>
+      <%= render 'govuk_component/title', title: @content_item.title %>
+    </legend>
+  </fieldset>
+<% end %>

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -1,6 +1,6 @@
 <%= render "components/back-link", href: @content_item.back_link %>
 
-<%= form_tag("/", method: "post") do %>
+<%= form_tag("/", method: "post", data: { module: 'track-radio-group' }) do %>
   <% legend_text = render 'govuk_component/title', title: @content_item.title %>
   <%= render "components/fieldset", legend_text: legend_text do %>
     <div class="grid-row">

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -1,0 +1,9 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+        context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
+        title: @content_item.title %>
+  </div>
+</div>
+
+<%= render 'govuk_component/lead_paragraph', text: @content_item.description %>

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -1,8 +1,12 @@
 <%= form_tag("/", method: "post") do %>
   <% legend_text = render 'govuk_component/title', title: @content_item.title %>
   <%= render "components/fieldset", legend_text: legend_text do %>
-    <%= render 'govuk_component/govspeak', content: @content_item.description %>
-    <%= render "components/radio", name: "option", items: @content_item.options %>
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <%= render 'govuk_component/govspeak', content: @content_item.description %>
+        <%= render "components/radio", name: "option", items: @content_item.options %>
+      </div>
+    </div>
   <% end %>
 
   <%= render 'govuk_component/button', text: t('service_sign_in.continue'), margin_bottom: true %>

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -4,4 +4,6 @@
     <%= render 'govuk_component/govspeak', content: @content_item.description %>
     <%= render "components/radio", name: "option", items: @content_item.options %>
   <% end %>
+
+  <%= render 'govuk_component/button', text: t('service_sign_in.continue'), margin_bottom: true %>
 <% end %>

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -1,12 +1,31 @@
 <%= render "components/back-link", href: @content_item.back_link %>
 
+<% if @error %>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <%= render "components/error-summary", {
+        title: t('service_sign_in.error.title'),
+        items: [
+          {
+            text: t('service_sign_in.error.option'),
+            href: "#option-0"
+          }
+        ]
+      } %>
+    </div>
+  </div>
+<% end %>
+
 <%= form_tag({controller: 'content_items', action: 'service_sign_in_options'}, method: "post", data: { module: 'track-radio-group' }) do %>
   <% legend_text = render 'govuk_component/title', title: @content_item.title %>
   <%= render "components/fieldset", legend_text: legend_text do %>
     <div class="grid-row">
       <div class="column-two-thirds">
         <%= render 'govuk_component/govspeak', content: @content_item.description %>
-        <%= render "components/radio", name: "option", items: @content_item.options %>
+        <% if @error %>
+          <%= render "components/error-message", text: t('service_sign_in.error.option') %>
+        <% end %>
+        <%= render "components/radio", id_prefix: "option", name: "option", items: @content_item.options %>
       </div>
     </div>
   <% end %>

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -1,8 +1,7 @@
 <%= form_tag("/", method: "post") do %>
-  <fieldset>
-    <legend>
-      <%= render 'govuk_component/title', title: @content_item.title %>
-    </legend>
+  <% legend_text = render 'govuk_component/title', title: @content_item.title %>
+  <%= render "components/fieldset", legend_text: legend_text do %>
     <%= render 'govuk_component/govspeak', content: @content_item.description %>
-  </fieldset>
+    <%= render "components/radio", name: "option", items: @content_item.options %>
+  <% end %>
 <% end %>

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -1,3 +1,5 @@
+<%= render "components/back-link", href: @content_item.back_link %>
+
 <%= form_tag("/", method: "post") do %>
   <% legend_text = render 'govuk_component/title', title: @content_item.title %>
   <%= render "components/fieldset", legend_text: legend_text do %>

--- a/app/views/content_items/service_sign_in/_create_new_account.html.erb
+++ b/app/views/content_items/service_sign_in/_create_new_account.html.erb
@@ -1,3 +1,5 @@
+<%= render "components/back-link", href: @content_item.back_link %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', title: @content_item.title %>

--- a/app/views/content_items/service_sign_in/_create_new_account.html.erb
+++ b/app/views/content_items/service_sign_in/_create_new_account.html.erb
@@ -3,5 +3,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', title: @content_item.title %>
+    <%= render 'govuk_component/govspeak', content: @content_item.body %>
   </div>
 </div>

--- a/app/views/content_items/service_sign_in/_create_new_account.html.erb
+++ b/app/views/content_items/service_sign_in/_create_new_account.html.erb
@@ -1,0 +1,5 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title', title: @content_item.title %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,6 +218,9 @@ en:
       research:
         one: Research and analysis
         other: Research and analysis
+      service_sign_in:
+        one: Service sign in
+        other: Service sign in
       speaking_notes:
         one: Speaking notes
         other: Speaking notes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -295,4 +295,7 @@ en:
     previous_page: "Previous"
     next_page: "Next"
   service_sign_in:
+    error:
+      title: You haven’t selected an option
+      option: "Please select an option"
     continue: "Continue"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,3 +294,5 @@ en:
     print_entire_guide: "Print entire guide"
     previous_page: "Previous"
     next_page: "Next"
+  service_sign_in:
+    continue: "Continue"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,6 @@ Rails.application.routes.draw do
         format: /atom/,
         locale: /\w{2}(-[\d\w]{2,3})?/,
       }
+
+  post '*path' => 'content_items#service_sign_in_options'
 end

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -362,14 +362,16 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_redirected_to link
   end
 
-  test "service_sign_in_options with no option param set displays choose_sign_in page" do
+  test "service_sign_in_options with no option param set displays choose_sign_in page with error" do
     content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
     path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
 
+    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
     post :service_sign_in_options, params: { path: path }
 
-    assert_response :redirect
-    assert_redirected_to "/#{path}"
+    assert_not_nil @controller.instance_variable_get(:@error)
+    assert_template :service_sign_in
   end
 
   def path_for(content_item, locale = nil)

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -85,6 +85,17 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_redirected_to content_item['base_path']
   end
 
+  test "renders choose_sign_in template for service_sign_in page" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
+
+    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    get :show, params: { path: path }
+
+    assert_template :service_sign_in
+  end
+
   test "returns HTML when an unspecific accepts header is requested (eg by IE8 and below)" do
     request.headers["Accept"] = "*/*"
     content_item = content_store_has_schema_example('travel_advice', 'full-country')

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -362,6 +362,16 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_redirected_to link
   end
 
+  test "service_sign_in_options with no option param set displays choose_sign_in page" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
+
+    post :service_sign_in_options, params: { path: path }
+
+    assert_response :redirect
+    assert_redirected_to "/#{path}"
+  end
+
   def path_for(content_item, locale = nil)
     base_path = content_item['base_path'].sub(/^\//, '')
     base_path.gsub!(/\.#{locale}$/, '') if locale

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -346,6 +346,22 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_equal response.headers["Access-Control-Allow-Origin"], "*"
   end
 
+  test "service_sign_in_options with option param set" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
+
+    option = content_item['details']['choose_sign_in']['options'][0]
+    value = option['text'].parameterize
+    link = option['url']
+
+    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    post :service_sign_in_options, params: { path: path, option: value }
+
+    assert_response :redirect
+    assert_redirected_to link
+  end
+
   def path_for(content_item, locale = nil)
     base_path = content_item['base_path'].sub(/^\//, '')
     base_path.gsub!(/\.#{locale}$/, '') if locale

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -96,6 +96,17 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_template :service_sign_in
   end
 
+  test "renders create_new_account template for service_sign_in page" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    path = "#{path_for(content_item)}/#{content_item['details']['create_new_account']['slug']}"
+
+    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    get :show, params: { path: path }
+
+    assert_template :service_sign_in
+  end
+
   test "returns HTML when an unspecific accepts header is requested (eg by IE8 and below)" do
     request.headers["Accept"] = "*/*"
     content_item = content_store_has_schema_example('travel_advice', 'full-country')

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -19,6 +19,7 @@ module ServiceSignIn
       setup_and_visit_choose_sign_in_page
 
       assert page.has_css?("title", text: 'Prove your identity to continue - GOV.UK', visible: false)
+      assert page.has_css?('meta[name="robots"][content="noindex, nofollow"]', visible: false)
       refute page.has_css?(shared_component_selector('breadcrumbs'))
       refute page.has_css?(shared_component_selector('government_navigation'))
 

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -30,6 +30,9 @@ module ServiceSignIn
             end
           end
 
+          within shared_component_selector('govspeak') do
+            assert page.has_text?("You can't file online until you've activated Government Gateway account using your Unique Taxpayer Reference(UTR).")
+          end
         end
       end
     end

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -23,6 +23,8 @@ module ServiceSignIn
       refute page.has_css?(shared_component_selector('breadcrumbs'))
       refute page.has_css?(shared_component_selector('government_navigation'))
 
+      assert page.has_css?('.app-c-back-link[href="/log-in-file-self-assessment-tax-return"]', text: 'Back')
+
       within "form" do
         within ".app-c-fieldset" do
           within ".app-c-fieldset__legend" do

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -24,6 +24,7 @@ module ServiceSignIn
       refute page.has_css?(shared_component_selector('government_navigation'))
 
       assert page.has_css?('.app-c-back-link[href="/log-in-file-self-assessment-tax-return"]', text: 'Back')
+      assert page.has_css?('form[data-module="track-radio-group"]')
 
       within "form" do
         within ".app-c-fieldset" do

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -47,6 +47,8 @@ module ServiceSignIn
             assert page.has_css?(".app-c-radio__label__hint", text: "You'll have an account if you've proved your identity with a certified company, such as the Post Office.")
           end
 
+          assert page.has_css?(".app-c-radio__block-text", text: "or")
+
           within ".app-c-radio:last-of-type" do
             assert page.has_css?(".app-c-radio__label__text", text: "Create an account")
           end

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -2,5 +2,47 @@ require 'test_helper'
 
 module ServiceSignIn
   class ChooseSignInTest < ActionDispatch::IntegrationTest
+    test "random but valid items do not error" do
+      schema = GovukSchemas::Schema.find(frontend_schema: schema_type)
+      random_example = GovukSchemas::RandomExample.new(schema: schema)
+
+      payload = random_example.merge_and_validate(document_type: schema_type)
+      path = payload["details"]["choose_sign_in"]["slug"]
+
+      stub_request(:get, %r{#{path}})
+        .to_return(status: 200, body: payload.to_json, headers: {})
+
+      visit path
+    end
+
+    test "page renders correctly" do
+      setup_and_visit_choose_sign_in_page
+
+      assert page.has_css?("title", text: 'Prove your identity to continue - GOV.UK', visible: false)
+      refute page.has_css?(shared_component_selector('breadcrumbs'))
+      refute page.has_css?(shared_component_selector('government_navigation'))
+
+      within "form" do
+        within ".app-c-fieldset" do
+          within ".app-c-fieldset__legend" do
+            within shared_component_selector('title') do
+              assert page.has_text?("Prove your identity to continue")
+            end
+          end
+
+        end
+      end
+    end
+
+    def setup_and_visit_choose_sign_in_page
+      content_item = get_content_example("service_sign_in")
+      path = content_item["base_path"] + "/choose-sign-in"
+      content_store_has_item(path, content_item.to_json)
+      visit(path)
+    end
+
+    def schema_type
+      "service_sign_in"
+    end
   end
 end

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -48,6 +48,7 @@ module ServiceSignIn
             assert page.has_css?(".app-c-radio__label__text", text: "Create an account")
           end
         end
+        assert page.has_css?(shared_component_selector('button'), text: "Continue")
       end
     end
 

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -33,6 +33,20 @@ module ServiceSignIn
           within shared_component_selector('govspeak') do
             assert page.has_text?("You can't file online until you've activated Government Gateway account using your Unique Taxpayer Reference(UTR).")
           end
+
+          within ".app-c-radio:first-of-type" do
+            assert page.has_css?(".app-c-radio__label__text", text: "Use Government Gateway")
+            assert page.has_css?(".app-c-radio__label__hint", text: "You'll have a user ID if you've registered to file your Self Assessment tax return online before.")
+          end
+
+          within ".app-c-radio:nth-of-type(2)" do
+            assert page.has_css?(".app-c-radio__label__text", text: "Use GOV.UK Verify")
+            assert page.has_css?(".app-c-radio__label__hint", text: "You'll have an account if you've proved your identity with a certified company, such as the Post Office.")
+          end
+
+          within ".app-c-radio:last-of-type" do
+            assert page.has_css?(".app-c-radio__label__text", text: "Create an account")
+          end
         end
       end
     end

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -58,6 +58,18 @@ module ServiceSignIn
       end
     end
 
+    test "renders errors correctly" do
+      setup_and_visit_choose_sign_in_page
+
+      page.execute_script('document.querySelector(\'form\').submit()')
+
+      assert page.has_css?(".app-c-error-summary")
+      assert page.has_css?(".app-c-error-summary__title", text: 'You haven’t selected an option')
+      assert page.has_css?(".app-c-error-summary__link[href='#option-0']", text: 'Please select an option')
+
+      assert page.has_css?(".app-c-error-message", text: 'Please select an option')
+    end
+
     def setup_and_visit_choose_sign_in_page
       content_item = get_content_example("service_sign_in")
       path = content_item["base_path"] + "/choose-sign-in"

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -1,0 +1,6 @@
+require 'test_helper'
+
+module ServiceSignIn
+  class ChooseSignInTest < ActionDispatch::IntegrationTest
+  end
+end

--- a/test/integration/service_sign_in/create_new_account_test.rb
+++ b/test/integration/service_sign_in/create_new_account_test.rb
@@ -26,6 +26,11 @@ module ServiceSignIn
       assert page.has_css?('meta[name="robots"][content="noindex, nofollow"]', visible: false)
       refute page.has_css?(shared_component_selector('breadcrumbs'))
       refute page.has_css?(shared_component_selector('government_navigation'))
+
+      assert page.has_css?(
+        '.app-c-back-link[href="/log-in-file-self-assessment-tax-return/sign-in/choose-sign-in"]',
+        text: 'Back'
+      )
     end
 
     def setup_and_visit_create_new_account_page

--- a/test/integration/service_sign_in/create_new_account_test.rb
+++ b/test/integration/service_sign_in/create_new_account_test.rb
@@ -22,6 +22,10 @@ module ServiceSignIn
       within shared_component_selector('title') do
         assert page.has_text?("Create an account")
       end
+
+      assert page.has_css?('meta[name="robots"][content="noindex, nofollow"]', visible: false)
+      refute page.has_css?(shared_component_selector('breadcrumbs'))
+      refute page.has_css?(shared_component_selector('government_navigation'))
     end
 
     def setup_and_visit_create_new_account_page

--- a/test/integration/service_sign_in/create_new_account_test.rb
+++ b/test/integration/service_sign_in/create_new_account_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+module ServiceSignIn
+  class CreateNewAccount < ActionDispatch::IntegrationTest
+    test "random but valid items do not error" do
+      schema = GovukSchemas::Schema.find(frontend_schema: schema_type)
+      random_example = GovukSchemas::RandomExample.new(schema: schema)
+
+      payload = random_example.merge_and_validate(document_type: schema_type)
+      path = payload["details"]["create_new_account"]["slug"]
+
+      stub_request(:get, %r{#{path}})
+        .to_return(status: 200, body: payload.to_json, headers: {})
+
+      visit path
+    end
+
+    def schema_type
+      "service_sign_in"
+    end
+  end
+end

--- a/test/integration/service_sign_in/create_new_account_test.rb
+++ b/test/integration/service_sign_in/create_new_account_test.rb
@@ -15,6 +15,22 @@ module ServiceSignIn
       visit path
     end
 
+    test "page renders correctly" do
+      setup_and_visit_create_new_account_page
+
+      assert page.has_css?("title", text: 'Create an account - GOV.UK', visible: false)
+      within shared_component_selector('title') do
+        assert page.has_text?("Create an account")
+      end
+    end
+
+    def setup_and_visit_create_new_account_page
+      content_item = get_content_example("service_sign_in")
+      path = content_item["base_path"] + "/create-new-account"
+      content_store_has_item(path, content_item.to_json)
+      visit(path)
+    end
+
     def schema_type
       "service_sign_in"
     end

--- a/test/integration/service_sign_in/create_new_account_test.rb
+++ b/test/integration/service_sign_in/create_new_account_test.rb
@@ -23,6 +23,8 @@ module ServiceSignIn
         assert page.has_text?("Create an account")
       end
 
+      assert_has_component_govspeak("<p>To use this service, you need to create either a Government Gateway or GOV.UK Verify account. These are used to help fight identity theft.</p><p>Once you have an account, you can use it to access other government services online. </p><h2>Choose a way to prove your identity</h2><h3>Government Gateway</h3><p>Registering with Government Gateway usually takes about 10 minutes. It works best if you have:</p><ul><li>your National Insurance number</li><li>a recent payslip or a P60 or valid UK passport</li></ul><a href='#'>Create a Government Gateway account</a>")
+
       assert page.has_css?('meta[name="robots"][content="noindex, nofollow"]', visible: false)
       refute page.has_css?(shared_component_selector('breadcrumbs'))
       refute page.has_css?(shared_component_selector('government_navigation'))

--- a/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
+++ b/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
@@ -30,5 +30,13 @@ class ServiceSignInPresenterTest
     test "presents the description" do
       assert_equal @choose_sign_in["description"], @presented_item.description
     end
+
+    test "presents options" do
+      @presented_item.options.each_with_index do |option, index|
+        assert_equal option[:text], @choose_sign_in["options"][index]["text"]
+        assert_equal option[:hint_text], @choose_sign_in["options"][index]["hint_text"]
+        assert_equal option[:value], @choose_sign_in["options"][index]["text"].parameterize
+      end
+    end
   end
 end

--- a/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
+++ b/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class ServiceSignInPresenterTest
+  class ChooseSignIn < ActiveSupport::TestCase
+    def schema_name
+      "service_sign_in"
+    end
+
+    def setup
+      @presented_item = present_example(schema_item)
+    end
+
+    def present_example(example)
+      ServiceSignIn::ChooseSignInPresenter.new(example)
+    end
+
+    def schema_item
+      @schema_item ||= govuk_content_schema_example(schema_name, schema_name)
+    end
+
+    test 'presents the schema_name' do
+      assert_equal schema_item['schema_name'], @presented_item.schema_name
+    end
+  end
+end

--- a/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
+++ b/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
@@ -38,5 +38,9 @@ class ServiceSignInPresenterTest
         assert_equal option[:value], @choose_sign_in["options"][index]["text"].parameterize
       end
     end
+
+    test 'presents the back_link' do
+      assert_equal schema_item['links']['parent'].first['base_path'], @presented_item.back_link
+    end
   end
 end

--- a/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
+++ b/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
@@ -26,5 +26,9 @@ class ServiceSignInPresenterTest
     test "presents the title" do
       assert_equal @choose_sign_in["title"], @presented_item.title
     end
+
+    test "presents the description" do
+      assert_equal @choose_sign_in["description"], @presented_item.description
+    end
   end
 end

--- a/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
+++ b/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
@@ -8,6 +8,7 @@ class ServiceSignInPresenterTest
 
     def setup
       @presented_item = present_example(schema_item)
+      @choose_sign_in = schema_item["details"]["choose_sign_in"]
     end
 
     def present_example(example)
@@ -20,6 +21,10 @@ class ServiceSignInPresenterTest
 
     test 'presents the schema_name' do
       assert_equal schema_item['schema_name'], @presented_item.schema_name
+    end
+
+    test "presents the title" do
+      assert_equal @choose_sign_in["title"], @presented_item.title
     end
   end
 end

--- a/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
+++ b/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
@@ -31,12 +31,19 @@ class ServiceSignInPresenterTest
       assert_equal @choose_sign_in["description"], @presented_item.description
     end
 
-    test "presents options" do
-      @presented_item.options.each_with_index do |option, index|
+    test "presents radio button options" do
+      options = @presented_item.options
+      options.delete(:or)
+
+      options.each_with_index do |option, index|
         assert_equal option[:text], @choose_sign_in["options"][index]["text"]
         assert_equal option[:hint_text], @choose_sign_in["options"][index]["hint_text"]
         assert_equal option[:value], @choose_sign_in["options"][index]["text"].parameterize
       end
+    end
+
+    test 'presents :or before last radio button option' do
+      assert_equal @presented_item.options[2], :or
     end
 
     test 'presents the back_link' do

--- a/test/presenters/service_sign_in/create_new_account_presenter_test.rb
+++ b/test/presenters/service_sign_in/create_new_account_presenter_test.rb
@@ -19,12 +19,20 @@ class ServiceSignInPresenterTest
       @schema_item ||= govuk_content_schema_example(schema_name, schema_name)
     end
 
+    def parent_slug
+      schema_item['details']['choose_sign_in']['slug']
+    end
+
     test 'presents the schema_name' do
       assert_equal schema_item['schema_name'], @presented_item.schema_name
     end
 
     test "presents the title" do
       assert_equal @create_new_account["title"], @presented_item.title
+    end
+
+    test 'presents the back_link' do
+      assert_equal "#{schema_item['base_path']}/#{parent_slug}", @presented_item.back_link
     end
   end
 end

--- a/test/presenters/service_sign_in/create_new_account_presenter_test.rb
+++ b/test/presenters/service_sign_in/create_new_account_presenter_test.rb
@@ -31,6 +31,10 @@ class ServiceSignInPresenterTest
       assert_equal @create_new_account["title"], @presented_item.title
     end
 
+    test "presents the body" do
+      assert_equal @create_new_account["body"], @presented_item.body
+    end
+
     test 'presents the back_link' do
       assert_equal "#{schema_item['base_path']}/#{parent_slug}", @presented_item.back_link
     end

--- a/test/presenters/service_sign_in/create_new_account_presenter_test.rb
+++ b/test/presenters/service_sign_in/create_new_account_presenter_test.rb
@@ -22,5 +22,9 @@ class ServiceSignInPresenterTest
     test 'presents the schema_name' do
       assert_equal schema_item['schema_name'], @presented_item.schema_name
     end
+
+    test "presents the title" do
+      assert_equal @create_new_account["title"], @presented_item.title
+    end
   end
 end

--- a/test/presenters/service_sign_in/create_new_account_presenter_test.rb
+++ b/test/presenters/service_sign_in/create_new_account_presenter_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class ServiceSignInPresenterTest
+  class CreateNewAccount < ActiveSupport::TestCase
+    def schema_name
+      "service_sign_in"
+    end
+
+    def setup
+      @presented_item = present_example(schema_item)
+      @create_new_account = schema_item["details"]["create_new_account"]
+    end
+
+    def present_example(example)
+      ServiceSignIn::CreateNewAccountPresenter.new(example)
+    end
+
+    def schema_item
+      @schema_item ||= govuk_content_schema_example(schema_name, schema_name)
+    end
+
+    test 'presents the schema_name' do
+      assert_equal schema_item['schema_name'], @presented_item.schema_name
+    end
+  end
+end


### PR DESCRIPTION
Add error handling to choose_sign_in template
We try not to use cookies where possible (alphagov/calculators@29c666a).

This implementation avoids using flashing (with a session) and instead sets an instance variable and re-renders the view.

Other considered alternative was redirecting with query params set.

- https://government-frontend-pr-603.herokuapp.com/examples/service_sign_in/service_sign_in/choose-sign-in
- https://government-frontend-pr-603.herokuapp.com/examples/service_sign_in/welsh/dewiswch-lofnodi
- https://government-frontend-pr-603.herokuapp.com/examples/service_sign_in/view_driving_licence/choose-sign-in
