### PR TITLE
Return 410 when Content Store returns 410

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -4,6 +4,7 @@ class ContentItemsController < ApplicationController
 
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from GdsApi::HTTPNotFound, with: :error_notfound
+  rescue_from GdsApi::HTTPGone, with: :error_410
   rescue_from GdsApi::InvalidUrl, with: :error_notfound
   rescue_from ActionView::MissingTemplate, with: :error_406
   rescue_from ActionController::UnknownFormat, with: :error_406
@@ -169,5 +170,9 @@ private
 
   def error_406
     render plain: 'Not acceptable', status: 406
+  end
+
+  def error_410
+    render plain: 'Gone', status: 410
   end
 end

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -230,6 +230,12 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_response :not_acceptable
   end
 
+  test "returns 410 for content items that are gone" do
+    content_store_has_gone_item('/gone-item')
+    get :show, params: { path: 'gone-item' }
+    assert_response :gone
+  end
+
   test "does not show taxonomy-navigation when no taxons are tagged to Detailed Guides" do
     content_item = content_store_has_schema_example('document_collection', 'document_collection')
     path = 'government/test/detailed-guide'


### PR DESCRIPTION
Addresses: https://github.com/alphagov/government-frontend/issues/437

Rather than returning a 500 exception for a gone piece of content this
will return a 410 result.

The scenario this can occur in is when the following sequence occurs

- A content item is updated in the content-store to be gone
- A request is made for that piece of content, the router proxies to
  government-frontend
- The content-store then updates the router that the content is gone
- Government-frontend requests the content from the content-store
- The content-store responds with a 410 response
- Government-frontend throws a 500 exception

A similar scenario also can occur with redirects however these are less
trivial to resolve.

---

Component guide for this PR:
https://government-frontend-pr-725.herokuapp.com/component-guide
