### PR TITLE
Bump GOVUK Navigation Helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '5.3.1'
 
 gem 'govuk_app_config', '~> 0.3.0'
-gem 'govuk_navigation_helpers', '~> 8.1.0'
+gem 'govuk_navigation_helpers', '~> 8.1.1'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
     govuk_frontend_toolkit (7.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (8.1.0)
+    govuk_navigation_helpers (8.1.1)
       activesupport (~> 5.1)
       gds-api-adapters (>= 43.0)
       govuk_ab_testing (~> 2.4)
@@ -356,7 +356,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 0.3.0)
   govuk_frontend_toolkit (= 7.2.0)
-  govuk_navigation_helpers (~> 8.1.0)
+  govuk_navigation_helpers (~> 8.1.1)
   govuk_publishing_components (~> 3.0.2)
   govuk_schemas
   htmlentities (= 4.3.4)


### PR DESCRIPTION
https://trello.com/c/1nhkSnqd/180-navigating-to-a-world-location-page-is-broken-from-the-sidebar

There's an update in version 8.1.1 of nav helpers which strips
non-alphanumeric characters from world location links, this will
help with a couple of broken links reported via zendesk.
https://govuk.zendesk.com/agent/tickets/2539244

### Example page
https://government-frontend-pr-639.herokuapp.com/government/speeches/the-joint-comprehensive-plan-of-action-is-one-of-the-greatest-diplomatic-successes-in-recent-memory


Review app component guide:
https://government-frontend-pr-XXX.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-XXX.surge.sh/gallery.html
