### PR TITLE
Revert using foreman in dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y
-
 RUN apt-get install -y build-essential nodejs && apt-get clean
+RUN gem install foreman
 
 ENV GOVUK_APP_NAME government-frontend
 ENV GOVUK_ASSET_ROOT http://assets-origin.dev.gov.uk
@@ -22,4 +22,4 @@ RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
 
-CMD bundle exec foreman run web
+CMD foreman run web

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ ruby File.read(".ruby-version").strip
 
 gem 'asset_bom_removal-rails', '~> 1.0'
 gem 'dalli'
-gem 'foreman', '~> 0.84'
 gem 'htmlentities', '~> 4.3'
 gem 'rack_strip_client_ip', '~> 0.0.2'
 gem 'rails', '~> 5.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,8 +90,6 @@ GEM
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.21)
-    foreman (0.84.0)
-      thor (~> 0.19.1)
     gds-api-adapters (51.2.0)
       addressable
       link_header
@@ -312,7 +310,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.4.0)
-    thor (0.19.4)
+    thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
     tzinfo (1.2.5)
@@ -357,7 +355,6 @@ DEPENDENCIES
   capybara
   dalli
   faker
-  foreman (~> 0.84)
   gds-api-adapters (~> 51.2)
   govuk-lint
   govuk_ab_testing (~> 2.4)

--- a/startup.sh
+++ b/startup.sh
@@ -8,14 +8,14 @@ if [[ $1 == "--live" ]] ; then
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
   PLEK_SERVICE_RUMMAGER_URI=${PLEK_SERVICE_RUMMAGER_URI-https://www.gov.uk/api} \
-  bundle exec foreman run web
+  bundle exec rails s -p 3090
 elif [[ $1 == "--dummy" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://govuk-content-store-examples.herokuapp.com/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
   PLEK_SERVICE_RUMMAGER_URI=${PLEK_SERVICE_RUMMAGER_URI-https://www.gov.uk/api} \
-  bundle exec foreman run web
+  bundle exec rails s -p 3090
 else
-  bundle exec foreman run web
+  bundle exec rails s -p 3090
 fi


### PR DESCRIPTION
Wider context: alphagov/publishing-e2e-tests#202

This removes foreman from the Gemfile and from the startup.sh usage and
instead installs foreman separately via `gem install` in the Dockerfile
so that it can be used in the docker environment.

The reason for this is that running everything via unicorn in dev can
cause some wtfs (such as breaking better_errors) and installing foreman
via Gemfile does contradict some contenious advice given by the foreman
gem maintainer.

---

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
