### PR TITLE
Fix typo in key for employment tribunal decisions

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,7 +164,7 @@ en:
       employment_appeal_tribunal_decision:
         one: Employment appeal tribunal decision
         other: Employment appeal tribunal decisions
-      employment__tribunal_decision:
+      employment_tribunal_decision:
         one: Employment tribunal decision
         other: Employment tribunal decisions
       esi_fund:


### PR DESCRIPTION
https://trello.com/c/Is4EnOqt/272-bug-employment-tribunal-decisions-missing-translation-for-finder-link

Employment tribunal decisions have a link to finder with a broken translation key:
https://www.gov.uk/employment-tribunal-decisions/miss-r-daley-v-charles-wilson-engineers-ltd-1801444-2017

Amended this looks like:

https://government-frontend-pr-771.herokuapp.com/miss-r-daley-v-charles-wilson-engineers-ltd-1801444-2017

---

Component guide for this PR:
https://government-frontend-pr-771.herokuapp.com/component-guide
