### PR TITLE
Refactor metadata presenter

### DIFF
--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -110,13 +110,6 @@ class ConsultationPresenter < ContentItemPresenter
     ways_to_respond["attachment_url"]
   end
 
-  # FIXME: This is a temporary removal of National Applicability
-  # Once all formats have moved to new publisher/important metadata
-  # components, we can remove here: app/presenters/content_item/national_applicability.rb:33
-  def publisher_metadata
-    super.tap { |m| m[:other].delete(:"Applies to") }
-  end
-
 private
 
   def display_date_and_time(date, rollback_midnight = false)

--- a/app/presenters/content_item/metadata.rb
+++ b/app/presenters/content_item/metadata.rb
@@ -25,17 +25,5 @@ module ContentItem
         }
       }
     end
-
-    def document_footer
-      {
-        from: from,
-        published: published,
-        updated: updated,
-        history: history,
-        part_of: part_of,
-        direction: text_direction,
-        other: {}
-      }
-    end
   end
 end

--- a/app/presenters/content_item/metadata.rb
+++ b/app/presenters/content_item/metadata.rb
@@ -15,6 +15,10 @@ module ContentItem
       }
     end
 
+    def important_metadata
+      metadata[:other]
+    end
+
     def publisher_metadata
       {
         published: published,

--- a/app/presenters/content_item/metadata.rb
+++ b/app/presenters/content_item/metadata.rb
@@ -16,7 +16,7 @@ module ContentItem
     end
 
     def important_metadata
-      metadata[:other]
+      {}
     end
 
     def publisher_metadata

--- a/app/presenters/content_item/national_applicability.rb
+++ b/app/presenters/content_item/national_applicability.rb
@@ -30,12 +30,6 @@ module ContentItem
       end
     end
 
-    def publisher_metadata
-      super.tap do |m|
-        m[:other] = { 'Applies to': applies_to }.merge(m[:other])
-      end
-    end
-
   private
 
     def translated_schema_name(count)

--- a/app/presenters/content_item/national_applicability.rb
+++ b/app/presenters/content_item/national_applicability.rb
@@ -24,9 +24,9 @@ module ContentItem
       applies_to
     end
 
-    def metadata
+    def important_metadata
       super.tap do |m|
-        m[:other]['Applies to'] = applies_to
+        m.merge!('Applies to' => applies_to)
       end
     end
 

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -16,24 +16,11 @@ class DetailedGuidePresenter < ContentItemPresenter
     content_item["details"]["image"]["url"] if content_item["details"]["image"]
   end
 
-  def document_footer
-    super.tap do |m|
-      m[:other][related_guides_title] = related_guides
-    end
-  end
-
   def related_navigation
     nav = super
     nav[:related_items] += related_links("related_mainstream_content")
     nav[:related_guides] = related_links("related_guides")
     nav
-  end
-
-  # FIXME: This is a temporary removal of National Applicability
-  # Once all formats have moved to new publisher/important metadata
-  # components, we can remove here: app/presenters/content_item/national_applicability.rb:33
-  def publisher_metadata
-    super.tap { |m| m[:other].delete(:"Applies to") }
   end
 
 private

--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -15,10 +15,10 @@ class FatalityNoticePresenter < ContentItemPresenter
     { "url" => ActionController::Base.helpers.asset_url("ministry-of-defence-crest.png"), "alt_text" => "Ministry of Defence crest" }
   end
 
-  def metadata
+  def important_metadata
     super.tap do |m|
       if field_of_operation
-        m[:other]['Field of operation'] = link_to(field_of_operation.title, field_of_operation.path)
+        m.merge!('Field of operation' => link_to(field_of_operation.title, field_of_operation.path))
       end
     end
   end

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -19,13 +19,6 @@ class PublicationPresenter < ContentItemPresenter
     document_type === "national_statistics"
   end
 
-  # FIXME: This is a temporary removal of National Applicability
-  # Once all formats have moved to new publisher/important metadata
-  # components, we can remove here: app/presenters/content_item/national_applicability.rb:33
-  def publisher_metadata
-    super.tap { |m| m[:other].delete(:"Applies to") }
-  end
-
 private
 
   def documents_list

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -26,18 +26,6 @@ class SpecialistDocumentPresenter < ContentItemPresenter
     end
   end
 
-  def document_footer
-    super.tap do |m|
-      m.delete(:published) if bulk_published?
-
-      m[:other_dates] = {}
-      facets_with_friendly_values.each do |facet|
-        type = facet['type'] == 'date' ? :other_dates : :other
-        m[type][facet['name']] = value_or_array_of_values(facet['values'])
-      end
-    end
-  end
-
   def breadcrumbs
     return [] unless finder
 

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -19,9 +19,13 @@ class SpecialistDocumentPresenter < ContentItemPresenter
   def metadata
     super.tap do |m|
       m.delete(:first_published) if bulk_published?
+    end
+  end
 
+  def important_metadata
+    super.tap do |m|
       facets_with_friendly_values.each do |facet|
-        m[:other][facet['name']] = value_or_array_of_values(facet['values'])
+        m.merge!(facet['name'] => value_or_array_of_values(facet['values']))
       end
     end
   end

--- a/app/presenters/speech_presenter.rb
+++ b/app/presenters/speech_presenter.rb
@@ -28,12 +28,9 @@ class SpeechPresenter < ContentItemPresenter
     end
   end
 
-  def metadata
+  def important_metadata
     super.tap do |m|
-      m[:other] = {
-        "Location" => location,
-        delivery_type => delivered_on_metadata
-      }
+      m.merge!("Location" => location, delivery_type => delivered_on_metadata)
     end
   end
 

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -22,13 +22,15 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
     content_item["details"].include?("previous_display_date")
   end
 
-  def metadata
+  def important_metadata
     super.tap do |m|
       if cancelled?
-        m[:other]["Proposed release"] = release_date
-        m[:other]["Cancellation date"] = cancellation_date
+        m.merge!(
+          "Proposed release" => release_date,
+          "Cancellation date" => cancellation_date
+        )
       else
-        m[:other]["Release date"] = release_date_and_status
+        m.merge!("Release date" => release_date_and_status)
       end
     end
   end

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -11,7 +11,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'components/important-metadata', items: @content_item.metadata[:other]  %>
+    <%= render 'components/important-metadata', items: @content_item.important_metadata %>
 
     <% if @content_item.unopened? %>
       <% content_item_unopened = capture do %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -19,8 +19,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'components/important-metadata',
-        items: @content_item.metadata[:other] %>
+    <%= render 'components/important-metadata', items: @content_item.important_metadata %>
 
     <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
       <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -20,7 +20,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'components/important-metadata',
-        items: @content_item.metadata[:other] %>
+        items: @content_item.important_metadata %>
 
     <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
       <div class="responsive-bottom-margin">

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -15,7 +15,7 @@
   <div class="column-two-thirds content-bottom-margin">
     <div class="responsive-bottom-margin">
       <%= render 'components/important-metadata',
-          items: @content_item.metadata[:other] %>
+          items: @content_item.important_metadata %>
       <%= render 'components/figure',
           src: @content_item.image["url"],
           alt: @content_item.image["alt_text"],

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -21,7 +21,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds responsive-bottom-margin">
-    <%= render 'components/important-metadata', items: @content_item.metadata[:other] %>
+    <%= render 'components/important-metadata', items: @content_item.important_metadata %>
     <div class="responsive-bottom-margin">
        <%= render 'publication_inline_body' %>
     </div>

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -15,7 +15,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'components/important-metadata',
-        items: @content_item.metadata[:other] %>
+        items: @content_item.important_metadata %>
 
     <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
       <div class="responsive-bottom-margin">

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -16,7 +16,7 @@
   <div class="column-two-thirds content-bottom-margin">
     <div class="responsive-bottom-margin">
       <%= render 'components/important-metadata',
-      items: @content_item.metadata[:other] %>
+      items: @content_item.important_metadata %>
 
       <%= render 'components/figure',
           src: @content_item.image["url"],

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -17,7 +17,7 @@
  
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'components/important-metadata', items: @content_item.metadata[:other] %>
+    <%= render 'components/important-metadata', items: @content_item.important_metadata %>
 
     <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
     <div class="responsive-bottom-margin">

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -10,7 +10,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render "components/important-metadata",
-        items: @content_item.metadata[:other],
+        items: @content_item.important_metadata,
         margin_bottom: true %>
 
     <% if @content_item.release_date_changed? %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,1 +1,0 @@
-<%= render 'govuk_component/document_footer', @content_item.document_footer %>

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -162,7 +162,7 @@ class SpecialistDocumentPresenterTest
       example = example_with_finder_facets([example_facet], values)
 
       presented = present_example(example)
-      assert_equal "document-value", presented.metadata[:other]["Facet name"]
+      assert_equal "document-value", presented.important_metadata["Facet name"]
     end
 
     test 'includes friendly label for facet value in metadata' do
@@ -179,7 +179,7 @@ class SpecialistDocumentPresenterTest
       example = example_with_finder_facets([example_facet(overrides)], values)
 
       presented = present_example(example)
-      assert_equal "Document value from label", presented.metadata[:other]["Facet name"]
+      assert_equal "Document value from label", presented.important_metadata["Facet name"]
     end
 
     test 'falls back to provided value if value not found in allowed list' do
@@ -201,7 +201,7 @@ class SpecialistDocumentPresenterTest
       )
 
       presented = present_example(example)
