### PR TITLE
Reduce border span on publisher metadata for fatality notices

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,7 @@
 @import "helpers/task-list-title";
 @import "helpers/content-bottom-margin";
 @import "helpers/publisher-metadata-with-logo";
+@import "helpers/horizontal-rule";
 
 // Components from this application
 @import 'components/*';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,7 +45,6 @@
 @import 'views/detailed-guide';
 @import 'views/publication';
 @import 'views/document-collection';
-@import 'views/fatality-notice';
 @import 'views/statistical-data-set';
 @import 'views/consultation';
 @import 'views/speech';

--- a/app/assets/stylesheets/helpers/_horizontal-rule.scss
+++ b/app/assets/stylesheets/helpers/_horizontal-rule.scss
@@ -1,0 +1,6 @@
+.app-c-horizontal-rule {
+  background-color: $border-colour;
+  display: inline-block;
+  height: 1px;
+  width: 100%;
+}

--- a/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
+++ b/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
@@ -3,7 +3,6 @@
 // formats so they may ultimately become component styles.
 .metadata-logo-wrapper {
   @extend %contain-floats;
-  border-top: 1px solid $border-colour;
   margin-left: $gutter-half;
   margin-right: $gutter-half;
 

--- a/app/assets/stylesheets/views/_fatality-notice.scss
+++ b/app/assets/stylesheets/views/_fatality-notice.scss
@@ -1,3 +1,0 @@
-.fatality-notice {
-  @include sidebar-with-body;
-}

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -6,10 +6,10 @@
   <%= render 'shared/translations' %>
   <div class="column-two-thirds">
     <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
+    <span class="app-c-horizontal-rule"></span>
+    <%= render 'components/publisher-metadata', @content_item.publisher_metadata %>
   </div>
 </div>
-
-<%= render 'shared/publisher_metadata_with_logo' %>
 
 <div class="grid-row">
   <div class="column-two-thirds content-bottom-margin">

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -1,4 +1,5 @@
 <% render_logo = @content_item.try(:national_statistics?) %>
+<span class="app-c-horizontal-rule"></span>
 <div class="grid-row">
   <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if render_logo %>">
     <div class="column-two-thirds metadata-column">


### PR DESCRIPTION
This format doesn't currently have a sidebar navigation
which means that the full-width border on the publisher
metadata + logo grid row extends out into an empty column.
This doesn't look very balanced, so constrain it to 2/3rds
width. We expect to iterate this format with better sidebar
navigation soon so this is a temporary design tweak.

![screenshot from 2017-12-19 14-38-03](https://user-images.githubusercontent.com/93511/34162030-45dd30e6-e4ca-11e7-9955-e0c723d55a0f.png)


Review app component guide:
https://government-frontend-pr-623.herokuapp.com/component-guide

Example:
https://government-frontend-pr-623.herokuapp.com/government/fatalities/fusilier-gordon-gentle
