### PR TITLE
Remove wildlife package test

### DIFF
--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -64,8 +64,6 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
       within(all(".app-c-important-metadata__definition")[1]) do
         assert page.has_link?("Arable land",
                               href: "/countryside-stewardship-grants?land_use%5B%5D=arable-land")
-        assert page.has_link?("Wildlife package",
-                              href: "/countryside-stewardship-grants?land_use%5B%5D=wildlife-package")
         assert page.has_link?("Water quality",
                               href: "/countryside-stewardship-grants?land_use%5B%5D=water-quality")
       end


### PR DESCRIPTION
We need to remove this check as we are renaming the field in content schema
and if we leave this value in we are unabel to get a green build.

We will investigate the value of adding this check back in with the update
link text once we have completed the content schema change.

https://trello.com/c/kRYLSnzm/3-countryside-stewardship-grants-rename-an-existing-category