### PR TITLE
Improve accessibility for metadata links

### DIFF
--- a/app/presenters/content_item/linkable.rb
+++ b/app/presenters/content_item/linkable.rb
@@ -3,7 +3,7 @@ module ContentItem
     include ActionView::Helpers::UrlHelper
 
     def from
-      organisations_ordered_by_importance + links_group(%w{worldwide_organisations ministers speaker})
+      organisations_ordered_by_importance(labelledby: 'metadata-from') + links_group(%w{worldwide_organisations ministers speaker}, labelledby: 'metadata-from')
     end
 
     def part_of
@@ -20,9 +20,9 @@ module ContentItem
 
   private
 
-    def links(type)
+    def links(type, labelledby: nil)
       expanded_links_from_content_item(type).map do |link|
-        link_for_type(type, link)
+        link_for_type(type, link, (labelledby.nil? ? {} : { labelledby: labelledby }))
       end
     end
 
@@ -31,13 +31,13 @@ module ContentItem
       content_item["links"][type]
     end
 
-    def links_group(types)
-      types.flat_map { |type| links(type) }.uniq
+    def links_group(types, labelledby: nil)
+      types.flat_map { |type| links(type, (labelledby.nil? ? {} : { labelledby: labelledby })) }.uniq
     end
 
-    def organisations_ordered_by_importance
+    def organisations_ordered_by_importance(labelledby: nil)
       organisations_with_emphasised_first.map do |link|
-        link_to(link["title"], link["base_path"])
+        link_to(link["title"], link["base_path"], (labelledby.nil? ? {} : { 'aria-labelledby': labelledby }))
       end
     end
 
@@ -52,14 +52,14 @@ module ContentItem
       content_item["details"]["emphasised_organisations"] || []
     end
 
-    def link_for_type(type, link)
-      return link_for_world_location(link) if type == "world_locations"
-      link_to(link["title"], link["base_path"])
+    def link_for_type(type, link, labelledby: nil)
+      return link_for_world_location(link, (labelledby.nil? ? {} : { 'labelledby': labelledby })) if type == "world_locations"
+      link_to(link["title"], link["base_path"], (labelledby.nil? ? {} : { 'aria-labelledby': labelledby }))
     end
 
-    def link_for_world_location(link)
+    def link_for_world_location(link, labelledby: nil)
       base_path = WorldLocationBasePath.for(link)
-      link_to(link["title"], base_path)
+      link_to(link["title"], base_path, (labelledby.nil? ? {} : { 'aria-labelledby': labelledby }))
     end
   end
 end

--- a/app/presenters/content_item/linkable.rb
+++ b/app/presenters/content_item/linkable.rb
@@ -3,7 +3,7 @@ module ContentItem
     include ActionView::Helpers::UrlHelper
 
     def from
-      organisations_ordered_by_importance(labelledby: 'metadata-from') + links_group(%w{worldwide_organisations ministers speaker}, labelledby: 'metadata-from')
+      organisations_ordered_by_importance(describedby: 'metadata-from') + links_group(%w{worldwide_organisations ministers speaker}, describedby: 'metadata-from')
     end
 
     def part_of
@@ -20,9 +20,9 @@ module ContentItem
 
   private
 
-    def links(type, labelledby: nil)
+    def links(type, describedby: nil)
       expanded_links_from_content_item(type).map do |link|
-        link_for_type(type, link, (labelledby.nil? ? {} : { labelledby: labelledby }))
+        link_for_type(type, link, (describedby.nil? ? {} : { describedby: describedby }))
       end
     end
 
@@ -31,13 +31,13 @@ module ContentItem
       content_item["links"][type]
     end
 
-    def links_group(types, labelledby: nil)
-      types.flat_map { |type| links(type, (labelledby.nil? ? {} : { labelledby: labelledby })) }.uniq
+    def links_group(types, describedby: nil)
+      types.flat_map { |type| links(type, (describedby.nil? ? {} : { describedby: describedby })) }.uniq
     end
 
-    def organisations_ordered_by_importance(labelledby: nil)
+    def organisations_ordered_by_importance(describedby: nil)
       organisations_with_emphasised_first.map do |link|
