### PR TITLE
Return to rubygems version of jasmine-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'govuk_navigation_helpers', '~> 8.2.0'
 group :development, :test do
   gem 'govuk-lint'
   gem 'govuk_schemas'
-  gem 'jasmine-rails', github: 'alphagov/jasmine-rails', branch: 'fix-monkey-patch'
+  gem 'jasmine-rails'
   gem 'pry-byebug'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: git://github.com/alphagov/jasmine-rails.git
-  revision: a35b53f89c5f8d2a7862972ed4e83c65fe73cb48
-  branch: fix-monkey-patch
-  specs:
-    jasmine-rails (0.14.2)
-      jasmine-core (>= 1.3, < 3.0)
-      phantomjs (>= 1.9)
-      railties (>= 3.2.0)
-      sprockets-rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -153,6 +142,11 @@ GEM
     image_size (1.5.0)
     io-like (0.3.0)
     jasmine-core (2.8.0)
+    jasmine-rails (0.14.7)
+      jasmine-core (>= 1.3, < 3.0)
+      phantomjs (>= 1.9)
+      railties (>= 3.2.0)
+      sprockets-rails
     json (2.1.0)
     json-schema (2.5.2)
       addressable (~> 2.3.8)
@@ -363,7 +357,7 @@ DEPENDENCIES
   govuk_publishing_components (~> 4.1)
   govuk_schemas
   htmlentities (= 4.3.4)
-  jasmine-rails!
+  jasmine-rails
   mocha
   plek (= 2.0.0)
   poltergeist


### PR DESCRIPTION
We had been [using a monkey-patched version of jasmine-rails](https://github.com/alphagov/government-frontend/pull/447) because of an issue with the
[OfflineAssetPaths monkey-patch](https://github.com/searls/jasmine-rails/issues/213) in the gem itself.

This was fixed in [PR #214](https://github.com/searls/jasmine-rails/pull/214) and released in [v0.14.3](https://github.com/searls/jasmine-rails/blob/832bf7f5f203f09801b395e5c95b5d23df83a3bf/CHANGELOG.md#v0143-2017-09-27) so we should be OK to return to the rubygems version.
