### PR TITLE
Constrain map image to column width

### DIFF
--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -12,5 +12,9 @@
     @include responsive-bottom-margin;
 
     margin-top: $gutter;
+
+    .map-image {
+      max-width: 100%;
+    }
   }
 }

--- a/app/views/shared/_travel_advice_summary.html.erb
+++ b/app/views/shared/_travel_advice_summary.html.erb
@@ -12,7 +12,7 @@
 <%= render 'govuk_component/metadata', content_item.metadata %>
 <% if content_item.map -%>
   <figure class="map">
-    <img src="<%= content_item.map["url"] %>" alt="<%= content_item.map["alt_text"] %>">
+    <img src="<%= content_item.map["url"] %>" alt="<%= content_item.map["alt_text"] %>" class="map-image">
     <% if content_item.map_download_url %>
       <figcaption>
         <%= render 'components/download-link', href: content_item.map_download_url, link_text: "Download map (PDF)" %>


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/2546303

This was an unintended consequence of [trying to isolate travel advice
figure styling from changes made in the universal layout design](https://github.com/alphagov/government-frontend/commit/4c5c866f8229ed05d01cbfcb30768f9159c25f52).
Updated so that if a large map image is used it should be constrained
to the body column width.

### Example

https://government-frontend-pr-688.herokuapp.com/foreign-travel-advice/tunisia

#### Before

![screenshot from 2018-01-11 12-16-07](https://user-images.githubusercontent.com/93511/34825165-44fdf348-f6c9-11e7-8cf3-f3b877858f55.png)

#### After

![screenshot from 2018-01-11 12-17-09](https://user-images.githubusercontent.com/93511/34825192-626f42ba-f6c9-11e7-93e2-acfb2d1dd02e.png)


Review app component guide:
https://government-frontend-pr-XXX.herokuapp.com/component-guide

Visual regression results:
https://government-frontend-pr-XXX.surge.sh/gallery.html


cc @boffbowsh @fofr 