-        link_to(link["title"], link["base_path"], (labelledby.nil? ? {} : { 'aria-labelledby': labelledby }))
+        link_to(link["title"], link["base_path"], (describedby.nil? ? {} : { 'aria-describedby': describedby }))
       end
     end
 
@@ -52,14 +52,14 @@ module ContentItem
       content_item["details"]["emphasised_organisations"] || []
     end
 
-    def link_for_type(type, link, labelledby: nil)
-      return link_for_world_location(link, (labelledby.nil? ? {} : { 'labelledby': labelledby })) if type == "world_locations"
-      link_to(link["title"], link["base_path"], (labelledby.nil? ? {} : { 'aria-labelledby': labelledby }))
+    def link_for_type(type, link, describedby: nil)
+      return link_for_world_location(link, (describedby.nil? ? {} : { 'describedby': describedby })) if type == "world_locations"
+      link_to(link["title"], link["base_path"], (describedby.nil? ? {} : { 'aria-describedby': describedby }))
     end
 
-    def link_for_world_location(link, labelledby: nil)
+    def link_for_world_location(link, describedby: nil)
       base_path = WorldLocationBasePath.for(link)
-      link_to(link["title"], base_path, (labelledby.nil? ? {} : { 'aria-labelledby': labelledby }))
+      link_to(link["title"], base_path, (describedby.nil? ? {} : { 'aria-describedby': describedby }))
     end
   end
 end

--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -18,7 +18,7 @@ class FatalityNoticePresenter < ContentItemPresenter
   def metadata
     super.tap do |m|
       if field_of_operation
-        m[:other]['Field of operation'] = link_to(field_of_operation.title, field_of_operation.path, 'aria-labelledby': 'metadata-field-of-operation')
+        m[:other]['Field of operation'] = link_to(field_of_operation.title, field_of_operation.path, 'aria-describedby': 'metadata-field-of-operation')
       end
     end
   end

--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -18,7 +18,7 @@ class FatalityNoticePresenter < ContentItemPresenter
   def metadata
     super.tap do |m|
       if field_of_operation
-        m[:other]['Field of operation'] = link_to(field_of_operation.title, field_of_operation.path)
+        m[:other]['Field of operation'] = link_to(field_of_operation.title, field_of_operation.path, 'aria-labelledby': 'metadata-field-of-operation')
       end
     end
   end

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -183,7 +183,7 @@ private
 
   def facet_link(label, value, key, name)
     finder_base_path = finder['base_path']
-    link_to(label, "#{finder_base_path}?#{key}%5B%5D=#{value}", 'aria-labelledby': "metadata-" + name.to_s.parameterize)
+    link_to(label, "#{finder_base_path}?#{key}%5B%5D=#{value}", 'aria-describedby': "metadata-" + name.to_s.parameterize)
   end
 
   def first_published_at_facet_key

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -178,12 +178,12 @@ private
     friendly_value = allowed_value['label']
 
     return friendly_value unless facet['filterable']
-    facet_link(friendly_value, allowed_value['value'], facet['key'])
+    facet_link(friendly_value, allowed_value['value'], facet['key'], facet['name'])
   end
 
-  def facet_link(label, value, key)
+  def facet_link(label, value, key, name)
     finder_base_path = finder['base_path']
-    link_to(label, "#{finder_base_path}?#{key}%5B%5D=#{value}")
+    link_to(label, "#{finder_base_path}?#{key}%5B%5D=#{value}", 'aria-labelledby': "metadata-" + name.to_s.parameterize)
   end
 
   def first_published_at_facet_key

--- a/app/views/components/_important-metadata.html.erb
+++ b/app/views/components/_important-metadata.html.erb
@@ -12,7 +12,8 @@
     <% end %>
     <dl data-module="track-click">
     <% items.each do |title, definition| %>
-      <dt class="app-c-important-metadata__term"><%= title %>: </dt>
+      <% metadata_id = definition.to_s =~ /href/ ?  "id=metadata-" + title.to_s.parameterize : "" %>
+      <dt class="app-c-important-metadata__term" <%= metadata_id %>><%= title %>: </dt>
       <dd class="app-c-important-metadata__definition"><%= definition %></dd>
     <% end %>
     </dl>

