### PR TITLE
Update to govuk_schemas-3.1 to fix some deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'govuk_navigation_helpers', '~> 8.2.0'
 
 group :development, :test do
   gem 'govuk-lint'
-  gem 'govuk_schemas'
+  gem 'govuk_schemas', '~> 3.1'
   gem 'jasmine-rails'
   gem 'pry-byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     anemone (0.7.2)
       nokogiri (>= 1.3.0)
       robotex (>= 1.0.0)
@@ -130,8 +131,8 @@ GEM
       rouge
       sass-rails (>= 5.0.4)
       slimmer (>= 11.1.0)
-    govuk_schemas (2.3.0)
-      json-schema (~> 2.5.0)
+    govuk_schemas (3.1.0)
+      json-schema (~> 2.8.0)
     hashdiff (0.3.7)
     highline (1.7.10)
     htmlentities (4.3.4)
@@ -148,8 +149,8 @@ GEM
       railties (>= 3.2.0)
       sprockets-rails
     json (2.1.0)
-    json-schema (2.5.2)
-      addressable (~> 2.3.8)
+    json-schema (2.8.0)
+      addressable (>= 2.4)
     kgio (2.11.1)
     kramdown (1.15.0)
     link_header (0.0.8)
@@ -201,6 +202,7 @@ GEM
     pry-byebug (3.5.1)
       byebug (~> 9.1)
       pry (~> 0.10)
+    public_suffix (3.0.1)
     rack (2.0.3)
     rack-cache (1.7.1)
       rack (>= 0.4)
@@ -355,7 +357,7 @@ DEPENDENCIES
   govuk_frontend_toolkit (= 7.2.0)
   govuk_navigation_helpers (~> 8.2.0)
   govuk_publishing_components (~> 4.1)
-  govuk_schemas
+  govuk_schemas (~> 3.1)
   htmlentities (= 4.3.4)
   jasmine-rails
   mocha

--- a/app/controllers/randomly_generated_content_item_controller.rb
+++ b/app/controllers/randomly_generated_content_item_controller.rb
@@ -2,8 +2,9 @@ class RandomlyGeneratedContentItemController < ContentItemsController
 private
 
   def load_content_item
-    schema = GovukSchemas::Schema.find(frontend_schema: params[:schema].underscore)
-    random_example = GovukSchemas::RandomExample.new(schema: schema).payload
+    random_example = GovukSchemas::RandomExample.for_schema(
+      frontend_schema: params[:schema].underscore,
+    )
 
     # Use provided schema_name rather than a randomly generated one
     random_example['schema_name'] = params[:schema].underscore

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -3,10 +3,7 @@ require 'test_helper'
 module ServiceSignIn
   class ChooseSignInTest < ActionDispatch::IntegrationTest
     test "random but valid items do not error" do
-      schema = GovukSchemas::Schema.find(frontend_schema: schema_type)
-      random_example = GovukSchemas::RandomExample.new(schema: schema)
-
-      payload = random_example.merge_and_validate(document_type: schema_type)
+      payload = GovukSchemas::RandomExample.for_schema(frontend_schema: schema_type)
       path = payload["details"]["choose_sign_in"]["slug"]
 
       stub_request(:get, %r{#{path}})

--- a/test/integration/service_sign_in/create_new_account_test.rb
+++ b/test/integration/service_sign_in/create_new_account_test.rb
@@ -3,19 +3,13 @@ require 'test_helper'
 module ServiceSignIn
   class CreateNewAccount < ActionDispatch::IntegrationTest
     test "random but valid items do not error" do
-      schema = GovukSchemas::Schema.find(frontend_schema: schema_type)
-      random_example = GovukSchemas::RandomExample.new(schema: schema)
-
-
       # Create new account is an optional field, so we need to try a few times to
       # get an example with it present.
-      payload = nil
-      loop do
-        payload = random_example.merge_and_validate(document_type: schema_type)
-        break if payload["details"]["create_new_account"].present?
+      path = nil
+      until path
+        payload = GovukSchemas::RandomExample.for_schema(frontend_schema: schema_type)
+        path = payload.dig("details", "create_new_account", "slug")
       end
-
-      path = payload["details"]["create_new_account"]["slug"]
 
       stub_request(:get, %r{#{path}})
         .to_return(status: 200, body: payload.to_json, headers: {})

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -191,10 +191,7 @@ class ActionDispatch::IntegrationTest
   end
 
   def setup_and_visit_random_content_item(document_type: schema_type)
-    schema = GovukSchemas::Schema.find(frontend_schema: schema_type)
-    random_example = GovukSchemas::RandomExample.new(schema: schema)
-
-    payload = random_example.merge_and_validate(document_type: document_type)
+    payload = GovukSchemas::RandomExample.for_schema(frontend_schema: schema_type)
     path = payload["base_path"]
 
     stub_request(:get, %r{#{path}})


### PR DESCRIPTION
This fixes lots of:
>warning: constant ::Fixnum is deprecated