### PR TITLE
Add an explicit dependency for phantomjs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ end
 group :test do
   gem 'capybara'
   gem 'mocha'
+  gem 'phantomjs', '~> 2.1'
   gem 'poltergeist', require: false
   gem 'webmock', '~> 2.3.0', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,6 +334,7 @@ DEPENDENCIES
   jasmine-rails!
   logstasher (= 0.6.1)
   mocha
+  phantomjs (~> 2.1)
   plek (= 1.11)
   poltergeist
   pry-byebug


### PR DESCRIPTION
poltergeist needs phantomjs but doesn't explicitly depend on it. The
reason it works now is because jasmine-rails is loading phantomjs. We
think it's clearer to explicitly call out this dependency as per the
readme of the poltergeist project.

Review app component guide:
https://government-frontend-pr-XXX.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-XXX.surge.sh/gallery.html
