### PR TITLE
Move corporate information page to universal layout

### DIFF
--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -1,36 +1,51 @@
+<% @additional_body = capture do %>
+  <% if @content_item.corporate_information? %>
+    <%= @content_item.corporate_information_heading_tag %>
+    <% @content_item.corporate_information.each do |group| %>
+      <%= group[:heading] %>
+      <ul>
+        <% group[:links].each do |link| %>
+          <li>
+            <%= link %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <% if @content_item.further_information.present? %>
+      <p>
+        <%= @content_item.further_information %>
+      </p>
+    <% end %>
+  <% end %>
+<% end %>
+
 <div class="<%= @content_item.organisation_brand_class %>">
   <div class="grid-row">
-    <div class="column-quarter">
+    <div class="column-two-thirds">
       <%= render 'govuk_component/organisation_logo', @content_item.organisation_logo %>
     </div>
   </div>
-  <%= render 'shared/title_and_translations', content_item: @content_item %>
-  <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
-  <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <%= render 'govuk_component/title',
+         title: @content_item.title,
+         average_title_length: "long" %>
+    </div>
+    <%= render 'shared/translations' %>
+    <div class="column-two-thirds">
+      <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
+      <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
+    </div>
+  </div>
 
-  <% @additional_body = capture do %>
-    <% if @content_item.corporate_information? %>
-      <%= @content_item.corporate_information_heading_tag %>
-      <% @content_item.corporate_information.each do |group| %>
-        <%= group[:heading] %>
-        <ul>
-          <% group[:links].each do |link| %>
-            <li>
-              <%= link %>
-            </li>
-          <% end %>
-        </ul>
+  <div class="grid-row ">
+    <div class="column-two-thirds">
+      <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
+        <div class="responsive-bottom-margin">
+          <%= render 'govuk_component/govspeak', content: "#{@content_item.body}#{@additional_body}" %>
+        </div>
       <% end %>
-
-      <% if @content_item.further_information.present? %>
-        <p>
-          <%= @content_item.further_information %>
-        </p>
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <%= render 'shared/sidebar_contents_with_body',
-        content_item: @content_item,
-        body: "#{@content_item.body}#{@additional_body}" %>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
Trello: https://trello.com/c/ZWoMdsNS/201-move-corporate-information-page-to-universal-layout

#### Example
https://government-frontend-pr-697.herokuapp.com/government/organisations/public-health-england/about/equality-and-diversity

#### Before
![screenshot from 2018-01-15 16-32-23](https://user-images.githubusercontent.com/93511/34952462-b5ff8c50-fa11-11e7-83d7-8ec49f3e4b21.png)


#### After
![screenshot from 2018-01-15 16-30-11](https://user-images.githubusercontent.com/93511/34952379-65ca3de8-fa11-11e7-972c-d49d79082dea.png)

---

Component guide for this PR:
https://government-frontend-pr-697.herokuapp.com/component-guide
