### PR TITLE
Changed world_locations in locals file back to 'World locations'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,7 @@ en:
       statistical_data_sets: "Statistical data set"
       topics: "Explore the topic"
       topical_events: "Topical event"
-      world_locations: 'Location'
+      world_locations: "World locations"
     published_dates:
       full_page_history: "full page history"
       last_updated: "Last updated %{date}"

--- a/test/components/related_navigation_test.rb
+++ b/test/components/related_navigation_test.rb
@@ -62,7 +62,7 @@ class RelatedNavigationTest < ComponentTestCase
       ]
     )
 
-    assert_select ".app-c-related-navigation__sub-heading", text: 'Location'
+    assert_select ".app-c-related-navigation__sub-heading", text: 'World locations'
     assert_select ".app-c-related-navigation__section-link[href=\"/world/usa/news\"]", text: 'USA'
   end
 


### PR DESCRIPTION
This was a change asked for on a Zen Desk ticket.
They wanted the "Locations" related link to be changed to "World locations" in the navigation side bar.

An example of the change is found here:
https://government-frontend-pr-704.herokuapp.com/government/news/dr-liam-fox-holds-uk-india-talks-as-ukef-boosts-trade-finance-support

Component guide for this PR:
https://government-frontend-pr-704.herokuapp.com/component-guide

Trello ticket:
https://trello.com/c/C9mkFHPT
