### PR TITLE
Fix universal layout component ordering

### DIFF
--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -1,7 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds responsive-top-margin">
     <%= render 'govuk_component/title', @content_item.title_and_context %>
-    <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
   </div>
   <%= render 'shared/translations' %>
   <div class="column-two-thirds">
@@ -10,6 +9,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 
 <div class="grid-row">
   <div class="column-two-thirds content-bottom-margin">

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -19,12 +19,9 @@
           alt: @content_item.image["alt_text"],
           caption: @content_item.image["caption"] if @content_item.image %>
 
-      <%= render 'components/important-metadata',
-          items: @content_item.metadata[:other] %>
-
       <%= render 'govuk_component/govspeak',
-        content: @content_item.body,
-        direction: page_text_direction %>
+          content: @content_item.body,
+          direction: page_text_direction %>
     </div>
 
     <%= render 'components/published-dates', {

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -6,13 +6,8 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo', content_item: @content_item %>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
-    <%= render 'shared/history_notice', content_item: @content_item %>
-  </div>
-</div>
+<%= render 'shared/history_notice', content_item: @content_item %>
+<%= render 'components/notice', @content_item.withdrawal_notice_component %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -3,13 +3,16 @@
     <%= render 'govuk_component/title', @content_item.title_and_context %>
   </div>
   <%= render 'shared/translations' %>
+</div>
+
+<%= render 'shared/publisher_metadata_with_logo', content_item: @content_item %>
+
+<div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
     <%= render 'shared/history_notice', content_item: @content_item %>
   </div>
 </div>
-
-<%= render 'shared/publisher_metadata_with_logo', content_item: @content_item %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -1,7 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>
-    <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
   </div>
   <%= render 'shared/translations' %>
   <div class="column-two-thirds">
@@ -10,6 +9,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 
 <div class="grid-row">
   <div class="column-two-thirds content-bottom-margin">

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -14,15 +14,15 @@
 <div class="grid-row">
   <div class="column-two-thirds content-bottom-margin">
     <div class="responsive-bottom-margin">
+      <%= render 'components/important-metadata',
+          items: @content_item.metadata[:other] %>
       <%= render 'components/figure',
           src: @content_item.image["url"],
           alt: @content_item.image["alt_text"],
           caption: @content_item.image["caption"] if @content_item.image %>
-      <%= render 'components/important-metadata',
-          items: @content_item.metadata[:other] %>
       <%= render 'govuk_component/govspeak',
-        content: @content_item.body,
-        direction: page_text_direction %>
+          content: @content_item.body,
+          direction: page_text_direction %>
     </div>
 
     <%= render 'components/published-dates', {

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -19,13 +19,9 @@
           src: @content_item.image["url"],
           alt: @content_item.image["alt_text"],
           caption: @content_item.image["caption"] if @content_item.image %>
-
-      <%= render 'components/important-metadata',
-          items: @content_item.metadata[:other] %>
-
       <%= render 'govuk_component/govspeak',
-        content: @content_item.body,
-        direction: page_text_direction %>
+          content: @content_item.body,
+          direction: page_text_direction %>
     </div>
 
     <div class="dont-print responsive-bottom-margin">

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -1,7 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>
-    <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
     <%= render 'shared/history_notice', content_item: @content_item %>
   </div>
   <%= render 'shared/translations' %>
@@ -11,6 +10,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 
 <div class="grid-row">
   <div class="column-two-thirds content-bottom-margin">

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -1,7 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>
-    <%= render 'shared/history_notice', content_item: @content_item %>
   </div>
   <%= render 'shared/translations' %>
   <div class="column-two-thirds">
@@ -10,6 +9,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 
 <div class="grid-row">

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -8,12 +8,8 @@
        title: @content_item.title,
        average_title_length: "long" %>
   </div>
-  <% if @content_item.available_translations.length > 1 %>
-    <div class="column-third">
-      <%= render 'components/translation-nav',
-          translations: @content_item.available_translations %>
-    </div>
-  <% end %>
+  <%= render 'shared/translations' %>
+
   <div class="column-two-thirds">
     <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
     <%= render 'components/notice', @content_item.withdrawal_notice_component  %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -12,11 +12,11 @@
 
   <div class="column-two-thirds">
     <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
-    <%= render 'shared/history_notice', content_item: @content_item %>
   </div>
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 
 <div class="grid-row">

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -12,12 +12,12 @@
 
   <div class="column-two-thirds">
     <%= render 'govuk_component/lead_paragraph', text: @content_item.description %>
-    <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
     <%= render 'shared/history_notice', content_item: @content_item %>
   </div>
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 
 <div class="grid-row">
   <div class="column-two-thirds responsive-bottom-margin">

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -3,7 +3,6 @@
 <div class="grid-row">
   <div class="column-two-thirds responsive-top-margin">
     <%= render 'govuk_component/title', @content_item.title_and_context %>
-    <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
   </div>
   <%= render 'shared/translations' %>
   <div class="column-two-thirds">

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -15,17 +15,17 @@
 <div class="grid-row">
   <div class="column-two-thirds content-bottom-margin">
     <div class="responsive-bottom-margin">
+      <%= render 'components/important-metadata',
+      items: @content_item.metadata[:other] %>
+
       <%= render 'components/figure',
           src: @content_item.image["url"],
           alt: @content_item.image["alt_text"],
           caption: @content_item.image["caption"] if @content_item.image %>
 
-      <%= render 'components/important-metadata',
-          items: @content_item.metadata[:other] %>
-
       <%= render 'govuk_component/govspeak',
-        content: @content_item.body,
-        direction: page_text_direction %>
+          content: @content_item.body,
+          direction: page_text_direction %>
     </div>
 
     <%= render 'components/published-dates', {

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -1,7 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>
-    <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
     <%= render 'shared/history_notice', content_item: @content_item %>
   </div>
   <%= render 'shared/translations' %>
@@ -11,6 +10,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 
 <div class="grid-row">
   <div class="column-two-thirds content-bottom-margin">

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -1,7 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>
-    <%= render 'shared/history_notice', content_item: @content_item %>
   </div>
   <%= render 'shared/translations' %>
   <div class="column-two-thirds">
@@ -10,6 +9,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 
 <div class="grid-row">

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -9,28 +9,34 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <% if @content_item.cancelled? %>
-      <%= render 'components/notice', title: 'Statistics release cancelled', description_text: @content_item.cancellation_reason, margin_bottom: true %>
-    <% end %>
-    <% if @content_item.forthcoming_publication? %>
-      <%= render 'components/notice', title: nbsp_between_last_two_words(@content_item.forthcoming_notice_title), margin_bottom: true %>
-    <% end %>
-
-    <%= render "components/important-metadata", items: @content_item.metadata[:other], margin_bottom: @content_item.release_date_changed? %>
+    <%= render "components/important-metadata",
+        items: @content_item.metadata[:other],
+        margin_bottom: true %>
 
     <% if @content_item.release_date_changed? %>
       <div class="release-date-changed">
         <%= render "components/important-metadata",
-          title: "The release date has been changed",
-          items: {
-            "Previous date" => @content_item.previous_release_date,
-            "Reason for change" => @content_item.release_date_change_reason,
-          }
+        title: "The release date has been changed",
+        items: {
+          "Previous date" => @content_item.previous_release_date,
+          "Reason for change" => @content_item.release_date_change_reason,
+        },
+        margin_bottom: true
         %>
       </div>
     <% end %>
-  </div>
 
+    <% if @content_item.cancelled? %>
+      <%= render 'components/notice',
+          title: 'Statistics release cancelled',
+          description_text: @content_item.cancellation_reason %>
+    <% end %>
+
+    <% if @content_item.forthcoming_publication? %>
+      <%= render 'components/notice',
+          title: nbsp_between_last_two_words(@content_item.forthcoming_notice_title) %>
+    <% end %>
+  </div>
   <div class="column-one-third">
     <%= render 'components/related-navigation', @content_item.related_navigation %>
   </div>

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -1,7 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>
-    <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
     <%= render 'shared/history_notice', content_item: @content_item %>
   </div>
   <%= render 'shared/translations' %>
@@ -11,6 +10,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 
 <div class="grid-row">
   <div class="column-two-thirds content-bottom-margin">

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -20,9 +20,6 @@
           alt: @content_item.image["alt_text"],
           caption: @content_item.image["caption"] if @content_item.image %>
 
-      <%= render 'components/important-metadata',
-          items: @content_item.metadata[:other] %>
-
       <%= render 'govuk_component/govspeak',
         content: @content_item.body,
         direction: page_text_direction %>

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -1,7 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>
-    <%= render 'shared/history_notice', content_item: @content_item %>
   </div>
   <%= render 'shared/translations' %>
   <div class="column-two-thirds">
@@ -10,6 +9,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 
 <div class="grid-row">


### PR DESCRIPTION
For https://trello.com/c/LgveTTm5/197-ensure-components-are-consistently-ordered-in-all-formats

- In this PR we review all formats that are now using the universal layout to ensure that the ordering of components is correct.
- There were some common occurrences of components being in the wrong order, so below are some example screenshots of how the ordering has changed.  
- There were also a few occurrences where the important metadata component was present for formats that would never have that data populated, and there was a withdrawal notice present for a format that can't be withdrawn, so they have been removed in this instance.
- Finally there was one instance of translations code being used unnecessarily in a view, which has now been replaced by the shared translations partial.

### Important metadata should appear above an image

*Before*
![fatality_notice_important_metadata_1](https://user-images.githubusercontent.com/13434452/35091900-d009a3d0-fc35-11e7-902e-ca7dc1fea287.png)

*After*
![fatality_notice_important_metadata_2](https://user-images.githubusercontent.com/13434452/35091909-d4c4f5d2-fc35-11e7-8b9c-1a36e437e079.png)

### Withdrawn notices should appear below publisher metadata

*Before*
![fatality_notice_withdrawn_1](https://user-images.githubusercontent.com/13434452/35091968-f2234b60-fc35-11e7-8124-b0c83ec5208e.png)

*After*
![fatality_notice_withdrawn_2](https://user-images.githubusercontent.com/13434452/35091977-f6e9ca5c-fc35-11e7-9e7a-d8acfb29776c.png)

### History notices should appear below publisher metadata

*Before*
![news_article_history_1](https://user-images.githubusercontent.com/13434452/35092020-0d165c78-fc36-11e7-983d-fa8e6ed4f947.png)

*After*
![news_article_history_2](https://user-images.githubusercontent.com/13434452/35092033-152ba09e-fc36-11e7-9c17-facabd374a14.png)

### When a history notice and withdrawal notice are present, the history notice should be above the withdrawal notice

*Before*
![news_article_withdrawn_history_1](https://user-images.githubusercontent.com/13434452/35092140-602fe8f2-fc36-11e7-9102-5a9da77dbea5.png)

*After*
![news_article_withdrawn_history_2](https://user-images.githubusercontent.com/13434452/35092147-64b4c5f0-fc36-11e7-9cdb-9c662f785037.png)

### Statistics notices should appear below important metadata

*Before*
![statistics_announcement_cancelled_1](https://user-images.githubusercontent.com/13434452/35093000-ef7b1ba6-fc38-11e7-972f-4d01f7b87963.png)

*After*
![statistics_announcement_cancelled_2](https://user-images.githubusercontent.com/13434452/35093014-f445cfe6-fc38-11e7-8afd-c67746a5e708.png)

---

Component guide for this PR:
https://government-frontend-pr-707.herokuapp.com/component-guide
