### PR TITLE
Render translations correctly on publications tagged to a taxon

### DIFF
--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -8,7 +8,12 @@
        title: @content_item.title,
        average_title_length: "long" %>
   </div>
-  <%= render 'shared/translations' %>
+  <% if @content_item.available_translations.length > 1 %>
+    <div class="column-third">
+      <%= render 'components/translation-nav',
+          translations: @content_item.available_translations %>
+    </div>
+  <% end %>
   <div class="column-two-thirds">
     <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
     <%= render 'components/notice', @content_item.withdrawal_notice_component  %>


### PR DESCRIPTION
Because of the way we use template variants, when we call the shared/translations partial it sometimes renders the shared/translations+taxonomy_navigation variant.

Publications that are tagged to a new taxonomy use this variant to show an alternative breadcrumb, so we can't remove the variant completely for Publications.

The taxonomy_nav version of the translation partial expects to be inlined in content, so doesn’t have a grid class wrapping it. Because of Rails magic loading in this variant the code looks fine, and it only breaks on certain publications which meet the taxonomy nav criteria.

* Don’t use the shared translations template

This duplicates some code which can be DRY’d up when we no longer need
the taxonomy_nav variants.

## Before
![screen shot 2018-01-03 at 17 49 54](https://user-images.githubusercontent.com/319055/34532585-8d27624c-f0ae-11e7-8ed8-e342ff9ae1a1.png)

## After
![screen shot 2018-01-03 at 17 48 46](https://user-images.githubusercontent.com/319055/34532571-790e2f84-f0ae-11e7-9baf-0ab851b24e8d.png)
  