### PR TITLE
Support aria-label in contents lists

### DIFF
--- a/app/views/components/_contents-list.html.erb
+++ b/app/views/components/_contents-list.html.erb
@@ -1,6 +1,7 @@
 <%
   format_numbers ||= false
   contents ||= []
+  aria_label ||= ''
   nested = !!contents.find { |c| c[:items] && c[:items].any? }
   parent_list_item_modifier = if nested
                                 'parent'
@@ -11,7 +12,13 @@
                               end
 %>
 <% if contents.any? %>
-  <nav role="navigation" class="app-c-contents-list">
+  <nav
+    role="navigation"
+    class="app-c-contents-list"
+    <% if aria_label.present? %>
+      aria-label="<%= aria_label %>"
+    <% end %>
+  >
     <h2>
       <%= t("content_item.contents") %>
     </h2>

--- a/app/views/components/docs/contents-list.yml
+++ b/app/views/components/docs/contents-list.yml
@@ -17,6 +17,9 @@ accessibility_criteria: |
   - convey the content structure
   - indicate the current page when contents span different pages, and not link to itself
 
+  The contents list may:
+  - include an aria-label to contextualise the list if helpful
+
   Links with formatted numbers must separate the number and text with a space for correct screen reader pronunciation. This changes pronunciation from "1 dot Item" to "1 Item".
 shared_accessibility_criteria:
   - link
@@ -39,9 +42,21 @@ examples:
           text: Another pretty long contents list entry, not as long as the first, but still a little.
         - href: "#third-thing"
           text: Third thing
-  active content link:
+  active_content_link:
     description: 'An active state allows for "you are here" items in a contents list that spans different pages to avoid linking back to the current page.'
     data:
+      contents:
+        - href: "#first-thing"
+          text: First
+        - href: "#two"
+          text: Second
+          active: true
+        - href: "#third-thing"
+          text: Third thing
+  aria_label:
+    description: 'An aria-label string can be used to contextualise the navigation for assistive technology.'
+    data:
+      aria_label: "Pages in this guide"
       contents:
         - href: "#first-thing"
           text: First

--- a/test/components/contents_list_component_test.rb
+++ b/test/components/contents_list_component_test.rb
@@ -107,4 +107,9 @@ class ContentsListComponentTest < ComponentTestCase
     assert_select "#{nested_link_selector} .app-c-contents-list__number", count: 0
     assert_select "#{nested_link_selector} .app-c-contents-list__numbered-text", count: 0
   end
+
+  test "aria label is rendered when supplied" do
+    render_component(contents: contents_list_with_active_item, aria_label: "All pages in this guide")
+    assert_select ".app-c-contents-list[aria-label=\"All pages in this guide\"]"
+  end
 end


### PR DESCRIPTION
This allows an aria-label to be added in order to contextualise
the contents list. It was requested by modelling services since
they will be using it for chapter headings on guides that were
previously contextualised for assistive technology.

---

Component guide for this PR:
https://government-frontend-pr-769.herokuapp.com/component-guide
