### PR TITLE
Move Travel Advice to universal layout

### DIFF
--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -1,8 +1,4 @@
-// FIXME the parts-ul mixin has been copied from the parts mixin to support _guide.scss
-// with different spacing in universal layout. When travel advice also has universal
-// layout they can be collapsed back into one.
-
-@mixin parts-ul {
+@mixin parts {
   .part-navigation-container {
     margin-top: $gutter;
     margin-bottom: $gutter;
@@ -43,47 +39,6 @@
     @include media(tablet) {
       margin-bottom: $gutter-two-thirds;
       margin-top: $gutter-two-thirds;
-    }
-  }
-}
-
-@mixin parts {
-  .part-navigation-container {
-    margin-top: $gutter;
-    margin-bottom: $gutter;
-
-    @include media(tablet) {
-      margin-top: 0;
-      margin-bottom: $gutter * 1.5;
-    }
-
-    border-bottom: 1px solid $grey-2;
-  }
-
-  .part-navigation {
-    margin-bottom: $gutter / 2;
-    @include core-19;
-
-    @include media(tablet) {
-      @include core-16;
-    }
-
-    li {
-      list-style: none;
-      margin-bottom: 0.75em;
-
-      a {
-        display: block;
-      }
-    }
-  }
-
-  .part-title {
-    @include bold-27;
-    margin-bottom: $gutter-half;
-
-    @include media(tablet) {
-      margin-bottom: $gutter-two-thirds;
     }
   }
 }

--- a/app/assets/stylesheets/views/_guide.scss
+++ b/app/assets/stylesheets/views/_guide.scss
@@ -1,5 +1,5 @@
 .guide {
-  @include parts-ul;
+  @include parts;
   @include add-title-margin;
 
   .part-navigation li {
@@ -19,14 +19,6 @@
   .govuk-govspeak {
     h2 {
       @include bold-24;
-    }
-  }
-
-  .task-list-sidebar {
-    margin-top: 0;
-
-    @include media(tablet) {
-      margin-top: 0;
     }
   }
 }

--- a/app/assets/stylesheets/views/_guide.scss
+++ b/app/assets/stylesheets/views/_guide.scss
@@ -21,4 +21,12 @@
       @include bold-24;
     }
   }
+
+  .task-list-sidebar {
+    margin-top: 0;
+
+    @include media(tablet) {
+      margin-top: 0;
+    }
+  }
 }

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -11,7 +11,11 @@
       <%= render 'shared/parts_navigation', content_item: @content_item, navigation_label: 'Travel advice pages' %>
       <%= render 'components/subscription-links', email_signup_link: @content_item.email_signup_link, feed_link: @content_item.feed_link %>
     </aside>
+  </div>
+</div>
 
+<div class="grid-row">
+  <div class="column-two-thirds">
     <h1 class="part-title">
       <%= @content_item.current_part_title %>
     </h1>
@@ -28,7 +32,5 @@
 
     <%= render 'components/print-link', href: @content_item.print_link, link_text: t("multi_page.print_entire_guide") %>
   </div>
-  <div class="column-one-third add-title-margin">
-    <%= render 'govuk_component/related_items', @content_item.related_items %>
-  </div>
+  <%= render "shared/sidebar_navigation" %>
 </div>


### PR DESCRIPTION
**Note:** We are awaiting departmental approval before this can be merged.

For https://trello.com/c/BluLBeZJ/150-move-travel-advice-format-to-universal-design

In this PR we move Travel Advice pages to use the universal layout.

Travel Advice pages have parts, which are also use by guides.  While moving guides to use the universal layout a temporary `parts-ul` mixin was created (see https://github.com/alphagov/government-frontend/pull/713) to correctly align the sidebar navigation with the top of the content body for guides, and prevent Travel Advice pages from having this change implemented before they were moved to use the new layout.  We now use this mixin temporarily for Travel Advice pages until we are able to coordinate deploys, as this format also needs to change the alignment of the sidebar navigation.  We then intend to remove the current `parts` mixin and rename `parts-ul` to `parts`.

**Examples**

- Foreign travel advice with new sidebar content: https://government-frontend-pr-714.herokuapp.com/foreign-travel-advice/spain
- Foreign travel advice with old sidebar content: https://government-frontend-pr-714.herokuapp.com/foreign-travel-advice/brunei

**Previous layout**
![travel_advice_original](https://user-images.githubusercontent.com/13434452/35161239-7e7e5382-fd37-11e7-871f-fe6def31a26a.png)


**Universal layout**
![travel_advice_new](https://user-images.githubusercontent.com/13434452/35161246-821b9a86-fd37-11e7-9235-53ceab3e3db2.png)

---

Component guide for this PR:
https://government-frontend-pr-714.herokuapp.com/component-guide
