### PR TITLE
Fix some warnings when running the test suite

### DIFF
--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -49,8 +49,10 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
 
     within '.release-date-changed .app-c-important-metadata' do
       assert page.has_text?("The release date has been changed")
-      assert page.has_text?("Previous date", "19 January 2016 9:30am")
-      assert page.has_text?("Reason for change", @content_item["details"]["latest_change_note"])
+      assert page.has_text?("Previous date")
+      assert page.has_text?("19 January 2016 9:30am")
+      assert page.has_text?("Reason for change")
+      assert page.has_text?(@content_item["details"]["latest_change_note"])
     end
   end
 

--- a/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
+++ b/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
@@ -37,8 +37,13 @@ class ServiceSignInPresenterTest
 
       options.each_with_index do |option, index|
         assert_equal option[:text], @choose_sign_in["options"][index]["text"]
-        assert_equal option[:hint_text], @choose_sign_in["options"][index]["hint_text"]
         assert_equal option[:value], @choose_sign_in["options"][index]["text"].parameterize
+
+        if option[:hint_text]
+          assert_equal option[:hint_text], @choose_sign_in["options"][index]["hint_text"]
+        else
+          assert_nil @choose_sign_in["options"][index]["hint_text"]
+        end
       end
       assert_equal "option", @presented_item.options_id
     end


### PR DESCRIPTION
Fixes:

>DEPRECATED: Use assert_nil if expecting nil from test/presenters/service_sign_in/choose_sign_in_presenter_test.rb:40. This will fail in Minitest 6.

>Unused parameters passed to Capybara::Queries::TextQuery