### PR TITLE
[Don't merge] Prototype of contextual navigation

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,7 +1,12 @@
 require 'gds_api/content_store'
+require 'gds_api/rummager'
 
 module Services
   def self.content_store
     @content_store ||= GdsApi::ContentStore.new(Plek.current.find("content-store"))
+  end
+
+  def self.rummager
+    @rummager ||= GdsApi::Rummager.new(Plek.current.find("rummager"))
   end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -88,6 +88,10 @@ class ContentItemPresenter
     @content_item["links"]["people"].to_a.first
   end
 
+  def taxon
+    @content_item["links"]["taxons"].to_a.first
+  end
+
 private
 
   def display_date(timestamp, format = "%-d %B %Y")

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -76,6 +76,10 @@ class ContentItemPresenter
     content_item.dig("links", "taxons").present?
   end
 
+  def publishing_organisation
+    @content_item["links"]["organisations"].to_a.first
+  end
+
 private
 
   def display_date(timestamp, format = "%-d %B %Y")

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -80,6 +80,14 @@ class ContentItemPresenter
     @content_item["links"]["organisations"].to_a.first
   end
 
+  def policy
+    @content_item["links"]["related_policies"].to_a.first
+  end
+
+  def person
+    @content_item["links"]["people"].to_a.first
+  end
+
 private
 
   def display_date(timestamp, format = "%-d %B %Y")

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,6 +48,7 @@
     <% end %>
     <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">
       <%= yield %>
+      <%= render 'shared/contextual_related_content' %>
     </main>
   </div>
 </body>

--- a/app/views/shared/_contextual_related_content.html.erb
+++ b/app/views/shared/_contextual_related_content.html.erb
@@ -13,55 +13,110 @@ def related_stuff(rummager_args)
 end
 %>
 
-<h2 class="app-c-related-navigation__main-heading">Popular pages published by <%= @content_item.publishing_organisation["title"] %></h2>
+<% if @content_item.publishing_organisation %>
+  <h2 class="app-c-related-navigation__main-heading">Popular pages published by <%= @content_item.publishing_organisation["title"] %></h2>
 
-<%= render "components/document-list", related_stuff(
-  reject_link: @content_item.base_path,
-  filter_organisation_content_ids: @content_item.publishing_organisation["content_id"]
-) %>
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_organisation_content_ids: @content_item.publishing_organisation["content_id"]
+  ) %>
 
-<h2 class="app-c-related-navigation__main-heading">Recent pages published by <%= @content_item.publishing_organisation["title"] %></h2>
+  <h2 class="app-c-related-navigation__main-heading">Recent pages published by <%= @content_item.publishing_organisation["title"] %></h2>
 
-<%= render "components/document-list", related_stuff(
-  reject_link: @content_item.base_path,
-  filter_organisation_content_ids: @content_item.publishing_organisation["content_id"],
-  order: '-public_timestamp'
-) %>
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_organisation_content_ids: @content_item.publishing_organisation["content_id"],
+    order: '-public_timestamp'
+  ) %>
 
-<h2 class="app-c-related-navigation__main-heading">Related pages published by <%= @content_item.publishing_organisation["title"] %></h2>
+  <h2 class="app-c-related-navigation__main-heading">Related pages published by <%= @content_item.publishing_organisation["title"] %></h2>
 
-<%= render "components/document-list", related_stuff(
-  reject_link: @content_item.base_path,
-  filter_organisation_content_ids: @content_item.publishing_organisation["content_id"],
-  similar_to: @content_item.base_path
-) %>
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_organisation_content_ids: @content_item.publishing_organisation["content_id"],
+    similar_to: @content_item.base_path
+  ) %>
 
-<h2 class="app-c-related-navigation__main-heading">Popular pages with document type <%= @content_item.document_type %></h2>
+  <h2 class="app-c-related-navigation__main-heading">Popular pages with document type <%= @content_item.document_type %></h2>
 
-<%= render "components/document-list", related_stuff(
-  reject_link: @content_item.base_path,
-  filter_content_store_document_type: @content_item.document_type,
-) %>
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_content_store_document_type: @content_item.document_type,
+  ) %>
+<% end %>
 
-<h2 class="app-c-related-navigation__main-heading">Recent pages with document type <%= @content_item.document_type %></h2>
+<% if @content_item.document_type %>
 
-<%= render "components/document-list", related_stuff(
-  reject_link: @content_item.base_path,
-  filter_content_store_document_type: @content_item.document_type,
-  order: '-public_timestamp'
-) %>
+  <h2 class="app-c-related-navigation__main-heading">Recent pages with document type <%= @content_item.document_type %></h2>
 