--- a/app/views/components/_publisher-metadata.html.erb
+++ b/app/views/components/_publisher-metadata.html.erb
@@ -18,7 +18,8 @@
             values = Array(values)
           %>
           <% if values.any? %>
-            <dt class="app-c-publisher-metadata__term"><%= title %>: </dt>
+            <% metadata_id = values.to_s =~ /href/ ?  "id=metadata-" + title.to_s.parameterize : "" %>
+            <dt class="app-c-publisher-metadata__term" <%= metadata_id %>><%= title %>: </dt>
             <dd class="app-c-publisher-metadata__definition"><%= values.to_sentence.html_safe %></dd>
           <% end %>
         <% end %>

--- a/app/views/components/docs/publisher-metadata.yml
+++ b/app/views/components/docs/publisher-metadata.yml
@@ -6,8 +6,9 @@ body: |
 
   Part of the universal navigation design.
 shared_accessibility_criteria:
-- link
-
+  - link
+accessibility_excluded_rules:
+  - duplicate-id
 examples:
   default:
     data:

--- a/test/components/important_metadata_test.rb
+++ b/test/components/important_metadata_test.rb
@@ -54,6 +54,19 @@ class ImportantMetadataTest < ComponentTestCase
                   text: "Mergers - phase 2 clearance with remedies"
   end
 
+  test "renders id and aria label for data it is given" do
+    render_component(items: {
+      "Market sector": ['<a aria-labelledby="metadata-market-sector" href="https://www.gov.uk/cma-cases?market_sector%5B%5D=motor-industry">Motor industry</a>'],
+      "Outcome": ['<a aria-labelledby="metadata-outcome" href="https://www.gov.uk/cma-cases?outcome_type%5B%5D=mergers-phase-2-clearance-with-remedies">Mergers - phase 2 clearance with remedies</a>'],
+    })
+
+    assert_select ".app-c-important-metadata #metadata-market-sector"
+    assert_select ".app-c-important-metadata dd a[aria-labelledby=\"metadata-market-sector\"]"
+    assert_select ".app-c-important-metadata #metadata-outcome"
+    assert_select ".app-c-important-metadata dd a[aria-labelledby=\"metadata-outcome\"]"
+  end
+
+
   test "link tracking is enabled" do
     render_component(items: { "Case type": ["<a href='https://www.gov.uk/cma-cases?case_type%5B%5D=mergers'>Mergers</a>"] })
     assert_select ".app-c-important-metadata dl[data-module='track-click']"

--- a/test/components/important_metadata_test.rb
+++ b/test/components/important_metadata_test.rb
@@ -56,14 +56,14 @@ class ImportantMetadataTest < ComponentTestCase
 
   test "renders id and aria label for data it is given" do
     render_component(items: {
-      "Market sector": ['<a aria-labelledby="metadata-market-sector" href="https://www.gov.uk/cma-cases?market_sector%5B%5D=motor-industry">Motor industry</a>'],
-      "Outcome": ['<a aria-labelledby="metadata-outcome" href="https://www.gov.uk/cma-cases?outcome_type%5B%5D=mergers-phase-2-clearance-with-remedies">Mergers - phase 2 clearance with remedies</a>'],
+      "Market sector": ['<a aria-describedby="metadata-market-sector" href="https://www.gov.uk/cma-cases?market_sector%5B%5D=motor-industry">Motor industry</a>'],
+      "Outcome": ['<a aria-describedby="metadata-outcome" href="https://www.gov.uk/cma-cases?outcome_type%5B%5D=mergers-phase-2-clearance-with-remedies">Mergers - phase 2 clearance with remedies</a>'],
     })
 
     assert_select ".app-c-important-metadata #metadata-market-sector"
-    assert_select ".app-c-important-metadata dd a[aria-labelledby=\"metadata-market-sector\"]"
+    assert_select ".app-c-important-metadata dd a[aria-describedby=\"metadata-market-sector\"]"
     assert_select ".app-c-important-metadata #metadata-outcome"
