### PR TITLE
Remove 'Published by' links from related navigation

### DIFF
--- a/app/views/components/_related-navigation.html.erb
+++ b/app/views/components/_related-navigation.html.erb
@@ -1,10 +1,9 @@
 <%
   max_section_length = 5
-  defined_sections = %w(topics publishers collections policies topical_events world_locations statistical_data_sets)
+  defined_sections = %w(topics collections policies topical_events world_locations statistical_data_sets)
   related_content = [
     {"related_items" => related_items ||= [] },
     {"topics" => topics ||= [] },
-    {"publishers" => publishers ||= [] },
     {"collections" => collections ||= [] },
     {"policies" => policies ||= [] },
     {"topical_events" => topical_events ||= [] },

--- a/app/views/components/docs/related-navigation.yml
+++ b/app/views/components/docs/related-navigation.yml
@@ -26,13 +26,6 @@ examples:
           path: /browse/working/finding-job
         - text: Apprenticeships
           path: /topic/further-education-skills/apprenticeships
-  with_publishing_entities:
-    data:
-      publishers:
-        - text: Department for Education
-          path: /government/department-for-education
-        - text: Department for Work and Pensions
-          path: /government/department-for-work-pensions
   with_collections:
     data:
       collections:
@@ -136,9 +129,6 @@ examples:
           path: /browse/working/finding-job
         - text: Apprenticeships
           path: /topic/further-education-skills/apprenticeships
-      publishers:
-        - text: Department for Education
-          path: /government/department-for-education
       collections:
         - text: Recruit an apprentice (formerly apprenticeship vacancies)
           path: /government/collections/apprenticeship-vacancies

--- a/test/components/related_navigation_test.rb
+++ b/test/components/related_navigation_test.rb
@@ -66,20 +66,6 @@ class RelatedNavigationTest < ComponentTestCase
     assert_select ".app-c-related-navigation__section-link[href=\"/world/usa/news\"]", text: 'USA'
   end
 
-  test "renders publisher section when passed publisher items" do
-    render_component(
-      publishers: [
-        {
-          text: "Department for Education",
-          path: '/government/organisation/department-for-education'
-        }
-      ]
-    )
-
-    assert_select ".app-c-related-navigation__sub-heading", text: 'Published by'
-    assert_select ".app-c-related-navigation__section-link[href=\"/government/organisation/department-for-education\"]", text: 'Department for Education'
-  end
-
   test "renders collection section when passed collection items" do
     render_component(
       collections: [

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -30,13 +30,6 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
           section_name: "related-nav-topics",
           section_text: "Explore the topic",
           links: { "PAYE": "/topic/business-tax/paye" }
-        },
-        {
-          section_name: "related-nav-publishers",
-          section_text: "Published by",
-          links: {
-            "Driver and Vehicle Standards Agency": "/government/organisations/driver-and-vehicle-standards-agency"
-          }
         }
       ]
     )

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -25,14 +25,6 @@ class StatisticalDataSetTest < ActionDispatch::IntegrationTest
     assert_has_related_navigation(
       [
         {
-          section_name: "related-nav-publishers",
-          section_text: "Published by",
-          links: {
-            "Department for Transport":
-              "/government/organisations/department-for-transport"
-          }
-        },
-        {
           section_name: "related-nav-collections",
           section_text: "Collection",
           links: {


### PR DESCRIPTION
https://trello.com/c/BeyCczNS/219-remove-published-by-label-in-org-component

## Examples

http://government-frontend-pr-723.herokuapp.com/government/statistics/nhs-sickness-absence-rates-july-2016

http://government-frontend-pr-723.herokuapp.com/government/collections/intellectual-property-unjustified-threats-bill

https://government-frontend-pr-723.herokuapp.com/government/statistical-data-sets/uk-house-price-index-data-downloads-december-2016

#### Before
![screenshot from 2018-01-26 14-13-23](https://user-images.githubusercontent.com/93511/35446705-7ee3ea00-02ad-11e8-9f34-249c3bcd412e.png)

#### After
![screenshot from 2018-01-26 14-11-37](https://user-images.githubusercontent.com/93511/35446715-87800608-02ad-11e8-820b-db7bc1ce5c38.png)


These links are duplicated in the publisher metadata
component and are contentious in that they can show
multiple organisations, not necessarily the primary
publishing organisation. They should also never show
up for mainstream content.

---

Component guide for this PR:
https://government-frontend-pr-723.herokuapp.com/component-guide
