### PR TITLE
Move consultations to universal layout

### DIFF
--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -110,6 +110,13 @@ class ConsultationPresenter < ContentItemPresenter
     ways_to_respond["attachment_url"]
   end
 
+  # FIXME: This is a temporary removal of National Applicability
+  # Once all formats have moved to new publisher/important metadata
+  # components, we can remove here: app/presenters/content_item/national_applicability.rb:33
+  def publisher_metadata
+    super.tap { |m| m[:other].delete(:"Applies to") }
+  end
+
 private
 
   def display_date_and_time(date, rollback_midnight = false)

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -1,175 +1,185 @@
-<%= render 'shared/title_and_translations', content_item: @content_item %>
-<%= render 'components/notice', @content_item.withdrawal_notice_component  %>
-<%= render 'shared/metadata', content_item: @content_item %>
-<%= render 'shared/history_notice', content_item: @content_item %>
-
-<% if @content_item.unopened? %>
-  <% content_item_unopened = capture do %>
-    This consultation opens
-    <% if @content_item.opening_date_midnight? %>on<% else %>at<% end %>
-    <time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time>
-  <% end %>
-  <%= render 'components/notice', title: "This consultation isn't open yet", description_text: content_item_unopened %>
-<% elsif @content_item.pending_final_outcome? %>
-  <% content_item_final_outcome = capture do %>
-    Visit this page again soon to download the outcome to this public&nbsp;feedback.
-  <% end %>
-  <%= render 'components/notice', title: 'We are analysing your feedback', description_text: content_item_final_outcome %>
-<% elsif @content_item.final_outcome? %>
-  <%= render 'components/notice', title: 'This consultation has concluded' %>
-
-  <% if @content_item.final_outcome_documents? %>
-    <div class="grid-row sidebar-with-body">
-      <div class="column-third">
-        <%= render 'components/heading', text: "Download the full outcome", id: "final-outcome-documents-title" %>
-      </div>
-      <div class="column-two-thirds" aria-labelledby="final-outcome-documents-title">
-        <%= render 'govuk_component/govspeak',
-            content: @content_item.final_outcome_documents,
-            direction: page_text_direction %>
-      </div>
-    </div>
-  <% end %>
-
-  <div class="grid-row sidebar-with-body">
-    <div class="column-third">
-      <%= render 'components/heading', text: "Detail of outcome", id: "final-outcome-detail-title" %>
-    </div>
-    <div class="column-two-thirds" aria-labelledby="final-outcome-detail-title">
-      <%= render 'govuk_component/govspeak',
-          content: @content_item.final_outcome_detail,
-          direction: page_text_direction %>
-    </div>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title', @content_item.title_and_context %>
   </div>
