### PR TITLE
Redirect service sign in page root

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -72,6 +72,11 @@ private
       return
     end
 
+    if @content_item.requesting_a_service_sign_in_page? && !@content_item.has_valid_path?
+      redirect_to @content_item.path
+      return
+    end
+
     request.variant = :print if params[:variant] == "print"
 
     respond_to do |format|
@@ -139,11 +144,11 @@ private
   def service_sign_in_presenter_name(content_item)
     slug = content_item_path.split("/").last
 
-    content_item["details"].each do |key, value|
-      if value["slug"] == slug
-        return "ServiceSignIn::#{key.classify}Presenter"
-      end
+    if content_item.dig("details", "create_new_account", "slug") == slug
+      return "ServiceSignIn::CreateNewAccountPresenter"
     end
+
+    "ServiceSignIn::ChooseSignInPresenter"
   end
 
   def setup_tasklist_header_ab_testing

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -30,6 +30,10 @@ class ContentItemPresenter
     false
   end
 
+  def requesting_a_service_sign_in_page?
+    false
+  end
+
   def available_translations
     translations = @content_item["links"]["available_translations"] || []
 

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -1,5 +1,7 @@
 module ServiceSignIn
   class ChooseSignInPresenter < ContentItemPresenter
+    include ServiceSignIn::Paths
+
     def page_type
       "choose_sign_in"
     end

--- a/app/presenters/service_sign_in/create_new_account_presenter.rb
+++ b/app/presenters/service_sign_in/create_new_account_presenter.rb
@@ -1,5 +1,7 @@
 module ServiceSignIn
   class CreateNewAccountPresenter < ContentItemPresenter
+    include ServiceSignIn::Paths
+
     def page_type
       "create_new_account"
     end

--- a/app/presenters/service_sign_in/paths.rb
+++ b/app/presenters/service_sign_in/paths.rb
@@ -1,0 +1,15 @@
+module ServiceSignIn
+  module Paths
+    def path
+      content_item["base_path"] + "/" + content_item["details"][page_type]["slug"]
+    end
+
+    def has_valid_path?
+      path == @requested_content_item_path
+    end
+
+    def requesting_a_service_sign_in_page?
+      true
+    end
+  end
+end

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -85,6 +85,32 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_redirected_to content_item['base_path']
   end
 
