### PR TITLE
Update test helpers

### DIFF
--- a/test/integration/case_study_test.rb
+++ b/test/integration/case_study_test.rb
@@ -30,9 +30,10 @@ class CaseStudyTest < ActionDispatch::IntegrationTest
   test "world location link" do
     setup_and_visit_content_item('translated')
 
-    within(".app-c-related-navigation__nav-section[aria-labelledby='related-nav-world_locations']") do
-      assert page.has_css?(".app-c-related-navigation__section-link", text: "Spain")
-      assert page.has_link?("Spain", href: "/world/spain/news")
-    end
+    assert_has_related_navigation(
+      section_name: "related-nav-world_locations",
+      section_text: "World locations",
+      links: { "Spain": "/world/spain/news" }
+    )
   end
 end

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -7,16 +7,22 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
 
-    within '.app-c-publisher-metadata' do
-      assert page.has_text?("Published 4 November 2016")
-      assert page.has_text?("Last updated 7 November 2016")
-      assert page.has_css?(".app-c-publisher-metadata__term", text: 'From')
-      assert page.has_css?(".app-c-publisher-metadata__definition a[href=\"/government/organisations/department-for-education\"]", text: 'Department for Education')
-    end
+    assert_has_publisher_metadata(
+      published: "Published 4 November 2016",
+      last_updated: "Last updated 7 November 2016",
+      metadata:  {
+        "From": { "Department for Education": "/government/organisations/department-for-education" }
+      }
+    )
 
-    within '.app-c-related-navigation' do
-      assert page.has_css?('.app-c-related-navigation__section-link[href="/topic/higher-education/administration"]', text: 'Higher education administration')
-    end
+    assert_footer_has_published_dates("Published 4 November 2016", "Last updated 7 November 2016")
+    assert_has_related_navigation([
+      {
+        section_name: "related-nav-topics",
+        section_text: "Explore the topic",
+        links: { "Higher education administration": "/topic/higher-education/administration" }
+      }
+    ])
 
     within '.consultation-description' do
       assert_has_component_govspeak(@content_item["details"]["body"])
@@ -108,9 +114,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
   test "consultation that only applies to a set of nations" do
     setup_and_visit_content_item('consultation_outcome_with_feedback')
 
-    within '.app-c-important-metadata' do
-      assert page.has_text?("Applies to: England")
-    end
+    assert_has_important_metadata("Applies to": "England")
   end
 
   test "ways to respond renders" do

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -15,8 +15,7 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
       {
         "From:":
           {
-            text: "Driver and Vehicle Standards Agency",
-            href: "/government/organisations/driver-and-vehicle-standards-agency"
+            "Driver and Vehicle Standards Agency": "/government/organisations/driver-and-vehicle-standards-agency"
           }
       }
     )
@@ -35,7 +34,9 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
         {
           section_name: "related-nav-publishers",
           section_text: "Published by",
-          links: { "Driver and Vehicle Standards Agency": "/government/organisations/driver-and-vehicle-standards-agency" }
+          links: {
+            "Driver and Vehicle Standards Agency": "/government/organisations/driver-and-vehicle-standards-agency"
+          }
         }
       ]
     )

--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -20,25 +20,18 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
 
     refute page.has_css?(".app-c-notice")
 
-    within(".app-c-publisher-metadata") do
-      within(".app-c-published-dates") do
-        assert page.has_content?("Published 27 February 1881")
-        assert page.has_content?("Last updated 14 September 2016")
-        assert page.has_link?("see all updates", href: "#history")
-      end
+    assert_has_publisher_metadata(
+      published: "Published 27 February 1881",
+      last_updated: "Last updated 14 September 2016",
+      history_link: true,
+      metadata: {
+        "From": { "Ministry of Defence": "/government/organisations/ministry-of-defence" }
+      }
+    )
 