-<% end %>
-
-<% if @content_item.public_feedback_documents? %>
-  <div class="grid-row sidebar-with-body">
-    <div class="column-third">
-      <%= render 'components/heading', text: "Feedback received", id: "public-feedback-documents-title" %>
-    </div>
-    <div class="column-two-thirds" aria-labelledby="public-feedback-documents-title">
-      <%= render 'govuk_component/govspeak',
-          content: @content_item.public_feedback_documents,
-          direction: page_text_direction %>
-    </div>
-  </div>
-<% end %>
-
-<% if @content_item.public_feedback_detail %>
-  <div class="grid-row sidebar-with-body">
-    <div class="column-third">
-      <%= render 'components/heading', text: "Detail of feedback received", id: "public-feedback-detail-title" %>
-    </div>
-    <div class="column-two-thirds" aria-labelledby="public-feedback-detail-title">
-      <%= render 'govuk_component/govspeak',
-          content: @content_item.public_feedback_detail,
-          direction: page_text_direction %>
-    </div>
-  </div>
-<% end %>
-
-<% if @content_item.final_outcome? %>
-  <section class="original-consultation">
-    <header>
-      <%= render 'components/heading', text: "Original consultation", id: "original-consultation-title", heading_level: 2 %>
-    </header>
-<% end %>
-
-<% consultation_date = capture do %>
-  <% if @content_item.closed? %>
-    This consultation ran from<br /><span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time> to
-    <time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
-  <% elsif @content_item.open? %>
-    This consultation closes at<br />
-    <span class="consultation-date"><time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
-  <% elsif @content_item.unopened? %>
-    This consultation opens <% if @content_item.opening_date_midnight? %>on<% else %>at<% end %><br />
-    <span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time></span><br />
-    It closes at<br />
-    <span class="consultation-date"><time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
-  <% end %>
-<% end %>
-
-<% consultation_desc = capture do %>
-  <%= @content_item.description %>
-  <% if @content_item.held_on_another_website? %>
-    <br/><br/>
-    <strong>This consultation <% if @content_item.closed? %>was<% else %>is being<% end %> held on <a href="<%= @content_item.held_on_another_website_url %>">another website</a>.</strong>
-  <% end %>
-<% end %>
-<%= render 'components/banner', text: consultation_desc, title: 'Summary', aside: consultation_date %>
-
-<% if @content_item.final_outcome? %>
-  </section>
-<% end %>
-
-<div class="grid-row sidebar-with-body">
-  <div class="column-third">
-    <%= render 'components/heading', text: "Consultation description", id: "description-title" %>
-  </div>
-  <div class="column-two-thirds" aria-labelledby="description-title">
-    <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
+  <%= render 'shared/translations' %>
+  <div class="column-two-thirds">
+    <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
+    <%= render 'shared/history_notice', content_item: @content_item %>
   </div>
 </div>
 
-<% if @content_item.documents? %>
-  <div class="grid-row sidebar-with-body">
-    <div class="column-third">
-      <%= render 'components/heading', text: "Documents", id: "documents-title" %>
-    </div>
-    <div class="column-two-thirds" aria-labelledby="documents-title">
-      <%= render 'govuk_component/govspeak',
-          content: @content_item.documents,
-          direction: page_text_direction %>
-    </div>
+<%= render 'shared/publisher_metadata_with_logo', content_item: @content_item %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'components/important-metadata', items: @content_item.metadata[:other]  %>
+
+    <% if @content_item.unopened? %>
+      <% content_item_unopened = capture do %>
+        This consultation opens
+        <% if @content_item.opening_date_midnight? %>on<% else %>at<% end %>
+        <time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time>
+      <% end %>
+      <%= render 'components/notice', title: "This consultation isn't open yet", description_text: content_item_unopened %>
+
+    <% elsif @content_item.pending_final_outcome? %>
+      <% content_item_final_outcome = capture do %>
+        Visit this page again soon to download the outcome to this public&nbsp;feedback.
+      <% end %>
+      <%= render 'components/notice', title: 'We are analysing your feedback', description_text: content_item_final_outcome %>
+
+    <% elsif @content_item.final_outcome? %>
+      <%= render 'components/notice', title: 'This consultation has concluded' %>
+
+      <% if @content_item.final_outcome_documents? %>
+        <%= render 'components/heading', text: "Download the full outcome", id: "final-outcome-documents-title" %>
+        <div aria-labelledby="final-outcome-documents-title">
+          <%= render 'govuk_component/govspeak',
+              content: @content_item.final_outcome_documents,
+              direction: page_text_direction %>
+        </div>
+      <% end %>
+
+      <%= render 'components/heading', text: "Detail of outcome", id: "final-outcome-detail-title" %>
+      <div aria-labelledby="final-outcome-detail-title">
+        <%= render 'govuk_component/govspeak',
+            content: @content_item.final_outcome_detail,
+            direction: page_text_direction %>
+      </div>
+    <% end %>
+
+    <% if @content_item.public_feedback_documents? %>
+      <%= render 'components/heading', text: "Feedback received", id: "public-feedback-documents-title" %>
+      <div aria-labelledby="public-feedback-documents-title">
+        <%= render 'govuk_component/govspeak',
+            content: @content_item.public_feedback_documents,
+            direction: page_text_direction %>
+      </div>
+    <% end %>
+
+
+    <% if @content_item.public_feedback_detail %>
+      <%= render 'components/heading', text: "Detail of feedback received", id: "public-feedback-detail-title" %>
+      <div aria-labelledby="public-feedback-detail-title">
+        <%= render 'govuk_component/govspeak',
+            content: @content_item.public_feedback_detail,
+            direction: page_text_direction %>
+      </div>
+    <% end %>
+
+    <% if @content_item.final_outcome? %>
+      <section class="original-consultation">
+        <header>
+          <%= render 'components/heading', text: "Original consultation", id: "original-consultation-title", heading_level: 2 %>
+        </header>
+    <% end %>
+
+    <% consultation_date = capture do %>
+      <% if @content_item.closed? %>
+        This consultation ran from<br /><span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time> to
+        <time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
+      <% elsif @content_item.open? %>
+        This consultation closes at<br />
+        <span class="consultation-date"><time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
+      <% elsif @content_item.unopened? %>
+        This consultation opens <% if @content_item.opening_date_midnight? %>on<% else %>at<% end %><br />
+        <span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time></span><br />
+        It closes at<br />
+        <span class="consultation-date"><time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
+      <% end %>
+    <% end %>
+
+      <% consultation_desc = capture do %>
+        <%= @content_item.description %>
+        <% if @content_item.held_on_another_website? %>
+          <br/><br/>
+          <strong>This consultation <% if @content_item.closed? %>was<% else %>is being<% end %> held on <a href="<%= @content_item.held_on_another_website_url %>">another website</a>.</strong>
+        <% end %>
+      <% end %>
+      <%= render 'components/banner', text: consultation_desc, title: 'Summary', aside: consultation_date %>
+
+      <% if @content_item.final_outcome? %>
+        </section>
+      <% end %>
   </div>
