### PR TITLE
Display contents lists under specific conditions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'faker'
   gem 'mocha'
   gem 'poltergeist', require: false
   gem 'webmock', '~> 3.3.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.0)
     execjs (2.7.0)
+    faker (1.8.7)
+      i18n (>= 0.7)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
@@ -354,6 +356,7 @@ DEPENDENCIES
   binding_of_caller
   capybara
   dalli
+  faker
   foreman (~> 0.84)
   gds-api-adapters (~> 51.2)
   govuk-lint

--- a/app/presenters/content_item/contents_list.rb
+++ b/app/presenters/content_item/contents_list.rb
@@ -4,6 +4,7 @@ module ContentItem
     include TypographyHelper
 
     CHARACTER_LIMIT = 100
+    CHARACTER_LIMIT_WITH_IMAGE = 50
     TABLE_ROW_LIMIT = 13
 
     def contents
@@ -23,7 +24,8 @@ module ContentItem
       return false if contents_items.count < 2
       return true if contents_items.count > 2
       first_item_has_long_content? ||
-        first_item_has_long_table?
+        first_item_has_long_table? ||
+        first_item_has_image_and_long_content?
     end
 
   private
@@ -37,7 +39,7 @@ module ContentItem
     end
 
     def first_item_has_long_content?
-      first_item_content > CHARACTER_LIMIT
+      first_item_character_count > CHARACTER_LIMIT
     end
 
     def first_item_content
@@ -48,7 +50,11 @@ module ContentItem
         first_item_text += element.text if element.name == 'p'
         element = element.next_element
       end
-      first_item_text.length
+      first_item_text
+    end
+
+    def first_item_character_count
+      @first_item_character_count ||= first_item_content.length
     end
 
     def first_item_has_long_table?
@@ -66,6 +72,19 @@ module ContentItem
         return element if element.name == 'table'
         element = element.next_element
       end
+    end
+
+    def first_item_has_image?
+      element = first_item.next_element
+
+      until element.name == 'h2'
+        return true if element.name == 'div' && element['class'] == 'img'
+        element = element.next_element
+      end
+    end
+
+    def first_item_has_image_and_long_content?
+      first_item_has_image? && first_item_character_count > CHARACTER_LIMIT_WITH_IMAGE
     end
 
     def parsed_body

--- a/app/presenters/content_item/contents_list.rb
+++ b/app/presenters/content_item/contents_list.rb
@@ -24,6 +24,8 @@ module ContentItem
     def show_contents_list?
       return false if contents_items.count < 2
       return true if contents_items.count > 2
+      return false if no_first_item?
+
       first_item_has_long_content? ||
         first_item_has_long_table? ||
         first_item_has_image_and_long_content? ||
@@ -100,6 +102,10 @@ module ContentItem
 
     def first_item
       parsed_body.css('h2').first
+    end
+
+    def no_first_item?
+      first_item.nil?
     end
   end
 end

--- a/app/presenters/content_item/contents_list.rb
+++ b/app/presenters/content_item/contents_list.rb
@@ -3,24 +3,58 @@ module ContentItem
     include ActionView::Helpers::UrlHelper
     include TypographyHelper
 
+    CHARACTER_LIMIT = 100
+
     def contents
-      @contents ||= contents_items.each do |item|
-        item[:href] = "##{item[:id]}"
-      end
+      @contents ||=
+        if show_contents_list?
+          contents_items.each { |item| item[:href] = "##{item[:id]}" }
+        else
+          []
+        end
     end
 
     def contents_items
-      extract_headings_with_ids(body)
+      extract_headings_with_ids
+    end
+
+    def show_contents_list?
+      return false if contents_items.count < 2
+      return true if contents_items.count > 2
+      first_item_has_long_content? if first_item.next_element.name == 'p'
     end
 
   private
 
-    def extract_headings_with_ids(html)
-      headings = Nokogiri::HTML(html).css('h2').map do |heading|
+    def extract_headings_with_ids
+      headings = parsed_body.css('h2').map do |heading|
         id = heading.attribute('id')
         { text: strip_trailing_colons(heading.text), id: id.value } if id
       end
       headings.compact