-      within(".app-c-publisher-metadata__other") do
-        assert page.has_content?("From: Ministry of Defence")
-        assert page.has_link?("Ministry of Defence",
-                              href: "/government/organisations/ministry-of-defence")
-      end
-    end
-
-    within(".app-c-important-metadata") do
-      assert page.has_content?("Field of operation: Zululand")
-      assert page.has_link?("Zululand",
-                            href: "/government/fields-of-operation/zululand")
-    end
+    assert_has_important_metadata(
+      "Field of operation": { "Zululand": "/government/fields-of-operation/zululand" }
+    )
 
     assert_component_parameter(
       "lead_paragraph",
@@ -72,14 +65,12 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
 
   test "fatality notice with minister" do
     setup_and_visit_content_item('fatality_notice_with_minister')
-
-    within(".app-c-publisher-metadata .app-c-publisher-metadata__other") do
-      assert page.has_content?("From: Ministry of Defence and The Rt Hon Sir Eric Pickles MP")
-      assert page.has_link?("Ministry of Defence",
-                            href: "/government/organisations/ministry-of-defence")
-      assert page.has_link?("The Rt Hon Sir Eric Pickles MP",
-                            href: "/government/people/eric-pickles")
-    end
+    assert_has_publisher_metadata_other(
+      "From": {
+        "Ministry of Defence": "/government/organisations/ministry-of-defence",
+        "The Rt Hon Sir Eric Pickles MP": "/government/people/eric-pickles",
+      }
+    )
   end
 
   test "fatality notice with withdrawn notice" do

--- a/test/integration/news_article_test.rb
+++ b/test/integration/news_article_test.rb
@@ -12,31 +12,28 @@ class NewsArticleTest < ActionDispatch::IntegrationTest
   test "renders first published and from in metadata and document footer" do
     setup_and_visit_content_item("news_article")
 
-    within(".app-c-publisher-metadata") do
-      within(".app-c-published-dates") do
-        assert page.has_content?("Published 25 December 2016")
-      end
+    assert_has_publisher_metadata(
+      published: "Published 25 December 2016",
+      metadata: {
+        "From": {
+          "Prime Minister's Office, 10 Downing Street":
+            "/government/organisations/prime-ministers-office-10-downing-street"
+        }
+      }
+    )
 
-      within(".app-c-publisher-metadata__other") do
-        assert page.has_content?("From: Prime Minister's Office, 10 Downing Street")
-        assert page.has_link?("Prime Minister's Office, 10 Downing Street",
-                              href: "/government/organisations/prime-ministers-office-10-downing-street")
-      end
-    end
-
-    within(".content-bottom-margin .app-c-published-dates") do
-      assert page.has_content?("Published 25 December 2016")
-    end
+    assert_footer_has_published_dates("Published 25 December 2016")
   end
 
 
   test "renders policy links" do
     setup_and_visit_content_item('news_article_government_response')
 
-    within(".app-c-related-navigation__nav-section[aria-labelledby='related-nav-policies']") do
-      assert page.has_css?(".app-c-related-navigation__section-link", text: "Marine environment")
-      assert page.has_link?("Marine environment", href: "/government/policies/marine-environment")
-    end
+    assert_has_related_navigation(
+      section_name: "related-nav-policies",
+      section_text: "Policy",
+      links: { "Marine environment": "/government/policies/marine-environment" }
+    )
   end
 
   test "renders translation links when there is more than one translation" do

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -19,18 +19,17 @@ class PublicationTest < ActionDispatch::IntegrationTest
   test "renders metadata and document footer" do
     setup_and_visit_content_item('publication')
 
-    within(".app-c-publisher-metadata") do
-      assert page.has_css?(".app-c-published-dates", text: "Published 3 May 2016")
+    assert_has_publisher_metadata(
+      published: "Published 3 May 2016",
+      metadata: {
+        "From": {
+          "Environment Agency": "/government/organisations/environment-agency",
+          "The Rt Hon Sir Eric Pickles MP": "/government/people/eric-pickles",
+        }
+      }
+    )
 
-      within(".app-c-publisher-metadata__other") do
-        assert page.has_link?("Environment Agency", href: "/government/organisations/environment-agency")
-        assert page.has_link?("The Rt Hon Sir Eric Pickles MP", href: "/government/people/eric-pickles")
-      end
-    end
-
-    within(".responsive-bottom-margin .app-c-published-dates") do
-      assert page.has_content?("Published 3 May 2016")
-    end
+    assert_footer_has_published_dates("Published 3 May 2016")
   end
 
   test "renders a govspeak block for attachments" do
@@ -67,12 +66,15 @@ class PublicationTest < ActionDispatch::IntegrationTest
   test "renders 'Applies to' block in important metadata when there are excluded nations" do
     setup_and_visit_content_item('statistics_publication')
 
-    within(".app-c-important-metadata") do
-      assert page.has_content?("Applies to: England (see publications for Northern Ireland, Scotland, and Wales)")
-      assert page.has_link?("Northern Ireland", href: "http://www.dsdni.gov.uk/index/stats_and_research/stats-publications/stats-housing-publications/housing_stats.htm")
-      assert page.has_link?("Scotland", href: "http://www.scotland.gov.uk/Topics/Statistics/Browse/Housing-Regeneration/HSfS")
-      assert page.has_link?("Wales", href: "http://wales.gov.uk/topics/statistics/headlines/housing2012/121025/?lang=en")
-    end
+    assert_has_important_metadata(
+      "Applies to": {
+        "England (see publications for Northern Ireland, Scotland, and Wales)": nil,
+        "Northern Ireland":
+          "http://www.dsdni.gov.uk/index/stats_and_research/stats-publications/stats-housing-publications/housing_stats.htm",
+        "Scotland": "http://www.scotland.gov.uk/Topics/Statistics/Browse/Housing-Regeneration/HSfS",
+        "Wales": "http://wales.gov.uk/topics/statistics/headlines/housing2012/121025/?lang=en",
+      }
+    )
   end
 
   test "doesn't render government navigation for pages with taxonomy navigation" do

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -19,20 +19,18 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
   test "renders from in publisher metadata" do
     setup_and_visit_content_item('aaib-reports')
 
-    within(".app-c-publisher-metadata__other") do
-      assert page.has_content?("From: Air Accidents Investigation Branch")
-      assert page.has_link?("Air Accidents Investigation Branch",
-                            href: "/government/organisations/air-accidents-investigation-branch")
-    end
+    assert_has_publisher_metadata_other(
+      "From": {
+        "Air Accidents Investigation Branch":
+          "/government/organisations/air-accidents-investigation-branch"
+      }
+    )
   end
 
   test "renders published and updated in metadata" do
     setup_and_visit_content_item('countryside-stewardship-grants')
 
-    within(all(".app-c-published-dates").first) do
-      assert page.has_content?("Published 2 April 2015")
-      assert page.has_content?("Last updated 29 March 2016")
-    end
+    assert_has_published_dates("Published 2 April 2015", "Last updated 29 March 2016")
   end
 
   test "renders change history in reverse chronological order" do
@@ -53,56 +51,33 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
   test "renders text facets correctly" do
     setup_and_visit_content_item('countryside-stewardship-grants')
 
-
-    within(".app-c-important-metadata") do
-      assert page.all(".app-c-important-metadata__term")[0].has_content?("Grant type")
-      within(all(".app-c-important-metadata__definition")[0]) do
-        assert page.has_link?("Option", href: "/countryside-stewardship-grants?grant_type%5B%5D=option")
-      end
-
-      assert page.all(".app-c-important-metadata__term")[1].has_content?("Land use")
-      within(all(".app-c-important-metadata__definition")[1]) do
-        assert page.has_link?("Arable land",
-                              href: "/countryside-stewardship-grants?land_use%5B%5D=arable-land")
-        assert page.has_link?("Water quality",
-                              href: "/countryside-stewardship-grants?land_use%5B%5D=water-quality")
-      end
-
-      assert page.all(".app-c-important-metadata__term")[2].has_content?("Tiers or standalone items")
-      within(all(".app-c-important-metadata__definition")[2]) do
-        assert page.has_link?("Higher Tier",
-                              href: "/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=higher-tier")
-        assert page.has_link?("Mid Tier",
-                              href: "/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=mid-tier")
-      end
-
-      assert page.all(".app-c-important-metadata__term")[3].has_content?("Funding (per unit per year)")
-      within(all(".app-c-important-metadata__definition")[3]) do
-        assert page.has_link?("More than £500",
-                              href: "/countryside-stewardship-grants?funding_amount%5B%5D=more-than-500")
-      end
-    end
+    assert_has_important_metadata(
+      "Grant type": { "Option": "/countryside-stewardship-grants?grant_type%5B%5D=option" },
+      "Land use": {
+        "Arable land": "/countryside-stewardship-grants?land_use%5B%5D=arable-land",
+        "Water quality": "/countryside-stewardship-grants?land_use%5B%5D=water-quality",
+      },
+      "Tiers or standalone items": {
+        "Higher Tier": "/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=higher-tier",
+        "Mid Tier": "/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=mid-tier",
+      },
+      "Funding (per unit per year)": {
+        "More than £500": "/countryside-stewardship-grants?funding_amount%5B%5D=more-than-500"
+      }
+    )
   end
 
   test "renders date facets correctly" do
     setup_and_visit_content_item('drug-device-alerts')
 
-    within(all(".app-c-published-dates").last) do
-      assert page.has_content?("Published 6 July 2015")
-    end
-
-    within(".app-c-important-metadata") do
-      assert page.has_css?(".app-c-important-metadata__term", text: "Issued")
-      assert page.has_css?(".app-c-important-metadata__definition", text: "6 July 2015")
-    end
+    assert_has_important_metadata("Issued": "6 July 2015")
+    assert_footer_has_published_dates("Published 6 July 2015")
   end
 
   test "renders when no facet or finder" do
     setup_and_visit_content_item('business-finance-support-scheme')
 
-    within(all(".app-c-published-dates").first) do
-      assert page.has_content?("Published 9 July 2015")
-    end
+    assert_has_published_dates("Published 9 July 2015")
   end
 
   test "renders a nested contents list" do

--- a/test/integration/speech_test.rb
+++ b/test/integration/speech_test.rb
@@ -20,38 +20,39 @@ class SpeechTest < ActionDispatch::IntegrationTest
   test "renders metadata and document footer, including speaker" do
     setup_and_visit_content_item('speech')
 
-    within(".app-c-publisher-metadata") do
-      within(".app-c-published-dates") do
-        assert page.has_content?("Published 8 March 2016")
-      end
+    assert_has_publisher_metadata(
+      published: "Published 8 March 2016",
+      metadata: {
+        "From": {
+          "Department of Energy & Climate Change and The Rt Hon Andrea Leadsom MP": nil,
+          "Department of Energy": "/government/organisations/department-of-energy-climate-change",
+          "The Rt Hon Andrea Leadsom MP": "/government/people/andrea-leadsom",
+        }
+      }
+    )
 
-      within(".app-c-publisher-metadata__other") do
-        assert page.has_content?("From: Department of Energy & Climate Change and The Rt Hon Andrea Leadsom MP")
-        assert page.has_link?("Department of Energy & Climate Change",
-                              href: "/government/organisations/department-of-energy-climate-change")
-        assert page.has_link?("The Rt Hon Andrea Leadsom MP",
-                              href: "/government/people/andrea-leadsom")
-      end
-    end
+    assert_has_important_metadata(
+      "Delivered on":
+        "2 February 2016 (Original script, may differ from delivered version)",
+      "Location":
+        "Women in Nuclear UK Conference, Church House Conference Centre, Dean's Yard, Westminster, London"
+    )
 
-    within(".app-c-important-metadata") do
-      assert page.has_content?("Delivered on: 2 February 2016 (Original script, may differ from delivered version)")
-      assert page.has_content?("Location: Women in Nuclear UK Conference, Church House Conference Centre, Dean's Yard, Westminster, London")
-    end
-
-    within(".content-bottom-margin .app-c-published-dates") do
-      assert page.has_content?("Published 8 March 2016")
-    end
+    assert_footer_has_published_dates("Published 8 March 2016")
   end
 
   test "renders related policy links" do
     setup_and_visit_content_item('speech-transcript')
 
-    within(".app-c-related-navigation__nav-section[aria-labelledby='related-nav-policies']") do
-      assert page.has_css?(".app-c-related-navigation__section-link", text: "Government transparency and accountability")
-      assert page.has_link?("Government transparency and accountability", href: "/government/policies/government-transparency-and-accountability")
-      assert page.has_css?(".app-c-related-navigation__section-link", text: "Tax evasion and avoidance")
-      assert page.has_link?("Tax evasion and avoidance", href: "/government/policies/tax-evasion-and-avoidance")
-    end
+    assert_has_related_navigation(
+      section_name: "related-nav-policies",
+      section_text: "Policy",
+      links: {
+        "Government transparency and accountability":
+          "/government/policies/government-transparency-and-accountability",
+        "Tax evasion and avoidance":
+          "/government/policies/tax-evasion-and-avoidance"
+      }
+    )
   end
 end

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -13,13 +13,8 @@ class StatisticalDataSetTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('statistical_data_set')
     assert_has_publisher_metadata(
       published: "Published 13 December 2012",
-      metadata:
-      {
-        "From:":
-        {
-          text: "Department for Transport",
-          href: "/government/organisations/department-for-transport"
-        }
+      metadata: {
+        "From:": { "Department for Transport": "/government/organisations/department-for-transport" }
       }
     )
     assert_footer_has_published_dates("Published 13 December 2012")
@@ -32,13 +27,19 @@ class StatisticalDataSetTest < ActionDispatch::IntegrationTest
         {
           section_name: "related-nav-publishers",
           section_text: "Published by",
-          links: { "Department for Transport": "/government/organisations/department-for-transport" }
+          links: {
+            "Department for Transport":
+              "/government/organisations/department-for-transport"
+          }
         },
         {
           section_name: "related-nav-collections",
           section_text: "Collection",
-          links: { "Transport Statistics Great Britain": "/government/collections/transport-statistics-great-britain" }
-        }
+          links: {
+            "Transport Statistics Great Britain":
+              "/government/collections/transport-statistics-great-britain"
+          }
+        },
       ]
     )
   end

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -7,9 +7,7 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
 
