### PR TITLE
Add support for blank hrefs

### DIFF
--- a/app/views/components/_contents-list.html.erb
+++ b/app/views/components/_contents-list.html.erb
@@ -16,20 +16,49 @@
       <%= t("content_item.contents") %>
     </h2>
     <ol class="app-c-contents-list__list">
-      <% contents.each do |contents_item| %>
+      <% contents.each.with_index(1) do |contents_item, position| %>
+        <%
+            active_class = "app-c-contents-list__list-item--active" if contents_item[:active]
+            aria_current = "aria-current = true" if contents_item[:active]
+        %>
         <li
-          class="app-c-contents-list__list-item app-c-contents-list__list-item--<%= parent_list_item_modifier %>"
+          class="app-c-contents-list__list-item app-c-contents-list__list-item--<%= parent_list_item_modifier %> <%= active_class %>"
+          <%= aria_current %>
         >
-          <%= link_to contents_item[:href], class: 'app-c-contents-list__link' do %>
-            <%= format_numbers ? wrap_numbers_with_spans(contents_item[:text]) : contents_item[:text] %>
-          <% end %>
+          <% link_text = format_numbers ? wrap_numbers_with_spans(contents_item[:text]) : contents_item[:text] %>
+          <%= link_to_if !contents_item[:active], link_text, contents_item[:href],
+               class: 'app-c-contents-list__link',
+               data: {
+                 track_category: 'contentsClicked',
+                 track_action: "content_item #{position}",
+                 track_label: contents_item[:href],
+                 track_options: {
+                   dimension29: contents_item[:text]
+                  }
+                }
+          %>
           <% if contents_item[:items] && contents_item[:items].any? %>
             <ol class="app-c-contents-list__nested-list">
-              <% contents_item[:items].each do |nested_contents_item| %>
-                <li class="app-c-contents-list__list-item app-c-contents-list__list-item--dashed">
-                  <%= link_to nested_contents_item[:href], class: 'app-c-contents-list__link' do %>
-                    <%= nested_contents_item[:text] %>
-                  <% end %>
+              <% contents_item[:items].each.with_index(1) do |nested_contents_item, nested_position| %>
+              <%
+                active_class = "app-c-contents-list__list-item--active" if nested_contents_item[:active]
+                aria_current = "aria-current = true" if nested_contents_item[:active]
+              %>
+                <li
+                  class="app-c-contents-list__list-item app-c-contents-list__list-item--dashed <%= active_class %>"
+                  <%= aria_current %>
+                >
+                  <%= link_to_if !nested_contents_item[:active], nested_contents_item[:text], nested_contents_item[:href],
+                    class: 'app-c-contents-list__link',
+                    data: {
+                      track_category: 'contentsClicked',
+                      track_action: "nested_content_item #{position}:#{nested_position}",
+                      track_label: nested_contents_item[:href],
+                      track_options: {
+                        dimension29: nested_contents_item[:text]
+                      }
+                    }
+                  %>
                 </li>
               <% end %>
             </ol>

--- a/app/views/components/docs/contents-list.yml
+++ b/app/views/components/docs/contents-list.yml
@@ -15,6 +15,7 @@ accessibility_criteria: |
 
   - inform the user how many items are in the list
   - convey the content structure
+  - indicate the current page when contents span different pages, and not link to itself
 
   Links with formatted numbers must separate the number and text with a space for correct screen reader pronunciation. This changes pronunciation from "1 dot Item" to "1 Item".
 shared_accessibility_criteria:
@@ -36,6 +37,17 @@ examples:
           text: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         - href: "#second-thing"
           text: Another pretty long contents list entry, not as long as the first, but still a little.
+        - href: "#third-thing"
+          text: Third thing
+  active content link:
+    description: 'An active state allows for "you are here" items in a contents list that spans different pages to avoid linking back to the current page.'
+    data:
+      contents:
+        - href: "#first-thing"
+          text: First
+        - href: "#two"
+          text: Second
+          active: true
         - href: "#third-thing"
           text: Third thing
   nested_contents_lists:
@@ -60,7 +72,8 @@ examples:
       contents:
         - href: "#first-thing"
           text: 1. First thing
-        - href: "#second-thing"
+        - href: "#two"
+          active: true
           text: 2. Second thing
         - href: "#third-thing"
           text: 3. Third thing