-<% end %>
+    <%= render 'shared/sidebar_navigation' %>
+</div>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'components/heading', text: "Consultation description", id: "description-title" %>
+    <div aria-labelledby="description-title">
+      <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
+    </div>
+
+    <% if @content_item.documents? %>
+      <%= render 'components/heading', text: "Documents", id: "documents-title" %>
+      <div aria-labelledby="documents-title">
+        <%= render 'govuk_component/govspeak',
+            content: @content_item.documents,
+            direction: page_text_direction %>
+      </div>
+    <% end %>
+  </div>
+</div>
 
 <% if @content_item.ways_to_respond? %>
-  <div class="grid-row sidebar-with-body">
-    <div class="column-third">
+  <div class="grid-row">
+    <div class="column-two-thirds">
       <%= render 'components/heading', text: "Ways to respond", id: "ways-to-respond-title" %>
-    </div>
-    <div class="column-two-thirds" aria-labelledby="ways-to-respond-title">
-      <% @ways_to_respond_body = capture do %>
-        <% if @content_item.respond_online_url %>
-          <div class="call-to-action">
-            <p><%= link_to 'Respond online', @content_item.respond_online_url %></p>
-          </div>
+      <div aria-labelledby="ways-to-respond-title">
+        <% @ways_to_respond_body = capture do %>
+          <% if @content_item.respond_online_url %>
+            <div class="call-to-action">
+              <p><%= link_to 'Respond online', @content_item.respond_online_url %></p>
+            </div>
 
-          <% if @content_item.email || @content_item.postal_address %>
-            <p>or</p>
+            <% if @content_item.email || @content_item.postal_address %>
+              <p>or</p>
+            <% end %>
           <% end %>
-        <% end %>
 
