### PR TITLE
Add asset precompile step to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN bundle install
 
 ADD . $APP_HOME
 
+RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
+
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
 
 CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"


### PR DESCRIPTION
The publishing-e2e-tests are being built in production mode now, and as part of
that require the assets to be compiled into the image.