### PR TITLE
Add worldwide organisations to published by

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8'
 
 gem 'govuk_app_config', '~> 0.3.0'
-gem 'govuk_navigation_helpers', '~> 7.2.0'
+gem 'govuk_navigation_helpers', '~> 7.3.0'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     govuk_frontend_toolkit (5.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (7.2.0)
+    govuk_navigation_helpers (7.3.0)
       gds-api-adapters (>= 43.0)
     govuk_publishing_components (2.0.0)
       govspeak (>= 5.0.3)
@@ -327,7 +327,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 0.3.0)
   govuk_frontend_toolkit (= 5.1.0)
-  govuk_navigation_helpers (~> 7.2.0)
+  govuk_navigation_helpers (~> 7.3.0)
   govuk_publishing_components (~> 2.0.0)
   govuk_schemas
   htmlentities (= 4.3.4)

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -59,7 +59,7 @@ class ContentItemPresenter
   end
 
   def related_navigation
-    @nav_helper.related_navigation_sidebar
+    merge_publishers_and_worldwide_organisations(@nav_helper.related_navigation_sidebar)
   end
 
   def related_items
@@ -68,10 +68,6 @@ class ContentItemPresenter
 
   def tagged_to_a_taxon?
     content_item.dig("links", "taxons").present?
-  end
-
-  def related_navigation_sidebar
-    @nav_helper.related_navigation_sidebar
   end
 
 private
@@ -102,5 +98,10 @@ private
 
   def native_language_name_for(locale)
     I18n.t("language_names.#{locale}", locale: locale)
+  end
+
+  def merge_publishers_and_worldwide_organisations(related_navigation)
+    related_navigation[:publishers] += related_navigation.delete(:worldwide_organisations)
+    related_navigation
   end
 end

--- a/app/views/components/_related-navigation.html.erb
+++ b/app/views/components/_related-navigation.html.erb
@@ -1,12 +1,13 @@
 <%
   max_section_length = 5
-  defined_sections = ["topics", "publishers", "collections", "policies", "world_locations"]
+  defined_sections = ["topics", "publishers", "collections", "policies", "topical_events", "world_locations"]
   related_content = [
     {"related_items" => related_items ||= [] },
     {"topics" => topics ||= [] },
     {"publishers" => publishers ||= [] },
     {"collections" => collections ||= [] },
     {"policies" => policies ||= [] },
+    {"topical_events" => topical_events ||= [] },
     {"world_locations" => world_locations ||= [] }
   ]
   other ||= []

--- a/app/views/components/docs/related-navigation.yml
+++ b/app/views/components/docs/related-navigation.yml
@@ -19,13 +19,6 @@ examples:
           path: /careers-helpline-for-teenagers
   with_curated_topics:
     data:
-      related_items:
-        - text: Find an apprenticeship
-          path: /apply-apprenticeship
-        - text: Training and study at work
-          path: /training-study-work-your-rights
-        - text: Careers helpline for teenagers
-          path: /careers-helpline-for-teenagers
       topics:
         - text: Apprenticeships, 14 to 19 education and training for work
           path: /browse/education/find-course
@@ -35,13 +28,6 @@ examples:
           path: /topic/further-education-skills/apprenticeships
   with_publishing_entities:
     data:
-      related_items:
-        - text: Find an apprenticeship
-          path: /apply-apprenticeship
-        - text: Training and study at work
-          path: /training-study-work-your-rights
-        - text: Careers helpline for teenagers
-          path: /careers-helpline-for-teenagers
       publishers:
         - text: Department for Education
           path: /government/department-for-education
@@ -49,13 +35,6 @@ examples:
           path: /government/department-for-work-pensions
   with_collections:
     data:
-      related_items:
-        - text: Find an apprenticeship
-          path: /apply-apprenticeship
-        - text: Training and study at work
-          path: /training-study-work-your-rights
-        - text: Careers helpline for teenagers
-          path: /careers-helpline-for-teenagers
       collections:
         - text: Recruit an apprentice (formerly apprenticeship vacancies)
           path: /government/collections/apprenticeship-vacancies
