### PR TITLE
Exclude all specialist date facets from finder link

### DIFF
--- a/app/presenters/navigation/specialist_documents.rb
+++ b/app/presenters/navigation/specialist_documents.rb
@@ -2,13 +2,6 @@ module Navigation
   module SpecialistDocuments
     include Finders
 
-    PARAMS_TO_IGNORE = %w(
-      bulk_published
-      opened_date
-      closed_date
-      date_of_occurrence
-    ).freeze
-
     def finder_path_and_params
       "#{finder_path}?#{facet_params}"
     end
@@ -25,8 +18,18 @@ module Navigation
     def facet_params
       content_item["details"]["metadata"]
         .each_value { |v| v.try(:sort!) }
-        .except(*PARAMS_TO_IGNORE)
+        .except(*params_to_ignore)
         .to_query
+    end
+
+    def params_to_ignore
+      %w(bulk_published) + date_facet_keys
+    end
+
+    def date_facet_keys
+      return [] unless finder
+      finder_details = finder.fetch("details", {})
+      finder_details.fetch("facets", {}).map { |f| f["key"] if f["type"] == "date" }.compact
     end
 
     def pluralised_document_type

--- a/test/presenters/navigation/specialist_documents_test.rb
+++ b/test/presenters/navigation/specialist_documents_test.rb
@@ -26,7 +26,19 @@ class SpecialistDocumentsTest < PresenterTestCase
 
   test "finder_path_and_params" do
     stub_content_item(
-      "links" => { "finder" => [{ "base_path" => "/cma-cases" }] },
+      "links" => {
+        "finder" => [
+          {
+            "base_path" => "/cma-cases",
+            "details" => {
+              "facets" => [
+                { "key" => "opened_date", "type" => "date" },
+                { "key" => "closed_date", "type" => "date" }
+              ]
+            }
+          }
+        ]
+      },
       "details" => {
         "metadata" => {
           "case_type" => "markets",
@@ -47,7 +59,16 @@ class SpecialistDocumentsTest < PresenterTestCase
 
   test "finder_path_and_params for a different document type" do
     stub_content_item(
-      "links" => { "finder" => [{ "base_path" => "/aaib-reports" }] },
+      "links" => {
+        "finder" => [
+          {
+            "base_path" => "/aaib-reports",
+            "details" => {
+              "facets" => [{ "key" => "date_of_occurrence", "type" => "date" }]
+            }
+          }
+        ]
+      },
       "details" => {
         "metadata" => {
           "date_of_occurrence" => "2017-06-18",


### PR DESCRIPTION
https://trello.com/c/nrAQ1eXm/198-iterate-related-navigation-to-show-other-similar-formats-from-the-same-organisation

Following up on https://github.com/alphagov/government-frontend/pull/739 we don't need to use any dates from metadata to filter the finders.
Date fields defined here: https://github.com/alphagov/govuk-content-schemas/blob/master/formats/shared/definitions/_specialist_document.jsonnet 

---

Component guide for this PR:
https://government-frontend-pr-740.herokuapp.com/component-guide
