### PR TITLE
Remove redundant conditionals for publishing components

### DIFF
--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,14 +1,12 @@
-if defined?(GovukPublishingComponents)
-  GovukPublishingComponents.configure do |c|
-    c.component_guide_title = "Government Frontend Component Guide"
-    c.application_print_stylesheet = "print"
-  end
+GovukPublishingComponents.configure do |c|
+  c.component_guide_title = "Government Frontend Component Guide"
+  c.application_print_stylesheet = "print"
+end
 
-  if Rails.env.development?
-    startup_message = "=> government-frontend component guide available at: /component-guide"
-    color_blue = 36
+if Rails.env.development?
+  startup_message = "=> government-frontend component guide available at: /component-guide"
+  color_blue = 36
 
-    # https://stackoverflow.com/questions/1489183/colorized-ruby-output
-    puts "\e[#{color_blue}m#{startup_message}\e[0m"
-  end
+  # https://stackoverflow.com/questions/1489183/colorized-ruby-output
+  puts "\e[#{color_blue}m#{startup_message}\e[0m"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   root to: 'development#index'
 
-  mount GovukPublishingComponents::Engine, at: "/component-guide" if defined?(GovukPublishingComponents)
+  mount GovukPublishingComponents::Engine, at: "/component-guide"
 
   get 'healthcheck', to: proc { [200, {}, ['']] }
 


### PR DESCRIPTION
We are always requiring the `govuk_publishing_components` gem, so `GovukPublishingComponents` will always be defined, making these conditionals always true.

We used to specify the gem with `require: false`, but that's no longer the case since we're using the gem to ship the task list component (https://github.com/alphagov/government-frontend/pull/578).

cc @Davidslv 