@@ -63,25 +42,18 @@ examples:
           path: /government/collections/the-future-of-jobs-and-skills
   with_policies:
     data:
-      related_items:
-        - text: Find an apprenticeship
-          path: /apply-apprenticeship
-        - text: Training and study at work
-          path: /training-study-work-your-rights
-        - text: Careers helpline for teenagers
-          path: /careers-helpline-for-teenagers
       policies:
         - text: Further education and training
           path: /government/policies/further-education-and-training
+        - text: Primary school education
+          path: /government/policies/primary-school-education
+  with_topical_events:
+    data:
+      topical_events:
+        - text: UK-China High-Level People to People Dialogue 2017
+          path: /government/topical-events/uk-china-high-level-people-to-people-dialogue-2017
   with_world_locations:
     data:
-      related_items:
-        - text: Find an apprenticeship
-          path: /apply-apprenticeship
-        - text: Training and study at work
-          path: /training-study-work-your-rights
-        - text: Careers helpline for teenagers
-          path: /careers-helpline-for-teenagers
       world_locations:
         - text: South Sudan
           path: /world/south-sudan/news
@@ -90,13 +62,6 @@ examples:
   with_external_related_links:
     description: The component can accept other related links, such as external links or other contacts. In these cases, the component must also be passed a heading for that section
     data:
-      related_items:
-        - text: Find an apprenticeship
-          path: /apply-apprenticeship
-        - text: Training and study at work
-          path: /training-study-work-your-rights
-        - text: Careers helpline for teenagers
-          path: /careers-helpline-for-teenagers
       other:
         -
           - title: "Elsewhere on the web"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
       publishers: "Published by"
       related_content: "Related content"
       topics: "Explore the topic"
+      topical_events: "Topical event"
       world_locations: 'Location'
     published_dates:
       full_page_history: "full page history"

--- a/test/components/related_navigation_test.rb
+++ b/test/components/related_navigation_test.rb
@@ -93,6 +93,20 @@ class RelatedNavigationTest < ComponentTestCase
     assert_select ".app-c-related-navigation__section-link[href=\"/government/policies/further-education-and-training\"]", text: 'Further education and training'
   end
 
+  test "renders topical events section when passed topical event items" do
+    render_component(
+      topical_events: [
+        {
+          text: "UK-China High-Level People to People Dialogue 2017",
+          path: '/government/topical-events/uk-china-high-level-people-to-people-dialogue-2017'
+        }
+      ]
+    )
+
+    assert_select ".app-c-related-navigation__sub-heading", text: 'Topical event'
+    assert_select ".app-c-related-navigation__section-link[href=\"/government/topical-events/uk-china-high-level-people-to-people-dialogue-2017\"]", text: 'UK-China High-Level People to People Dialogue 2017'
+  end
+
   test "renders other links section when passed external related links" do
     render_component(
       other: [

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -26,6 +26,7 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
       related_items: [],
       collections: [],
       topics: [],
+      topical_events: [],
       policies: [],
       publishers: [],
       world_locations: [],


### PR DESCRIPTION
... in the related navigation component

The new related navigation is not displaying topical events or worldwide organisations. We want to display both of these.

**Worldwide organisations example (before and after):**
<img width="713" alt="screen shot 2017-12-14 at 11 16 39" src="https://user-images.githubusercontent.com/29889908/33989691-4d77ef20-e0c0-11e7-9b77-4a7df0c84ec0.png">
[Live example](https://government-frontend-pr-609.herokuapp.com/government/news/paralympic-legacy-and-disability-rights)

**Topical events example (before and after):**
<img width="671" alt="screen shot 2017-12-14 at 11 29 32" src="https://user-images.githubusercontent.com/29889908/33990265-3ff26ce8-e0c2-11e7-84c3-84ad8389bc80.png">
[Live example](https://government-frontend-pr-609.herokuapp.com/government/news/uk-china-relations-flourish-at-the-2017-people-to-people-dialogue)

[Component Guide link](https://government-frontend-pr-609.herokuapp.com/component-guide/related-navigation)
