### PR TITLE
Remove ERB trim mode chars

### DIFF
--- a/app/views/components/_important-metadata.html.erb
+++ b/app/views/components/_important-metadata.html.erb
@@ -5,16 +5,16 @@
   items = items.merge(items) { |k,v| Array(v).join(", ").html_safe }
   margin_bottom_class = " app-c-important-metadata--bottom-margin" unless local_assigns[:margin_bottom]
 -%>
-<% if items.any? -%>
+<% if items.any? %>
   <div class="app-c-important-metadata<%= margin_bottom_class %>">
     <% if title %>
       <h2 class="app-c-important-metadata__title"><%= title %></h2>
     <% end %>
     <dl data-module="track-click">
-    <% items.each do |title, definition| -%>
+    <% items.each do |title, definition| %>
       <dt class="app-c-important-metadata__term"><%= title %>: </dt>
       <dd class="app-c-important-metadata__definition"><%= definition %></dd>
-    <% end -%>
+    <% end %>
     </dl>
   </div>
-<% end -%>
+<% end %>

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -1,4 +1,4 @@
-<% render_logo = @content_item.try(:national_statistics?) -%>
+<% render_logo = @content_item.try(:national_statistics?) %>
 <div class="grid-row">
   <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if render_logo %>">
     <div class="column-two-thirds metadata-column">

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -2,7 +2,7 @@
   <%= render 'shared/sidebar_tasklist', tasklist_content: tasklist_content, no_margin: true %>
 <% else %>
   <div class="column-third">
-  <% if @navigation.should_present_taxonomy_navigation? -%>
+  <% if @navigation.should_present_taxonomy_navigation? %>
     <%= render partial: 'govuk_component/taxonomy_sidebar', locals: @content_item.taxonomy_sidebar %>
   <% else %>
     <%= render partial: 'components/related-navigation', locals: @content_item.related_navigation %>

--- a/app/views/shared/_travel_advice_summary.html.erb
+++ b/app/views/shared/_travel_advice_summary.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 
 <%= render 'govuk_component/metadata', content_item.metadata %>
-<% if content_item.map -%>
+<% if content_item.map %>
   <figure class="map">
     <img src="<%= content_item.map["url"] %>" alt="<%= content_item.map["alt_text"] %>">
     <% if content_item.map_download_url %>
@@ -19,4 +19,4 @@
       </figcaption>
     <% end %>
   </figure>
-<% end -%>
+<% end %>


### PR DESCRIPTION
I mistakenly (and inconsistently :-1:) added these chars to a few erb files.
[While `erb_trim_mode` removes trailing whitespace](https://apidock.com/rails/v4.2.1/ActionView/Base) it's not necessary and not consistent in this app so I've found and replaced all instances.