### PR TITLE
Put space between items in important metadata

### DIFF
--- a/app/views/components/_important-metadata.html.erb
+++ b/app/views/components/_important-metadata.html.erb
@@ -2,7 +2,7 @@
   title = local_assigns[:title]
   items = local_assigns[:items] || {}
   items = items.reject { |k,v| v.nil? }
-  items = items.merge(items) { |k,v| Array(v).join(",").html_safe }
+  items = items.merge(items) { |k,v| Array(v).join(", ").html_safe }
   margin_bottom_class = " app-c-important-metadata--bottom-margin" unless local_assigns[:margin_bottom]
 -%>
 <% if items.any? -%>

--- a/app/views/components/docs/important-metadata.yml
+++ b/app/views/components/docs/important-metadata.yml
@@ -20,6 +20,13 @@ examples:
         Date of occurrence: 29 November 2013
         Aircraft category: <a href="https://www.gov.uk/aaib-reports?aircraft_category%5B%5D=general-aviation">General Aviation</a>
         Report type: <a href="https://www.gov.uk/aaib-reports?report-type%5B%5D=%5B%5D=formal-report">Formal Report</a>
+  with_multiple_items_per_thing:
+    data:
+      items:
+        Many things:
+          - First thing
+          - Second thing
+          - Third thing
   with_title:
     description: Used on statistics announcements to display release date changed information, [see example](https://gov.uk/government/statistics/announcements/museums-and-galleries-monthly-visits--8)
     data:


### PR DESCRIPTION
* Include example with multiples

Review app component guide:
https://government-frontend-pr-676.herokuapp.com/component-guide/important-metadata/with_multiple_items_per_thing

## Before
![screen shot 2018-01-09 at 17 39 37](https://user-images.githubusercontent.com/319055/34734584-2625293e-f564-11e7-8d70-573825079c9c.png)

## After
![screen shot 2018-01-09 at 17 39 47](https://user-images.githubusercontent.com/319055/34734585-263fb25e-f564-11e7-9ca3-323772f3d58a.png)
  