### PR TITLE
Move specialist documents to universal layout

### DIFF
--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -1,27 +1,51 @@
 .app-c-contents-list-with-body__link-container {
   margin: 0 auto;
+  padding: 0;
 
   @include media(tablet) {
-    max-width: 990px;
+    max-width: 1024px;
   }
 
   .app-c-back-to-top {
     margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+.app-c-contents-list-with-body__link-wrapper {
+  padding-bottom: $gutter-one-third;
+
+  .app-c-back-to-top {
+    padding-bottom: $gutter-one-third;
   }
 }
 
 .app-c-contents-list-with-body__link-wrapper.govuk-sticky-element--stuck-to-window {
   background-color: $panel-colour;
+  bottom: -1px; // 'Fix' for anomalous 1px margin which sporadically appears below this element.
   left: 0;
-  padding: $gutter-half;
+  margin: 0;
+  padding: 0;
+  padding-left: $gutter-one-third;
   width: 100%;
   z-index: 1;
 
   @include media(mobile) {
+    padding-left: 0;
     position: fixed;
   }
 
   .app-c-back-to-top {
     margin-bottom: 0;
+    padding: $gutter-two-thirds;
+    width: percentage(2 / 3);
+
+    @include media(mobile) {
+      padding: $gutter-half;
+    }
+
+    @include media(laptop) {
+      padding: $gutter-two-thirds;
+    }
   }
 }

--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -12,11 +12,10 @@
 
 .app-c-contents-list-with-body__link-wrapper.govuk-sticky-element--stuck-to-window {
   background-color: $panel-colour;
-  display: inline;
-  float: left;
   left: 0;
   padding: $gutter-half;
   width: 100%;
+  z-index: 1;
 
   @include media(mobile) {
     position: fixed;

--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -1,0 +1,28 @@
+.app-c-contents-list-with-body__link-container {
+  margin: 0 auto;
+
+  @include media(tablet) {
+    max-width: 990px;
+  }
+
+  .app-c-back-to-top {
+    margin-left: 0;
+  }
+}
+
+.app-c-contents-list-with-body__link-wrapper.govuk-sticky-element--stuck-to-window {
+  background-color: $panel-colour;
+  display: inline;
+  float: left;
+  left: 0;
+  padding: $gutter-half;
+  width: 100%;
+
+  @include media(mobile) {
+    position: fixed;
+  }
+
+  .app-c-back-to-top {
+    margin-bottom: 0;
+  }
+}

--- a/app/views/components/_contents-list-with-body.html.erb
+++ b/app/views/components/_contents-list-with-body.html.erb
@@ -1,0 +1,18 @@
+<% block = yield %>
+<% unless block.empty? %>
+  <%
+    contents ||= []
+    sticky_attr = ' data-module="sticky-element-container"'.html_safe if contents.any?
+  %>
+  <div id="contents" class="app-c-contents-list-with-body"<%= sticky_attr %>>
+    <%= render 'components/contents-list', contents: contents if contents.any? %>
+    <%= block %>
+    <% if contents.any? %>
+      <div data-sticky-element class="app-c-contents-list-with-body__link-wrapper">
+        <div class="app-c-contents-list-with-body__link-container">
+          <%= render 'components/back-to-top', href: "#contents" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/components/_contents-list-with-body.html.erb
+++ b/app/views/components/_contents-list-with-body.html.erb
@@ -5,7 +5,11 @@
     sticky_attr = ' data-module="sticky-element-container"'.html_safe if contents.any?
   %>
   <div id="contents" class="app-c-contents-list-with-body"<%= sticky_attr %>>
-    <%= render 'components/contents-list', contents: contents if contents.any? %>
+    <% if contents.any? %>
+      <div class="responsive-bottom-margin">
+        <%= render 'components/contents-list', contents: contents %>
+      </div>
+    <% end %>
     <%= block %>
     <% if contents.any? %>
       <div data-sticky-element class="app-c-contents-list-with-body__link-wrapper">

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -15,7 +15,7 @@
     <% if link_to_history && history.empty? %>
       &mdash; <a href="#history"><%= t('components.published_dates.see_all_updates') %></a>
     <% elsif history.any? %>
-      <a href="#full-history" data-controls="full-history" data-expanded="false">&#43;&nbsp;<%= t('components.published_dates.full_page_history') %></a>
+      <a href="#full-history" data-controls="full-history" data-expanded="false">+ <%= t('components.published_dates.full_page_history') %></a>
       <div class="app-c-published-dates__change-history js-hidden" id="full-history">
         <ol>
           <% history.each do |change| %>

--- a/app/views/components/docs/contents-list-with-body.yml
+++ b/app/views/components/docs/contents-list-with-body.yml
@@ -2,7 +2,7 @@ name: Contents list with body
 description: Combines contents-list and back-to-top components with block of body markup
 body: |
   Wraps the HTML/ERB block passed with a content list and back to top link.
-  
+
   Expects one argument:
 
   * `contents` - The contents to build a contents list, if this item is empty the contents-list and back-to-top links are excluded but the block passed is still rendered.
@@ -79,7 +79,6 @@ examples:
             <p>Please send written representations about any competition issues to:</p>
             <div class="address"><div class="adr org fn"><p>
 
-            Nick Wright
             <br>Competition and Markets Authority 
             <br>Victoria House 
             <br>Southampton Row 
@@ -87,5 +86,4 @@ examples:
             <br>WC1B 4AD
             <br>
             </p></div></div>
-            <p><a href="mailto:Nick.Wright@cma.gsi.gov.uk">Nick.Wright@cma.gsi.gov.uk</a></p>
           </div>

--- a/app/views/components/docs/contents-list-with-body.yml
+++ b/app/views/components/docs/contents-list-with-body.yml
@@ -1,0 +1,91 @@
+name: Contents list with body
+description: Combines contents-list and back-to-top components with block of body markup
+body: |
+  Wraps the HTML/ERB block passed with a content list and back to top link.
+  
+  Expects one argument:
+
+  * `contents` - The contents to build a contents list, if this item is empty the contents-list and back-to-top links are excluded but the block passed is still rendered.
+
+accessibility_criteria: |
+  The component embeds contents-list and back-to-top components. Please see the relevant accessibility criteria:
+
+  * [back-to-top](/component-guide/back-to-top)
+  * [contents-list](/component-guide/contents-list)
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      contents:
+        - href: "#reference-unless-undertakings-accepted"
+          text: Reference unless undertakings accepted
+        - href: "#notice-of-extension-of-the-preliminary-assessment-period"
+          text: Notice of extension of the preliminary assessment period
+        - href: "#invitation-to-comment-closes-13-november-2017"
+          text: "Invitation to comment: closes 13 November 2017"
+        - href: "#launch-of-merger-inquiry"
+          text: Launch of merger inquiry
+      block: |
+        <div class="govuk-govspeak direction-ltr">
+            <h2 id="statutory-timetable">Statutory timetable</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Phase 1 date</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>3 January 2018</td>
+                  <td>Decision announced</td>
+                </tr>
+                <tr>
+                  <td>30 October to 13 November 2017</td>
+                  <td>Invitation to comment</td>
+                </tr>
+                <tr>
+                  <td>27 October 2017</td>
+                  <td>Launch of merger inquiry</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2 id="phase-1">Phase 1</h2>
+
+            <h3 id="reference-unless-undertakings-accepted">Reference unless undertakings accepted</h3>
+
+            <p>3 January 2018: The CMA has decided, on the information currently available to it, that it is or may be the case that this merger may be expected to result in a substantial lessening of competition within a market or markets in the United Kingdom. This merger will be referred for a phase 2 investigation unless the parties offer acceptable undertakings to address these competition concerns. The full text of the decision will be available shortly.</p>
+            <ul>
+              <li>Press release: <a href="https://www.gov.uk/government/news/shoppers-could-face-higher-prices-due-to-soft-drink-merger">Shoppers could face higher prices due to soft drink merger</a> (3.1.18)</li>
+            </ul>
+            <h3 id="notice-of-extension-of-the-preliminary-assessment-period">Notice of extension of the preliminary assessment period</h3>
+            <ul>
+              <li>
+            <span class="attachment-inline"><a href="https://assets.publishing.service.gov.uk/media/5a311ebfe5274a4936ee7776/refresco-notice-of-termination-of-extension.pdf">Notice of termination of extension (Refresco) </a></span> (13.12.17)</li>
+              <li>
+            <span class="attachment-inline"><a href="https://assets.publishing.service.gov.uk/media/5a26693240f0b659d1fca8d0/refresco-extension-notice.pdf">Notice of extension (Refresco)  </a></span> (5.12.17)</li>
+            </ul>
+            <h3 id="invitation-to-comment-closes-13-november-2017">Invitation to comment: closes 13 November 2017</h3>
+            <p>30 October 2017: The Competition and Markets Authority (CMA) is considering whether it is or may be the case that this transaction, if carried into effect, will result in the creation of a relevant merger situation under the merger provisions of the Enterprise Act 2002 and, if so, whether the creation of that situation may be expected to result in a substantial lessening of competition within any market or markets in the United Kingdom for goods or services.</p>
+            <h3 id="launch-of-merger-inquiry">Launch of merger inquiry</h3>
+            <p>27 October 2017: The CMA announced the launch of its merger inquiry by notice to the parties.</p>
+            <ul>
+              <li>
+            <span class="attachment-inline"><a href="https://assets.publishing.service.gov.uk/media/59f6f28d40f0b66bbc806ed1/notice_of_commencement_of_initial_period.pdf">Commencement of initial period notice</a></span> (30.10.17)</li>
+            </ul>
+            <h3 id="contact">Contact</h3>
+            <p>Please send written representations about any competition issues to:</p>
+            <div class="address"><div class="adr org fn"><p>
+
+            Nick Wright
+            <br>Competition and Markets Authority 
+            <br>Victoria House 
+            <br>Southampton Row 
+            <br>London 
+            <br>WC1B 4AD
+            <br>
+            </p></div></div>
+            <p><a href="mailto:Nick.Wright@cma.gsi.gov.uk">Nick.Wright@cma.gsi.gov.uk</a></p>
+          </div>

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -1,28 +1,45 @@
 <% content_for :simple_header, true %>
 
-<%= render 'shared/title_and_translations', content_item: @content_item %>
-<%= render 'shared/metadata', content_item: @content_item %>
-<%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
-
-<div class="grid-row sidebar-with-body">
-  <% if @content_item.contents.any? %>
-    <div class="column-third">
-      <%= render 'components/contents-list', contents: @content_item.contents %>
-    </div>
-  <% end %>
-  <div class="column-two-thirds <% unless @content_item.contents.any? %>offset-one-third<% end %>">
-    <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
-
-    <% if @content_item.continuation_link %>
-      <%= render(
-          'govuk_component/button',
-          start: true,
-          href: @content_item.continuation_link,
-          text: "Find out more",
-          info_text: @content_item.will_continue_on
-      ) %>
-    <% end %>
+<div class="grid-row">
+  <div class="column-two-thirds responsive-top-margin">
+    <%= render 'govuk_component/title', @content_item.title_and_context %>
+    <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
+  </div>
+  <%= render 'shared/translations' %>
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
   </div>
 </div>
 
-<%= render 'shared/footer', @content_item.document_footer %>
+<%= render 'shared/publisher_metadata_with_logo' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'components/important-metadata',
+        items: @content_item.metadata[:other] %>
+
+    <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
+      <div class="responsive-bottom-margin">
+        <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
+        <% if @content_item.continuation_link %>
+          <%= render(
+              'govuk_component/button',
+              start: true,
+              href: @content_item.continuation_link,
+              text: "Find out more",
+              info_text: @content_item.will_continue_on
+          ) %>
+        <% end %>
+      </div>
+
+      <div class="responsive-bottom-margin">
+        <%= render 'components/published-dates', {
+            published: @content_item.published,
+            last_updated: @content_item.updated,
+            history: @content_item.history
+          } %>
+      </div>
+    <% end %>
+  </div>
+  <%= render "shared/sidebar_navigation" %>
+</div>

--- a/test/components/contents_list_with_body_test.rb
+++ b/test/components/contents_list_with_body_test.rb
@@ -1,0 +1,55 @@
+require 'component_test_helper'
+
+class ContentsListWithBodyTest < ComponentTestCase
+  def component_path
+    "components/contents-list-with-body"
+  end
+
+  def contents_list
+    [
+      { href: '/one', text: "1. One" },
+      { href: '/two', text: "2. Two" }
+    ]
+  end
+
+  def block
+    "<p>Foo</p>".html_safe
+  end
+
+  test "renders nothing without a block" do
+    assert_empty render(component_path, contents: contents_list)
+  end
+
+  test "yields the block without contents data" do
+    assert_includes(render(component_path, {}) { block }, block)
+  end
+
+  test "renders a sticky-element-container" do
+    render(component_path, contents: contents_list) { block }
+
+    assert_select("#contents.app-c-contents-list-with-body")
+    assert_select("#contents[data-module='sticky-element-container']")
+  end
+
+  test "does not apply the sticky-element-container data-module without contents data" do
+    render(component_path, {}) { block }
+
+    assert_select("#contents[data-module='sticky-element-container']", count: 0)
+  end
+
+  test "renders a contents-list component" do
+    render(component_path, contents: contents_list) { block }
+
+    assert_select(".app-c-contents-list-with-body .app-c-contents-list")
+    assert_select ".app-c-contents-list__link[href='/one']", text: "1. One"
+  end
+
+  test "renders a back-to-top component" do
+    render(component_path, contents: contents_list) { block }
+
+    assert_select(%(.app-c-contents-list-with-body
+                    .app-c-contents-list-with-body__link-wrapper
+                    .app-c-contents-list-with-body__link-container
+                    .app-c-back-to-top[href='#contents']))
+  end
+end

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -16,98 +16,104 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
     assert_has_component_govspeak(@content_item["details"]["body"])
   end
 
-  test "renders from in metadata and document footer" do
+  test "renders from in publisher metadata" do
     setup_and_visit_content_item('aaib-reports')
 
-    aaib = "<a href=\"/government/organisations/air-accidents-investigation-branch\">Air Accidents Investigation Branch</a>"
-    assert_has_component_metadata_pair("from", [aaib])
-    assert_has_component_document_footer_pair("from", [aaib])
+    within(".app-c-publisher-metadata__other") do
+      assert page.has_content?("From: Air Accidents Investigation Branch")
+      assert page.has_link?("Air Accidents Investigation Branch",
+                            href: "/government/organisations/air-accidents-investigation-branch")
+    end
   end
 
-  test "renders published and updated in metadata and document footer" do
+  test "renders published and updated in metadata" do
     setup_and_visit_content_item('countryside-stewardship-grants')
 
-    assert_has_component_metadata_pair("first_published", "2 April 2015")
-    assert_has_component_metadata_pair("last_updated", "29 March 2016")
-
-    assert_has_component_document_footer_pair("published", "2 April 2015")
-    assert_has_component_document_footer_pair("updated", "29 March 2016")
+    within(all(".app-c-published-dates").first) do
+      assert page.has_content?("Published 2 April 2015")
+      assert page.has_content?("Last updated 29 March 2016")
+    end
   end
 
   test "renders change history in reverse chronological order" do
     setup_and_visit_content_item('countryside-stewardship-grants')
 
-    within shared_component_selector("document_footer") do
-      component_args = JSON.parse(page.text)
-      history = component_args.fetch("history")
-      assert_equal history.first["note"], @content_item["details"]["change_history"].last["note"]
-      assert_equal history.last["note"], @content_item["details"]["change_history"].first["note"]
-      assert_equal history.size, @content_item["details"]["change_history"].size
+    within(".app-c-published-dates__change-history") do
+      assert_match @content_item["details"]["change_history"].last["note"],
+        page.find(".app-c-published-dates__change-item:first-child").text
+
+      assert_match @content_item["details"]["change_history"].first["note"],
+        page.find(".app-c-published-dates__change-item:last-child").text
+
+      assert_equal all(".app-c-published-dates__change-item").size,
+        @content_item["details"]["change_history"].size
     end
   end
 
   test "renders text facets correctly" do
     setup_and_visit_content_item('countryside-stewardship-grants')
 
-    def test_meta(component)
-      tiers = [
-        "<a href=\"/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=higher-tier\">Higher Tier</a>",
-        "<a href=\"/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=mid-tier\">Mid Tier</a>"
-      ]
 
-      land_use = [
-        "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=arable-land\">Arable land</a>",
-        "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=wildlife-package\">Wildlife package</a>",
-        "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=water-quality\">Water quality</a>",
-        "<a href=\"/countryside-stewardship-grants?land_use%5B%5D=wildlife-package\">Wildlife package</a>"
-      ]
+    within(".app-c-important-metadata") do
+      assert page.all(".app-c-important-metadata__term")[0].has_content?("Grant type")
+      within(all(".app-c-important-metadata__definition")[0]) do
+        assert page.has_link?("Option", href: "/countryside-stewardship-grants?grant_type%5B%5D=option")
+      end
 
-      within shared_component_selector(component) do
-        component_args = JSON.parse(page.text)
-        assert_equal component_args["other"]["Grant type"], "<a href=\"/countryside-stewardship-grants?grant_type%5B%5D=option\">Option</a>"
-        assert_equal component_args["other"]["Tiers or standalone items"], tiers
-        assert_equal component_args["other"]["Land use"], land_use
-        assert_equal component_args["other"]["Funding (per unit per year)"],
-        "<a href=\"/countryside-stewardship-grants?funding_amount%5B%5D=more-than-500\">More than £500</a>"
+      assert page.all(".app-c-important-metadata__term")[1].has_content?("Land use")
+      within(all(".app-c-important-metadata__definition")[1]) do
+        assert page.has_link?("Arable land",
+                              href: "/countryside-stewardship-grants?land_use%5B%5D=arable-land")
+        assert page.has_link?("Wildlife package",
+                              href: "/countryside-stewardship-grants?land_use%5B%5D=wildlife-package")
+        assert page.has_link?("Water quality",
+                              href: "/countryside-stewardship-grants?land_use%5B%5D=water-quality")
+      end
+
+      assert page.all(".app-c-important-metadata__term")[2].has_content?("Tiers or standalone items")
+      within(all(".app-c-important-metadata__definition")[2]) do
+        assert page.has_link?("Higher Tier",
+                              href: "/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=higher-tier")
+        assert page.has_link?("Mid Tier",
+                              href: "/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=mid-tier")
+      end
+
+      assert page.all(".app-c-important-metadata__term")[3].has_content?("Funding (per unit per year)")
+      within(all(".app-c-important-metadata__definition")[3]) do
+        assert page.has_link?("More than £500",
+                              href: "/countryside-stewardship-grants?funding_amount%5B%5D=more-than-500")
       end
     end
-    test_meta("document_footer")
-    test_meta("metadata")
   end
 
   test "renders date facets correctly" do
     setup_and_visit_content_item('drug-device-alerts')
 
-    within shared_component_selector("document_footer") do
-      component_args = JSON.parse(page.text)
-      assert_equal component_args["other_dates"]["Issued"], "6 July 2015"
+    within(all(".app-c-published-dates").last) do
+      assert page.has_content?("Published 6 July 2015")
     end
 
-    within shared_component_selector("metadata") do
-      component_args = JSON.parse(page.text)
-      assert_equal component_args["other"]["Issued"], "6 July 2015"
+    within(".app-c-important-metadata") do
+      assert page.has_css?(".app-c-important-metadata__term", text: "Issued")
+      assert page.has_css?(".app-c-important-metadata__definition", text: "6 July 2015")
     end
   end
 
   test "renders when no facet or finder" do
     setup_and_visit_content_item('business-finance-support-scheme')
-    assert_has_component_metadata_pair("first_published", "9 July 2015")
 
-    within shared_component_selector("document_footer") do
-      component_args = JSON.parse(page.text)
-      assert_equal component_args["other_dates"], {}
-    end
-
-    within shared_component_selector("metadata") do
-      component_args = JSON.parse(page.text)
-      assert_equal component_args["other"], {}
+    within(all(".app-c-published-dates").first) do
+      assert page.has_content?("Published 9 July 2015")
     end
   end
 
   test "renders a nested contents list" do
     setup_and_visit_content_item('aaib-reports')
 
-    assert page.has_css?(".app-c-contents-list")
+    assert page.has_css?("#contents .app-c-contents-list")
+    assert page.has_css?(%(#contents .app-c-contents-list-with-body__link-wrapper
+                          .app-c-contents-list-with-body__link-container a.app-c-back-to-top))
+
     within ".app-c-contents-list" do
       @content_item['details']['headers'].each do |heading|
         assert_nested_content_item(heading)


### PR DESCRIPTION
https://trello.com/c/OvoXIWYp/184-move-specialist-documents-to-universal-design

Moves specialist documents to universal layout. This format contains extensive metadata specific to the various document types and often long content lists.

- Adds a `contents-list-with-body` component which decorates content with a `contents-list` and `back-to-top` link

![screenshot from 2018-01-03 18-36-32](https://user-images.githubusercontent.com/93511/34534216-3c69a610-f0b5-11e7-9faa-04c9ae05d35b.png)

#### Sticky _back-to-top_ contents link:

![screenshot from 2018-01-03 18-50-01](https://user-images.githubusercontent.com/93511/34534668-f41a9926-f0b6-11e7-9c99-b4564bb13a6a.png)


### Examples

#### CMA Case

- https://government-frontend-pr-659.herokuapp.com/cma-cases/euro-car-parts-andrew-page-merger-inquiry

#### AAIB Report

- https://government-frontend-pr-659.herokuapp.com/aaib-reports/aaib-investigation-to-agusta-aw139-g-cipw

#### Business Finance Support

- https://government-frontend-pr-659.herokuapp.com/business-finance-support/business-development-grant-scheme-scarborough-borough

#### Drug Safety Update

- https://government-frontend-pr-659.herokuapp.com/drug-safety-update/paraffin-based-treatments-risk-of-fire-hazard

#### Countryside Stewardship Grants

- https://government-frontend-pr-659.herokuapp.com/countryside-stewardship-grants/creation-of-inter-tidal-and-saline-habitat-on-intensive-grassland-ct7

Review app component guide:
https://government-frontend-pr-659.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-XXX.surge.sh/gallery.html

  
 Component guide for the new `content-list-with-body` component needs this https://github.com/alphagov/govuk_publishing_components/pull/117 to correctly render the component added in this PR.
  