### PR TITLE
Rephrase finder links with more detail, accuracy.

### DIFF
--- a/app/presenters/navigation/announcements.rb
+++ b/app/presenters/navigation/announcements.rb
@@ -14,9 +14,7 @@ module Navigation
     def facet_params
       departments
         .merge(filter_option)
-        .merge(people)
-        .merge(topics)
-        .merge(world_locations).to_query
+        .merge(topics).to_query
     end
 
     def filter_option

--- a/app/presenters/navigation/finders.rb
+++ b/app/presenters/navigation/finders.rb
@@ -27,16 +27,8 @@ module Navigation
       multiple_options_from_links("organisations", "departments")
     end
 
-    def people
-      multiple_options_from_links("people")
-    end
-
     def topics
       multiple_options_from_links("policy_areas", "topics")
-    end
-
-    def world_locations
-      multiple_options_from_links("world_locations")
     end
 
     def multiple_options_from_links(link_type, option_key = nil)

--- a/app/presenters/navigation/finders.rb
+++ b/app/presenters/navigation/finders.rb
@@ -1,5 +1,14 @@
 module Navigation
   module Finders
+    UPPERCASE_POLICY_AREA_PREFIXES = %w(
+      Europe
+      National Health Service
+      Northern Ireland
+      Scotland
+      UK
+      Wales
+    ).freeze
+
     def related_navigation
       nav = super
       nav[:related_items] << finder_link
@@ -8,7 +17,7 @@ module Navigation
 
     def finder_link
       {
-        text: "Related #{pluralised_document_type}",
+        text: link_text,
         path: finder_path_and_params,
         finder: true,
       }
@@ -32,12 +41,19 @@ module Navigation
 
     def multiple_options_from_links(link_type, option_key = nil)
       option_key ||= link_type
-      links = content_item["links"].fetch(link_type, [])
 
-      options = links.map { |l| option_value(l) }
+      options = links_by_type(link_type).map { |l| option_value(l) }
       options = %w(all) if options.empty?
 
       { option_key => options }
+    end
+
+    def link_titles(link_type)
+      links_by_type(link_type).map { |l| l["title"] }
+    end
+
+    def links_by_type(link_type)
+      content_item["links"].fetch(link_type, [])
     end
 
     def option_value(link)
@@ -48,10 +64,23 @@ module Navigation
       end
     end
 
-    def pluralised_document_type
-      doctype = I18n.t("content_item.schema_name.#{document_type}", count: 2, locale: :en)
-      doctype[0] = doctype[0].downcase
-      doctype
+    def policy_area_name
+      name = link_titles("policy_areas").first
+      return unless name
+      name.downcase! unless name.start_with?(*UPPERCASE_POLICY_AREA_PREFIXES)
+      name
+    end
+
+    def publishing_organisation
+      link_titles("primary_publishing_organisation").first ||
+        link_titles("organisations").first
+    end
+
+    def link_text
+      buf = ["More #{pluralised_document_type}"]
+      buf << "about #{policy_area_name}" if policy_area_name
+      buf << "from #{publishing_organisation}"
+      buf.join(" ")
     end
   end
 end

--- a/app/presenters/navigation/publications.rb
+++ b/app/presenters/navigation/publications.rb
@@ -2,11 +2,7 @@ module Navigation
   module Publications
     include Finders
 
-    UPPERCASE_DOCTYPES = %w(
-      foi_release
-      national_statistics
-      official_statistics
-    ).freeze
+    STATISTICS_DOCTYPES = %w(national_statistics official_statistics).freeze
 
     def finder_path_and_params
       "/government/publications?#{facet_params}"
@@ -27,8 +23,11 @@ module Navigation
     end
 
     def pluralised_document_type
+      return "Statistics" if STATISTICS_DOCTYPES.include?(document_type)
+      return "FOI releases" if document_type == "foi_release"
+
       doctype = I18n.t("content_item.schema_name.#{document_type}", count: 2, locale: :en)
