### PR TITLE
Protect against missing org

### DIFF
--- a/app/presenters/content_item/organisation_branding.rb
+++ b/app/presenters/content_item/organisation_branding.rb
@@ -38,12 +38,14 @@ module ContentItem
     # Remove this in the future after migrating organisations to the content store API,
     # and updating them with the correct brand in the actual store.
     def organisation_brand(organisation)
+      return unless organisation
       brand = organisation["details"]["brand"]
       brand = "executive-office" if executive_order_crest?(organisation)
       brand
     end
 
     def executive_order_crest?(organisation)
+      return unless organisation
       organisation["details"]["logo"]["crest"] == "eo"
     end
   end

--- a/test/presenters/content_item/organisation_branding_test.rb
+++ b/test/presenters/content_item/organisation_branding_test.rb
@@ -37,6 +37,14 @@ class ContentItemOrganisationBrandingTest < ActiveSupport::TestCase
     assert_equal organisation_brand(organisation), "executive-office"
   end
 
+  test "no branding when organisation is not set" do
+    organisation = nil
+
+    assert_nil organisation_brand(organisation)
+    assert_nil executive_order_crest?(organisation)
+  end
+
+
   test "includes an image organisations with a custom logo" do
     organisation = test_organisation
     organisation["details"]["logo"]["image"] = {


### PR DESCRIPTION
Fixes an issue where 
/government/organisations/counter-fraud-and-security-management-service/about
is throwing errors due to having no organisation set.

eg

https://sentry.io/govuk/app-government-frontend/issues/436288507/

Pages render on live and error silently, but can be seen in a broken/fixed state on dev, eg:
http://government-frontend.dev.gov.uk/government/organisations/counter-fraud-and-security-management-service/about was failing before this fix.