-      assert_equal "not-an-allowed-value", presented.metadata[:other]["Facet name"]
+      assert_equal "not-an-allowed-value", presented.important_metadata["Facet name"]
     end
 
     test 'ignores facets in metadata if not a valid finder facet' do
@@ -249,7 +249,7 @@ class SpecialistDocumentPresenterTest
       example = example_with_finder_facets([example_facet(overrides)], values)
 
       presented = present_example(example)
-      assert_equal %w{One Two}, presented.metadata[:other]["Facet name"]
+      assert_equal %w{One Two}, presented.important_metadata["Facet name"]
     end
 
     test 'creates links for filterable friendly values' do
@@ -268,7 +268,7 @@ class SpecialistDocumentPresenterTest
 
       presented = present_example(example)
       expected_link = "<a href=\"/finder-base-path?facet-key%5B%5D=something\">Something</a>"
-      assert_equal expected_link, presented.metadata[:other]["Facet name"]
+      assert_equal expected_link, presented.important_metadata["Facet name"]
     end
 
     test 'includes friendly dates for date facets in metadata' do
@@ -276,7 +276,7 @@ class SpecialistDocumentPresenterTest
       values = { "facet-key" => "2010-01-01" }
       example = example_with_finder_facets([example_facet(overrides)], values)
 
