### PR TITLE
Update tasklist content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8'
 
 gem 'govuk_app_config', '~> 0.3.0'
-gem 'govuk_navigation_helpers', '~> 7.5.1'
+gem 'govuk_navigation_helpers', '~> 8.0.0'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     govuk_frontend_toolkit (7.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (7.5.1)
+    govuk_navigation_helpers (8.0.0)
       activesupport (~> 5.1)
       gds-api-adapters (>= 43.0)
       govuk_ab_testing (~> 2.4)
@@ -332,7 +332,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 0.3.0)
   govuk_frontend_toolkit (= 7.2.0)
-  govuk_navigation_helpers (~> 7.5.1)
+  govuk_navigation_helpers (~> 8.0.0)
   govuk_publishing_components (~> 3.0.2)
   govuk_schemas
   htmlentities (= 4.3.4)

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -38,14 +38,6 @@ private
     current_tasklist_ab_test.set_response_header(response)
   end
 
-  def publication_with_sidebar?
-    current_tasklist_ab_test.publication_with_sidebar?
-  end
-
-  def publication_with_sidebar_template_name
-    current_tasklist_ab_test.publication_with_sidebar_template_name
-  end
-
   # Allow guides to pass access token to each part to allow
   # fact checking of all content
   def set_guide_draft_access_token


### PR DESCRIPTION
By using this we inherit the updated tasklist content in https://github.com/alphagov/govuk_navigation_helpers/pull/99.

We also remove the bits that rely on things that were removed in https://github.com/alphagov/govuk_navigation_helpers/pull/98.
This was around special handling for publications before they were moved to a template which had a sidebar.  
We'd already removed some of this in https://github.com/alphagov/government-frontend/pull/621, so this is not called from anywhere.