@@ -107,6 +120,7 @@ examples:
           - href: "#second-thing"
             text: No numbers here
           - href: "#third-thing"
+            active: true
             text: None here either
   right_to_left:
     data:

--- a/test/components/contents_list_component_test.rb
+++ b/test/components/contents_list_component_test.rb
@@ -12,6 +12,14 @@ class ContentsListComponentTest < ComponentTestCase
     ]
   end
 
+  def contents_list_with_active_item
+    [
+      { href: '/one', text: "1. One" },
+      { href: '/two', text: "2. Two", active: true },
+      { href: '/three', text: "3. Three" }
+    ]
+  end
+
   def nested_contents_list
     contents_list << {
                        href: '/three',
@@ -33,6 +41,25 @@ class ContentsListComponentTest < ComponentTestCase
     assert_select ".app-c-contents-list"
     assert_select ".app-c-contents-list__link[href='/one']", text: "1. One"
     assert_select ".app-c-contents-list__link[href='/two']", text: "2. Two"
+  end
+
+  test "renders text only when link is active" do
+    render_component(contents: contents_list_with_active_item)
+    assert_select ".app-c-contents-list"
+    assert_select ".app-c-contents-list__link[href='/one']", text: "1. One"
+    assert_select ".app-c-contents-list__link[href='/two']", count: 0
+    assert_select ".app-c-contents-list__list-item[2]", text: '2. Two'
+    assert_select ".app-c-contents-list__list-item--active[aria-current='true']"
+  end
+
+  test "renders text only when link is active for numbered lists" do
+    render_component(contents: contents_list_with_active_item, format_numbers: true)
+    assert_select ".app-c-contents-list"
+    assert_select ".app-c-contents-list__link[href='/one']", text: "1. One"
+    assert_select ".app-c-contents-list__link[href='/two']", count: 0
+    assert_select ".app-c-contents-list__list-item[2]", text: '2. Two'
+    assert_select ".app-c-contents-list__list-item[2] .app-c-contents-list__number", text: '2.'
+    assert_select ".app-c-contents-list__list-item--active[aria-current='true']"
   end
 
   test "renders a nested list of contents links" do

--- a/test/components/contents_list_component_test.rb
+++ b/test/components/contents_list_component_test.rb
@@ -32,6 +32,10 @@ class ContentsListComponentTest < ComponentTestCase
                      }
   end
 
+  def assert_tracking_link(name, value, total = 1)
+    assert_select "a[data-track-#{name}='#{value}']", total
+  end
+
   test "renders nothing without provided contents" do
     assert_empty render_component({})
   end
@@ -69,6 +73,20 @@ class ContentsListComponentTest < ComponentTestCase
     assert_select "#{nested_link_selector}[href='/nested-one']", text: "Nested one"
     assert_select "#{nested_link_selector}[href='/nested-two']", text: "Nested two"
   end
+
+  test "renders data attributes for tracking" do
+    render_component(contents: nested_contents_list)
+
+    assert_tracking_link("category", "contentsClicked", 6)
+    assert_tracking_link("action", "content_item 1")
+    assert_tracking_link("label", "/one")
+    assert_tracking_link("options", { dimension29: "1. One" }.to_json)
+
+    assert_tracking_link("action", "nested_content_item 3:1")
+    assert_tracking_link("label", "/nested-one")
+    assert_tracking_link("options", { dimension29: "Nested one" }.to_json)
+  end
+
 
   test "formats numbers in contents links" do
     render_component(contents: contents_list, format_numbers: true)


### PR DESCRIPTION
Guide chapter headings are changing to match the format of Content
Lists. Rather than creating a new component it makes sense to
reuse this one. The main difference is that the guides have contents
that span different urls and it isn't desirable to link a page
directly to itself. This adds support for a list item without a link
in a contents list.

Additionally, tracking has been added, as per https://trello.com/c/prpbSir0/486-create-or-adapt-a-frontend-component-for-mainstream-guides-chapters-with-tracking - all links are labelled as content_item or nested_content_item for tracking purposes. This was a requirement for Guide chapter headings so it made sense to apply it across the board.

![screen shot 2018-02-12 at 11 23 10](https://user-images.githubusercontent.com/31649453/36094716-3e5596fe-0fe7-11e8-8cc0-5de2cdcc248b.png)
---

Component guide for this PR:
https://government-frontend-pr-753.herokuapp.com/component-guide
