### PR TITLE
AB test guide chapter navigation

### DIFF
--- a/app/controllers/concerns/guide_nav_ab_testable.rb
+++ b/app/controllers/concerns/guide_nav_ab_testable.rb
@@ -1,0 +1,68 @@
+module GuideNavAbTestable
+  DIMENSION = 61
+  TEST_NAME = "GuideChapterNav".freeze
+
+  def self.included(base)
+    base.helper_method(
+      :guide_test_variant,
+      :is_tested_guide?,
+      :show_alternate_guide_chapters?
+    )
+
+    base.after_action :set_guide_test_response_header
+  end
+
+  def guide_test
+    @guide_nav_test ||= set_ab_test(
+      name: TEST_NAME,
+      dimension: DIMENSION
+    )
+  end
+
+  def guide_test_variant
+    @guide_test_variant ||=
+      guide_test.requested_variant(request.headers)
+  end
+
+  def show_alternate_guide_chapters?
+    guide_test_variant.variant?('B') && is_tested_guide?
+  end
+
+  def is_tested_guide?
+    is_guide? && !is_education?
+  end
+
+  def set_guide_test_response_header
+    guide_test_variant.configure_response(response) if is_tested_guide?
+  end
+
+private
+
+  def is_guide?
+    content_item.is_a?(GuidePresenter)
+  end
+
+  def is_education?
+    @is_education ||= root_taxon_slugs(content_item.content_item).include?("/education")
+  end
+
+  def root_taxon_slugs(content_item)
+    root_taxon_set = Set.new
+
+    links = content_item["links"]
+
+    parent_taxons = (links["parent_taxons"] || links["taxons"]) unless links.nil?
+    if parent_taxons.blank?
+      root_taxon_set << content_item["base_path"] if content_item["document_type"] == 'taxon'
+    else
+      parent_taxons.each do |parent_taxon|
+        root_taxon_set += root_taxon_slugs(parent_taxon)
+      end
+    end
+    root_taxon_set
+  end
+
+  def set_ab_test(name:, dimension:)
+    GovukAbTesting::AbTest.new(name, dimension: dimension)
+  end
+end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,4 +1,6 @@
 class ContentItemsController < ApplicationController
+  include GuideNavAbTestable
+
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from GdsApi::HTTPNotFound, with: :error_notfound
   rescue_from GdsApi::HTTPGone, with: :error_410

--- a/app/presenters/content_item/parts.rb
+++ b/app/presenters/content_item/parts.rb
@@ -59,6 +59,16 @@ module ContentItem
       nav
     end
 
+    def part_link_elements
+      parts.map do |part|
+        if part['slug'] != current_part['slug']
+          { href: part['full_path'], text: part['title'] }
+        else
+          { href: part['full_path'], text: part['title'], active: true }
+        end
+      end
+    end
+
   private
 
     def raw_parts

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -12,7 +12,11 @@
     <% if @content_item.has_parts? %>
       <% if @content_item.multi_page_guide? %>
         <h1 class="part-title">
-          <%= @content_item.current_part_title_with_index %>
+          <% if show_alternate_guide_chapters? %>
+            <%= @content_item.current_part_title %>
+          <% else %>
+            <%= @content_item.current_part_title_with_index %>
+          <% end %>
         </h1>
       <% end %>
       <%= render 'govuk_component/govspeak',

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
   <meta name="govuk:content-id" content="<%= @content_item.content_id %>" />
-
+  <%= guide_test_variant.analytics_meta_tag.html_safe if is_tested_guide? %>
   <%= yield :extra_head_content %>
 </head>
 <body>

--- a/app/views/shared/_parts_navigation.html.erb
+++ b/app/views/shared/_parts_navigation.html.erb
@@ -1,16 +1,20 @@
-<nav role="navigation" class="grid-row part-navigation" aria-label="<%= navigation_label %>">
-  <% content_item.parts_navigation.each_with_index do |part_group, i| %>
-    <ol
-      class="column-half"
-      <% if i == 1 %>
-        start="<%= content_item.parts_navigation_second_list_start %>"
-      <% end %>
-    >
-      <% part_group.each do |part_nav_item| %>
-        <li>
-          <%= part_nav_item %>
-        </li>
-      <% end %>
-    </ol>
-  <% end %>
-</nav>
+<% if show_alternate_guide_chapters? %>
+  <%= render "components/contents-list", aria_label: navigation_label, contents: content_item.part_link_elements %>
+<% else %>
+  <nav role="navigation" class="grid-row part-navigation" aria-label="<%= navigation_label %>">
+    <% content_item.parts_navigation.each_with_index do |part_group, i| %>
+      <ol
+        class="column-half"
+        <% if i == 1 %>
+          start="<%= content_item.parts_navigation_second_list_start %>"
+        <% end %>
+      >
+        <% part_group.each do |part_nav_item| %>
+          <li>
+            <%= part_nav_item %>
+          </li>
+        <% end %>
+      </ol>
+    <% end %>
+  </nav>
+<% end %>

