### PR TITLE
Adds test for new specialist doc type

### DIFF
--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -21,6 +21,7 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('international-development-funding')
     setup_and_visit_content_item('maib-reports')
     setup_and_visit_content_item('raib-reports')
+    setup_and_visit_content_item('residential-property-tribunal-decision')
     setup_and_visit_content_item('service-standard-report')
     setup_and_visit_content_item('tax-tribunal-decision')
     setup_and_visit_content_item('utaac-decision')
@@ -28,6 +29,14 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
 
   test "renders title, description and body" do
     setup_and_visit_content_item('aaib-reports')
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+    assert_has_component_govspeak(@content_item["details"]["body"])
+  end
+
+  test "returns example for residential tribunal decision" do
+    setup_and_visit_content_item('residential-property-tribunal-decision')
 
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])


### PR DESCRIPTION
## What this does 
Updates tests on government-frontend to check for a new document type for specialist documents: `residential_property_tribunal_decision`

## Caveat

Depends on: https://github.com/alphagov/govuk-content-schemas/pull/705 being merged and deployed.

For: https://trello.com/c/qzSMAFHZ/6-3-moj-residential-tribunals-finder

---

Component guide for this PR:
https://government-frontend-pr-708.herokuapp.com/component-guide