-<h2 class="app-c-related-navigation__main-heading">Related pages with document type <%= @content_item.document_type %></h2>
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_content_store_document_type: @content_item.document_type,
+    order: '-public_timestamp'
+  ) %>
 
-<%= render "components/document-list", related_stuff(
-  reject_link: @content_item.base_path,
-  filter_content_store_document_type: @content_item.document_type,
-  similar_to: @content_item.base_path
-) %>
+  <h2 class="app-c-related-navigation__main-heading">Related pages with document type <%= @content_item.document_type %></h2>
 
-<h2 class="app-c-related-navigation__main-heading">Popular pages with document type <%= @content_item.document_type %></h2>
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_content_store_document_type: @content_item.document_type,
+    similar_to: @content_item.base_path
+  ) %>
 
-<%= render "components/document-list", related_stuff(
-  reject_link: @content_item.base_path,
-  filter_content_store_document_type: @content_item.document_type,
-) %>
+  <h2 class="app-c-related-navigation__main-heading">Popular pages with document type <%= @content_item.document_type %></h2>
+
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_content_store_document_type: @content_item.document_type,
+  ) %>
+<% end %>
+
+<% if @content_item.policy %>
+  <h2 class="app-c-related-navigation__main-heading">Recent pages with policy <%= @content_item.policy["title"] %></h2>
+
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_policies: @content_item.policy["base_path"].gsub("/government/policies/", ""),
+    order: '-public_timestamp'
+  ) %>
+
+  <h2 class="app-c-related-navigation__main-heading">Related pages with policy <%= @content_item.policy["title"] %></h2>
+
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_policies: @content_item.policy["base_path"].gsub("/government/policies/", ""),
+    similar_to: @content_item.base_path
+  ) %>
+
+  <h2 class="app-c-related-navigation__main-heading">Popular pages with policy <%= @content_item.policy["title"] %></h2>
+
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_policies: @content_item.policy["base_path"].gsub("/government/policies/", ""),
+  ) %>
+<% end %>
+
+<% if @content_item.person %>
+  <h2 class="app-c-related-navigation__main-heading">Recent pages from <%= @content_item.person["title"] %></h2>
+
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_people: @content_item.person["base_path"].gsub("/government/people/", ""),
+    order: '-public_timestamp'
+  ) %>
+
+  <h2 class="app-c-related-navigation__main-heading">Related pages from <%= @content_item.person["title"] %></h2>
+
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_people: @content_item.person["base_path"].gsub("/government/people/", ""),
+    similar_to: @content_item.base_path
+  ) %>
+
+  <h2 class="app-c-related-navigation__main-heading">Popular pages from <%= @content_item.person["title"] %></h2>
+
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_people: @content_item.person["base_path"].gsub("/government/people/", ""),
+  ) %>
+<% end %>

--- a/app/views/shared/_contextual_related_content.html.erb
+++ b/app/views/shared/_contextual_related_content.html.erb
@@ -16,12 +16,14 @@ end
 <h2 class="app-c-related-navigation__main-heading">Popular pages published by <%= @content_item.publishing_organisation["title"] %></h2>
 
 <%= render "components/document-list", related_stuff(
+  reject_link: @content_item.base_path,
   filter_organisation_content_ids: @content_item.publishing_organisation["content_id"]
 ) %>
 
 <h2 class="app-c-related-navigation__main-heading">Recent pages published by <%= @content_item.publishing_organisation["title"] %></h2>
 
 <%= render "components/document-list", related_stuff(
+  reject_link: @content_item.base_path,
   filter_organisation_content_ids: @content_item.publishing_organisation["content_id"],
   order: '-public_timestamp'
 ) %>
@@ -29,20 +31,22 @@ end
 <h2 class="app-c-related-navigation__main-heading">Related pages published by <%= @content_item.publishing_organisation["title"] %></h2>
 
 <%= render "components/document-list", related_stuff(
+  reject_link: @content_item.base_path,
   filter_organisation_content_ids: @content_item.publishing_organisation["content_id"],
-  similar_to: @content_item.base_path,
-  reject_link: @content_item.base_path
+  similar_to: @content_item.base_path
 ) %>
 
 <h2 class="app-c-related-navigation__main-heading">Popular pages with document type <%= @content_item.document_type %></h2>
 
 <%= render "components/document-list", related_stuff(
+  reject_link: @content_item.base_path,
   filter_content_store_document_type: @content_item.document_type,
 ) %>
 
 <h2 class="app-c-related-navigation__main-heading">Recent pages with document type <%= @content_item.document_type %></h2>
 
 <%= render "components/document-list", related_stuff(
+  reject_link: @content_item.base_path,
   filter_content_store_document_type: @content_item.document_type,
   order: '-public_timestamp'
 ) %>
