### PR TITLE
Add Welsh translations for service_sign_in pages

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -6,6 +6,8 @@ cy:
   components:
     radio:
       or: 'neu'
+    back_link:
+      back: "Yn ôl"
   content_item:
     schema_name:
       announcement:
@@ -260,6 +262,9 @@ cy:
         few:
         many:
         other: Nodiadau siarad
+      service_sign_in:
+        one: Gwasanaeth Mewngofnodi
+        other: Gwasanaeth Mewngofnodi
       speech:
         zero:
         one: Araith
@@ -352,3 +357,8 @@ cy:
       print_entire_guide: "Tudalen hawdd ei hargraffu"
       previous_page: "Llywio i’r rhan flaenorol"
       next_page: "Llywio i’r rhan nesaf"
+  service_sign_in:
+    error:
+      title: Dydych chi ddim wedi dewis
+      option: Dewiswch
+    continue: Bwrw ymlaen

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -96,7 +96,7 @@ module ServiceSignIn
       assert page.has_css?("title", text: 'Profwch pwy ydych chi i fwrw ymlaen - GOV.UK', visible: false)
 
       # TODO: This needs to be translated
-      assert page.has_css?('.app-c-back-link', text: 'Back')
+      assert page.has_css?('.app-c-back-link', text: 'Yn ôl')
 
       within "form" do
         within ".app-c-fieldset" do
@@ -128,7 +128,7 @@ module ServiceSignIn
         end
 
         # TODO: This needs to be translated
-        assert page.has_css?(shared_component_selector('button'), text: "Continue")
+        assert page.has_css?(shared_component_selector('button'), text: "Bwrw ymlaen")
       end
     end
 


### PR DESCRIPTION
Trello card: https://trello.com/c/T5zKxHRw
Depends on PR: https://github.com/alphagov/government-frontend/pull/610

Add the Welsh translation to the locales for:

* Back link
* Continue button
* Error messages
