### PR TITLE
Remove Webchat section from Construction Industry Scheme contact page

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -176,7 +176,6 @@ private
       '/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries' => 1034,
       '/government/organisations/hm-revenue-customs/contact/trusts' => 1036,
       '/government/organisations/hm-revenue-customs/contact/employer-enquiries' => 1023,
-      '/government/organisations/hm-revenue-customs/contact/construction-industry-scheme' => 1048,
       '/government/organisations/hm-revenue-customs/contact/online-services-helpdesk' => 1003,
     }
   end


### PR DESCRIPTION
The CIS webchat service is ending soon, so do not show it on their contact page.

https://trello.com/c/r7m8kVIo/64-remove-webchat-from-contact-page

Marked as DO NOT MERGE until we're ready to deploy it.