### PR TITLE
Turn off CSRF protection on service_sign_in POST route

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery prepend: true
+  protect_from_forgery except: :service_sign_in_options
 
   def show_tasklist_header?
     if defined?(should_show_tasklist_header?)


### PR DESCRIPTION
Related to: PR #610 

When we tried submitting a radio button on the choose-sign-in page the
following error is thrown:

`Can't verify CSRF token authenticity.`

As we are not submitting and sensitive data, and are just redirecting users,
we don't need this protection on the form.

We don't currently have a session store due to the layers of caching, so we
did not try to set the authenticity token, and have instead disabled it.

We did not reproduce this issue on Heroku and will investigate why later.
