### PR TITLE
Render European structural investment funds logo

### DIFF
--- a/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
+++ b/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
@@ -12,6 +12,8 @@
   }
 
   .metadata-logo {
+    max-height: 90px;
+    max-width: 100%;
     padding-bottom: $gutter-half;
     padding-top: $gutter-half;
 

--- a/app/presenters/content_item/national_statistics_logo.rb
+++ b/app/presenters/content_item/national_statistics_logo.rb
@@ -1,0 +1,8 @@
+module ContentItem
+  module NationalStatisticsLogo
+    def logo
+      return unless national_statistics?
+      { path: "national-statistics.png", alt_text: "National Statistics" }
+    end
+  end
+end

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -23,6 +23,12 @@ class DetailedGuidePresenter < ContentItemPresenter
     nav
   end
 
+  def logo
+    image = content_item.dig("details", "image")
+    return unless image
+    { path: image["url"], alt_text: "European structural investment funds" }
+  end
+
 private
 
   def related_links(key)

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -1,6 +1,7 @@
 class PublicationPresenter < ContentItemPresenter
   include ContentItem::Metadata
   include ContentItem::NationalApplicability
+  include ContentItem::NationalStatisticsLogo
   include ContentItem::Political
   include Navigation::Publications
 

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -1,5 +1,6 @@
 class StatisticsAnnouncementPresenter < ContentItemPresenter
   include ContentItem::Metadata
+  include ContentItem::NationalStatisticsLogo
   include ContentItem::TitleAndContext
   include Navigation::Statistics
   include StatisticsAnnouncementHelper

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -1,14 +1,12 @@
-<% render_logo = @content_item.try(:national_statistics?) %>
 <div class="grid-row">
-  <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if render_logo %>">
+  <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if @content_item.try(:logo) %>">
     <div class="column-two-thirds metadata-column">
       <%= render "components/publisher-metadata", @content_item.publisher_metadata %>
     </div>
     <div class="column-one-third">
-      <% if render_logo %>
-        <%= image_tag "national-statistics.png",
-          alt: "National Statistics",
-          height: "90px",
+      <% if @content_item.try(:logo) %>
+        <%= image_tag @content_item.logo[:path],
+          alt: @content_item.logo[:alt_text],
           class: "metadata-logo" %>
       <% end %>
     </div>

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -125,4 +125,10 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item("national_applicability_alternative_url_detailed_guide")
     refute page.has_css?(".app-c-contents-list")
   end
+
+  test "conditionally renders a logo" do
+    setup_and_visit_content_item("england-2014-to-2020-european-structural-and-investment-funds")
+
+    assert page.has_css?(".metadata-logo[alt='European structural investment funds']")
+  end
 end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -96,4 +96,14 @@ class DetailedGuidePresenterTest < PresenterTestCase
       assert_equal I18n.t("content_item.schema_name.guidance", count: 1), presented_item.title_and_context[:context]
     end
   end
+
+  test 'eu structural fund logo is presented where applicable' do
+    presented = presented_item('england-2014-to-2020-european-structural-and-investment-funds')
+
+    expected = {
+      alt_text: 'European structural investment funds',
+      path: 'https://assets.publishing.service.gov.uk/media/5540ab8aed915d15d8000030/european-structural-investment-funds.png'
+    }
+    assert_equal presented.logo, expected
+  end
 end


### PR DESCRIPTION
Responding to urgent ZD ticket https://govuk.zendesk.com/agent/tickets/2578725

![screenshot from 2018-02-09 11-30-19](https://user-images.githubusercontent.com/93511/36027339-c9288eb4-0d92-11e8-808b-637f12512765.png)


### Example

https://government-frontend-pr-746.herokuapp.com/guidance/england-2014-to-2020-european-structural-and-investment-funds

Publisher metadata should render the relevant logo next to it,
previously this worked for National Statistics but the European
structural investment funds logo was not tested and therefore
not included in the move to a new layout.
This commit adds a presenter unit test and a format specific
integration test to cover the rendering of this logo.

---

Component guide for this PR:
https://government-frontend-pr-746.herokuapp.com/component-guide