+    end
+
+    def first_item_has_long_content?
+      first_item_content > CHARACTER_LIMIT
+    end
+
+    def first_item_content
+      element = first_item.next_element
+      first_item_text = ''
+
+      until element.name == 'h2'
+        first_item_text += element.text if element.name == 'p'
+        element = element.next_element
+      end
+      first_item_text.length
+    end
+
+    def parsed_body
+      @parsed_body ||= Nokogiri::HTML(body)
+    end
+
+    def first_item
+      parsed_body.css('h2').first
     end
   end
 end

--- a/app/presenters/content_item/contents_list.rb
+++ b/app/presenters/content_item/contents_list.rb
@@ -3,8 +3,8 @@ module ContentItem
     include ActionView::Helpers::UrlHelper
     include TypographyHelper
 
-    CHARACTER_LIMIT = 100
-    CHARACTER_LIMIT_WITH_IMAGE = 50
+    CHARACTER_LIMIT = 415
+    CHARACTER_LIMIT_WITH_IMAGE = 224
     TABLE_ROW_LIMIT = 13
     TABLE_ROW_LIMIT_WITH_IMAGE = 6
 

--- a/app/presenters/content_item/contents_list.rb
+++ b/app/presenters/content_item/contents_list.rb
@@ -6,6 +6,7 @@ module ContentItem
     CHARACTER_LIMIT = 100
     CHARACTER_LIMIT_WITH_IMAGE = 50
     TABLE_ROW_LIMIT = 13
+    TABLE_ROW_LIMIT_WITH_IMAGE = 6
 
     def contents
       @contents ||=
@@ -25,7 +26,8 @@ module ContentItem
       return true if contents_items.count > 2
       first_item_has_long_content? ||
         first_item_has_long_table? ||
-        first_item_has_image_and_long_content?
+        first_item_has_image_and_long_content? ||
+        first_item_has_image_and_long_table?
     end
 
   private
@@ -58,11 +60,7 @@ module ContentItem
     end
 
     def first_item_has_long_table?
-      table = find_table
-      return unless table.present?
-
-      row_count = table.css('tr').count
-      row_count > TABLE_ROW_LIMIT
+      first_item_table_rows > TABLE_ROW_LIMIT
     end
 
     def find_table
@@ -72,6 +70,11 @@ module ContentItem
         return element if element.name == 'table'
         element = element.next_element
       end
+    end
+
+    def first_item_table_rows
+      @table ||= find_table
+      @table.present? ? @table.css('tr').count : 0
     end
 
     def first_item_has_image?
@@ -85,6 +88,10 @@ module ContentItem
 
     def first_item_has_image_and_long_content?
       first_item_has_image? && first_item_character_count > CHARACTER_LIMIT_WITH_IMAGE
+    end
+
+    def first_item_has_image_and_long_table?
+      first_item_has_image? && first_item_table_rows > TABLE_ROW_LIMIT_WITH_IMAGE
     end
 
     def parsed_body

--- a/app/presenters/content_item/contents_list.rb
+++ b/app/presenters/content_item/contents_list.rb
@@ -65,7 +65,7 @@ module ContentItem
       first_item_table_rows > TABLE_ROW_LIMIT
     end
 
-    def find_table
+    def find_first_table
       element = first_item.next_element
 
       until element.name == 'h2' do
@@ -75,7 +75,7 @@ module ContentItem
     end
 
     def first_item_table_rows
-      @table ||= find_table
+      @table ||= find_first_table
       @table.present? ? @table.css('tr').count : 0
     end
 

--- a/app/presenters/content_item/contents_list.rb
+++ b/app/presenters/content_item/contents_list.rb
@@ -4,6 +4,7 @@ module ContentItem
     include TypographyHelper
 
     CHARACTER_LIMIT = 100
+    TABLE_ROW_LIMIT = 13
 
     def contents
       @contents ||=
@@ -21,7 +22,8 @@ module ContentItem
     def show_contents_list?
       return false if contents_items.count < 2
       return true if contents_items.count > 2
-      first_item_has_long_content? if first_item.next_element.name == 'p'
+      first_item_has_long_content? ||
+        first_item_has_long_table?
     end
 
   private
@@ -47,6 +49,23 @@ module ContentItem
         element = element.next_element
       end
       first_item_text.length
