### PR TITLE
Move statistical data sets to univeral layout

### DIFF
--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -1,7 +1,38 @@
-<%= render 'shared/title_and_translations', content_item: @content_item %>
-<%= render 'components/notice', @content_item.withdrawal_notice_component  %>
-<%= render 'shared/metadata', content_item: @content_item %>
-<%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
-<%= render 'shared/sidebar_contents_with_body', content_item: @content_item %>
-<%= render 'shared/footer', @content_item.document_footer %>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+               context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
+               title: @content_item.title,
+               average_title_length: "long" %>
+  </div>
+  <%= render 'shared/translations', content_item: @content_item %>
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
+    <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
+    <%= render 'shared/history_notice', content_item: @content_item %>
+  </div>
+</div>
+
+<%= render 'shared/publisher_metadata_with_logo' %>
+ 
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'components/important-metadata', items: @content_item.metadata[:other] %>
+
+    <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
+    <div class="responsive-bottom-margin">
+      <%= render 'govuk_component/govspeak',
+                 content: @content_item.body,
+                 direction: page_text_direction %>
+    </div>
+    <div class="responsive-bottom-margin">
+      <%= render 'components/published-dates', {
+          published: @content_item.published,
+          last_updated: @content_item.updated,
+          history: @content_item.history
+      } %>
+    </div>
+    <% end %>
+  </div>
+  <%= render "shared/sidebar_navigation" %>
+</div>

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -11,14 +11,36 @@ class StatisticalDataSetTest < ActionDispatch::IntegrationTest
 
   test "renders metadata and document footer" do
     setup_and_visit_content_item('statistical_data_set')
+    assert_has_publisher_metadata(
+      published: "Published 13 December 2012",
+      metadata:
+      {
+        "From:":
+        {
+          text: "Department for Transport",
+          href: "/government/organisations/department-for-transport"
+        }
+      }
+    )
+    assert_footer_has_published_dates("Published 13 December 2012")
+  end
 
-    assert_has_component_metadata_pair("first_published", "13 December 2012")
-    link1 = "<a href=\"/government/organisations/department-for-transport\">Department for Transport</a>"
-    assert_has_component_metadata_pair("from", [link1])
-    assert_has_component_document_footer_pair("from", [link1])
-
-    assert_has_component_metadata_pair("part_of", ["<a href=\"/government/collections/transport-statistics-great-britain\">Transport Statistics Great Britain</a>"])
-    assert_has_component_document_footer_pair("part_of", ["<a href=\"/government/collections/transport-statistics-great-britain\">Transport Statistics Great Britain</a>"])
+  test "render related side bar navigation" do
+    setup_and_visit_content_item('statistical_data_set')
+    assert_has_related_navigation(
+      [
+        {
+          section_name: "related-nav-publishers",
+          section_text: "Published by",
+          links: { "Department for Transport": "/government/organisations/department-for-transport" }
+        },
+        {
+          section_name: "related-nav-collections",
+          section_text: "Collection",
+          links: { "Transport Statistics Great Britain": "/government/collections/transport-statistics-great-britain" }
+        }
+      ]
+    )
   end
 
   test "renders withdrawn notification" do


### PR DESCRIPTION
Trello https://trello.com/c/yreeM1zm/199-move-statistical-data-sets-to-universal-layout

---
Example of new layout:
![screen shot 2018-01-12 at 16 44 32](https://user-images.githubusercontent.com/20514501/34885485-0bab7dc8-f7b8-11e7-9426-d67a30cbf5e5.png)


Component guide for this PR:
https://government-frontend-pr-695.herokuapp.com/component-guide

Example on heroku:
https://government-frontend-pr-695.herokuapp.com/government/statistical-data-sets/tra04-pedal-cycle-traffic