-      presented_metadata = present_example(example).metadata[:other]
+      presented_metadata = present_example(example).important_metadata
       assert_equal "1 January 2010", presented_metadata["Facet name"]
     end
 
@@ -309,7 +309,7 @@ class SpecialistDocumentPresenterTest
                                             "more-text" => "More text")
 
       expected_order = ["First date facet", "Second date facet", "Facet name", "More text"]
-      assert_equal expected_order, present_example(example).metadata[:other].keys
+      assert_equal expected_order, present_example(example).important_metadata.keys
     end
 
     test 'breadcrumbs' do
@@ -334,7 +334,7 @@ class SpecialistDocumentPresenterTest
         extra: { error_message: 'Finder not found in /aaib-reports/aaib-investigation-to-rotorsport-uk-calidus-g-pcpc content item' }
       )
 
-      present_example(example).metadata
+      present_example(example).important_metadata
     end
 
     test 'no breadcrumbs render with no finder' do

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -118,15 +118,12 @@ class SpecialistDocumentPresenterTest
       example["details"]["metadata"]["bulk_published"] = true
 
       refute present_example(example).metadata[:first_published]
-      refute present_example(example).document_footer[:published]
 
       example["details"]["metadata"]["bulk_published"] = false
       assert present_example(example).metadata[:first_published]
-      assert present_example(example).document_footer[:published]
 
       example["details"]["metadata"] = {}
       assert present_example(example).metadata[:first_published]
-      assert present_example(example).document_footer[:published]
     end
   end
 
@@ -160,16 +157,15 @@ class SpecialistDocumentPresenterTest
       }.merge(overrides)
     end
 
-    test 'includes non-filterable facet as text in metadata and document footer' do
+    test 'includes non-filterable facet as text in metadata' do
       values = { "facet-key" => "document-value" }
       example = example_with_finder_facets([example_facet], values)
 
       presented = present_example(example)
       assert_equal "document-value", presented.metadata[:other]["Facet name"]
-      assert_equal "document-value", presented.document_footer[:other]["Facet name"]
     end
 