-    within '.app-c-important-metadata' do
-      assert page.has_text?("Release date: 20 January 2016 9:30am (confirmed)")
-    end
+    assert_has_important_metadata("Release date": "20 January 2016 9:30am (confirmed)")
   end
 
   test "national statistics" do
@@ -34,10 +32,10 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
       assert page.has_text?(@content_item["details"]["cancellation_reason"]), "displays cancelleation reason"
     end
 
-    within '.app-c-important-metadata' do
-      assert page.has_text?("Proposed release: 20 January 2016 9:30am")
-      assert page.has_text?("Cancellation date: 17 January 2016 2:19pm")
-    end
+    assert_has_important_metadata(
+      "Proposed release": "20 January 2016 9:30am",
+      "Cancellation date": "17 January 2016 2:19pm"
+    )
   end
 
   test "statistics with a changed release date" do

--- a/test/integration/world_location_news_article_test.rb
+++ b/test/integration/world_location_news_article_test.rb
@@ -17,28 +17,25 @@ class WorldLocationNewsArticleTest < ActionDispatch::IntegrationTest
   test "renders first published, from and part of in metadata and document footer" do
     setup_and_visit_content_item('world_location_news_article')
 
-    within(".app-c-publisher-metadata .app-c-published-dates") do
-      assert page.has_content?("Published 24 November 2015")
-    end
-
-    within(".content-bottom-margin .app-c-published-dates") do
-      assert page.has_content?("Published 24 November 2015")
-    end
+    assert_has_published_dates("Published 24 November 2015")
+    assert_footer_has_published_dates("Published 24 November 2015")
   end
 
   test "renders organisation and location links" do
     setup_and_visit_content_item('world_location_news_article')
 