+    end
+
+    def first_item_has_long_table?
+      table = find_table
+      return unless table.present?
+
+      row_count = table.css('tr').count
+      row_count > TABLE_ROW_LIMIT
+    end
+
+    def find_table
+      element = first_item.next_element
+
+      until element.name == 'h2' do
+        return element if element.name == 'table'
+        element = element.next_element
+      end
     end
 
     def parsed_body

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -6,6 +6,7 @@ class SpecialistDocumentPresenter < ContentItemPresenter
   include ContentItem::Metadata
   include Navigation::SpecialistDocuments
   include TypographyHelper
+  include ContentItem::ContentsList
 
   def title_and_context
     super.tap do |t|
@@ -14,7 +15,8 @@ class SpecialistDocumentPresenter < ContentItemPresenter
   end
 
   def contents
-    @contents ||= headers_to_contents(nested_headers.clone)
+    @contents ||=
+      show_contents_list? ? headers_to_contents(nested_headers.clone) : []
   end
 
   def metadata

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -14,7 +14,6 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
- 
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'components/important-metadata', items: @content_item.important_metadata %>

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -9,7 +9,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render "components/contents-list-with-body", {
-      contents: @content_item.contents
+      contents: @content_item.contents,
     } do %>
       <%= render 'govuk_component/govspeak',
           content: @content_item.body,

--- a/test/integration/corporate_information_page_test.rb
+++ b/test/integration/corporate_information_page_test.rb
@@ -17,6 +17,19 @@ class CorporateInformationPageTest < ActionDispatch::IntegrationTest
     ])
   end
 
+  test "renders without contents list if it has fewer than 3 items" do
+    item = get_content_example("corporate_information_page")
+    item["details"]["body"] = "<div class='govspeak'>
+      <h2>Item one</h2><p>Content about item one</p>
+      <h2>Item two</h2><p>Content about item two</p>
+      </div>"
+
+    content_store_has_item(item["base_path"], item.to_json)
+    visit(item["base_path"])
+
+    refute page.has_css?(".app-c-contents-list")
+  end
+
   test "renders corporate information with body when present" do
     setup_and_visit_content_item('corporate_information_page')
 

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -115,4 +115,14 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
 
     assert page.has_css?('.app-c-translation-nav')
   end
+
+  test "renders a contents list" do
+    setup_and_visit_content_item("detailed_guide")
+    assert page.has_css?(".app-c-contents-list")
+  end
+
+  test "renders without contents list if it has fewer than 3 items" do
+    setup_and_visit_content_item("national_applicability_alternative_url_detailed_guide")
+    refute page.has_css?(".app-c-contents-list")
+  end
 end

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -47,6 +47,21 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "renders without contents list if it has fewer than 3 items" do
+    item = get_content_example("document_collection")
+    item["details"]["collection_groups"] = [
+      {
+        "title" => "Item one",
+        "body" => "<p>Content about item one</p>",
+        "documents" => ["a-content-id"]
+      },
+    ]
+    content_store_has_item(item["base_path"], item.to_json)
+    visit(item["base_path"])
+
+    refute page.has_css?(".app-c-contents-list")
+  end
+
   test "renders each collection group" do
     setup_and_visit_content_item('document_collection')
     groups = @content_item["details"]["collection_groups"]

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -108,7 +108,7 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
   end
 
   test "renders a nested contents list" do
