### PR TITLE
[Do not merge] Move html publications to universal layout

### DIFF
--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -55,6 +55,17 @@ class HtmlPublicationPresenter < ContentItemPresenter
     request.base_url + request.path
   end
 
+  def related_navigation
+    nav = super
+    raw_links = content_item["links"]
+    parent_publication = raw_links.fetch("parent", []).first
+    nav[:related_items].unshift(
+      path: parent_publication["base_path"],
+      text: parent_publication["title"]
+    ) if parent_publication
+    nav
+  end
+
 private
 
   def public_timestamp

--- a/app/views/components/_contents-list-with-body.html.erb
+++ b/app/views/components/_contents-list-with-body.html.erb
@@ -2,12 +2,13 @@
 <% unless block.empty? %>
   <%
     contents ||= []
+    format_numbers ||= false
     sticky_attr = ' data-module="sticky-element-container"'.html_safe if contents.any?
   %>
   <div id="contents" class="app-c-contents-list-with-body"<%= sticky_attr %>>
     <% if contents.any? %>
       <div class="responsive-bottom-margin">
-        <%= render 'components/contents-list', contents: contents %>
+        <%= render 'components/contents-list', contents: contents, format_numbers: format_numbers %>
       </div>
     <% end %>
     <%= block %>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -12,32 +12,27 @@
   </ol>
 </div>
 
-<%= render 'components/publication-header', title: @content_item.title, context: I18n.t("content_item.schema_name.#{@content_item.format_sub_type}", count: 1), last_changed: @content_item.last_changed %>
+<%= render 'components/publication-header',
+    title: @content_item.title,
+    context: I18n.t("content_item.schema_name.#{@content_item.format_sub_type}", count: 1),
+    last_changed: @content_item.last_changed %>
 
 <%= render 'components/notice', @content_item.withdrawal_notice_component  %>
 
-<div
-  class="grid-row sidebar-with-body"
-  data-module="sticky-element-container"
-  id="contents"
->
-  <% if @content_item.contents.any? %>
-    <div class="column-quarter-desktop-only">
-      <%= render 'components/contents-list', contents: @content_item.contents, format_numbers: true %>
-    </div>
-  <% end %>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'components/contents-list-with-body',
+        contents: @content_item.contents,
+        format_numbers: true do %>
 
-  <div class="print-wrapper">
-    <div class="print-meta-data">
-      <%= render partial: "content_items/html_publication/print_meta_data" %>
-    </div>
-  </div>
+      <div class="print-wrapper">
+        <div class="print-meta-data">
+          <%= render partial: "content_items/html_publication/print_meta_data" %>
+        </div>
+      </div>
 
-  <div class="column-three-quarters-desktop-only <% unless @content_item.contents.any? %>offset-quarter-desktop-only<% end %>">
-    <%= render 'govuk_component/govspeak_html_publication', @content_item.govspeak_body %>
+      <%= render 'govuk_component/govspeak_html_publication', @content_item.govspeak_body %>
+    <% end %>
   </div>
-
-  <div data-sticky-element class="govuk-sticky-element">
-    <%= render 'components/back-to-top', href: "#contents" %>
-  </div>
+  <%= render 'shared/sidebar_navigation' %>
 </div>

--- a/test/components/contents_list_with_body_test.rb
+++ b/test/components/contents_list_with_body_test.rb
@@ -52,4 +52,10 @@ class ContentsListWithBodyTest < ComponentTestCase
                     .app-c-contents-list-with-body__link-container
                     .app-c-back-to-top[href='#contents']))
   end
+
+  test "passes 'format_numbers' param to contents-list component" do
+    render(component_path, contents: contents_list, format_numbers: true) { block }
+
+    assert_select(".app-c-contents-list__list-item--numbered a[href='/one']")
+  end
 end

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -15,7 +15,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       assert page.has_text?("Published 17 January 2016")
     end
 
-    within ".sidebar-with-body" do
+    within ".app-c-contents-list-with-body" do
       assert page.has_text?("Contents")
       assert page.has_css?('.app-c-contents-list')
     end

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -65,4 +65,12 @@ class HtmlPublicationPresenterTest < PresenterTestCase
     assert presented.organisations.count > 1
     refute presented.organisation_logo(organisation)[:organisation][:image]
   end
+
+  test 'prepends the parent publication to related items' do
+    presented = presented_item("published")
+    parent_publication_link = presented.content_item["links"]["parent"].first
+    parent_publication = presented.related_navigation[:related_items].first
+    assert_equal parent_publication_link["base_path"], parent_publication[:path]
+    assert_equal parent_publication_link["title"], parent_publication[:text]
+  end
 end


### PR DESCRIPTION
https://trello.com/c/yXZeP5nC/202-move-html-publications-to-universal-layout

Move HTML Publications to universal navigation.

### Example

https://government-frontend-pr-715.herokuapp.com/government/publications/uk-breeds-at-risk-from-exotic-animal-disease-outbreaks/uk-breeds-at-risk-list-bar

#### Before

![screenshot from 2018-01-19 16-40-13](https://user-images.githubusercontent.com/93511/35161218-753eaff6-fd37-11e7-92b9-d1ed463eef7a.png)

#### After

![screenshot from 2018-01-19 16-39-43](https://user-images.githubusercontent.com/93511/35161238-7dfe42d2-fd37-11e7-9aca-0d4111f59b24.png)

---

Component guide for this PR:
https://government-frontend-pr-715.herokuapp.com/component-guide
