### PR TITLE
Capitalise certain document types in finders link

### DIFF
--- a/app/presenters/navigation/publications.rb
+++ b/app/presenters/navigation/publications.rb
@@ -2,6 +2,12 @@ module Navigation
   module Publications
     include Finders
 
+    UPPERCASE_DOCTYPES = %w(
+      foi_release
+      national_statistics
+      official_statistics
+    ).freeze
+
     def finder_path_and_params
       "/government/publications?#{facet_params}"
     end
@@ -22,7 +28,7 @@ module Navigation
 
     def pluralised_document_type
       doctype = I18n.t("content_item.schema_name.#{document_type}", count: 2, locale: :en)
-      doctype[0] = doctype[0].downcase unless doctype.match?(/^(National|Official) Statistics$/)
+      doctype[0] = doctype[0].downcase unless UPPERCASE_DOCTYPES.include?(document_type)
       doctype
     end
   end

--- a/test/presenters/navigation/publications_test.rb
+++ b/test/presenters/navigation/publications_test.rb
@@ -48,4 +48,18 @@ class PublicationsTest < PresenterTestCase
 
     assert_equal expected(publication_filter_option: "all"), finder_path_and_params
   end
+
+  test "pluralised_document_type capitalises certain document types" do
+    self.stubs(:document_type).returns("foi_release")
+    assert_equal("FOI releases", pluralised_document_type)
+
+    self.stubs(:document_type).returns("national_statistics")
+    assert_equal("National Statistics", pluralised_document_type)
+
+    self.stubs(:document_type).returns("official_statistics")
+    assert_equal("Official Statistics", pluralised_document_type)
+
+    self.stubs(:document_type).returns("press_release")
+    assert_equal("press releases", pluralised_document_type)
+  end
 end


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/2581092

Some document types need to capitalised, National Statistics for example.
Others like FOI releases contain acronyms which also need to stay in caps.

### Examples

https://government-frontend-pr-754.herokuapp.com/government/statistics/security-situation-statistics-for-northern-ireland-period-ending-31-january-2018

https://government-frontend-pr-754.herokuapp.com/government/publications/dvsa-foi-disclosure-log-december-2017

---

Component guide for this PR:
https://government-frontend-pr-754.herokuapp.com/component-guide