-    assert_select ".app-c-important-metadata dd a[aria-labelledby=\"metadata-outcome\"]"
+    assert_select ".app-c-important-metadata dd a[aria-describedby=\"metadata-outcome\"]"
   end
 
 

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -42,9 +42,9 @@ class CaseStudyPresenterTest < PresenterTestCase
     }
 
     expected_from_links = [
-      link_to('Lead org', '/orgs/lead'),
-      link_to('Supporting org', '/orgs/supporting'),
-      link_to('DFID Pakistan', '/government/world/organisations/dfid-pakistan'),
+      link_to('Lead org', '/orgs/lead', "aria-labelledby": 'metadata-from'),
+      link_to('Supporting org', '/orgs/supporting', "aria-labelledby": 'metadata-from'),
+      link_to('DFID Pakistan', '/government/world/organisations/dfid-pakistan', "aria-labelledby": 'metadata-from'),
     ]
 
     assert_equal expected_from_links, presented_item(schema_name, with_organisations).from

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -42,9 +42,9 @@ class CaseStudyPresenterTest < PresenterTestCase
     }
 
     expected_from_links = [
-      link_to('Lead org', '/orgs/lead', "aria-labelledby": 'metadata-from'),
-      link_to('Supporting org', '/orgs/supporting', "aria-labelledby": 'metadata-from'),
-      link_to('DFID Pakistan', '/government/world/organisations/dfid-pakistan', "aria-labelledby": 'metadata-from'),
+      link_to('Lead org', '/orgs/lead', "aria-describedby": 'metadata-from'),
+      link_to('Supporting org', '/orgs/supporting', "aria-describedby": 'metadata-from'),
+      link_to('DFID Pakistan', '/government/world/organisations/dfid-pakistan', "aria-describedby": 'metadata-from'),
     ]
 
     assert_equal expected_from_links, presented_item(schema_name, with_organisations).from

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -37,7 +37,7 @@ class PublicationPresenterTest < PresenterTestCase
 
   test '#from presents ministers' do
     minister = schema_item["links"]["ministers"][0]
-    assert presented_item.from.include?("<a href=\"#{minister['base_path']}\">#{minister['title']}</a>")
+    assert presented_item.from.include?("<a aria-labelledby=\"metadata-from\" href=\"#{minister['base_path']}\">#{minister['title']}</a>")
   end
 
   test '#part_of presents topical events' do

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -37,7 +37,7 @@ class PublicationPresenterTest < PresenterTestCase
 
   test '#from presents ministers' do
     minister = schema_item["links"]["ministers"][0]
-    assert presented_item.from.include?("<a aria-labelledby=\"metadata-from\" href=\"#{minister['base_path']}\">#{minister['title']}</a>")
+    assert presented_item.from.include?("<a aria-describedby=\"metadata-from\" href=\"#{minister['base_path']}\">#{minister['title']}</a>")
   end
 
   test '#part_of presents topical events' do

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -275,7 +275,7 @@ class SpecialistDocumentPresenterTest
       example = example_with_finder_facets([example_facet(overrides)], values)
 
       presented = present_example(example)
-      expected_link = "<a aria-labelledby=\"metadata-facet-name\" href=\"/finder-base-path?facet-key%5B%5D=something\">Something</a>"
+      expected_link = "<a aria-describedby=\"metadata-facet-name\" href=\"/finder-base-path?facet-key%5B%5D=something\">Something</a>"
       assert_equal expected_link, presented.metadata[:other]["Facet name"]
       assert_equal expected_link, presented.document_footer[:other]["Facet name"]
     end

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -275,7 +275,7 @@ class SpecialistDocumentPresenterTest
       example = example_with_finder_facets([example_facet(overrides)], values)
 
       presented = present_example(example)
-      expected_link = "<a href=\"/finder-base-path?facet-key%5B%5D=something\">Something</a>"
+      expected_link = "<a aria-labelledby=\"metadata-facet-name\" href=\"/finder-base-path?facet-key%5B%5D=something\">Something</a>"
       assert_equal expected_link, presented.metadata[:other]["Facet name"]
       assert_equal expected_link, presented.document_footer[:other]["Facet name"]
     end

--- a/test/presenters/speech_presenter_test.rb
+++ b/test/presenters/speech_presenter_test.rb
@@ -39,7 +39,7 @@ class SpeechPresenterTest
     end
 
     test 'from includes speaker' do
