### PR TITLE
Add error handling to choose_sign_in template

### DIFF
--- a/app/assets/stylesheets/components/_error-message.scss
+++ b/app/assets/stylesheets/components/_error-message.scss
@@ -3,9 +3,7 @@
 .app-c-error-message {
   display: block;
 
-  margin: 0;
-  // TODO: use a var for padding
-  padding: 2px 0;
+  margin-bottom: $app-spacing-scale-3;
 
   clear: both;
 

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -28,14 +28,13 @@ class ContentItemsController < ApplicationController
 
   def service_sign_in_options
     if params[:option].blank?
-      redirect_path = root_path + params[:path]
+      @error = true
+      show
     else
       load_content_item
       selected = @content_item.selected_option(params[:option])
-      redirect_path = selected[:url]
+      redirect_to selected[:url]
     end
-
-    redirect_to redirect_path
   end
 
 private

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -29,6 +29,10 @@ module ServiceSignIn
       end
     end
 
+    def options_id
+      "option"
+    end
+
     def back_link
       content_item['links']['parent'].first['base_path']
     end

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -8,7 +8,7 @@
         items: [
           {
             text: t('service_sign_in.error.option'),
-            href: "#option-0"
+            href: "##{@content_item.options_id}-0"
           }
         ]
       } %>
@@ -25,7 +25,7 @@
         <% if @error %>
           <%= render "components/error-message", text: t('service_sign_in.error.option') %>
         <% end %>
-        <%= render "components/radio", id_prefix: "option", name: "option", items: @content_item.options %>
+        <%= render "components/radio", id_prefix: @content_item.options_id, name: "option", items: @content_item.options %>
       </div>
     </div>
   <% end %>

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -1,12 +1,31 @@
 <%= render "components/back-link", href: @content_item.back_link %>
 
+<% if @error %>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <%= render "components/error-summary", {
+        title: t('service_sign_in.error.title'),
+        items: [
+          {
+            text: t('service_sign_in.error.option'),
+            href: "#option-0"
+          }
+        ]
+      } %>
+    </div>
+  </div>
+<% end %>
+
 <%= form_tag({controller: 'content_items', action: 'service_sign_in_options'}, method: "post", data: { module: 'track-radio-group' }) do %>
   <% legend_text = render 'govuk_component/title', title: @content_item.title %>
   <%= render "components/fieldset", legend_text: legend_text do %>
     <div class="grid-row">
       <div class="column-two-thirds">
         <%= render 'govuk_component/govspeak', content: @content_item.description %>
-        <%= render "components/radio", name: "option", items: @content_item.options %>
+        <% if @error %>
+          <%= render "components/error-message", text: t('service_sign_in.error.option') %>
+        <% end %>
+        <%= render "components/radio", id_prefix: "option", name: "option", items: @content_item.options %>
       </div>
     </div>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -295,4 +295,7 @@ en:
     previous_page: "Previous"
     next_page: "Next"
   service_sign_in:
+    error:
+      title: You haven’t selected an option
+      option: "Please select an option"
     continue: "Continue"

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -362,14 +362,16 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_redirected_to link
   end
 
-  test "service_sign_in_options with no option param set displays choose_sign_in page" do
+  test "service_sign_in_options with no option param set displays choose_sign_in page with error" do
     content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
     path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
 
+    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
     post :service_sign_in_options, params: { path: path }
 
-    assert_response :redirect
-    assert_redirected_to "/#{path}"
+    assert_not_nil @controller.instance_variable_get(:@error)
+    assert_template :service_sign_in
   end
 
   def path_for(content_item, locale = nil)

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -67,6 +67,9 @@ module ServiceSignIn
       assert page.has_css?(".app-c-error-summary__title", text: 'You haven’t selected an option')
       assert page.has_css?(".app-c-error-summary__link[href='#option-0']", text: 'Please select an option')
 
+      # Make sure the id is the same as the link href so that they'll link together properly.
+      assert page.has_css?(".app-c-radio__input[id='option-0'][value='use-government-gateway']", visible: false)
+
       assert page.has_css?(".app-c-error-message", text: 'Please select an option')
     end
 

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -58,6 +58,18 @@ module ServiceSignIn
       end
     end
 
+    test "renders errors correctly" do
+      setup_and_visit_choose_sign_in_page
+
+      page.execute_script('document.querySelector(\'form\').submit()')
+
+      assert page.has_css?(".app-c-error-summary")
+      assert page.has_css?(".app-c-error-summary__title", text: 'You haven’t selected an option')
+      assert page.has_css?(".app-c-error-summary__link[href='#option-0']", text: 'Please select an option')
+
+      assert page.has_css?(".app-c-error-message", text: 'Please select an option')
+    end
+
     def setup_and_visit_choose_sign_in_page
       content_item = get_content_example("service_sign_in")
       path = content_item["base_path"] + "/choose-sign-in"

--- a/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
+++ b/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
@@ -40,6 +40,7 @@ class ServiceSignInPresenterTest
         assert_equal option[:hint_text], @choose_sign_in["options"][index]["hint_text"]
         assert_equal option[:value], @choose_sign_in["options"][index]["text"].parameterize
       end
+      assert_equal "option", @presented_item.options_id
     end
 
     test 'presents :or before last radio button option' do


### PR DESCRIPTION
Add error handling to choose_sign_in template
We try not to use cookies where possible (alphagov/calculators@29c666a).

This implementation avoids using flashing (with a session) and instead sets an instance variable and re-renders the view.

Other considered alternative was redirecting with query params set.

- https://government-frontend-pr-605.herokuapp.com/examples/service_sign_in/service_sign_in/choose-sign-in

<img width="747" alt="screen shot 2017-12-13 at 16 02 05" src="https://user-images.githubusercontent.com/2445413/33949901-d241c0b2-e022-11e7-8dc0-939f1ed6b5e6.png">

As part of  https://trello.com/c/vsmhbjLt/245-build-the-choose-sign-in-options-template-2