### PR TITLE
Temporarily disable webchat for self-assessment-online-services-helpdesk

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -164,12 +164,11 @@ private
   end
 
   def webchat_ids
-    {
+    ids = {
       '/government/organisations/hm-revenue-customs/contact/child-benefit' => 1027,
       '/government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees' => 1030,
       '/government/organisations/hm-revenue-customs/contact/vat-online-services-helpdesk' => 1026,
       '/government/organisations/hm-revenue-customs/contact/national-insurance-numbers' => 1021,
-      '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk' => 1003,
       '/government/organisations/hm-revenue-customs/contact/self-assessment' => 1004,
       '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries' => 1016,
       '/government/organisations/hm-revenue-customs/contact/vat-enquiries' => 1028,
@@ -178,6 +177,13 @@ private
       '/government/organisations/hm-revenue-customs/contact/employer-enquiries' => 1023,
       '/government/organisations/hm-revenue-customs/contact/online-services-helpdesk' => 1003,
     }
+    # https://govuk.zendesk.com/agent/tickets/2582003
+    # The webchat service for this page will be suspended from 19 to 25 February.
+    if Date.today < Date.new(2018, 2, 19) || Date.today > Date.new(2018, 2, 25)
+      ids['/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk'] = 1003
+    end
+
+    ids
   end
 
   def v_card_part(v_card_class, value)

--- a/test/presenters/contact_presenter_test.rb
+++ b/test/presenters/contact_presenter_test.rb
@@ -157,5 +157,31 @@ class ContactPresenterTest
       assert_equal presented.webchat_availability_url, "https://www.tax.service.gov.uk/csp-partials/availability/1030"
       assert_equal presented.webchat_open_url, "https://www.tax.service.gov.uk/csp-partials/open/1030"
     end
+
+    test 'webchat_ids include self-assessment-online-services-helpdesk before 19 Feb 2018 and after 25 Feb 2018' do
+      schema = schema_item('contact')
+      schema['base_path'] = '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk'
+
+      travel_to(Date.new(2018, 2, 18)) do
+        assert present_example(schema).show_webchat?
+      end
+
+      travel_to(Date.new(2018, 2, 26)) do
+        assert present_example(schema).show_webchat?
+      end
+    end
+
+    test 'webchat_ids exclude self-assessment-online-services-helpdesk between 19 Feb 2018 and 25 Feb 2018' do
+      schema = schema_item('contact')
+      schema['base_path'] = '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk'
+
+      travel_to(Date.new(2018, 2, 19)) do
+        refute present_example(schema).show_webchat?
+      end
+
+      travel_to(Date.new(2018, 2, 25)) do
+        refute present_example(schema).show_webchat?
+      end
+    end
   end
 end


### PR DESCRIPTION
This service will be unavailable between 19 Feb and 25 Feb 2018, after that
this code can be reverted.

https://govuk.zendesk.com/agent/tickets/2582003

---

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
