### PR TITLE
Only run E2E tests which involve government-frontend

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,6 @@ REPOSITORY = 'government-frontend'
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-government-frontend")
   govuk.buildProject(publishingE2ETests: true)
 }


### PR DESCRIPTION
Hey :wave:,

We've tagged all the tests in the E2E repo which interact and depend on the government-frontend application in some way.

By only running the tests which interact with the government-frontend app we can reduce the running time of the E2E tests for commits against this app without reducing the confidence that the E2E tests bring. 🎉 