### PR TITLE
Move corporate information page to universal layout

### DIFF
--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -36,6 +36,7 @@
   }
 
   .app-c-back-to-top {
+    color: $link-colour;
     margin-bottom: 0;
     padding: $gutter-half;
     width: percentage(2 / 3);
@@ -44,4 +45,12 @@
       padding: $gutter-two-thirds;
     }
   }
+
+  .app-c-back-to-top:hover {
+    color: $link-hover-colour;
+  }
+
+  .app-c-back-to-top:active {
+    color: $link-active-colour;
+   }
 }

--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -46,6 +46,10 @@
     }
   }
 
+  .app-c-back-to-top:focus {
+    outline: 0;
+  }
+
   .app-c-back-to-top:hover {
     color: $link-hover-colour;
   }

--- a/app/views/components/docs/contents-list-with-body.yml
+++ b/app/views/components/docs/contents-list-with-body.yml
@@ -8,10 +8,11 @@ body: |
   * `contents` - The contents to build a contents list, if this item is empty the contents-list and back-to-top links are excluded but the block passed is still rendered.
 
 accessibility_criteria: |
-  The component embeds contents-list and back-to-top components. Please see the relevant accessibility criteria:
+  - The component must have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA.
+  - The component embeds contents-list and back-to-top components. Please see the relevant accessibility criteria:
 
-  * [back-to-top](/component-guide/back-to-top)
-  * [contents-list](/component-guide/contents-list)
+    * [back-to-top](/component-guide/back-to-top)
+    * [contents-list](/component-guide/contents-list)
 shared_accessibility_criteria:
   - link
 examples:

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -1,36 +1,49 @@
+<% @additional_body = capture do %>
+  <% if @content_item.corporate_information? %>
+    <%= @content_item.corporate_information_heading_tag %>
+    <% @content_item.corporate_information.each do |group| %>
+      <%= group[:heading] %>
+      <ul>
+        <% group[:links].each do |link| %>
+          <li>
+            <%= link %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <% if @content_item.further_information.present? %>
+      <p>
+        <%= @content_item.further_information %>
+      </p>
+    <% end %>
+  <% end %>
+<% end %>
+
 <div class="<%= @content_item.organisation_brand_class %>">
   <div class="grid-row">
-    <div class="column-quarter">
+    <div class="column-two-thirds">
       <%= render 'govuk_component/organisation_logo', @content_item.organisation_logo %>
     </div>
   </div>
-  <%= render 'shared/title_and_translations', content_item: @content_item %>
-  <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
-  <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <%= render 'govuk_component/title', title: @content_item.title %>
+    </div>
+    <%= render 'shared/translations' %>
+    <div class="column-two-thirds">
+      <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
+      <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
+    </div>
+  </div>
 
-  <% @additional_body = capture do %>
-    <% if @content_item.corporate_information? %>
-      <%= @content_item.corporate_information_heading_tag %>
-      <% @content_item.corporate_information.each do |group| %>
-        <%= group[:heading] %>
-        <ul>
-          <% group[:links].each do |link| %>
-            <li>
-              <%= link %>
-            </li>
-          <% end %>
-        </ul>
+  <div class="grid-row ">
+    <div class="column-two-thirds">
+      <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
+        <div class="responsive-bottom-margin">
+          <%= render 'govuk_component/govspeak', content: "#{@content_item.body}#{@additional_body}" %>
+        </div>
       <% end %>
-
-      <% if @content_item.further_information.present? %>
-        <p>
-          <%= @content_item.further_information %>
-        </p>
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <%= render 'shared/sidebar_contents_with_body',
-        content_item: @content_item,
-        body: "#{@content_item.body}#{@additional_body}" %>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
https://trello.com/c/ZWoMdsNS/201-move-corporate-information-page-to-universal-layout

Reworking of https://github.com/alphagov/government-frontend/pull/697 which was merged then reverted.

#### Example

https://government-frontend-pr-703.herokuapp.com/government/organisations/treasury-solicitor-s-department/about/our-energy-use

#### Before

![screenshot from 2018-01-16 15-35-49](https://user-images.githubusercontent.com/93511/34997022-39d2c896-fad3-11e7-94d3-f0bacea9d7e8.png)


#### After

![screenshot from 2018-01-16 15-35-01](https://user-images.githubusercontent.com/93511/34997029-3edbe1e2-fad3-11e7-93f3-2cb1f7091fdd.png)


Addresses 2 problems found with previous PR:

- Title font size
- Content link colour when departmental colours are used.

---

Component guide for this PR:
https://government-frontend-pr-703.herokuapp.com/component-guide
