### PR TITLE
Specify all css classes in one attribute

### DIFF
--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -20,7 +20,7 @@
         <ol>
           <% history.each do |change| %>
             <li class="app-c-published-dates__change-item">
-              <time class="app-c-published-dates__change-date" datetime="<%= change[:timestamp] %>" class="timestamp"><%= change[:display_time] %></time>
+              <time class="app-c-published-dates__change-date timestamp" datetime="<%= change[:timestamp] %>"><%= change[:display_time] %></time>
               <%= change[:note] %>
             </li>
           <% end %>


### PR DESCRIPTION
The `time` element in the `published-dates` component specified two class attributes
for two CSS classes, this is causing the E2E tests to return the failure:
`RuntimeError: In backend response: '126:117: ERROR: Attribute class redefined'`

See https://github.com/alphagov/government-frontend/pull/659#issuecomment-355234836 for full context. Thanks @adrianclay for clarifying this.

Also: Linting, where were you? Too busy with whitespace?

Review app component guide:
https://government-frontend-pr-XXX.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-XXX.surge.sh/gallery.html

  