### PR TITLE
Add statistical data sets to sidebar navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8'
 
 gem 'govuk_app_config', '~> 0.3.0'
-gem 'govuk_navigation_helpers', '~> 8.0.0'
+gem 'govuk_navigation_helpers', '~> 8.1.0'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
     govuk_frontend_toolkit (7.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (8.0.0)
+    govuk_navigation_helpers (8.1.0)
       activesupport (~> 5.1)
       gds-api-adapters (>= 43.0)
       govuk_ab_testing (~> 2.4)
@@ -340,7 +340,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 0.3.0)
   govuk_frontend_toolkit (= 7.2.0)
-  govuk_navigation_helpers (~> 8.0.0)
+  govuk_navigation_helpers (~> 8.1.0)
   govuk_publishing_components (~> 3.0.2)
   govuk_schemas
   htmlentities (= 4.3.4)

--- a/app/views/components/_related-navigation.html.erb
+++ b/app/views/components/_related-navigation.html.erb
@@ -1,6 +1,6 @@
 <%
   max_section_length = 5
-  defined_sections = ["topics", "publishers", "collections", "policies", "topical_events", "world_locations"]
+  defined_sections = %w(topics publishers collections policies topical_events world_locations statistical_data_sets)
   related_content = [
     {"related_items" => related_items ||= [] },
     {"topics" => topics ||= [] },
@@ -8,7 +8,8 @@
     {"collections" => collections ||= [] },
     {"policies" => policies ||= [] },
     {"topical_events" => topical_events ||= [] },
-    {"world_locations" => world_locations ||= [] }
+    {"world_locations" => world_locations ||= [] },
+    {"statistical_data_sets" => statistical_data_sets ||= []},
   ]
   other ||= []
   format_data_for_related_navigation(related_content, other)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
       policies: "Policy"
       publishers: "Published by"
       related_content: "Related content"
+      statistical_data_sets: "Statistical data set"
       topics: "Explore the topic"
       topical_events: "Topical event"
       world_locations: 'Location'

--- a/test/components/related_navigation_test.rb
+++ b/test/components/related_navigation_test.rb
@@ -37,6 +37,21 @@ class RelatedNavigationTest < ComponentTestCase
     assert_select ".app-c-related-navigation__section-link[href=\"/finding-a-job\"]", text: 'Finding a job'
   end
 
+  test "renders statistical data set section when passed statistical data set items" do
+    render_component(
+      statistical_data_sets: [
+        {
+          text: "Air quality statistics",
+          path: '/air-quality-statistics'
+        }
+      ]
+    )
+
+    assert_select ".app-c-related-navigation__sub-heading", text: 'Statistical data set'
+    assert_select ".app-c-related-navigation__section-link[href=\"/air-quality-statistics\"]", text: 'Air quality statistics'
+  end
+
+
   test "renders world locations section when passed world location items" do
     render_component(
       world_locations: [

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -25,6 +25,7 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     expected = {
       related_items: [],
       collections: [],
+      statistical_data_sets: [],
       topics: [],
       topical_events: [],
       policies: [],


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/2538570

![screenshot from 2017-12-19 16-33-29](https://user-images.githubusercontent.com/93511/34167691-5f11e678-e4da-11e7-988c-343cbc34bf95.png)


- Add tests to support this change.

Review app example:
https://government-frontend-pr-628.herokuapp.com/government/statistics/air-quality-statistics

Review app component guide:
https://government-frontend-pr-XXX.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-XXX.surge.sh/gallery.html