-        <% if @content_item.response_form? %>
-          <p>
-            Complete a <%= link_to 'response form', @content_item.attachment_url %> and
-            <% if @content_item.email && @content_item.postal_address %>either<% end %>
-          </p>
-        <% end %>
+          <% if @content_item.response_form? %>
+            <p>
+              Complete a <%= link_to 'response form', @content_item.attachment_url %> and
+              <% if @content_item.email && @content_item.postal_address %>either<% end %>
+            </p>
+          <% end %>
 
         <% if @content_item.email %>
           <h3>Email to:</h3>
           <p><%= mail_to @content_item.email, @content_item.email %></p>
         <% end %>
 
-        <% if @content_item.postal_address %>
-          <h3>Write to:</h3>
-          <div class="contact">
-            <div class="content">
-              <%= simple_format(@content_item.postal_address) %>
+          <% if @content_item.postal_address %>
+            <h3>Write to:</h3>
+            <div class="contact">
+              <div class="content">
+                <%= simple_format(@content_item.postal_address) %>
+              </div>
             </div>
-          </div>
+          <% end %>
         <% end %>
-      <% end %>
-      <%= render 'govuk_component/govspeak',
+
+        <%= render 'govuk_component/govspeak',
           content: @ways_to_respond_body,
           direction: page_text_direction %>
+      </div>
     </div>
   </div>
 <% end %>
 
-<%= render 'shared/share_links_offset_in_grid', share_links: @content_item.share_links %>
-<%= render 'shared/footer', @content_item.document_footer %>
+<div class="grid-row">
+  <div class="column-two-thirds content-bottom-margin">
+     <div class="dont-print responsive-bottom-margin">
+        <%= render 'components/share-links', @content_item.share_links %>
+    </div>
+
+    <%= render 'components/published-dates', {
+        published: @content_item.published,
+        last_updated: @content_item.updated,
+        history: @content_item.history
+      } %>
+  </div>
+</div>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -55,7 +55,7 @@
         <%= render 'govuk_component/govspeak',
             content: @content_item.public_feedback_documents,
             direction: page_text_direction %>
-    </div >
+      </div >
     <% end %>
 
     <% if @content_item.public_feedback_detail %>
@@ -89,92 +89,87 @@
       <% end %>
     <% end %>
 
-      <% consultation_desc = capture do %>
-        <%= @content_item.description %>
-        <% if @content_item.held_on_another_website? %>
-          <br/><br/>
-          <strong>This consultation <% if @content_item.closed? %>was<% else %>is being<% end %> held on <a href="<%= @content_item.held_on_another_website_url %>">another website</a>.</strong>
-        <% end %>
+    <% consultation_desc = capture do %>
+      <%= @content_item.description %>
+      <% if @content_item.held_on_another_website? %>
+        <br/><br/>
+        <strong>This consultation <% if @content_item.closed? %>was<% else %>is being<% end %> held on <a href="<%= @content_item.held_on_another_website_url %>">another website</a>.</strong>
       <% end %>
-      <%= render 'components/banner', text: consultation_desc, title: 'Summary', aside: consultation_date %>
+    <% end %>
+    <%= render 'components/banner', text: consultation_desc, title: 'Summary', aside: consultation_date %>
 
-      <% if @content_item.final_outcome? %>
-        </section>
+    <% if @content_item.final_outcome? %>
+      </section>
+    <% end %>
+
+
+    <div class="consultation-description">
+      <%= render 'components/heading', text: "Consultation description" %>
+      <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
+
+      <% if @content_item.documents? %>
+        <%= render 'components/heading', text: "Documents" %>
+        <div class="consultation-documents">
+          <%= render 'govuk_component/govspeak',
+              content: @content_item.documents,
+              direction: page_text_direction %>
+        </div>
       <% end %>
-  </div>
-    <%= render 'shared/sidebar_navigation' %>
-</div>
+    </div>
 
