### PR TITLE
Update hmrc webchat endpoints

### DIFF
--- a/app/assets/javascripts/webchat.js
+++ b/app/assets/javascripts/webchat.js
@@ -4,37 +4,12 @@
 
 var $ = window.$
 
-
-EGAIN_NORMALISATION = {
-  0: "AVAILABLE",
-  1: "UNAVAILABLE",
-  2: "BUSY"
-}
-
-var webChatNormalise = function(res){
-  var $xml = $(res)
-  var proxyResponse = parseInt($xml.find('checkEligibility').attr('responseType'), 10)
-  var response = EGAIN_NORMALISATION[proxyResponse]
-  if (!response) {
-    return {
-      status: "failure",
-      response: "unknown"
-    }
-  }
-
-  return {
-    status: "success",
-      response: response
-  }
-}
-
 $(document).ready(function () {
   var GOVUK = window.GOVUK
   if (GOVUK.Webchat) {
     $('.js-webchat').map(function () {
       return new GOVUK.Webchat({
         $el: $(this),
-        responseNormaliser: webChatNormalise
       })
     })
   }

--- a/app/assets/javascripts/webchat/library.js
+++ b/app/assets/javascripts/webchat/library.js
@@ -20,7 +20,6 @@
     var availabilityUrl     = $el.attr('data-availability-url')
     var $openButton         = $el.find('.js-webchat-open-button')
     var webchatStateClass   = 'js-webchat-advisers-'
-    var responseNormaliser  = options.responseNormaliser
     var intervalID          = null
     var lastRecordedState   = null
 
@@ -49,8 +48,6 @@
     }
 
     function apiSuccess (result) {
-      if (responseNormaliser) result = responseNormaliser(result)
-
       var validState  = API_STATES.indexOf(result.response) != -1
       var state       = validState ? result.response : "ERROR"
       advisorStateChange(state)

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -105,11 +105,11 @@ class ContactPresenter < ContentItemPresenter
   end
 
   def webchat_availability_url
-    "https://online.hmrc.gov.uk/webchatprod/egain/chat/entrypoint/checkEligibility/#{webchat_id}"
+    "https://www.tax.service.gov.uk/csp-partials/availability/#{webchat_id}"
   end
 
   def webchat_open_url
-    "https://online.hmrc.gov.uk/webchatprod/templates/chat/hmrc7/chat.html?entryPointId=#{webchat_id}&templateName=hmrc7&languageCode=en&countryCode=US&ver=v11"
+    "https://www.tax.service.gov.uk/csp-partials/open/#{webchat_id}"
   end
 
   def breadcrumbs

--- a/spec/javascripts/webchat.spec.js
+++ b/spec/javascripts/webchat.spec.js
@@ -52,7 +52,7 @@ describe('Webchat', function () {
   })
 
 
-  describe('on valid application locations that are pre normalised', function () {
+  describe('on valid application locations', function () {
     function mount () {
       $webchat.map(function () {
         return new GOVUK.Webchat({
@@ -161,108 +161,6 @@ describe('Webchat', function () {
       expect(analyticsCalled).toBe(2)
       expect(analyticsReceived).toEqual(analyticsExpects)
       clock.uninstall();
-    })
-  })
-
-  describe('on valid application locations that are not normalised and get normalised in js', function () {
-    function mount () {
-      $webchat.map(function () {
-        return new GOVUK.Webchat({
-          $el: $(this),
-          location: '/government/organisations/hm-revenue-customs/contact/child-benefit',
-          pollingEnabled: true,
-          endPoints: {
-            openUrl: CHILD_BENEFIT_API_URL,
-            proxyUrl: CHILD_BENEFIT_API_URL,
-          },
-          responseNormaliser: function(res){
-            res.response = (res.response) ? res.response.replace("FOO", "") : ""
-            return res;
-          }
-        })
-      })
-    }
-
-    it('should poll for availability', function () {
-      spyOn($, 'ajax')
-      mount()
-      expect(
-        $.ajax
-      ).toHaveBeenCalledWith({ url: CHILD_BENEFIT_API_URL, type: 'GET', timeout: jasmine.any(Number), success: jasmine.any(Function), error: jasmine.any(Function) })
-    })
-
-    it('should inform user whether advisors are available', function () {
-      spyOn($, 'ajax').and.callFake(function (options) {
-        options.success(jsonMangledAvailable)
-      })
-      mount()
-      expect($advisersAvailable.hasClass('hidden')).toBe(false)
-
-      expect($advisersBusy.hasClass('hidden')).toBe(true)
-      expect($advisersError.hasClass('hidden')).toBe(true)
-      expect($advisersUnavailable.hasClass('hidden')).toBe(true)
-    })
-
-    it('should inform user whether advisors are unavailable', function () {
-      spyOn($, 'ajax').and.callFake(function (options) {
-        options.success(jsonMangledUnavailable)
-      })
-      mount()
-      expect($advisersUnavailable.hasClass('hidden')).toBe(false)
-
-      expect($advisersAvailable.hasClass('hidden')).toBe(true)
-      expect($advisersBusy.hasClass('hidden')).toBe(true)
-      expect($advisersError.hasClass('hidden')).toBe(true)
-    })
-
-    it('should inform user whether advisors are busy', function () {
-      spyOn($, 'ajax').and.callFake(function (options) {
-        options.success(jsonMangledBusy)
-      })
-      mount()
-      expect($advisersBusy.hasClass('hidden')).toBe(false)
-
-      expect($advisersAvailable.hasClass('hidden')).toBe(true)
-      expect($advisersError.hasClass('hidden')).toBe(true)
-      expect($advisersUnavailable.hasClass('hidden')).toBe(true)
-    })
-
-    it('should inform user whether there was an error', function () {
-      spyOn($, 'ajax').and.callFake(function (options) {
-        options.success(jsonMangledError)
-      })
-      mount()
-      expect($advisersError.hasClass('hidden')).toBe(false)
-
-      expect($advisersAvailable.hasClass('hidden')).toBe(true)
-      expect($advisersBusy.hasClass('hidden')).toBe(true)
-      expect($advisersUnavailable.hasClass('hidden')).toBe(true)
-    })
-  })
-
-  describe('egain normalisaton', function () {
-
-    var egainResponse = function (responseType) {
-      return $.parseXML(
-        '<checkEligibility ' +
-        'xmlns:ns5="http://jabber.org/protocol/httpbind" ' +
-        'xmlns:ns2="http://bindings.egain.com/chat" ' +
-        'xmlns:ns4="urn:ietf:params:xml:ns:xmpp-stanzas" ' +
-        'xmlns:ns3="jabber:client" ' +
-        'responseType="' +
-        responseType +
-        '" />'
-      )
-    }
-
-    it('should normalise the responses to the api', function () {
-      expect(webChatNormalise(egainResponse(0))).toEqual(jsonNormalisedAvailable)
-      expect(webChatNormalise(egainResponse(1))).toEqual(jsonNormalisedUnavailable)
-      expect(webChatNormalise(egainResponse(2))).toEqual(jsonNormalisedBusy)
-      expect(webChatNormalise(egainResponse(3))).toEqual({
-        status: "failure",
-        response: "unknown"
-      })
     })
   })
 })

--- a/spec/javascripts/webchat.spec.js
+++ b/spec/javascripts/webchat.spec.js
@@ -8,7 +8,7 @@ describe('Webchat', function () {
   // Stub analytics.
   GOVUK.analytics = GOVUK.analytics || {}
   GOVUK.analytics.trackEvent = function () {}
-  var CHILD_BENEFIT_API_URL = 'https://online.hmrc.gov.uk/webchatprod/egain/chat/entrypoint/checkEligibility/' +
+  var CHILD_BENEFIT_API_URL = 'https://www.tax.service.gov.uk/csp-partials/open/' +
     1027
   var INSERTION_HOOK = '<div class="js-webchat" data-availability-url="' + CHILD_BENEFIT_API_URL + '" data-open-url="' + CHILD_BENEFIT_API_URL + '">' +
     '<div class="js-webchat-advisers-error">Error</div>' +

--- a/test/presenters/contact_presenter_test.rb
+++ b/test/presenters/contact_presenter_test.rb
@@ -154,8 +154,8 @@ class ContactPresenterTest
       schema = schema_item('contact_with_webchat')
       presented = present_example(schema)
       assert_equal true, presented.show_webchat?
-      assert_equal presented.webchat_availability_url, "https://online.hmrc.gov.uk/webchatprod/egain/chat/entrypoint/checkEligibility/1030"
-      assert_equal presented.webchat_open_url, "https://online.hmrc.gov.uk/webchatprod/templates/chat/hmrc7/chat.html?entryPointId=1030&templateName=hmrc7&languageCode=en&countryCode=US&ver=v11"
+      assert_equal presented.webchat_availability_url, "https://www.tax.service.gov.uk/csp-partials/availability/1030"
+      assert_equal presented.webchat_open_url, "https://www.tax.service.gov.uk/csp-partials/open/1030"
     end
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/ebGpJZui

## Detail

We have been working with HMRC to update their Webchat API. We are asking them to normalise their endpoints and responses to match that in the [reference-webchat-proxy](https://github.com/alphagov/reference-webchat-proxy) to make it easier for us to allow other departments to set up their own webchats.

HMRC have done their side of the work so we are ready to call the new endpoints.

At the moment we are only doing a one-to-one replacement. When another department is ready to add Webchat to their contact pages, we will have to think about how we are going to store which endpoint to call and whether this is something we should add to Publisher.