### PR TITLE
Remove unused 'metadata' variable

### DIFF
--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -1,5 +1,3 @@
-<% metadata ||= @content_item.publisher_metadata %>
-
 <% render_logo = @content_item.try(:national_statistics?) -%>
 <div class="grid-row">
   <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if render_logo %>">


### PR DESCRIPTION
Remove unused variable in publisher metadata with logo partial.

At the moment, there's no use case for passing in other data to this partial, all uses use the default @content_item.publisher_metadata.

[Example page including partial](https://government-frontend-pr-654.herokuapp.com/government/statistics/primary-school-performance-tables-2017)