### PR TITLE
Increase test coverage of tasklists

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,10 +11,6 @@ require "rails/test_unit/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-if !Rails.env.production? || ENV['HEROKU_APP_NAME'].present?
-  require 'govuk_publishing_components'
-end
-
 module GovernmentFrontend
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/test/controllers/task_list_ab_testing_content_items_controller_test.rb
+++ b/test/controllers/task_list_ab_testing_content_items_controller_test.rb
@@ -4,9 +4,8 @@ class ContentItemsControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::ContentStore
   include GovukAbTesting::MinitestHelpers
 
-  %w(guide answer).each do |schema_name|
+  %w(guide answer publication).each do |schema_name|
     test "#{schema_name} honours Tasklist AB Testing cookie" do
-      schema_name = "guide"
       content_item = content_store_has_schema_example(schema_name, schema_name)
       content_item['base_path'] = "/pass-plus"
       path = content_item['base_path'][1..-1]

--- a/test/controllers/task_list_header_ab_testing_content_items_controller_test.rb
+++ b/test/controllers/task_list_header_ab_testing_content_items_controller_test.rb
@@ -6,7 +6,6 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   %w(guide answer publication).each do |schema_name|
     test "#{schema_name} honours Tasklist Header AB Testing cookie" do
-      schema_name = "guide"
       content_item = content_store_has_schema_example(schema_name, schema_name)
       content_item['base_path'] = "/pass-plus"
       path = content_item['base_path'][1..-1]


### PR DESCRIPTION
We weren't testing publications or answers here which missed a breaking change.

We also had a require for the govuk_publishing_components gem which we no longer needed as we always load it in the Gemfile now (since https://github.com/alphagov/government-frontend/pull/578)