-    setup_and_visit_content_item('aaib-reports')
+    setup_and_visit_content_item('countryside-stewardship-grants')
 
     assert page.has_css?("#contents .app-c-contents-list")
     assert page.has_css?(%(#contents .app-c-contents-list-with-body__link-wrapper
@@ -179,5 +179,11 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
       "land_use" => %w(arable-land water-quality wildlife-package wildlife-package),
       "tiers_or_standalone_items" => %w(higher-tier mid-tier)
     )
+  end
+
+  test 'does not render a contents list if there are fewer than three items in the contents list' do
+    setup_and_visit_content_item('aaib-reports')
+
+    refute page.has_css?('#contents .app-c-contents-list')
   end
 end

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -65,4 +65,30 @@ class StatisticalDataSetTest < ActionDispatch::IntegrationTest
       assert page.has_text?('This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government')
     end
   end
+
+  test "renders with contents list" do
+    setup_and_visit_content_item('statistical_data_set')
+
+    assert_has_contents_list([
+      { text: "Olympics", id: "olympics" },
+      { text: "Table TSGB1001", id: "table-tsgb1001" },
+      { text: "Table TSGB1002", id: "table-tsgb1002" },
+      { text: "Table TSGB1003", id: "table-tsgb1003" },
+      { text: "Table TSGB1004", id: "table-tsgb1004" },
+      { text: "Table TSGB1005", id: "table-tsgb1005" },
+    ])
+  end
+
+  test "renders without contents list if it has fewer than 3 items" do
+    item = get_content_example("statistical_data_set")
+    item["details"]["body"] = "<div class='govspeak'>
+      <h2>Item one</h2><p>Content about item one</p>
+      <h2>Item two</h2><p>Content about item two</p>
+      </div>"
+
+    content_store_has_item(item["base_path"], item.to_json)
+    visit(item["base_path"])
+
+    refute page.has_css?(".app-c-contents-list")
+  end
 end

--- a/test/integration/topical_event_about_page_test.rb
+++ b/test/integration/topical_event_about_page_test.rb
@@ -49,9 +49,45 @@ class TopicalEventAboutPageTest < ActionDispatch::IntegrationTest
     refute page.has_css?('.contents-list.contents-list-dashed')
   end
 
+  test "contents list not displayed when fewer than three items" do
+    @content_item = get_content_example("topical_event_about_page")
+    @content_item["details"]["body"] = body_with_two_contents_list_items
+
+    content_store_has_item(@content_item["base_path"], @content_item.to_json)
+
+    visit @content_item["base_path"]
+    refute page.has_css?(".app-c-contents-list")
+  end
+
+  test "contents list displayed when fewer than three items and first item word count is greater than 100" do
+    @content_item = get_content_example("topical_event_about_page")
+    @content_item["details"]["body"] = long_first_item_body
+
+    content_store_has_item(@content_item["base_path"], @content_item.to_json)
+
+    visit @content_item["base_path"]
+    assert page.has_css?(".app-c-contents-list")
+  end
+
 private
 
   def topical_event_end_date
     Date.parse(@content_item['links']['parent'][0]['details']['end_date'])
+  end
+
+  def long_first_item_body
+    "<div class='govspeak'><h2 id='response-in-the-uk'>Item 1</h2>
+    <p>#{Faker::Lorem.characters(50)}</p>
+    <p>#{Faker::Lorem.characters(51)}</p>
+    <h2 id='response-in-africa'>Item 2</h2>
+    <p>#{Faker::Lorem.sentence}</p></div>"
+  end
+
+  def body_with_two_contents_list_items
+    "<div class='govspeak'>
+    <h2 id='response-in-the-uk'>Item 1</h2>
+    <p>Content about item 1</p>
+    <h2 id='response-in-africa'>Item 2</h2>
+    <p>Content about item 2</p></div>"
   end
 end

--- a/test/integration/topical_event_about_page_test.rb
+++ b/test/integration/topical_event_about_page_test.rb
@@ -77,8 +77,8 @@ private
 
   def long_first_item_body
     "<div class='govspeak'><h2 id='response-in-the-uk'>Item 1</h2>
-    <p>#{Faker::Lorem.characters(50)}</p>
-    <p>#{Faker::Lorem.characters(51)}</p>
+    <p>#{Faker::Lorem.characters(200)}</p>
+    <p>#{Faker::Lorem.characters(216)}</p>
     <h2 id='response-in-africa'>Item 2</h2>
     <p>#{Faker::Lorem.sentence}</p></div>"
   end

--- a/test/integration/working_group_test.rb
+++ b/test/integration/working_group_test.rb
@@ -34,13 +34,22 @@ class WorkingGroupTest < ActionDispatch::IntegrationTest
     assert page.has_text?("Policies")
     assert page.has_text?(policy["title"])
 
-    # Should render the in-page navigation to Policies with a destination that exists
-    assert_has_contents_list([
-      { text: "Policies", id: "policies" },
-    ])
     within_component_govspeak do |component_args|
       html = Nokogiri::HTML.parse(component_args.fetch("content"))
       assert_not_nil html.at_css("h2#policies")
     end
+  end
+
+  test "renders without contents list if it has fewer than 3 items" do
+    item = get_content_example("short")
+    item["details"]["body"] = "<div class='govspeak'>
+      <h2>Item one</h2><p>Content about item one</p>
+      <h2>Item two</h2><p>Content about item two</p>
+      </div>"
+
+    content_store_has_item(item["base_path"], item.to_json)
+    visit(item["base_path"])
+
+    refute page.has_css?(".app-c-contents-list")
   end
 end

--- a/test/presenters/content_item/contents_list_test.rb
+++ b/test/presenters/content_item/contents_list_test.rb
@@ -144,4 +144,17 @@ class ContentItemContentsListTest < ActiveSupport::TestCase
     end
     refute @contents_list.show_contents_list?
   end
+
+  test "#show_contents_list? returns true if image and over 50 characters are present in the first item" do
+    class << @contents_list
+      def body
+        "<h2 id='one'>One</h2>
+        <div class='img'><img src='www.gov.uk/img.png'></div>
+        <p>#{Faker::Lorem.characters(51)}</p>
+        <h2 id='two'>Two</h2>
+        <p>#{Faker::Lorem.sentence}</p>"
+      end
+    end
+    assert @contents_list.show_contents_list?
+  end
 end

--- a/test/presenters/content_item/contents_list_test.rb
+++ b/test/presenters/content_item/contents_list_test.rb
@@ -78,4 +78,45 @@ class ContentItemContentsListTest < ActiveSupport::TestCase
       { text: "Four", id: "four" }
     ], @contents_list.contents_items
   end