@@ -50,13 +54,14 @@ end
 <h2 class="app-c-related-navigation__main-heading">Related pages with document type <%= @content_item.document_type %></h2>
 
 <%= render "components/document-list", related_stuff(
+  reject_link: @content_item.base_path,
   filter_content_store_document_type: @content_item.document_type,
-  similar_to: @content_item.base_path,
-  reject_link: @content_item.base_path
+  similar_to: @content_item.base_path
 ) %>
 
 <h2 class="app-c-related-navigation__main-heading">Popular pages with document type <%= @content_item.document_type %></h2>
 
 <%= render "components/document-list", related_stuff(
+  reject_link: @content_item.base_path,
   filter_content_store_document_type: @content_item.document_type,
 ) %>

--- a/app/views/shared/_contextual_related_content.html.erb
+++ b/app/views/shared/_contextual_related_content.html.erb
@@ -1,0 +1,62 @@
+<%
+def related_stuff(rummager_args)
+  results = Services.rummager.search({ count: 5, fields: %w[title public_timestamp link content_store_document_type]}.merge(rummager_args))["results"]
+
+  items = results.map do |r|
+    {
+      link: { text: r["title"], path: r["link"] },
+      metadata: { public_updated_at: Time.parse(r["public_timestamp"]), document_type: "other" }
+    }
+  end
+
+  { items: items }
+end
+%>
+
+<h2 class="app-c-related-navigation__main-heading">Popular pages published by <%= @content_item.publishing_organisation["title"] %></h2>
+
+<%= render "components/document-list", related_stuff(
+  filter_organisation_content_ids: @content_item.publishing_organisation["content_id"]
+) %>
+
+<h2 class="app-c-related-navigation__main-heading">Recent pages published by <%= @content_item.publishing_organisation["title"] %></h2>
+
+<%= render "components/document-list", related_stuff(
+  filter_organisation_content_ids: @content_item.publishing_organisation["content_id"],
+  order: '-public_timestamp'
+) %>
+
+<h2 class="app-c-related-navigation__main-heading">Related pages published by <%= @content_item.publishing_organisation["title"] %></h2>
+
+<%= render "components/document-list", related_stuff(
+  filter_organisation_content_ids: @content_item.publishing_organisation["content_id"],
+  similar_to: @content_item.base_path,
+  reject_link: @content_item.base_path
+) %>
+
+<h2 class="app-c-related-navigation__main-heading">Popular pages with document type <%= @content_item.document_type %></h2>
+
+<%= render "components/document-list", related_stuff(
+  filter_content_store_document_type: @content_item.document_type,
+) %>
+
+<h2 class="app-c-related-navigation__main-heading">Recent pages with document type <%= @content_item.document_type %></h2>
+
+<%= render "components/document-list", related_stuff(
+  filter_content_store_document_type: @content_item.document_type,
+  order: '-public_timestamp'
+) %>
+
+<h2 class="app-c-related-navigation__main-heading">Related pages with document type <%= @content_item.document_type %></h2>
+
+<%= render "components/document-list", related_stuff(
+  filter_content_store_document_type: @content_item.document_type,
+  similar_to: @content_item.base_path,
+  reject_link: @content_item.base_path
+) %>
+
+<h2 class="app-c-related-navigation__main-heading">Popular pages with document type <%= @content_item.document_type %></h2>
+
+<%= render "components/document-list", related_stuff(
+  filter_content_store_document_type: @content_item.document_type,
+) %>

--- a/app/views/shared/_contextual_related_content.html.erb
+++ b/app/views/shared/_contextual_related_content.html.erb
@@ -120,3 +120,28 @@ end
     filter_people: @content_item.person["base_path"].gsub("/government/people/", ""),
   ) %>
 <% end %>