-      doctype[0] = doctype[0].downcase unless UPPERCASE_DOCTYPES.include?(document_type)
+      doctype[0] = doctype[0].downcase
       doctype
     end
   end

--- a/app/presenters/navigation/publications.rb
+++ b/app/presenters/navigation/publications.rb
@@ -11,9 +11,7 @@ module Navigation
     def facet_params
       departments
         .merge(filter_option)
-        .merge(people)
-        .merge(topics)
-        .merge(world_locations).to_query
+        .merge(topics).to_query
     end
 
     def filter_option

--- a/app/presenters/navigation/specialist_documents.rb
+++ b/app/presenters/navigation/specialist_documents.rb
@@ -35,5 +35,9 @@ module Navigation
     def pluralised_document_type
       I18n.t("content_item.schema_name.#{document_type}", count: 2, locale: :en)
     end
+
+    def link_text
+      "More #{pluralised_document_type}"
+    end
   end
 end

--- a/app/presenters/navigation/statistics.rb
+++ b/app/presenters/navigation/statistics.rb
@@ -12,14 +12,19 @@ module Navigation
 
     def finder_path
       path = "statistics"
-      path += "/announcements" if schema_name == "statistics_announcement"
+      path += "/announcements" if announcement?
       path
     end
 
     def pluralised_document_type
+      return "statistics announcements" if announcement?
       doctype = I18n.t("content_item.schema_name.#{document_type}", count: 2, locale: :en)
       doctype[0] = doctype[0].downcase
       doctype
+    end
+
+    def announcement?
+      schema_name == "statistics_announcement"
     end
   end
 end

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -28,10 +28,8 @@ class ConsultationTest < ActionDispatch::IntegrationTest
       "More open consultations about higher education from Department for Education",
       "/government/publications",
       "departments[]" => "department-for-education",
-      "people[]" => "all",
       "publication_filter_option" => "consultations",
       "topics[]" => "higher-education",
-      "world_locations[]" => "all"
     )
 
     within '.consultation-description' do

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -25,7 +25,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     ])
 
     assert_has_link_to_finder(
-      "Related open consultations",
+      "More open consultations about higher education from Department for Education",
       "/government/publications",
       "departments[]" => "department-for-education",
       "people[]" => "all",

--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -63,7 +63,7 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
     end
 
     assert_has_link_to_finder(
-      "Related fatality notices",
+      "More fatality notices about defence and armed forces from Ministry of Defence",
       "/government/announcements",
       "departments[]" => "ministry-of-defence",
       "people[]" => "all",

--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -66,10 +66,8 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
       "More fatality notices about defence and armed forces from Ministry of Defence",
       "/government/announcements",
       "departments[]" => "ministry-of-defence",
-      "people[]" => "all",
       "announcement_filter_option" => "fatality-notices",
       "topics[]" => "defence-and-armed-forces",
-      "world_locations[]" => "all"
     )
   end
 

--- a/test/integration/news_article_test.rb
+++ b/test/integration/news_article_test.rb
@@ -28,10 +28,8 @@ class NewsArticleTest < ActionDispatch::IntegrationTest
       "More news stories from Prime Minister's Office, 10 Downing Street",
       "/government/announcements",
       "departments[]" => "prime-ministers-office-10-downing-street",
-      "people[]" => "all",
       "announcement_filter_option" => "news-stories",
       "topics[]" => "all",
-      "world_locations[]" => "all"
     )
   end
 

