### PR TITLE
Move working group pages to universal layout

### DIFF
--- a/app/views/components/docs/contents-list-with-body.yml
+++ b/app/views/components/docs/contents-list-with-body.yml
@@ -78,7 +78,6 @@ examples:
             <h3 id="contact">Contact</h3>
             <p>Please send written representations about any competition issues to:</p>
             <div class="address"><div class="adr org fn"><p>
-
             <br>Competition and Markets Authority 
             <br>Victoria House 
             <br>Southampton Row 

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -1,6 +1,3 @@
-<%= render 'shared/title_and_translations', content_item: @content_item %>
-<%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
-
 <% @additional_body = capture do %>
   <% if @content_item.policies.any? %>
     <h2 id="policies">Policies</h2>
@@ -17,6 +14,17 @@
   <% end %>
 <% end %>
 
-<%= render 'shared/sidebar_contents_with_body',
-      content_item: @content_item,
-      body: "#{@content_item.body} #{@additional_body}" %>
+<div class="grid-row">
+  <div class="column-two-thirds responsive-top-margin">
+    <%= render 'govuk_component/title', @content_item.title_and_context %>
+  </div>
+  <%= render 'shared/translations' %>
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
+    <%= render 'components/contents-list-with-body', contents: @content_item.contents do %>
+      <%= render 'govuk_component/govspeak',
+            content: "#{@content_item.body} #{@additional_body}",
+            direction: page_text_direction %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
https://trello.com/c/oLC1enhS/133-move-formats-that-have-a-content-list-to-universal-design

### Example working group page

https://government-frontend-pr-637.herokuapp.com/government/groups/joint-vat-consultative-committee-jvcc

![screenshot from 2017-12-20 17-17-27](https://user-images.githubusercontent.com/93511/34219683-e6852c94-e5a9-11e7-9fca-67b67a27ddea.png)

### Sticky link:

![screenshot from 2017-12-20 17-17-52](https://user-images.githubusercontent.com/93511/34219702-ee1debf8-e5a9-11e7-90e0-21a720a1a5c2.png)


Review app component guide:
https://government-frontend-pr-XXX.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-XXX.surge.sh/gallery.html