-    within(".app-c-publisher-metadata__other") do
-      assert page.has_css?(".app-c-publisher-metadata__term", text: "From:")
-      assert page.has_css?(".app-c-publisher-metadata__definition", text: "British High Commission Nairobi")
-      assert page.has_link?("British High Commission Nairobi", href: "/government/world/organisations/british-high-commission-nairobi")
-    end
+    assert_has_publisher_metadata(metadata: {
+      "From": {
+        "British High Commission Nairobi":
+          "/government/world/organisations/british-high-commission-nairobi"
+      }
+    })
 
-    within(".app-c-related-navigation__nav-section[aria-labelledby='related-nav-world_locations']") do
-      assert page.has_css?(".app-c-related-navigation__section-link", text: "Kenya")
-      assert page.has_link?("Kenya", href: "/world/kenya/news")
-    end
+    assert_has_related_navigation(
+      section_name: "related-nav-world_locations",
+      section_text: "World locations",
+      links: { "Kenya": "/world/kenya/news" }
+    )
   end
 
   test "renders translation links when there is more than one translation" do


### PR DESCRIPTION
No Trello, this is a bit of cleanup to integration tests following recent format layout changes.

Amends a few test helper methods for publisher metadata, important metadata and related navigation:

* Adds helpful error messages to underlying `assert` methods.
* Accepts varying metadata argument types for simplicity.
* Uses new navigation test helpers across all relevant formats.

---

Component guide for this PR:
https://government-frontend-pr-716.herokuapp.com/component-guide
