### PR TITLE
Remove unused and untested method

### DIFF
--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -12,10 +12,6 @@ class DetailedGuidePresenter < ContentItemPresenter
     end
   end
 
-  def image
-    content_item["details"]["image"]["url"] if content_item["details"]["image"]
-  end
-
   def related_navigation
     nav = super
     nav[:related_items] += related_links("related_mainstream_content")


### PR DESCRIPTION
I should have removed this as part of https://github.com/alphagov/government-frontend/pull/746
Images, specifically logos, appear next to the publisher metadata.
If a presenter instance responds to `:logo` then the returned hash
is used to present the logo. The method I'm removing here is a
duplication of this functionality.

---

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