-    test 'includes friendly label for facet value in metadata and document footer' do
+    test 'includes friendly label for facet value in metadata' do
       overrides = {
         "allowed_values" => [
           {
@@ -184,7 +180,6 @@ class SpecialistDocumentPresenterTest
 
       presented = present_example(example)
       assert_equal "Document value from label", presented.metadata[:other]["Facet name"]
-      assert_equal "Document value from label", presented.document_footer[:other]["Facet name"]
     end
 
     test 'falls back to provided value if value not found in allowed list' do
@@ -200,14 +195,13 @@ class SpecialistDocumentPresenterTest
       values = { "facet-key" => "not-an-allowed-value" }
       example = example_with_finder_facets([example_facet(overrides)], values)
 
-      GovukError.expects(:notify).twice.with(
+      GovukError.expects(:notify).once.with(
         'Facet value not in list of allowed values',
         extra: { error_message: "Facet value 'not-an-allowed-value' not an allowed value for facet 'Facet name' on /aaib-reports/aaib-investigation-to-rotorsport-uk-calidus-g-pcpc content item" }
       )
 
       presented = present_example(example)
       assert_equal "not-an-allowed-value", presented.metadata[:other]["Facet name"]
-      assert_equal "not-an-allowed-value", presented.document_footer[:other]["Facet name"]
     end
 
     test 'ignores facets in metadata if not a valid finder facet' do
@@ -216,7 +210,6 @@ class SpecialistDocumentPresenterTest
 
       presented = present_example(example)
       assert_empty presented.metadata[:other]
-      assert_empty presented.document_footer[:other]
     end
 
     test 'ignores facets if valid key but set to an empty string' do
@@ -238,7 +231,7 @@ class SpecialistDocumentPresenterTest
       assert_empty present_example(example).metadata[:other]
     end
 
-    test 'passes array of multiple values to metadata and document_footer components' do
+    test 'passes array of multiple values to metadata' do
       overrides = {
         "allowed_values" => [
           {
@@ -257,7 +250,6 @@ class SpecialistDocumentPresenterTest
 
       presented = present_example(example)
       assert_equal %w{One Two}, presented.metadata[:other]["Facet name"]
-      assert_equal %w{One Two}, presented.document_footer[:other]["Facet name"]
     end
 
     test 'creates links for filterable friendly values' do
@@ -277,7 +269,6 @@ class SpecialistDocumentPresenterTest
       presented = present_example(example)
       expected_link = "<a href=\"/finder-base-path?facet-key%5B%5D=something\">Something</a>"
       assert_equal expected_link, presented.metadata[:other]["Facet name"]
-      assert_equal expected_link, presented.document_footer[:other]["Facet name"]
     end
 
     test 'includes friendly dates for date facets in metadata' do
@@ -286,15 +277,6 @@ class SpecialistDocumentPresenterTest
       example = example_with_finder_facets([example_facet(overrides)], values)
 
       presented_metadata = present_example(example).metadata[:other]
-      assert_equal "1 January 2010", presented_metadata["Facet name"]
-    end
-
-    test 'includes friendly dates in other_dates for date facets in document footer' do
-      overrides = { "type" => "date" }
-      values = { "facet-key" => "2010-01-01" }
-      example = example_with_finder_facets([example_facet(overrides)], values)
-
-      presented_metadata = present_example(example).document_footer[:other_dates]
       assert_equal "1 January 2010", presented_metadata["Facet name"]
     end
 
@@ -375,7 +357,6 @@ class SpecialistDocumentPresenterTest
       example = example_with_finder_facets(facets, "first_published_at" => "2010-01-01")
 
       presented = present_example(example)
-      refute presented.document_footer[:other_dates]['Published']
       refute presented.metadata[:other]['Published']
     end
 

--- a/test/presenters/speech_presenter_test.rb
+++ b/test/presenters/speech_presenter_test.rb
@@ -21,7 +21,7 @@ class SpeechPresenterTest
     end
 
     test 'presents a speech location' do
-      assert_equal schema_item['details']['location'], presented_item.metadata[:other]["Location"]
+      assert_equal schema_item['details']['location'], presented_item.important_metadata["Location"]
     end
 
     test 'presents how speech was delivered' do

--- a/test/presenters/statistics_announcement_presenter_test.rb
+++ b/test/presenters/statistics_announcement_presenter_test.rb
@@ -34,19 +34,19 @@ class StatisticsAnnouncementPresenterTest < PresenterTestCase
     assert_equal '20 January 2016 9:30am', statistics_announcement_cancelled.release_date_and_status
   end
 
-  test "present other metadata when confirmed" do
-    other = {
+  test "present important metadata when confirmed" do
+    metadata = {
       "Release date" => "20 January 2016 9:30am (confirmed)"
     }
-    assert_equal other, statistics_announcement.metadata[:other]
+    assert_equal metadata, statistics_announcement.important_metadata
   end
 
-  test "present other metadata when cancelled" do
-    other = {
+  test "present important metadata when cancelled" do
+    metadata = {
       "Proposed release" => "20 January 2016 9:30am",
       "Cancellation date" => "17 January 2016 2:19pm"
     }
-    assert_equal other, statistics_announcement_cancelled.metadata[:other]
+    assert_equal metadata, statistics_announcement_cancelled.important_metadata
   end
 
   test "shows the cancellation reason when cancelled" do


### PR DESCRIPTION
https://trello.com/c/CfGoDBRh/218-simplify-metadata-presenter-module

Addresses some of the presenter tech debt caused by splitting metadata into two components.

---

Component guide for this PR:
https://government-frontend-pr-730.herokuapp.com/component-guide
