### PR TITLE
Take lists into account when checking content length

### DIFF
--- a/app/presenters/content_item/contents_list.rb
+++ b/app/presenters/content_item/contents_list.rb
@@ -49,9 +49,10 @@ module ContentItem
     def first_item_content
       element = first_item
       first_item_text = ''
+      allowed_elements = %w(p ul ol)
 
       until element.name == 'h2'
-        first_item_text += element.text if element.name == 'p'
+        first_item_text += element.text if element.name.in?(allowed_elements)
         element = element.next_element
         break if element.nil?
       end

--- a/test/presenters/content_item/contents_list_test.rb
+++ b/test/presenters/content_item/contents_list_test.rb
@@ -92,6 +92,24 @@ class ContentItemContentsListTest < ActiveSupport::TestCase
     assert @contents_list.show_contents_list?
   end
 
+  test "#show_contents_list? returns true if number of contents items is 2 and the first item's character count is above 415 including a list" do
+    class << @contents_list
+      def body
+        "<h2 id='one'>One</h2>
+         <p>#{Faker::Lorem.characters(40)}</p>
+         <ul>
+          <li>#{Faker::Lorem.characters(100)}</li>
+          <li>#{Faker::Lorem.characters(100)}</li>
+          <li>#{Faker::Lorem.characters(200)}</li>
+         </ul>
+         <p>#{Faker::Lorem.characters(40)}</p>
+         <h2 id='two'>Two</h2>
+         <p>#{Faker::Lorem.sentence}</p>"
+      end
+    end
+    assert @contents_list.show_contents_list?
+  end
+
   test "#show_contents_list? returns true if number of contents items is 3 or more" do
     class << @contents_list
       def body


### PR DESCRIPTION
Our contents lists appear according to whether the length
of content warrants it. This fix addresses a problem whereby
sections with content in list format were excluding the list
from the calculation of length.

Before:
![screen shot 2018-02-15 at 10 41 29](https://user-images.githubusercontent.com/31649453/36252611-1c05a654-123d-11e8-868a-03c87e60974b.png)
After:
![screen shot 2018-02-15 at 10 41 10](https://user-images.githubusercontent.com/31649453/36252634-2bcfe6c6-123d-11e8-9f0d-19790bea895d.png)


---

Examples:
https://government-frontend-pr-765.herokuapp.com/government/collections/rare-and-imported-pathogens-laboratory-ripl
https://government-frontend-pr-765.herokuapp.com/government/collections/fraud-error-debt-and-grants-function