-<div class="grid-row consultation-description">
-  <div class="column-two-thirds">
-    <%= render 'components/heading', text: "Consultation description" %>
-    <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
+    <% if @content_item.ways_to_respond? %>
+      <div class="consultation-ways-to-respond">
+        <%= render 'components/heading', text: "Ways to respond" %>
+          <% @ways_to_respond_body = capture do %>
+            <% if @content_item.respond_online_url %>
+              <div class="call-to-action">
+                <p><%= link_to 'Respond online', @content_item.respond_online_url %></p>
+              </div>
 
-    <% if @content_item.documents? %>
-      <%= render 'components/heading', text: "Documents" %>
-      <div class="consultation-documents">
+              <% if @content_item.email || @content_item.postal_address %>
+                <p>or</p>
+              <% end %>
+            <% end %>
+
+            <% if @content_item.response_form? %>
+              <p>
+                Complete a <%= link_to 'response form', @content_item.attachment_url %> and
+                <% if @content_item.email && @content_item.postal_address %>either<% end %>
+              </p>
+            <% end %>
+
+            <% if @content_item.email %>
+              <h3>Email to:</h3>
+              <p><%= mail_to @content_item.email, @content_item.email %></p>
+            <% end %>
+
+            <% if @content_item.postal_address %>
+              <h3>Write to:</h3>
+              <div class="contact">
+                <div class="content">
+                  <%= simple_format(@content_item.postal_address) %>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+
         <%= render 'govuk_component/govspeak',
-            content: @content_item.documents,
-            direction: page_text_direction %>
+          content: @ways_to_respond_body,
+          direction: page_text_direction %>
       </div>
     <% end %>
-  </div>
-</div>
 
-<% if @content_item.ways_to_respond? %>
-  <div class="grid-row consultation-ways-to-respond">
-    <div class="column-two-thirds">
-      <%= render 'components/heading', text: "Ways to respond" %>
-      <% @ways_to_respond_body = capture do %>
-        <% if @content_item.respond_online_url %>
-          <div class="call-to-action">
-            <p><%= link_to 'Respond online', @content_item.respond_online_url %></p>
-          </div>
-
-          <% if @content_item.email || @content_item.postal_address %>
-            <p>or</p>
-          <% end %>
-        <% end %>
-
-        <% if @content_item.response_form? %>
-          <p>
-            Complete a <%= link_to 'response form', @content_item.attachment_url %> and
-            <% if @content_item.email && @content_item.postal_address %>either<% end %>
-          </p>
-        <% end %>
-
-        <% if @content_item.email %>
-          <h3>Email to:</h3>
-          <p><%= mail_to @content_item.email, @content_item.email %></p>
-        <% end %>
-
-        <% if @content_item.postal_address %>
-          <h3>Write to:</h3>
-          <div class="contact">
-            <div class="content">
-              <%= simple_format(@content_item.postal_address) %>
-            </div>
-          </div>
-        <% end %>
-      <% end %>
-
-      <%= render 'govuk_component/govspeak',
-        content: @ways_to_respond_body,
-        direction: page_text_direction %>
-    </div>
-  </div>
-<% end %>
-
-<div class="grid-row">
-  <div class="column-two-thirds content-bottom-margin">
-     <div class="dont-print responsive-bottom-margin">
+    <div class="content-bottom-margin">
+      <div class="dont-print responsive-bottom-margin">
         <%= render 'components/share-links', @content_item.share_links %>
-    </div>
+      </div>
 
     <%= render 'components/published-dates', {
         published: @content_item.published,
         last_updated: @content_item.updated,
         history: @content_item.history
       } %>
+    </div>
   </div>
+  <%= render 'shared/sidebar_navigation' %>
 </div>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -33,16 +33,16 @@
       <%= render 'components/notice', title: 'This consultation has concluded' %>
 
       <% if @content_item.final_outcome_documents? %>
-        <%= render 'components/heading', text: "Download the full outcome", id: "final-outcome-documents-title" %>
-        <div aria-labelledby="final-outcome-documents-title">
+        <%= render 'components/heading', text: "Download the full outcome" %>
+        <div class="consultation-outcome">
           <%= render 'govuk_component/govspeak',
               content: @content_item.final_outcome_documents,
               direction: page_text_direction %>
         </div>
       <% end %>
 
