### PR TITLE
Make publisher metadata styling consistent

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@
 @import 'helpers/add-title-margin';
 @import "helpers/task-list-title";
 @import "helpers/content-bottom-margin";
+@import "helpers/publisher-metadata-with-logo";
 
 // components
 @import 'components/*';

--- a/app/assets/stylesheets/components/_publisher-metadata.scss
+++ b/app/assets/stylesheets/components/_publisher-metadata.scss
@@ -1,7 +1,6 @@
 .app-c-publisher-metadata {
   @include responsive-bottom-margin;
   @include core-16;
-  border-top: 1px solid $border-colour;
   padding-top: $gutter-half;
 }
 

--- a/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
+++ b/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
@@ -1,0 +1,22 @@
+// FIXME: These styles will become ubiquitous as we
+// roll out the combination of metadata + logo across
+// formats so they may ultimately become component styles.
+.metadata-logo-wrapper {
+  @extend %contain-floats;
+  border-top: 1px solid $border-colour;
+  margin-left: $gutter-half;
+  margin-right: $gutter-half;
+
+  .metadata-column {
+    padding-left: 0;
+  }
+
+  .metadata-logo {
+    padding-bottom: $gutter-half;
+    padding-top: $gutter-half;
+
+    @include media(tablet) {
+      float: right;
+    }
+  }
+}

--- a/app/assets/stylesheets/views/_publication.scss
+++ b/app/assets/stylesheets/views/_publication.scss
@@ -6,36 +6,6 @@
     direction: rtl;
     text-align: start;
   }
-
-  // FIXME: These styles will become ubiquitous as we
-  // roll out the combination of metadata + logo across
-  // formats so they can ultimately become component styles.
-  .metadata-logo-wrapper {
-    @extend %contain-floats;
-    border-top: 1px solid $border-colour;
-    margin-left: $gutter-half;
-    margin-right: $gutter-half;
-
-    .metadata-column {
-      padding-left: 0;
-    }
-
-    // FIXME: This override can be removed once all formats
-    // with the publisher-metadata component are converted
-    // to render metadata + optional logo
-    .app-c-publisher-metadata {
-      border: 0;
-    }
-
-    .metadata-logo {
-      padding-bottom: $gutter-half;
-      padding-top: $gutter-half;
-
-      @include media(tablet) {
-        float: right;
-      }
-    }
-  }
 }
 
 

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -6,9 +6,10 @@
   <%= render 'shared/translations' %>
   <div class="column-two-thirds">
     <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
-    <%= render 'components/publisher-metadata', @content_item.publisher_metadata %>
   </div>
 </div>
+
+<%= render 'shared/publisher_metadata_with_logo' %>
 
 <div class="grid-row">
   <div class="column-two-thirds content-bottom-margin">

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -6,9 +6,10 @@
   <%= render 'shared/translations' %>
   <div class="column-two-thirds">
     <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
-    <%= render 'components/publisher-metadata', @content_item.publisher_metadata %>
   </div>
 </div>
+
+<%= render 'shared/publisher_metadata_with_logo' %>
 
 <div class="grid-row">
   <div class="column-two-thirds content-bottom-margin">

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -7,9 +7,10 @@
   <%= render 'shared/translations' %>
   <div class="column-two-thirds">
     <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
-    <%= render 'components/publisher-metadata', @content_item.publisher_metadata %>
   </div>
 </div>
+
+<%= render 'shared/publisher_metadata_with_logo' %>
 
 <div class="grid-row">
   <div class="column-two-thirds content-bottom-margin">

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -7,9 +7,10 @@
   <%= render 'shared/translations' %>
   <div class="column-two-thirds">
     <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
-    <%= render 'components/publisher-metadata', @content_item.publisher_metadata %>
   </div>
 </div>
+
+<%= render 'shared/publisher_metadata_with_logo' %>
 
 <div class="grid-row">
   <div class="column-two-thirds content-bottom-margin">

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -7,9 +7,10 @@
   <%= render 'shared/translations' %>
   <div class="column-two-thirds">
     <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
-    <%= render 'components/publisher-metadata', @content_item.publisher_metadata %>
   </div>
 </div>
+
+<%= render 'shared/publisher_metadata_with_logo' %>
 
 <div class="grid-row">
   <div class="column-two-thirds content-bottom-margin">

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -1,4 +1,4 @@
-<% render_logo = @content_item.national_statistics? -%>
+<% render_logo = @content_item.try(:national_statistics?) -%>
 <div class="grid-row">
   <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if render_logo %>">
     <div class="column-two-thirds metadata-column">


### PR DESCRIPTION
https://trello.com/c/Q9io9cQU/132-move-publications-format-to-universal-design

When moving publications to the new layout we wanted
to combine the publisher metadata with an optional
logo and make the combination span all 3 columns.
This change needs to be reflected in formats which
won't have logos but will have a full width publisher
metadata border.
I've made a partial rendering the metadata component
in a 2/3 width column and the logo in the 1/3 column
because it seemed the most reasonable way to combine
both without compromising the component design.

![screenshot from 2017-12-18 11-51-16](https://user-images.githubusercontent.com/93511/34104791-ca8ae7e8-e3e9-11e7-8a91-aab0d15b5038.png)


### Example case study

https://government-frontend-pr-616.herokuapp.com/government/case-studies/who-will-and-won-t-be-enrolled-into-a-workplace-pension-fictional-case-studies

### Example news article

https://government-frontend-pr-616.herokuapp.com/government/news/apprenticeships-will-contribute-34-billion-to-uk-economy-this-year

Review app component guide:
https://government-frontend-pr-XXX.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-XXX.surge.sh/gallery.html
