### PR TITLE
Bump govuk_navigation_helpers version to 8.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '5.3.1'
 
 gem 'govuk_app_config', '~> 0.3.0'
-gem 'govuk_navigation_helpers', '~> 8.1.0'
+gem 'govuk_navigation_helpers', '~> 8.1.1'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
     govuk_frontend_toolkit (7.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (8.1.0)
+    govuk_navigation_helpers (8.1.1)
       activesupport (~> 5.1)
       gds-api-adapters (>= 43.0)
       govuk_ab_testing (~> 2.4)
@@ -356,7 +356,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 0.3.0)
   govuk_frontend_toolkit (= 7.2.0)
-  govuk_navigation_helpers (~> 8.1.0)
+  govuk_navigation_helpers (~> 8.1.1)
   govuk_publishing_components (~> 3.0.2)
   govuk_schemas
   htmlentities (= 4.3.4)


### PR DESCRIPTION
There have been changes in `govuk_navigation_helpers` so we need to bump the gem version.

Related PR's:
Update to tasklists - https://github.com/alphagov/govuk_navigation_helpers/pull/104
Bump version to 8.1.1 - https://github.com/alphagov/govuk_navigation_helpers/pull/105