-      <%= render 'components/heading', text: "Detail of outcome", id: "final-outcome-detail-title" %>
-      <div aria-labelledby="final-outcome-detail-title">
+      <%= render 'components/heading', text: "Detail of outcome" %>
+      <div class="consultation-outcome-detail">
         <%= render 'govuk_component/govspeak',
             content: @content_item.final_outcome_detail,
             direction: page_text_direction %>
@@ -50,18 +50,17 @@
     <% end %>
 
     <% if @content_item.public_feedback_documents? %>
-      <%= render 'components/heading', text: "Feedback received", id: "public-feedback-documents-title" %>
-      <div aria-labelledby="public-feedback-documents-title">
+      <%= render 'components/heading', text: "Feedback received" %>
+      <div class="consultation-feedback-documents">
         <%= render 'govuk_component/govspeak',
             content: @content_item.public_feedback_documents,
             direction: page_text_direction %>
-      </div>
+    </div >
     <% end %>
 
-
     <% if @content_item.public_feedback_detail %>
-      <%= render 'components/heading', text: "Detail of feedback received", id: "public-feedback-detail-title" %>
-      <div aria-labelledby="public-feedback-detail-title">
+      <%= render 'components/heading', text: "Detail of feedback received" %>
+      <div class="consultation-feedback">
         <%= render 'govuk_component/govspeak',
             content: @content_item.public_feedback_detail,
             direction: page_text_direction %>
@@ -106,16 +105,14 @@
     <%= render 'shared/sidebar_navigation' %>
 </div>
 
-<div class="grid-row">
+<div class="grid-row consultation-description">
   <div class="column-two-thirds">
-    <%= render 'components/heading', text: "Consultation description", id: "description-title" %>
-    <div aria-labelledby="description-title">
-      <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
-    </div>
+    <%= render 'components/heading', text: "Consultation description" %>
+    <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
 
     <% if @content_item.documents? %>
-      <%= render 'components/heading', text: "Documents", id: "documents-title" %>
-      <div aria-labelledby="documents-title">
+      <%= render 'components/heading', text: "Documents" %>
+      <div class="consultation-documents">
         <%= render 'govuk_component/govspeak',
             content: @content_item.documents,
             direction: page_text_direction %>
@@ -125,47 +122,45 @@
 </div>
 
 <% if @content_item.ways_to_respond? %>
-  <div class="grid-row">
+  <div class="grid-row consultation-ways-to-respond">
     <div class="column-two-thirds">
-      <%= render 'components/heading', text: "Ways to respond", id: "ways-to-respond-title" %>
-      <div aria-labelledby="ways-to-respond-title">
-        <% @ways_to_respond_body = capture do %>
-          <% if @content_item.respond_online_url %>
-            <div class="call-to-action">
-              <p><%= link_to 'Respond online', @content_item.respond_online_url %></p>
-            </div>
+      <%= render 'components/heading', text: "Ways to respond" %>
+      <% @ways_to_respond_body = capture do %>
+        <% if @content_item.respond_online_url %>
+          <div class="call-to-action">
+            <p><%= link_to 'Respond online', @content_item.respond_online_url %></p>
+          </div>
 
-            <% if @content_item.email || @content_item.postal_address %>
-              <p>or</p>
-            <% end %>
+          <% if @content_item.email || @content_item.postal_address %>
+            <p>or</p>
           <% end %>
+        <% end %>
 
-          <% if @content_item.response_form? %>
-            <p>
-              Complete a <%= link_to 'response form', @content_item.attachment_url %> and
-              <% if @content_item.email && @content_item.postal_address %>either<% end %>
-            </p>
-          <% end %>
+        <% if @content_item.response_form? %>
+          <p>
+            Complete a <%= link_to 'response form', @content_item.attachment_url %> and
+            <% if @content_item.email && @content_item.postal_address %>either<% end %>
+          </p>
+        <% end %>
 
         <% if @content_item.email %>
           <h3>Email to:</h3>
           <p><%= mail_to @content_item.email, @content_item.email %></p>
         <% end %>
 