--- a/test/controllers/guide_chapter_nav_ab_test_controller_test.rb
+++ b/test/controllers/guide_chapter_nav_ab_test_controller_test.rb
@@ -1,0 +1,93 @@
+require 'test_helper'
+
+class ContentItemsControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::ContentStore
+  include GovukAbTesting::MinitestHelpers
+
+  %w(A B).each do |test_variant|
+    test "GuideChapterNav variant #{test_variant} does not affect guides in the education taxonomy" do
+      # this sample guide is part of the education taxon
+      content_item = content_store_has_schema_example("guide", "guide")
+      content_store_has_item(content_item['base_path'], content_item)
+
+      setup_ab_variant("GuideChapterNav", test_variant)
+
+      get :show, params: { path: path_for(content_item) }
+      assert_response 200
+      assert_response_not_modified_for_ab_test("GuideChapterNav")
+    end
+
+    test "GuideChapterNav variant #{test_variant} works for guides not in the education taxon" do
+      #this sample guide is not part of the education taxon
+      content_item = content_store_has_schema_example("guide", "single-page-guide")
+      content_store_has_item(content_item['base_path'], content_item)
+
+      with_variant GuideChapterNav: test_variant do
+        get :show, params: { path: path_for(content_item) }
+        assert_response 200
+
+        ab_test = GovukAbTesting::AbTest.new("GuideChapterNav", dimension: 61)
+        requested = ab_test.requested_variant(request.headers)
+        assert requested.variant?(test_variant)
+      end
+    end
+
+    test "GuideChapterNav variant #{test_variant} does not affect travel advice content" do
+      content_item = content_store_has_schema_example("travel_advice", "full-country")
+      content_store_has_item(content_item['base_path'], content_item)
+
+      setup_ab_variant("GuideChapterNav", test_variant)
+
+      get :show, params: { path: path_for(content_item) }
+      assert_response 200
+      assert_response_not_modified_for_ab_test("GuideChapterNav")
+    end
+  end
+
+  test "GuideChapterNav shows the original nav on variant A" do
+    # The example schema is in the education taxon which would remove it from
+    # the test, so we'll stub it here
+    @controller.stubs(:is_education?).returns(false)
+
+    content_item = content_store_has_schema_example("guide", "guide")
+    content_store_has_item(content_item['base_path'], content_item)
+
+    with_variant GuideChapterNav: "A" do
+      get :show, params: { path: path_for(content_item) }
+      assert_response 200
+
+      #original navigation section
+      assert_match("part-navigation", response.body)
+
+      #parts are still numbers
+      assert_match("1. Overview", response.body)
+    end
+  end
+
+  test "GuideChapterNav shows the alternate nav on variant B" do
+    # The example schema is in the education taxon which would remove it from
+    # the test, so we'll stub it here
+    @controller.stubs(:is_education?).returns(false)
+
+    content_item = content_store_has_schema_example("guide", "guide")
+    content_store_has_item(content_item['base_path'], content_item)
+
+    with_variant GuideChapterNav: "B" do
+      get :show, params: { path: path_for(content_item) }
+      assert_response 200
+
+      #alternate navigation component
+      assert_match("app-c-contents-list", response.body)
+
+      #remove numbering from parts
+      refute_match("1. Overview", response.body)
+      assert_match("Overview", response.body)
+    end
+  end
+
+  def path_for(content_item, locale = nil)
+    base_path = content_item['base_path'].sub(/^\//, '')
+    base_path.gsub!(/\.#{locale}$/, '') if locale
+    base_path
+  end
+end


### PR DESCRIPTION
The diffs are best viewed [without whitespace](https://github.com/alphagov/government-frontend/pull/774/files?w=1) because of indentation changes in markup

We want to test chapter navigation which does not use numbers, as we think this may not aid comprehension and may be confused with step by step navigation.

We're using the [contents-list component](https://government-frontend.herokuapp.com/component-guide/contents-list) as the alternate, because it fits our needs and is already used in other formats.

We are not including Education format as there are other tests inbound for this and we don't want to affect them.

https://trello.com/c/iYJRN2kM/487-set-up-an-a-b-test-for-mainstream-guide-chapter-changes

## Guide with step by step navigation
![screen shot 2018-02-19 at 12 28 43](https://user-images.githubusercontent.com/773037/36379828-efb9bf52-1577-11e8-87a0-800172f3aeeb.png)

## Guide with related links
![screen shot 2018-02-19 at 12 26 33](https://user-images.githubusercontent.com/773037/36379831-f0037ee4-1577-11e8-9c80-7692d402a88a.png)