+
+  test "#show_contents_list? returns true if number of contents items is less than 3 and the first item's character count is above 100" do
+    class << @contents_list
+      def body
+        "<h2 id='one'>One</h2>
+         <p>#{Faker::Lorem.characters(50)}</p>
+         <p>#{Faker::Lorem.characters(51)}</p>
+         <h2 id='two'>Two</h2>
+         <p>#{Faker::Lorem.sentence}</p>"
+      end
+    end
+    assert @contents_list.show_contents_list?
+  end
+
+  test "#show_contents_list? returns true if number of contents items is 3 or more" do
+    class << @contents_list
+      def body
+        "<h2 id='one'>One</h2>
+         <p>#{Faker::Lorem.sentence}</p>
+         <h2 id='two'>Two</h2>
+         <p>#{Faker::Lorem.sentence}</p>
+         <h2 id='three'>Three</h2>
+         <h3>Pi</h3>
+         <h2 id='four'>#{Faker::Lorem.sentence}</h2>"
+      end
+    end
+    assert @contents_list.show_contents_list?
+  end
+
+  test "#show_contents_list? returns false if number of contents times is less than 3 and first item's character count is less than 100" do
+    class << @contents_list
+      def body
+        "<h2 id='one'>One</h2>
+         <p>#{Faker::Lorem.characters(10)}</p>
+         <p>#{Faker::Lorem.characters(10)}</p>
+         <h2 id='two'>Two</h2>
+         <p>#{Faker::Lorem.sentence}</p>"
+      end
+    end
+    refute @contents_list.show_contents_list?
+  end
 end

--- a/test/presenters/content_item/contents_list_test.rb
+++ b/test/presenters/content_item/contents_list_test.rb
@@ -83,8 +83,8 @@ class ContentItemContentsListTest < ActiveSupport::TestCase
     class << @contents_list
       def body
         "<h2 id='one'>One</h2>
-         <p>#{Faker::Lorem.characters(50)}</p>
-         <p>#{Faker::Lorem.characters(51)}</p>
+         <p>#{Faker::Lorem.characters(220)}</p>
+         <p>#{Faker::Lorem.characters(196)}</p>
          <h2 id='two'>Two</h2>
          <p>#{Faker::Lorem.sentence}</p>"
       end
@@ -150,7 +150,7 @@ class ContentItemContentsListTest < ActiveSupport::TestCase
       def body
         "<h2 id='one'>One</h2>
         <div class='img'><img src='www.gov.uk/img.png'></div>
-        <p>#{Faker::Lorem.characters(51)}</p>
+        <p>#{Faker::Lorem.characters(225)}</p>
         <h2 id='two'>Two</h2>
         <p>#{Faker::Lorem.sentence}</p>"
       end

--- a/test/presenters/content_item/contents_list_test.rb
+++ b/test/presenters/content_item/contents_list_test.rb
@@ -119,4 +119,29 @@ class ContentItemContentsListTest < ActiveSupport::TestCase
     end
     refute @contents_list.show_contents_list?
   end