-      assert presented_item.from.include?("<a aria-labelledby=\"metadata-from\" href=\"/government/people/andrea-leadsom\">The Rt Hon Andrea Leadsom MP</a>")
+      assert presented_item.from.include?("<a aria-describedby=\"metadata-from\" href=\"/government/people/andrea-leadsom\">The Rt Hon Andrea Leadsom MP</a>")
     end
   end
 
@@ -88,8 +88,8 @@ class SpeechPresenterTest
 
     test 'includes speaker without profile in from_with_speaker' do
       assert_equal [
-        "<a aria-labelledby=\"metadata-from\" href=\"/government/organisations/prime-ministers-office-10-downing-street\">Prime Minister&#39;s Office, 10 Downing Street</a>",
-        "<a aria-labelledby=\"metadata-from\" href=\"/government/organisations/cabinet-office\">Cabinet Office</a>",
+        "<a aria-describedby=\"metadata-from\" href=\"/government/organisations/prime-ministers-office-10-downing-street\">Prime Minister&#39;s Office, 10 Downing Street</a>",
+        "<a aria-describedby=\"metadata-from\" href=\"/government/organisations/cabinet-office\">Cabinet Office</a>",
         "Her Majesty the Queen"
         ], presented_item(example_schema_name).from
     end

--- a/test/presenters/speech_presenter_test.rb
+++ b/test/presenters/speech_presenter_test.rb
@@ -39,7 +39,7 @@ class SpeechPresenterTest
     end
 
     test 'from includes speaker' do
-      assert presented_item.from.include?("<a href=\"/government/people/andrea-leadsom\">The Rt Hon Andrea Leadsom MP</a>")
+      assert presented_item.from.include?("<a aria-labelledby=\"metadata-from\" href=\"/government/people/andrea-leadsom\">The Rt Hon Andrea Leadsom MP</a>")
     end
   end
 
@@ -88,8 +88,8 @@ class SpeechPresenterTest
 
     test 'includes speaker without profile in from_with_speaker' do
       assert_equal [
-        "<a href=\"/government/organisations/prime-ministers-office-10-downing-street\">Prime Minister&#39;s Office, 10 Downing Street</a>",
-        "<a href=\"/government/organisations/cabinet-office\">Cabinet Office</a>",
+        "<a aria-labelledby=\"metadata-from\" href=\"/government/organisations/prime-ministers-office-10-downing-street\">Prime Minister&#39;s Office, 10 Downing Street</a>",
+        "<a aria-labelledby=\"metadata-from\" href=\"/government/organisations/cabinet-office\">Cabinet Office</a>",
         "Her Majesty the Queen"
         ], presented_item(example_schema_name).from
     end

--- a/test/presenters/statistics_announcement_presenter_test.rb
+++ b/test/presenters/statistics_announcement_presenter_test.rb
@@ -9,7 +9,7 @@ class StatisticsAnnouncementPresenterTest < PresenterTestCase
 
   test 'presents from as links to organisations' do
     links = [
-      link_to('NHS England', '/government/organisations/nhs-commissioning-board')
+      link_to('NHS England', '/government/organisations/nhs-commissioning-board', "aria-labelledby": 'metadata-from')
     ]
     assert_equal links, statistics_announcement.from
   end

--- a/test/presenters/statistics_announcement_presenter_test.rb
+++ b/test/presenters/statistics_announcement_presenter_test.rb
@@ -9,7 +9,7 @@ class StatisticsAnnouncementPresenterTest < PresenterTestCase
 
   test 'presents from as links to organisations' do
     links = [
-      link_to('NHS England', '/government/organisations/nhs-commissioning-board', "aria-labelledby": 'metadata-from')
+      link_to('NHS England', '/government/organisations/nhs-commissioning-board', "aria-describedby": 'metadata-from')
     ]
     assert_equal links, statistics_announcement.from
   end


### PR DESCRIPTION
This adds the ability to optionally pass a "labelledby" string
to our link_to methods.

The important metadata and publisher metadata components
implement this as an "aria-labelledby" attribute which means
these links are contextualised for assistive tech.

---

Component guide for this PR:
https://government-frontend-pr-722.herokuapp.com/component-guide