+  test "redirects route for root service_sign_in page" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    invalid_part_path = "#{path_for(content_item)}"
+
+    stub_request(:get, %r{#{invalid_part_path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    get :show, params: { path: invalid_part_path }
+
+    assert_response :redirect
+    redirect_path = "#{content_item['base_path']}/#{content_item['details']['choose_sign_in']['slug']}"
+    assert_redirected_to redirect_path
+  end
+
+  test "redirects route for leaf service_sign_in page" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    invalid_part_path = "#{path_for(content_item)}/invalid-slug"
+
+    stub_request(:get, %r{#{invalid_part_path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    get :show, params: { path: invalid_part_path }
+
+    assert_response :redirect
+    redirect_path = "#{content_item['base_path']}/#{content_item['details']['choose_sign_in']['slug']}"
+    assert_redirected_to redirect_path
+  end
+
   test "renders choose_sign_in template for service_sign_in page" do
     content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
     path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -84,55 +84,6 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_response :redirect
     assert_redirected_to content_item['base_path']
   end
-
-  test "redirects route for root service_sign_in page" do
-    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
-    invalid_part_path = "#{path_for(content_item)}"
-
-    stub_request(:get, %r{#{invalid_part_path}}).to_return(status: 200, body: content_item.to_json, headers: {})
-
-    get :show, params: { path: invalid_part_path }
-
-    assert_response :redirect
-    redirect_path = "#{content_item['base_path']}/#{content_item['details']['choose_sign_in']['slug']}"
-    assert_redirected_to redirect_path
-  end
-
-  test "redirects route for leaf service_sign_in page" do
-    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
-    invalid_part_path = "#{path_for(content_item)}/invalid-slug"
-
-    stub_request(:get, %r{#{invalid_part_path}}).to_return(status: 200, body: content_item.to_json, headers: {})
-
-    get :show, params: { path: invalid_part_path }
-
-    assert_response :redirect
-    redirect_path = "#{content_item['base_path']}/#{content_item['details']['choose_sign_in']['slug']}"
-    assert_redirected_to redirect_path
-  end
-
-  test "renders choose_sign_in template for service_sign_in page" do
-    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
-    path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
-
-    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
-
-    get :show, params: { path: path }
-
-    assert_template :service_sign_in
-  end
-
-  test "renders create_new_account template for service_sign_in page" do
-    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
-    path = "#{path_for(content_item)}/#{content_item['details']['create_new_account']['slug']}"
-
-    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
-
-    get :show, params: { path: path }
-
-    assert_template :service_sign_in
-  end
-
   test "returns HTML when an unspecific accepts header is requested (eg by IE8 and below)" do
     request.headers["Accept"] = "*/*"
     content_item = content_store_has_schema_example('travel_advice', 'full-country')
@@ -370,34 +321,6 @@ class ContentItemsControllerTest < ActionController::TestCase
     get :show, params: { path: 'foreign-travel-advice/albania', format: 'atom' }
 
     assert_equal response.headers["Access-Control-Allow-Origin"], "*"
-  end
-
-  test "service_sign_in_options with option param set" do
-    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
-    path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
-
-    option = content_item['details']['choose_sign_in']['options'][0]
-    value = option['text'].parameterize
-    link = option['url']
-
-    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
-
-    post :service_sign_in_options, params: { path: path, option: value }
-
-    assert_response :redirect
-    assert_redirected_to link
-  end
-
-  test "service_sign_in_options with no option param set displays choose_sign_in page with error" do
-    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
-    path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
-
-    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
-
-    post :service_sign_in_options, params: { path: path }
-
-    assert_not_nil @controller.instance_variable_get(:@error)
-    assert_template :service_sign_in
   end
 
   def path_for(content_item, locale = nil)

--- a/test/controllers/service_sign_in_content_item_controller_test.rb
+++ b/test/controllers/service_sign_in_content_item_controller_test.rb
@@ -1,0 +1,89 @@
+require 'test_helper'
+
+class ContentItemsControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::ContentStore
+
+  test "redirects route for root service_sign_in page" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    invalid_part_path = path_for(content_item)
+
+    stub_request(:get, %r{#{invalid_part_path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    get :show, params: { path: invalid_part_path }
+
+    assert_response :redirect
+    redirect_path = "#{content_item['base_path']}/#{content_item['details']['choose_sign_in']['slug']}"
+    assert_redirected_to redirect_path
+  end
+
+  test "redirects route for leaf service_sign_in page" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    invalid_part_path = "#{path_for(content_item)}/invalid-slug"
+
+    stub_request(:get, %r{#{invalid_part_path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    get :show, params: { path: invalid_part_path }
+
+    assert_response :redirect
+    redirect_path = "#{content_item['base_path']}/#{content_item['details']['choose_sign_in']['slug']}"
+    assert_redirected_to redirect_path
+  end
+
+  test "renders choose_sign_in template for service_sign_in page" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
+
+    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    get :show, params: { path: path }
+
+    assert_template :service_sign_in
+  end
+
+  test "renders create_new_account template for service_sign_in page" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    path = "#{path_for(content_item)}/#{content_item['details']['create_new_account']['slug']}"
+
+    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    get :show, params: { path: path }
+
+    assert_template :service_sign_in
+  end
+
+
+
+  test "service_sign_in_options with option param set" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
+
+    option = content_item['details']['choose_sign_in']['options'][0]
+    value = option['text'].parameterize
+    link = option['url']
+
+    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    post :service_sign_in_options, params: { path: path, option: value }
+
+    assert_response :redirect
+    assert_redirected_to link
+  end
+
+  test "service_sign_in_options with no option param set displays choose_sign_in page with error" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
+
+    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    post :service_sign_in_options, params: { path: path }
+
+    assert_not_nil @controller.instance_variable_get(:@error)
+    assert_template :service_sign_in
+  end
+
+  def path_for(content_item, locale = nil)
+    base_path = content_item['base_path'].sub(/^\//, '')
+    base_path.gsub!(/\.#{locale}$/, '') if locale
+    base_path
+  end
+end


### PR DESCRIPTION
This approach mirrors the existing way that guides handles redirects.

Makes sure that only the routes specified in the content_item for service sign-in pages results in a page, and any other routes get redirected to the choose-sign-in page.

## Examples

- [Default](https://government-frontend-pr-626.herokuapp.com/log-in-file-self-assessment-tax-return/sign-in/prove-identity)
    - [Create new account](https://government-frontend-pr-626.herokuapp.com/log-in-file-self-assessment-tax-return/sign-in/register-self-assessment)
    - [Redirected root](https://government-frontend-pr-626.herokuapp.com/log-in-file-self-assessment-tax-return/sign-in)
    - [Redirected suffix](https://government-frontend-pr-626.herokuapp.com/log-in-file-self-assessment-tax-return/sign-in/invalid-url)

## Welsh examples

- [Welsh](https://government-frontend-pr-626.herokuapp.com/mewngofnodi-chyflwynoch-ffurflen-dreth-huanasesiad/sign-in/profi-pwy-ydw-i)
    - [Create a new account](https://government-frontend-pr-626.herokuapp.com/mewngofnodi-chyflwynoch-ffurflen-dreth-huanasesiad/sign-in/cofrestru-hunan-asesiad)
    - [Redirected root](https://government-frontend-pr-626.herokuapp.com/mewngofnodi-chyflwynoch-ffurflen-dreth-huanasesiad/sign-in)
    - [Redirected suffix](https://government-frontend-pr-626.herokuapp.com/mewngofnodi-chyflwynoch-ffurflen-dreth-huanasesiad/sign-in/invalid-url)

As part of https://trello.com/c/dRORE0DA/290-make-the-choose-sign-in-page-the-default-page-for-the-servicesignin-format

---

Through doing this it feels like our 'one controller for everything' approach might need to be looked at again soon.

I imagine some of this logic should be in the routes but rather we seem to be doing routing mixed up in the presenter / controller.

Maybe we could have distinct paths into the application, so specific service sign-in controller etc.