### PR TITLE
Improve accessibility labelling on Notice component and navigation

### DIFF
--- a/app/views/components/_notice.html.erb
+++ b/app/views/components/_notice.html.erb
@@ -4,7 +4,7 @@
     description_govspeak ||= false
     margin_bottom_class = " app-c-notice--bottom-margin" unless local_assigns[:margin_bottom]
   %>
-  <section class="app-c-notice<%= margin_bottom_class %>" aria-label="Notice">
+  <section class="app-c-notice<%= margin_bottom_class %>" aria-label="Notice" role="region">
     <% if description_text || description_govspeak %>
       <h2 class="app-c-notice__title"><%= title %></h2>
     <% else %>

--- a/app/views/components/_related-navigation.html.erb
+++ b/app/views/components/_related-navigation.html.erb
@@ -1,6 +1,6 @@
 <% related_content = build_related_content(local_assigns) %>
 <% if related_content.map(&:values).flatten.any? || other.flatten.any? %>
-  <aside class="app-c-related-navigation" role="complementary">
+  <div class="app-c-related-navigation">
     <h2 id="related-nav-related_items"
         class="app-c-related-navigation__main-heading"
         data-track-count="sidebarRelatedItemSection" >
@@ -11,17 +11,17 @@
       <% section.each do |section_title, links| %>
         <% if links.any? %>
           <% section_index += 1 %>
-          <% unless section_title === "related_items" %>
-            <h3 id="related-nav-<%= section_title %>"
-              data-track-count="sidebarRelatedItemSection"
-              class="<%= section_css_class("app-c-related-navigation__sub-heading", section_title) %>">
-              <%= construct_section_heading(section_title) %>
-            </h3>
-          <% end %>
           <nav role="navigation"
                class="app-c-related-navigation__nav-section"
                aria-labelledby="related-nav-<%= section_title %>"
                data-module="toggle">
+            <% unless section_title === "related_items" %>
+              <h3 id="related-nav-<%= section_title %>"
+                data-track-count="sidebarRelatedItemSection"
+                class="<%= section_css_class("app-c-related-navigation__sub-heading", section_title) %>">
+                <%= construct_section_heading(section_title) %>
+              </h3>
+            <% end %>
             <ul class="app-c-related-navigation_link-list" data-module="track-click">
               <% constructed_link_array = [] %>
               <% section_link_limit = calculate_section_link_limit(links) %>
@@ -71,5 +71,5 @@
         <% end %>
       <% end %>
     <% end %>
-  </aside>
+  </div>
 <% end %>

--- a/app/views/components/docs/related-navigation.yml
+++ b/app/views/components/docs/related-navigation.yml
@@ -1,8 +1,8 @@
 name: Related Navigation
 description: Component showing related content, including topics, guidance, collections and policies (where applicable)
 accessibility_criteria: |
-  - Should have a role of 'complementary' as it complements the main page content
   - Should have a role of 'navigation' on any navigation elements inside the component
+  - Should be marked up as navigation and not as tangential content
 shared_accessibility_criteria:
   - link
 accessibility_excluded_rules:

--- a/test/components/notice_test.rb
+++ b/test/components/notice_test.rb
@@ -24,9 +24,9 @@ class NoticeGovspeakTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders a notice with an aria label" do
+  test "renders a notice with an aria label and region" do
     visit '/component-guide/notice/default'
-    assert page.has_selector?(".component-guide-preview section[aria-label]")
+    assert page.has_selector?(".component-guide-preview section[aria-label][role=region]")
   end
 
   test "renders a notice with a title and description text" do


### PR DESCRIPTION
This is based on feedback from the accessibility team and does the following:
    
    - Moves the navigation title inside the navigation block
    - Removes complementary role and aside (replaced with div)
    - Adds a role of “region” to notice section and makes test for it more specific

The accessibility team have agreed that the navigation component should be marked up as navigation and not as tangential content (see [Trello card](https://trello.com/c/S96QAn30/274-improve-accessibilty-context-of-related-navigation-link-grouping)).

Example page:
https://government-frontend-pr-775.herokuapp.com/government/speeches/elizabeth-truss-calls-for-a-renaissance-in-maths
