### PR TITLE
Improve published dates component

### DIFF
--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -15,3 +15,8 @@
   display: block;
   @include bold-16;
 }
+
+.app-c-published-dates--history {
+  padding-top: $gutter-one-third;
+  border-top: 1px solid $border-colour;
+}

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -4,9 +4,10 @@
   history = Array(history)
   last_updated ||= false
   link_to_history ||= false
+  history_class = "app-c-published-dates--history" if history.any?
 %>
 <% if published || last_updated %>
-<div class="app-c-published-dates" <% if history.any? %>id="history" data-module="toggle"<% end %>>
+<div class="app-c-published-dates <%= history_class %>" <% if history.any? %>id="history" data-module="toggle"<% end %>>
   <% if published %>
     <%= t('components.published_dates.published', date: published) %>
   <% end %>
@@ -15,7 +16,11 @@
     <% if link_to_history && history.empty? %>
       &mdash; <a href="#history"><%= t('components.published_dates.see_all_updates') %></a>
     <% elsif history.any? %>
-      <a href="#full-history" data-controls="full-history" data-expanded="false">+ <%= t('components.published_dates.full_page_history') %></a>
+      <a href="#full-history"
+      data-controls="full-history"
+      data-expanded="false"
+      data-toggled-text="&#45;&nbsp;<%= t('components.published_dates.hide_all_updates') %>">&#43;&nbsp;<%= t('components.published_dates.show_all_updates')
+       %></a>
       <div class="app-c-published-dates__change-history js-hidden" id="full-history">
         <ol>
           <% history.each do |change| %>

--- a/app/views/components/docs/published-dates.yml
+++ b/app/views/components/docs/published-dates.yml
@@ -26,7 +26,7 @@ examples:
       last_updated: 20th October 2016
       link_to_history: true
   display_page_history:
-    description: This will set up an expandable section on the page to let users toggle the display of the page history.
+    description: This will set up an expandable section on the page, with a top border, to let users toggle the display of the page history.
     data:
       published: 1st January 1990
       last_updated: 20th October 2016

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,8 @@ en:
       topical_events: "Topical event"
       world_locations: "World locations"
     published_dates:
-      full_page_history: "full page history"
+      show_all_updates: "show all updates"
+      hide_all_updates: "hide all updates"
       last_updated: "Last updated %{date}"
       published: "Published %{date}"
       see_all_updates: "see all updates"

--- a/test/components/published_dates_test.rb
+++ b/test/components/published_dates_test.rb
@@ -32,7 +32,7 @@ class PublishedDatesTest < ComponentTestCase
       history: [display_time: "23 August 2013", note: "Updated with new data"]
     )
     assert_select ".app-c-published-dates__change-history#full-history"
-    assert_select ".app-c-published-dates .app-c-published-dates__change-date", text: "23 August 2013"
+    assert_select ".app-c-published-dates--history .app-c-published-dates__change-date", text: "23 August 2013"
   end
 
   test "only adds history id when passed page history" do
@@ -71,8 +71,8 @@ class PublishedDatesTest < ComponentTestCase
       last_updated: "15th July 2015",
       history: [display_time: "23 August 2013", note: "Updated with new data"]
     )
-    assert_select ".app-c-published-dates[data-module=\"toggle\"]"
-    assert_select ".app-c-published-dates a[href=\"#full-history\"][data-controls=\"full-history\"]"
-    assert_select ".app-c-published-dates a[href=\"#full-history\"][data-expanded=\"false\"]"
+    assert_select ".app-c-published-dates--history[data-module=\"toggle\"]"
+    assert_select ".app-c-published-dates--history a[href=\"#full-history\"][data-controls=\"full-history\"]"
+    assert_select ".app-c-published-dates--history a[href=\"#full-history\"][data-expanded=\"false\"]"
   end
 end

--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -56,7 +56,7 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
     within(".content-bottom-margin .app-c-published-dates") do
       assert page.has_content?("Published 27 February 1881")
       assert page.has_content?("Last updated 14 September 2016")
-      assert page.has_link?("full page history", href: "#full-history")
+      assert page.has_link?("show all updates", href: "#full-history")
 
       within(".app-c-published-dates__change-history") do
         within(".app-c-published-dates__change-item:first-child") do


### PR DESCRIPTION
- Add a top border to separate from rest of page
- Reword open/closed states to be more explicit

---

Component guide for this PR:
https://government-frontend-pr-698.herokuapp.com/component-guide


Before:
<img width="493" alt="screen shot 2018-01-16 at 09 32 47" src="https://user-images.githubusercontent.com/31649453/34982976-edc48202-faa3-11e7-81c0-7bf7f91782ac.png">

After:
<img width="656" alt="screen shot 2018-01-16 at 09 35 49" src="https://user-images.githubusercontent.com/31649453/34982982-f5f593f8-faa3-11e7-826a-da9c03938837.png">



