### PR TITLE
Remove visual regression link from PR template

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE
+++ b/docs/PULL_REQUEST_TEMPLATE
@@ -1,5 +1,4 @@
-Review app component guide:
-https://government-frontend-pr-XXX.herokuapp.com/component-guide
+---
 
-Visual regression results:
-https://government-frontend-pr-XXX.surge.sh/gallery.html
+Component guide for this PR:
+https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide


### PR DESCRIPTION
Visual regression from https://github.com/alphagov/govuk-visual-regression has stopped working because uploading to Surge from Heroku no longer works.

* Remove the misleading links.
* Make it clearer that the link needs a PR number inserting into it

See https://github.com/alphagov/govuk-visual-regression/issues/3