-          <% if @content_item.postal_address %>
-            <h3>Write to:</h3>
-            <div class="contact">
-              <div class="content">
-                <%= simple_format(@content_item.postal_address) %>
-              </div>
+        <% if @content_item.postal_address %>
+          <h3>Write to:</h3>
+          <div class="contact">
+            <div class="content">
+              <%= simple_format(@content_item.postal_address) %>
             </div>
-          <% end %>
+          </div>
         <% end %>
+      <% end %>
 
-        <%= render 'govuk_component/govspeak',
-          content: @ways_to_respond_body,
-          direction: page_text_direction %>
-      </div>
+      <%= render 'govuk_component/govspeak',
+        content: @ways_to_respond_body,
+        direction: page_text_direction %>
     </div>
   </div>
 <% end %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -27,7 +27,7 @@
       <% content_item_final_outcome = capture do %>
         Visit this page again soon to download the outcome to this public&nbsp;feedback.
       <% end %>
-      <%= render 'components/notice', title: 'We are analysing your feedback', description_text: content_item_final_outcome %>
+      <%= render 'components/notice', title: 'We are analysing your feedback', description_text: content_item_final_outcome, margin_bottom: 0 %>
 
     <% elsif @content_item.final_outcome? %>
       <%= render 'components/notice', title: 'This consultation has concluded' %>

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -18,7 +18,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
       assert page.has_css?('.app-c-related-navigation__section-link[href="/topic/higher-education/administration"]', text: 'Higher education administration')
     end
 
-    within '[aria-labelledby="description-title"]' do
+    within '.consultation-description' do
       assert_has_component_govspeak(@content_item["details"]["body"])
     end
   end
@@ -26,7 +26,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
   test "consultation documents render" do
     setup_and_visit_content_item('closed_consultation')
 
-    within '[aria-labelledby="documents-title"]' do
+    within '.consultation-documents' do
       assert_has_component_govspeak(@content_item["details"]["documents"].join(''))
     end
   end
@@ -74,7 +74,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     assert page.has_text?("ran from")
     assert page.has_text?("4pm on 20 April 2016 to 10:45pm on 13 July 2016")
 
-    within '[aria-labelledby="final-outcome-detail-title"]' do
+    within '.consultation-outcome-detail' do
       assert_has_component_govspeak(@content_item["details"]["final_outcome_detail"])
     end
   end
@@ -83,7 +83,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('consultation_outcome_with_feedback')
 
     assert page.has_text?("Detail of feedback received")
-    within '[aria-labelledby="public-feedback-detail-title"]' do
+    within '.consultation-feedback' do
       assert_has_component_govspeak(@content_item["details"]["public_feedback_detail"])
     end
   end
@@ -91,7 +91,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
   test "consultation outcome documents render" do
     setup_and_visit_content_item('consultation_outcome')
 
-    within '[aria-labelledby="final-outcome-documents-title"]' do
+    within '.consultation-outcome' do
       assert_has_component_govspeak(@content_item["details"]["final_outcome_documents"].join(''))
     end
   end
@@ -100,7 +100,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('consultation_outcome_with_feedback')
 
     assert page.has_text?("Feedback received")
-    within '[aria-labelledby="public-feedback-documents-title"]' do
+    within '.consultation-feedback-documents' do
       assert_has_component_govspeak(@content_item["details"]["public_feedback_documents"].join(''))
     end
   end
@@ -116,7 +116,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
   test "ways to respond renders" do
     setup_and_visit_content_item('open_consultation_with_participation')
 
-    within '[aria-labelledby="ways-to-respond-title"]' do
+    within '.consultation-ways-to-respond' do
       within_component_govspeak do |component_args|
         content = component_args.fetch("content")
         html = Nokogiri::HTML.parse(content)
