### PR TITLE
Reduced the spacing between on related nav

### DIFF
--- a/app/assets/stylesheets/components/_related-navigation.scss
+++ b/app/assets/stylesheets/components/_related-navigation.scss
@@ -23,7 +23,6 @@
 }
 
 .app-c-related-navigation__nav-section {
-  margin-top: $gutter-one-third / 2;
   margin-bottom: $gutter;
 }
 


### PR DESCRIPTION
Done in order to visually tighten up the grouping.

Review app component guide:
https://government-frontend-pr-633.herokuapp.com/component-guide

Before:
<img width="377" alt="screen shot 2017-12-20 at 11 31 07" src="https://user-images.githubusercontent.com/18534862/34205293-c5ab19a0-e579-11e7-91f4-a18acb2b1fa3.png">

After:
<img width="374" alt="screen shot 2017-12-20 at 11 30 51" src="https://user-images.githubusercontent.com/18534862/34205301-cb0b87a4-e579-11e7-8317-959a92126af6.png">

Link to check:
https://www.gov.uk/government/publications/russia-tax-treaties