### PR TITLE
Fixes and expands tests for specialist doc types

### DIFF
--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class SpecialistDocumentTest < ActionDispatch::IntegrationTest
-  test "random but valid items do not error" do
+  test "random but valid specialist documents do not error" do
     setup_and_visit_random_content_item(document_type: 'aaib_report')
     setup_and_visit_random_content_item(document_type: 'raib_report')
     setup_and_visit_random_content_item(document_type: 'tax_tribunal_decision')

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -8,6 +8,24 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
     setup_and_visit_random_content_item(document_type: 'cma_case')
   end
 
+  test "specialist document subtypes do not error" do
+    setup_and_visit_content_item('aaib-reports')
+    setup_and_visit_content_item('asylum-support-decision')
+    setup_and_visit_content_item('business-finance-support-scheme')
+    setup_and_visit_content_item('cma-cases')
+    setup_and_visit_content_item('countryside-stewardship-grants')
+    setup_and_visit_content_item('drug-safety-update')
+    setup_and_visit_content_item('employment-appeal-tribunal-decision')
+    setup_and_visit_content_item('employment-tribunal-decision')
+    setup_and_visit_content_item('european-structural-investment-funds')
+    setup_and_visit_content_item('international-development-funding')
+    setup_and_visit_content_item('maib-reports')
+    setup_and_visit_content_item('raib-reports')
+    setup_and_visit_content_item('service-standard-report')
+    setup_and_visit_content_item('tax-tribunal-decision')
+    setup_and_visit_content_item('utaac-decision')
+  end
+
   test "renders title, description and body" do
     setup_and_visit_content_item('aaib-reports')
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -220,13 +220,15 @@ class ActionDispatch::IntegrationTest
     end
   end
 
-  def setup_and_visit_random_content_item(document_type: schema_type)
-    payload = GovukSchemas::RandomExample.for_schema(frontend_schema: schema_type)
-    path = payload["base_path"]
+  def setup_and_visit_random_content_item(document_type: nil)
+    content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: schema_type) do |payload|
+      payload.merge('document_type' => document_type) unless document_type.nil?
+      payload
+    end
+    path = content_item["base_path"]
 
     stub_request(:get, %r{#{path}})
-      .to_return(status: 200, body: payload.to_json, headers: {})
-
+      .to_return(status: 200, body: content_item.to_json, headers: {})
     visit path
   end
 


### PR DESCRIPTION
For: https://trello.com/c/qzSMAFHZ/6-3-moj-residential-tribunals-finder

As a consequence of adding a test for a new doc type: `residential-property-tribunal-decision`, we discovered that the tests were not doing what was expected (generate a random example of a certain document type).
This has been fixed in this PR.

We've also added more tests to include all of the specialist doc types available.

---

Component guide for this PR:
https://government-frontend-pr-712.herokuapp.com/component-guide