+
+  test "#show_contents_list? returns true if number of table rows in the first item is more than 13" do
+    class << @contents_list
+      def body
+        base = "<h2 id='one'>One</h2><table>\n<tbody>\n"
+        14.times do
+          base += "<tr>\n<td>#{Faker::Lorem.word}</td>\n<td>#{Faker::Lorem.word}/td>\n</tr>\n"
+        end
+        base += "</tbody>\n</table><h2 id='two'>Two</h2>"
+      end
+    end
+    assert @contents_list.show_contents_list?
+  end
+
+  test "#show_contents_list? returns false if number of table rows in the first item is less than 13" do
+    class << @contents_list
+      def body
+        "<h2 id='one'>One</h2><table>\n<tbody>\n
+        <tr>\n<td>#{Faker::Lorem.word}</td>\n<td>#{Faker::Lorem.word}/td>\n</tr>\n
+        <tr>\n<td>#{Faker::Lorem.word}</td>\n<td>#{Faker::Lorem.word}/td>\n</tr>\n
+        </tbody>\n</table><h2 id='two'>Two</h2>"
+      end
+    end
+    refute @contents_list.show_contents_list?
+  end
 end

--- a/test/presenters/content_item/contents_list_test.rb
+++ b/test/presenters/content_item/contents_list_test.rb
@@ -157,4 +157,18 @@ class ContentItemContentsListTest < ActiveSupport::TestCase
     end
     assert @contents_list.show_contents_list?
   end
+
+  test "#show_contents_list? returns true if image and table over 6 rows are present in the first item" do
+    class << @contents_list
+      def body
+        base = "<h2 id='one'>One</h2><div class='img'>
+          <img src='www.gov.uk/img.png'></div><table>\n<tbody>\n"
+        7.times do
+          base += "<tr>\n<td>#{Faker::Lorem.word}</td>\n<td>#{Faker::Lorem.word}/td>\n</tr>\n"
+        end
+        base += "</tbody>\n</table><h2 id='two'>Two</h2>"
+      end
+    end
+    assert @contents_list.show_contents_list?
+  end
 end

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -24,14 +24,12 @@ class SpecialistDocumentPresenterTest
 
     test 'presents headers as nested contents (with trailing colons removed)' do
       expected_headers = [
-        {
-          text: "Summary", id: "summary", href: "#summary", items: [
-            { text: "Download report", id: "download-report", href: "#download-report" },
-            { text: "Download glossary of abbreviations", id: "download-glossary-of-abbreviations", href: "#download-glossary-of-abbreviations" }
-          ]
-        }
+        { text: "Reports of diabetic acidosis", id: "reports-of-diabetic-acidosis", href: "#reports-of-diabetic-acidosis" },
+        { text: "SGLT2 inhibitors – medicines in this class", id: "sglt2-inhibitors--medicines-in-this-class", href: "#sglt2-inhibitors--medicines-in-this-class" },
+        { text: "Further information", id: "further-information", href: "#further-information" }
       ]
-      assert_equal expected_headers, presented_item('aaib-reports').contents
+
+      assert_equal expected_headers, presented_item('drug-safety-update').contents
     end
 
     test 'presents updates based on change history' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ require 'rails/test_help'
 require 'capybara/rails'
 require 'slimmer/test_helpers/govuk_components'
 require 'mocha/mini_test'
+require 'faker'
 
 Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 


### PR DESCRIPTION
For https://trello.com/c/2UIR4Sen/210-investigate-how-to-deal-with-short-content-lists

We have identified that there are occasions where it's not appropriate to display a contents list, for example when there is only one item on the list.  Having spiked an approach for displaying a contents list dependent on certain conditions, this PR implements the approach.  We've reached the below criteria for displaying a contents list in conjunction with Si Stephens-Manassiev in the content team:

1) We won't show a contents list that has one item.
2) We will show a contents list with 2 items if the first item's character count is over 415.
3) We will show a contents list with 2 items if the first item contains a table with more than 13 rows.
4) We will show a contents list with 2 items if the first item contains an image and character count is over 224.
5) We will show a contents list with 2 items if the first item contains an image and a table with more than 6 rows.
6) We will show a contents list with 3 items or more.

**To Do**
- [x] Update detailed guides after https://github.com/alphagov/government-frontend/pull/706 has been merged.

Component guide for this PR:
https://government-frontend-pr-719.herokuapp.com/component-guide