--- a/test/integration/news_article_test.rb
+++ b/test/integration/news_article_test.rb
@@ -25,7 +25,7 @@ class NewsArticleTest < ActionDispatch::IntegrationTest
     assert_footer_has_published_dates("Published 25 December 2016")
 
     assert_has_link_to_finder(
-      "Related news stories",
+      "More news stories from Prime Minister's Office, 10 Downing Street",
       "/government/announcements",
       "departments[]" => "prime-ministers-office-10-downing-street",
       "people[]" => "all",

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -19,10 +19,8 @@ class PublicationTest < ActionDispatch::IntegrationTest
       "More notices from Environment Agency",
       "/government/publications",
       "departments[]" => "environment-agency",
-      "people[]" => "all",
       "publication_filter_option" => "notices",
       "topics[]" => "all",
-      "world_locations[]" => "all"
     )
   end
 

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -16,7 +16,7 @@ class PublicationTest < ActionDispatch::IntegrationTest
     end
 
     assert_has_link_to_finder(
-      "Related notices",
+      "More notices from Environment Agency",
       "/government/publications",
       "departments[]" => "environment-agency",
       "people[]" => "all",

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -172,7 +172,7 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('countryside-stewardship-grants')
 
     assert_has_link_to_finder(
-      "Related Countryside Stewardship grants",
+      "More Countryside Stewardship grants",
       "/countryside-stewardship-grants",
       "funding_amount" => %w(more-than-500),
       "grant_type" => "option",

--- a/test/integration/speech_test.rb
+++ b/test/integration/speech_test.rb
@@ -63,10 +63,8 @@ class SpeechTest < ActionDispatch::IntegrationTest
       "More speeches about energy from Department of Energy & Climate Change",
       "/government/announcements",
       "departments[]" => "department-of-energy-climate-change",
-      "people[]" => "andrea-leadsom",
       "announcement_filter_option" => "speeches",
       "topics[]" => "energy",
-      "world_locations[]" => "all"
     )
   end
 end

--- a/test/integration/speech_test.rb
+++ b/test/integration/speech_test.rb
@@ -60,7 +60,7 @@ class SpeechTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('speech')
 
     assert_has_link_to_finder(
-      "Related speeches",
+      "More speeches about energy from Department of Energy & Climate Change",
       "/government/announcements",
       "departments[]" => "department-of-energy-climate-change",
       "people[]" => "andrea-leadsom",

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -36,7 +36,7 @@ class StatisticalDataSetTest < ActionDispatch::IntegrationTest
     )
 
     assert_has_link_to_finder(
-      "Related statistical data sets",
+      "More statistical data sets from Department for Transport",
       "/government/statistics",
       "departments[]" => "department-for-transport",
       "topics[]" => "all"

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -8,9 +8,8 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
     assert page.has_text?(@content_item["description"])
 
     assert_has_important_metadata("Release date": "20 January 2016 9:30am (confirmed)")
-
     assert_has_link_to_finder(
-      "Related official statistics announcements",
+      "More statistics announcements about National Health Service from NHS England",
       "/government/statistics/announcements",
       "departments[]" => "nhs-commissioning-board",
       "topics[]" => "national-health-service"

--- a/test/integration/world_location_news_article_test.rb
+++ b/test/integration/world_location_news_article_test.rb
@@ -41,10 +41,8 @@ class WorldLocationNewsArticleTest < ActionDispatch::IntegrationTest
       "More news articles",
       "/government/announcements",
       "departments[]" => "all",
-      "people[]" => "all",
       "announcement_filter_option" => "all",
       "topics[]" => "all",
-      "world_locations[]" => "kenya"
     )
   end
 

--- a/test/integration/world_location_news_article_test.rb
+++ b/test/integration/world_location_news_article_test.rb
@@ -38,7 +38,7 @@ class WorldLocationNewsArticleTest < ActionDispatch::IntegrationTest
     )
 
     assert_has_link_to_finder(
-      "Related news articles",
+      "More news articles",
       "/government/announcements",
       "departments[]" => "all",
       "people[]" => "all",

--- a/test/presenters/navigation/announcements_test.rb
+++ b/test/presenters/navigation/announcements_test.rb
@@ -23,9 +23,7 @@ class AnnouncementsTest < PresenterTestCase
     expected_params = {
       announcement_filter_option: "news-stories",
       departments: ["cabinet-office"],
-      people: ["all"],
       topics: ["arts-and-culture"],
-      world_locations: ["all"]
     }.merge(params)
 
     "/government/announcements?#{expected_params.to_query}"

--- a/test/presenters/navigation/publications_test.rb
+++ b/test/presenters/navigation/publications_test.rb
@@ -29,9 +29,7 @@ class PublicationsTest < PresenterTestCase
     expected_params = {
       publication_filter_option: "policy-papers",
       departments: ["uk-visas-and-immigration"],
-      people: ["all"],
       topics: ["borders-and-immigration"],
-      world_locations: ["all"]
     }.merge(params)
 
     "/government/publications?#{expected_params.to_query}"

--- a/test/presenters/navigation/publications_test.rb
+++ b/test/presenters/navigation/publications_test.rb
@@ -54,12 +54,29 @@ class PublicationsTest < PresenterTestCase
     assert_equal("FOI releases", pluralised_document_type)
 
     self.stubs(:document_type).returns("national_statistics")
-    assert_equal("National Statistics", pluralised_document_type)
+    assert_equal("Statistics", pluralised_document_type)
 
     self.stubs(:document_type).returns("official_statistics")
-    assert_equal("Official Statistics", pluralised_document_type)
+    assert_equal("Statistics", pluralised_document_type)
 
     self.stubs(:document_type).returns("press_release")
     assert_equal("press releases", pluralised_document_type)
+  end
+
+  test "finder link text" do
+    self.stubs(:document_type).returns("publication")
+    stub_content_item
+
+    assert_equal "More publications about borders and immigation from UK Visas and Immigration", link_text
+  end
+
+  test "finder link text with policy area capitalisation preserved" do
+    self.stubs(:document_type).returns("publication")
+    stub_content_item("links" => {
+      "primary_publishing_organisation" => [{ "title" => "Department of Health and Social Care" }],
+      "policy_areas" => [{ "title" => "National Health Service" }]
+    })
+
+    assert_equal "More publications about National Health Service from Department of Health and Social Care", link_text
   end
 end

--- a/test/presenters/navigation/statistics_test.rb
+++ b/test/presenters/navigation/statistics_test.rb
@@ -47,4 +47,19 @@ class StatisticsTest < PresenterTestCase
 
     assert_equal expected("/government/statistics/announcements"), finder_path_and_params
   end
+
+  test "pluralised_document_type default" do
+    stub_content_item
+    self.stubs(:schema_name).returns("statistics")
+    self.stubs(:document_type).returns("statistical_data_set")
+
+    assert_equal "statistical data sets", pluralised_document_type
+  end
+
+  test "pluralise_document_type for announcements" do
+    stub_content_item
+    self.stubs(:schema_name).returns("statistics_announcement")
+
+    assert_equal "statistics announcements", pluralised_document_type
+  end
 end


### PR DESCRIPTION
https://trello.com/c/Es6gHzer/271-rephrase-links-to-finders

The engagement for the existing links to finders was fairly low, we'd like to understand if the link text being more descriptive and accurate can improve this. 

![screenshot from 2018-02-19 11-41-30](https://user-images.githubusercontent.com/93511/36376518-436f9944-156b-11e8-8fe0-694ebcd83ebe.png)


## Examples

- https://government-frontend-pr-773.herokuapp.com/government/speeches/opening-speech-by-lord-hill-of-oareford-on-the-second-reading-of-the-academies-bill

 - https://government-frontend-pr-773.herokuapp.com/government/consultations/great-western-rail-franchise

- https://government-frontend-pr-773.herokuapp.com/government/statistics/announcements/criminal-court-statistics-quarterly-january-to-march-2018

---

Addresses https://github.com/alphagov/government-frontend/issues/745

Component guide for this PR:
https://government-frontend-pr-773.herokuapp.com/component-guide