@@ -131,7 +131,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
   test "ways to respond postal address is formatted with line breaks" do
     setup_and_visit_content_item('open_consultation_with_participation')
 
-    within '[aria-labelledby="ways-to-respond-title"]' do
+    within '.consultation-ways-to-respond' do
       within_component_govspeak do |component_args|
         content = component_args.fetch("content")
         html = Nokogiri::HTML.parse(content)

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -7,16 +7,16 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
 
-    assert_has_component_metadata_pair("first_published", "4 November 2016")
-    assert_has_component_metadata_pair("last_updated", "7 November 2016")
+    within '.app-c-publisher-metadata' do
+      assert page.has_text?("Published 4 November 2016")
+      assert page.has_text?("Last updated 7 November 2016")
+      assert page.has_css?(".app-c-publisher-metadata__term", text: 'From')
+      assert page.has_css?(".app-c-publisher-metadata__definition a[href=\"/government/organisations/department-for-education\"]", text: 'Department for Education')
+    end
 
-    link1 = "<a href=\"/topic/higher-education/administration\">Higher education administration</a>"
-    link2 = "<a href=\"/government/organisations/department-for-education\">Department for Education</a>"
-
-    assert_has_component_metadata_pair("part_of", [link1])
-    assert_has_component_document_footer_pair("part_of", [link1])
-    assert_has_component_metadata_pair("from", [link2])
-    assert_has_component_document_footer_pair("from", [link2])
+    within '.app-c-related-navigation' do
+      assert page.has_css?('.app-c-related-navigation__section-link[href="/topic/higher-education/administration"]', text: 'Higher education administration')
+    end
 
     within '[aria-labelledby="description-title"]' do
       assert_has_component_govspeak(@content_item["details"]["body"])
@@ -108,7 +108,9 @@ class ConsultationTest < ActionDispatch::IntegrationTest
   test "consultation that only applies to a set of nations" do
     setup_and_visit_content_item('consultation_outcome_with_feedback')
 
-    assert_has_component_metadata_pair('Applies to', 'England')
+    within '.app-c-important-metadata' do
+      assert page.has_text?("Applies to: England")
+    end
   end
 
   test "ways to respond renders" do


### PR DESCRIPTION
**Before:**
![screen shot 2018-01-02 at 11 08 04](https://user-images.githubusercontent.com/29889908/34481983-1dfd7e9e-efad-11e7-94e0-bc6f485e4193.png)

**After:**
<img width="508" alt="screen shot 2017-12-22 at 11 40 38" src="https://user-images.githubusercontent.com/29889908/34296916-f8346e6e-e70c-11e7-84c4-9ca4ea615a7e.png">

**Links to Test:**
- [Open Consultation](https://government-frontend-pr-650.herokuapp.com/government/consultations/keeping-children-safe-in-education-proposed-revisions)
- [Closed Consultation](https://government-frontend-pr-650.herokuapp.com/government/consultations/offensive-and-dangerous-weapons-new-legislation)
- [Consultation Outcome](https://government-frontend-pr-650.herokuapp.com/government/consultations/short-inspections-of-good-schools-maintained-schools-and-academies)
- [Consultation with History Notice](https://government-frontend-pr-650.herokuapp.com/government/consultations/science-advisory-council-sac-and-the-advisory-committee-on-releases-to-the-environment-acre-triennial-review-2014)
- [Consultation with Feedback](https://government-frontend-pr-650.herokuapp.com/government/consultations/uk-smi-v-37-chlamydia-trachomatis-infection-testing-by-nucleic-acid-amplification-tests-naat)
- [Consultation with Ways to Respond](https://government-frontend-pr-650.herokuapp.com/government/consultations/review-of-the-smoke-and-carbon-monoxide-alarm-regulations-2015)

Review app component guide:
https://government-frontend-pr-650.herokuapp.com/component-guide
