### PR TITLE
Exclude date of occurrence from finder link

### DIFF
--- a/app/presenters/navigation/specialist_documents.rb
+++ b/app/presenters/navigation/specialist_documents.rb
@@ -2,7 +2,12 @@ module Navigation
   module SpecialistDocuments
     include Finders
 
-    PARAMS_TO_IGNORE = %w(bulk_published opened_date closed_date).freeze
+    PARAMS_TO_IGNORE = %w(
+      bulk_published
+      opened_date
+      closed_date
+      date_of_occurrence
+    ).freeze
 
     def finder_path_and_params
       "#{finder_path}?#{facet_params}"

--- a/test/presenters/navigation/specialist_documents_test.rb
+++ b/test/presenters/navigation/specialist_documents_test.rb
@@ -61,7 +61,6 @@ class SpecialistDocumentsTest < PresenterTestCase
     )
 
     assert_equal expected("/aaib-reports",
-      date_of_occurrence: "2017-06-18",
       aircraft_category: ["sport-aviation-and-balloons"],
       report_type: "correspondence-investigation",
       location: "Ince Airfield, Merseyside",


### PR DESCRIPTION
https://trello.com/c/nrAQ1eXm/198-iterate-related-navigation-to-show-other-similar-formats-from-the-same-organisation

Follow up from https://github.com/alphagov/government-frontend/pull/720

We don't want to filter specialist content by date of occurrence
as this provides too narrow (ie. empty) a result set.

### Example

https://government-frontend-pr-739.herokuapp.com/aaib-reports/boeing-737-3m8-g-ezyb-13-march-2002

---

Component guide for this PR:
https://government-frontend-pr-739.herokuapp.com/component-guide