+
+<% if @content_item.taxon %>
+  <h2 class="app-c-related-navigation__main-heading">Recent pages with taxon <%= @content_item.taxon["title"] %></h2>
+
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_taxons: @content_item.taxon["content_id"],
+    order: '-public_timestamp'
+  ) %>
+
+  <h2 class="app-c-related-navigation__main-heading">Related pages with taxon <%= @content_item.taxon["title"] %></h2>
+
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_taxons: @content_item.taxon["content_id"],
+    similar_to: @content_item.base_path
+  ) %>
+
+  <h2 class="app-c-related-navigation__main-heading">Popular pages with taxon <%= @content_item.taxon["title"] %></h2>
+
+  <%= render "components/document-list", related_stuff(
+    reject_link: @content_item.base_path,
+    filter_taxons: @content_item.taxon["content_id"],
+  ) %>
+<% end %>

--- a/app/views/shared/_contextual_related_content.html.erb
+++ b/app/views/shared/_contextual_related_content.html.erb
@@ -29,7 +29,7 @@ end
     order: '-public_timestamp'
   ) %>
 
-  <h2 class="app-c-related-navigation__main-heading">Related pages published by <%= @content_item.publishing_organisation["title"] %></h2>
+  <h2 class="app-c-related-navigation__main-heading">Similar pages published by <%= @content_item.publishing_organisation["title"] %></h2>
 
   <%= render "components/document-list", related_stuff(
     reject_link: @content_item.base_path,
@@ -55,7 +55,7 @@ end
     order: '-public_timestamp'
   ) %>
 
-  <h2 class="app-c-related-navigation__main-heading">Related pages with document type <%= @content_item.document_type %></h2>
+  <h2 class="app-c-related-navigation__main-heading">Similar pages with document type <%= @content_item.document_type %></h2>
 
   <%= render "components/document-list", related_stuff(
     reject_link: @content_item.base_path,
@@ -80,7 +80,7 @@ end
     order: '-public_timestamp'
   ) %>
 
-  <h2 class="app-c-related-navigation__main-heading">Related pages with policy <%= @content_item.policy["title"] %></h2>
+  <h2 class="app-c-related-navigation__main-heading">Similar pages with policy <%= @content_item.policy["title"] %></h2>
 
   <%= render "components/document-list", related_stuff(
     reject_link: @content_item.base_path,
@@ -105,7 +105,7 @@ end
     order: '-public_timestamp'
   ) %>
 
-  <h2 class="app-c-related-navigation__main-heading">Related pages from <%= @content_item.person["title"] %></h2>
+  <h2 class="app-c-related-navigation__main-heading">Similar pages from <%= @content_item.person["title"] %></h2>
 
   <%= render "components/document-list", related_stuff(
     reject_link: @content_item.base_path,
@@ -130,7 +130,7 @@ end
     order: '-public_timestamp'
   ) %>
 
-  <h2 class="app-c-related-navigation__main-heading">Related pages with taxon <%= @content_item.taxon["title"] %></h2>
+  <h2 class="app-c-related-navigation__main-heading">Similar pages with taxon <%= @content_item.taxon["title"] %></h2>
 
   <%= render "components/document-list", related_stuff(
     reject_link: @content_item.base_path,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,6 +112,12 @@ en:
       announcement:
         one: Announcement
         other: Announcements
+      other:
+        one: '-'
+        other: '-'
+      transaction:
+        one: Answer
+        other: Answers
       case_study:
         one: Case study
         other: Case studies


### PR DESCRIPTION
This is a prototype where we generate lists of "related" content for pages.

There are a bunch of examples here:

- Popular/Recent/Similar pages published by the publishing org 
- Popular/Recent/Similar pages with the same document type 
- Popular/Recent/Similar pages with the same policy 
- Popular/Recent/Similar pages with the same person 
- Popular/Recent/Similar pages with the same taxon

"Popular" uses the search-api's popularity (number of pageviews in the last 45 days). "Similar" uses the search-api's "similar to" feature that looks in the text to find related pages.

The idea here is that we can try out different scopes (org, document type) with the different sorting mechanisms (popular/similar/recent). Click data can show us which perform better.

Other scopes that we could try:

- [x] Organisation
- [x] Document type
- [x] Policy
- [x] Person
- [x] Taxon
- [ ] Content purpose supertype
- [ ] Group
- [ ] Taxon and children
- [ ] Taxon and parents
- [ ] Legacy topic
- [ ] Mainstream browse
- [ ] Topical event
- [ ] Policy area
- [ ] Statistical dataset

### Examples

- https://government-frontend-pr-643.herokuapp.com/government/speeches/pm-statement-on-eu-negotiations-11-december-2017 (with a person)
- https://government-frontend-pr-643.herokuapp.com/1619-bursary-fund (taxon)