### PR TITLE
Remove invalid div from figure component

### DIFF
--- a/app/assets/stylesheets/components/_figure.scss
+++ b/app/assets/stylesheets/components/_figure.scss
@@ -16,24 +16,23 @@
   }
 }
 
-.app-c-figure__figcaption-wrapper {
-  @include media(tablet) {
-    box-sizing: border-box;
-    float: left;
-    padding-left: $gutter-half;
-    width: 50%;
-  }
-}
-
 .app-c-figure__figcaption {
   @include core-16;
 
-  width: 100%;
 
   @include media(tablet) {
     @include core-14;
 
     display: block;
     vertical-align: top;
+
+    box-sizing: border-box;
+    float: left;
+    padding-left: $gutter-half;
+    width: 50%;
+  }
+
+  @include media(mobile) {
+    margin-top: $gutter-one-third;
   }
 }

--- a/app/views/components/_figure.html.erb
+++ b/app/views/components/_figure.html.erb
@@ -5,10 +5,8 @@
 <figure class="app-c-figure">
   <img class="app-c-figure__image" src="<%= src %>" alt="<%= alt %>">
   <% unless caption.blank? %>
-  <div class="app-c-figure__figcaption-wrapper">
     <figcaption class="app-c-figure__figcaption">
       <%= caption %>
     </figcaption>
-  </div>
   <% end %>
 </figure>


### PR DESCRIPTION
This removes a div from the figure component. It is invalid
HTML to nest the figcaption within a div and it is not
necessary here. Relevant css has been switched to the figcaption
instead of the div with no visible difference.

Trello: https://trello.com/c/cH3Yn5yk/241-fix-invalid-html-around-figcaption

Examples:
https://government-frontend-pr-736.herokuapp.com/government/case-studies/out-of-syria-back-into-school
https://government-frontend-pr-736.herokuapp.com/government/case-studies/first-deployment-of-a-uk-team-of-experts-to-the-syrian-border

Padding:
Before:
![screen shot 2018-02-06 at 12 46 39](https://user-images.githubusercontent.com/31649453/35860468-0e086f4e-0b3c-11e8-80c6-399b7386288f.png)

After:
![screen shot 2018-02-06 at 12 47 57](https://user-images.githubusercontent.com/31649453/35860479-1a0ef772-0b3c-11e8-8a49-12ea3fefa3e8.png)



---

Component guide for this PR:
https://government-frontend-pr-736.herokuapp.com/component-guide
