### PR TITLE
Trial new "create account" pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,3 +50,4 @@
 @import 'views/answer';
 @import 'views/help-page';
 @import "views/guide";
+@import "views/service_sign_in";

--- a/app/assets/stylesheets/views/_service_sign_in.scss
+++ b/app/assets/stylesheets/views/_service_sign_in.scss
@@ -1,0 +1,37 @@
+@import "grid_layout";
+
+.service-sign-in {
+  .column-one-half { @include grid-column(1 / 2); };
+  .column-two-thirds { @include grid-column(2 / 3); };
+  .column-full { @include grid-column(1); };
+
+  h3 {
+    @include bold-24;
+    margin-bottom: 4px;
+  }
+
+  hr {
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
+
+  a {
+    text-decoration: underline;
+  }
+
+  .gem-c-back-link {
+    text-decoration: none;
+  }
+
+  .pub-c-button {
+    text-decoration: none;
+  }
+
+  .fixed-height {
+    height: 40px;
+
+    @include media(mobile) {
+      height: auto;
+    }
+  }
+}

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -6,6 +6,10 @@ module ServiceSignIn
       "choose_sign_in"
     end
 
+    def partial_type
+      "choose_sign_in"
+    end
+
     def title
       choose_sign_in["title"]
     end

--- a/app/presenters/service_sign_in/create_new_account_presenter.rb
+++ b/app/presenters/service_sign_in/create_new_account_presenter.rb
@@ -6,6 +6,10 @@ module ServiceSignIn
       "create_new_account"
     end
 
+    def partial_type
+      "create_new_account"
+    end
+
     def title
       create_new_account["title"]
     end

--- a/app/presenters/service_sign_in/verify_hub_trial_create_new_account_presenter.rb
+++ b/app/presenters/service_sign_in/verify_hub_trial_create_new_account_presenter.rb
@@ -1,0 +1,45 @@
+# Trial new start page payout for update company car details and income tax services (by verify hub improvements team)
+# Due for teardown/review on 8th March 2018 - Jira card HUB-39
+
+module ServiceSignIn
+  class VerifyHubTrialCreateNewAccountPresenter < ContentItemPresenter
+    include ServiceSignIn::Paths
+
+    GOV_GATE_URL_FOR_COMPANY_CAR = "https://www.tax.service.gov.uk/paye/company-car/start-government-gateway".freeze
+    GOV_GATE_URL_FOR_INCOME_TAX = "https://www.tax.service.gov.uk/check-income-tax/start-government-gateway?_ga=2.114080007.145612230.1512381177-373904926.147".freeze
+    VERIFY_URL_FOR_COMPANY_CAR = "https://www.tax.service.gov.uk/paye/company-car/start-verify".freeze
+    VERIFY_URL_FOR_INCOME_TAX = "https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.114080007.145612230.1512381177-373904926.1473694521".freeze
+
+    def page_type
+      "create_new_account"
+    end
+
+    def partial_type
+      "verify_hub_trial_create_new_account"
+    end
+
+    def govenment_gateway_url
+      return GOV_GATE_URL_FOR_COMPANY_CAR if content_item['base_path'].include?("update-company-car-details")
+      return GOV_GATE_URL_FOR_INCOME_TAX if content_item['base_path'].include?("check-income-tax-current-year")
+    end
+
+    def verify_url
+      return VERIFY_URL_FOR_COMPANY_CAR if content_item['base_path'].include?("update-company-car-details")
+      return VERIFY_URL_FOR_INCOME_TAX if content_item['base_path'].include?("check-income-tax-current-year")
+    end
+
+    def back_link
+      "#{content_item['base_path']}/#{parent_slug}"
+    end
+
+  private
+
+    def parent_slug
+      content_item["details"]["choose_sign_in"]["slug"]
+    end
+
+    def create_new_account
+      content_item["details"]["create_new_account"]
+    end
+  end
+end

--- a/app/services/presenter_builder.rb
+++ b/app/services/presenter_builder.rb
@@ -36,13 +36,26 @@ private
   end
 
   def service_sign_in_presenter_name
-    slug = content_item_path.split("/").last
-
-    if content_item.dig("details", "create_new_account", "slug") == slug
-      return "ServiceSignIn::CreateNewAccountPresenter"
+    if new_create_account_page?
+      "ServiceSignIn::VerifyHubTrialCreateNewAccountPresenter"
+    elsif content_path_create_account?
+      "ServiceSignIn::CreateNewAccountPresenter"
+    else
+      "ServiceSignIn::ChooseSignInPresenter"
     end
+  end
 
-    "ServiceSignIn::ChooseSignInPresenter"
+  def new_create_account_page?
+    content_path_create_account? && service_included_for_trial?
+  end
+
+  def service_included_for_trial?
+    content_item_path.include?("update-company-car-details") || content_item_path.include?("check-income-tax-current-year")
+  end
+
+  def content_path_create_account?
+    slug = content_item_path.split("/").last
+    content_item.dig("details", "create_new_account", "slug") == slug
   end
 
   class RedirectRouteReturned < StandardError

--- a/app/views/content_items/service_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in.html.erb
@@ -5,4 +5,4 @@
   <meta name="robots" content="noindex, nofollow">
 <% end %>
 
-<%= render partial: "content_items/service_sign_in/#{@content_item.page_type}" %>
+<%= render partial: "content_items/service_sign_in/#{@content_item.partial_type}" %>

--- a/app/views/content_items/service_sign_in/_verify_hub_trial_create_new_account.html.erb
+++ b/app/views/content_items/service_sign_in/_verify_hub_trial_create_new_account.html.erb
@@ -1,0 +1,98 @@
+<%= render "govuk_publishing_components/components/back_link", href: @content_item.back_link %>
+
+<%= render "components/heading", {
+    text: "Create an account",
+    heading_level: 1
+} %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <div class="govuk-govspeak">
+      <p>You can choose to use Government Gateway or GOV.UK Verify. You'll be able to apply for a basic criminal record check with either.</p>
+    </div>
+  </div>
+</div>
+
+<div class="grid-row govuk-govspeak">
+  <div class="column-one-half">
+    <h3>Government Gateway</h3>
+    <hr>
+
+    <h4>What you need</h4>
+
+    <p class="fixed-height">Government Gateway works best if you have:</p>
+
+    <ul class="list list-bullet">
+      <li>your National Insurance number</li>
+    </ul>
+
+    <p>And one of the following:</p>
+
+    <ul class="list list-bullet">
+      <li>a P60</li>
+      <li>a recent payslip</li>
+      <li>a UK passport</li>
+    </ul>
+    <%= render 'govuk_component/button',
+               text: 'Create a Government Gateway account',
+               href: @content_item.govenment_gateway_url,
+               margin_bottom: true,
+               rel: "external"
+    %>
+      <hr>
+      <h4>How long it takes, on average</h4>
+      <p>10 minutes</p>
+      <hr>
+      <h4>How it works</h4>
+
+      <p>Your details will be shared with the department that runs the 'apply for a basic criminal record check certificate' service.</p>
+  </div>
+
+  <div class="column-one-half">
+    <h3>GOV.UK Verify</h3>
+    <hr>
+    <h4>What you need</h4>
+    <p class="fixed-height">GOV.UK Verify requires you to:</p>
+
+    <ul class="list list-bullet">
+      <li>have a UK address</li>
+      <li>be over 18 years old</li>
+    </ul>
+
+    <p>It works best if you can provide either:</p>
+
+    <ul class="list list-bullet">
+      <li>a valid passport</li>
+      <li>a driving licence</li>
+    </ul>
+    <%= render 'govuk_component/button',
+               text: 'Create an account with GOV.UK Verify',
+               href: @content_item.verify_url,
+               margin_bottom: true,
+               rel: "external"
+    %>
+    <hr>
+    <h4>How long it takes, on average</h4>
+
+    <p>15 minutes</p>
+    <hr>
+    <h4>How it works</h4>
+
+    <p>A certified company with double check your identity. All companies involved have met security standards set by government</p>
+  </div>
+
+  <div class="column-full">
+    <hr>
+  </div>
+
+  <div class="column-two-thirds">
+    <div></div>
+    <h4>Personal tax account</h4>
+
+    <p>
+      Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
+    </p>
+  </div>
+</div>
+
+

--- a/test/integration/service_sign_in/verify_hub_trial_create_new_account_test.rb
+++ b/test/integration/service_sign_in/verify_hub_trial_create_new_account_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+
+module ServiceSignIn
+  class VerifyHubTrialCreateNewAccount < ActionDispatch::IntegrationTest
+    test "random but valid items do not error" do
+      # Create new account is an optional field, so we need to try a few times to
+      # get an example with it present.
+      path = nil
+      until path
+        payload = GovukSchemas::RandomExample.for_schema(frontend_schema: schema_type)
+        path = payload.dig("details", "create_new_account", "slug")
+      end
+
+      stub_request(:get, %r{#{path}})
+        .to_return(status: 200, body: payload.to_json, headers: {})
+
+      visit path
+    end
+
+    test "page renders correctly for company car details" do
+      setup_and_visit_create_new_account_page("/update-company-car-details/sign-in")
+      assert page.has_text?('Create an account')
+      assert page.has_text?("You can choose to use Government Gateway or GOV.UK Verify. You'll be able to apply for a basic criminal record check with either.")
+      assert page.has_css?(shared_component_selector('button'), text: "Create a Government Gateway account")
+      assert page.has_css?(shared_component_selector('button'), text: "Create an account with GOV.UK Verify")
+      assert page.has_css?('meta[name="robots"][content="noindex, nofollow"]', visible: false)
+      assert page.has_css?('.gem-c-back-link[href="/update-company-car-details/sign-in/choose-sign-in"]', text: 'Back')
+    end
+
+    test "page renders correctly for income tax details" do
+      setup_and_visit_create_new_account_page("/check-income-tax-current-year/sign-in")
+      assert page.has_text?('Create an account')
+      assert page.has_text?("You can choose to use Government Gateway or GOV.UK Verify. You'll be able to apply for a basic criminal record check with either.")
+      assert page.has_css?(shared_component_selector('button'), text: "Create a Government Gateway account")
+      assert page.has_css?(shared_component_selector('button'), text: "Create an account with GOV.UK Verify")
+      assert page.has_css?('meta[name="robots"][content="noindex, nofollow"]', visible: false)
+      assert page.has_css?('.gem-c-back-link[href="/check-income-tax-current-year/sign-in/choose-sign-in"]', text: 'Back')
+    end
+
+    test "page renders correctly for self_assessment" do
+      setup_and_visit_create_new_account_page("/log-in-file-self-assessment-tax-return/sign-in")
+      assert page.has_css?("title", text: 'Create an account - GOV.UK', visible: false)
+      within shared_component_selector('title') do
+        assert page.has_text?("Create an account")
+      end
+
+      assert_has_component_govspeak("<p>To use this service, you need to create either a Government Gateway or GOV.UK Verify account. These are used to help fight identity theft.</p><p>Once you have an account, you can use it to access other government services online.</p><h2 id='choose-a-way-to-prove-your-identity'>Choose a way to prove your identity</h2><h3 id='government-gateway'>Government Gateway</h3><p>Registering with Government Gateway usually takes about 10 minutes. It works best if you have:</p><ul><li>your National Insurance number</li><li>a recent payslip or P60 or a valid UK passport</li></ul><p><a rel='external' href='https://www.tax.service.gov.uk/check-income-tax/start-government-gateway?_ga=2.114080007.145612230.1512381177-373904926.1473694521'>Create a Government Gateway account.</a></p><h3 id='govuk-verify'>GOV.UK Verify</h3><p>Registering with GOV.UK Verify usually takes about 15 minutes. It works best if you have:</p><ul><li>a UK address</li><li>a valid passport or photocard driving licence</li></ul><p><a rel='external' href='https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.114080007.145612230.1512381177-373904926.1473694521'>Create a GOV.UK Verify account.</a></p><p>A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.</p><h2 id='personal-tax-account'>Personal tax account</h2><p>Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.</p>")
+
+      assert page.has_css?('meta[name="robots"][content="noindex, nofollow"]', visible: false)
+      refute page.has_css?(shared_component_selector('breadcrumbs'))
+      refute page.has_css?(shared_component_selector('government_navigation'))
+
+      assert page.has_css?(
+        '.gem-c-back-link[href="/log-in-file-self-assessment-tax-return/sign-in/choose-sign-in"]',
+        text: 'Back'
+      )
+    end
+
+    def setup_and_visit_create_new_account_page(service_base_path)
+      content_item = get_content_example("service_sign_in")
+      content_item["base_path"] = service_base_path
+      path = content_item["base_path"] + "/create-new-account"
+      content_store_has_item(path, content_item.to_json)
+      visit(path)
+    end
+
+    def schema_type
+      "service_sign_in"
+    end
+  end
+end

--- a/test/presenters/service_sign_in/verify_hub_trial_create_new_account_presenter_test.rb
+++ b/test/presenters/service_sign_in/verify_hub_trial_create_new_account_presenter_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class ServiceSignInPresenterTest
+  class VerifyHubTrialCreateNewAccount < ActiveSupport::TestCase
+    GOV_GATE_URL_FOR_COMPANY_CAR = "https://www.tax.service.gov.uk/paye/company-car/start-government-gateway".freeze
+    GOV_GATE_URL_FOR_INCOME_TAX = "https://www.tax.service.gov.uk/check-income-tax/start-government-gateway?_ga=2.114080007.145612230.1512381177-373904926.147".freeze
+    VERIFY_URL_FOR_COMPANY_CAR = "https://www.tax.service.gov.uk/paye/company-car/start-verify".freeze
+    VERIFY_URL_FOR_INCOME_TAX = "https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.114080007.145612230.1512381177-373904926.1473694521".freeze
+
+    def schema_name
+      "service_sign_in"
+    end
+
+    def setup
+      @presented_item = present_example(schema_item)
+      @create_new_account = schema_item["details"]["create_new_account"]
+    end
+
+    def present_example(example)
+      ServiceSignIn::VerifyHubTrialCreateNewAccountPresenter.new(example)
+    end
+
+    def schema_item
+      @schema_item ||= govuk_content_schema_example(schema_name, schema_name)
+    end
+
+    def parent_slug
+      schema_item['details']['choose_sign_in']['slug']
+    end
+
+    test 'presents the schema_name' do
+      assert_equal schema_item['schema_name'], @presented_item.schema_name
+    end
+
+    test 'presents correct url for gateway sign up - update company car details' do
+      schema_item['base_path'] = "update-company-car-details/sign-in"
+      assert_equal GOV_GATE_URL_FOR_COMPANY_CAR, @presented_item.govenment_gateway_url
+    end
+
+    test 'presents correct url for verify sign up - update company car details' do
+      schema_item['base_path'] = "update-company-car-details/sign-in"
+      assert_equal VERIFY_URL_FOR_COMPANY_CAR, @presented_item.verify_url
+    end
+
+    test 'presents correct url for gateway sign up - check income tax' do
+      schema_item['base_path'] = "check-income-tax-current-year/sign-in"
+      assert_equal GOV_GATE_URL_FOR_INCOME_TAX, @presented_item.govenment_gateway_url
+    end
+
+    test 'presents correct url for verify sign up - check income tax' do
+      schema_item['base_path'] = "check-income-tax-current-year/sign-in"
+      assert_equal VERIFY_URL_FOR_INCOME_TAX, @presented_item.verify_url
+    end
+
+    test 'presents the back_link' do
+      assert_equal "#{schema_item['base_path']}/#{parent_slug}", @presented_item.back_link
+    end
+  end
+end


### PR DESCRIPTION
[PR description by @tijmenb)

This pull request implements 2 new "create account" pages as a trial. They're built by GOV.UK Verify and will run on the site for 2 weeks. Note that `HUB-39` refers to an issue on Verify's non-public issue tracker.

The [comment below](https://github.com/alphagov/government-frontend/pull/776#issuecomment-366957909) captures most of the reasoning behind the change.

## Before

![screen shot 2018-02-22 at 13 41 33](https://user-images.githubusercontent.com/233676/36541528-1f43ca96-17d6-11e8-8915-78cfa2c418b6.png)

## After

![screen shot 2018-02-22 at 13 42 10](https://user-images.githubusercontent.com/233676/36541551-3347f33c-17d6-11e8-94d1-789dfb5e8042.png)

Trello ticket on GOV.UK board: https://trello.com/b/a9IKJvu5
