### PR TITLE
Add track-click to contents-list

### DIFF
--- a/app/views/components/_contents-list.html.erb
+++ b/app/views/components/_contents-list.html.erb
@@ -15,6 +15,7 @@
   <nav
     role="navigation"
     class="app-c-contents-list"
+    data-module="track-click"
     <% if aria_label.present? %>
       aria-label="<%= aria_label %>"
     <% end %>

--- a/test/components/contents_list_component_test.rb
+++ b/test/components/contents_list_component_test.rb
@@ -77,6 +77,8 @@ class ContentsListComponentTest < ComponentTestCase
   test "renders data attributes for tracking" do
     render_component(contents: nested_contents_list)
 
+    assert_select ".app-c-contents-list[data-module='track-click']"
+
     assert_tracking_link("category", "contentsClicked", 6)
     assert_tracking_link("action", "content_item 1")
     assert_tracking_link("label", "/one")


### PR DESCRIPTION
We need to add the track click data module to a parent element in order to pick
up link tracking on the content links.

