### PR TITLE
Show withdrawal notice on Service Sign In Pages

### DIFF
--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -1,5 +1,5 @@
 <%= render "components/back-link", href: @content_item.back_link %>
-
+<%= render 'components/notice', @content_item.withdrawal_notice_component %>
 <% if @error %>
   <div class="grid-row">
     <div class="column-two-thirds">


### PR DESCRIPTION
For https://trello.com/c/HewVN7nP/237-create-a-rake-task-to-unpublish-service-sign-in-pages

We add a notice component to the `service_sign_in/choose_sign_in` view so that
when content in this format is withdrawn we display a withdrawal notice.

![screen shot 2018-01-02 at 10 37 37](https://user-images.githubusercontent.com/13434452/34481262-0bc1b690-efa9-11e7-9dbc-953dff491ae2.png)
