### PR TITLE
Add logic to handle different layouts

### DIFF
--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -1,5 +1,5 @@
 <% if local_assigns.has_key?(:tasklist_content) && current_tasklist_ab_test.show_tasklist_sidebar? %>
-  <%= render 'shared/sidebar_tasklist', tasklist_content: tasklist_content %>
+  <%= render 'shared/sidebar_tasklist', tasklist_content: tasklist_content, no_margin: true %>
 <% else %>
   <div class="column-third">
   <% if @navigation.should_present_taxonomy_navigation? -%>

--- a/app/views/shared/_sidebar_tasklist.html.erb
+++ b/app/views/shared/_sidebar_tasklist.html.erb
@@ -1,4 +1,7 @@
-<nav class="column-third task-list-sidebar">
+<%
+  no_margin ||= false
+%>
+<nav class="column-third <%= "task-list-sidebar" unless no_margin %>">
   <%= render 'components/task_list_related', links: [{
       href: tasklist_content.base_path,
       text: tasklist_content.title


### PR DESCRIPTION
- top margin applied to task list sidebar only if it is not appearing on a universal layout page

Example of problem (in universal layout):

![screen shot 2017-12-20 at 08 21 18](https://user-images.githubusercontent.com/861310/34197547-e8955860-e55e-11e7-83b9-b614872883cc.png)

Fix (in universal layout):

![screen shot 2017-12-20 at 08 21 54](https://user-images.githubusercontent.com/861310/34197559-f44fa03e-e55e-11e7-8b7e-8f58a6b11d01.png)

Example of layout required in all other layouts (note deliberate margin above task list):

![screen shot 2017-12-20 at 08 20 58](https://user-images.githubusercontent.com/861310/34197575-0756996c-e55f-11e7-929c-9d61fade04d1.png)

Review app component guide:
https://government-frontend-pr-629.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-629.surge.sh/gallery.html
