### PR TITLE
Link tracking on classic part navigation

### DIFF
--- a/app/presenters/content_item/parts.rb
+++ b/app/presenters/content_item/parts.rb
@@ -84,9 +84,17 @@ module ContentItem
     end
 
     def part_links
-      parts.map do |part|
+      parts.map.with_index(1) do |part, position|
         if part['slug'] != current_part['slug']
-          link_to part['title'], part['full_path']
+          link_to part['title'], part['full_path'],
+            data: {
+            track_category: 'contentsClicked',
+            track_action: "content_item #{position}",
+            track_label: part['full_path'],
+            track_options: {
+              dimension29: part['title']
+             }
+           }
         else
           part['title']
         end

--- a/app/views/shared/_parts_navigation.html.erb
+++ b/app/views/shared/_parts_navigation.html.erb
@@ -1,7 +1,7 @@
 <% if show_alternate_guide_chapters? %>
   <%= render "components/contents-list", aria_label: navigation_label, contents: content_item.part_link_elements %>
 <% else %>
-  <nav role="navigation" class="grid-row part-navigation" aria-label="<%= navigation_label %>">
+  <nav role="navigation" class="grid-row part-navigation" aria-label="<%= navigation_label %>" data-module="track-click">
     <% content_item.parts_navigation.each_with_index do |part_group, i| %>
       <ol
         class="column-half"

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -26,6 +26,12 @@ class GuideTest < ActionDispatch::IntegrationTest
     assert page.has_css?('h1', text: "1. #{@content_item['details']['parts'].first['title']}")
     assert page.has_css?(shared_component_selector("previous_and_next_navigation"))
     assert page.has_css?('.app-c-print-link a[href$="/print"]')
+
+    assert page.has_css?(".part-navigation[data-module='track-click']")
+    assert_tracking_link("category", "contentsClicked", (@content_item['details']['parts'].size - 1))
+    assert_tracking_link("action", "content_item 2")
+    assert_tracking_link("label", "/national-curriculum/key-stage-1-and-2")
+    assert_tracking_link("options", { dimension29: "Key stage 1 and 2" }.to_json)
   end
 
   test "draft access tokens are appended to part links within navigation" do
@@ -40,5 +46,9 @@ class GuideTest < ActionDispatch::IntegrationTest
     refute page.has_css?('h1', text: @content_item['details']['parts'].first['title'])
     refute page.has_css?('.part-navigation')
     refute page.has_css?('.app-c-print-link')
+  end
+
+  def assert_tracking_link(name, value, total = 1)
+    assert page.has_css?("a[data-track-#{name}='#{value}']", count: total)
   end
 end

--- a/test/presenters/content_item/parts_test.rb
+++ b/test/presenters/content_item/parts_test.rb
@@ -148,16 +148,23 @@ class ContentItemPartsTest < ActiveSupport::TestCase
     assert_equal @parts.current_part_title, 'first-title'
   end
 
-  test 'navigation items are presented as links unless they are the current part' do
+  test 'navigation items are presented as trackable links unless they are the current part' do
     presenting_first_part_in_content_item
     assert_equal @parts.current_part_title, 'first-title'
-    assert_equal @parts.parts_navigation, [["first-title", "<a href=\"/base-path/second-slug\">second-title</a>"]]
+    assert_equal @parts.parts_navigation,
+      [[
+        "first-title",
+        "<a data-track-category=\"contentsClicked\" data-track-action=\"content_item 2\" "\
+        "data-track-label=\"/base-path/second-slug\" "\
+        "data-track-options=\"{&quot;dimension29&quot;:&quot;second-title&quot;}\" "\
+        "href=\"/base-path/second-slug\">second-title</a>"
+      ]]
   end
 
   test 'links to the first part ignore the part\'s slug and use the base path' do
     presenting_second_part_in_content_item
     assert_equal @parts.current_part_title, 'second-title'
-    assert_equal @parts.parts_navigation, [["<a href=\"/base-path\">first-title</a>", "second-title"]]
+    assert @parts.parts_navigation[0][0].include? "href=\"/base-path\""
   end
 
   test 'navigation items link to all parts' do
@@ -204,8 +211,22 @@ class ContentItemPartsTest < ActiveSupport::TestCase
     end
 
     assert_equal @parts.parts_navigation, [
-        ["first-title", "<a href=\"/base-path/second-slug\">second-title</a>"],
-        ["<a href=\"/base-path/third-slug\">third-title</a>", "<a href=\"/base-path/fourth-slug\">fourth-title</a>"]
+        [
+          "first-title", "<a data-track-category=\"contentsClicked\" "\
+          "data-track-action=\"content_item 2\" data-track-label=\"/base-path/second-slug\" "\
+          "data-track-options=\"{&quot;dimension29&quot;:&quot;second-title&quot;}\" "\
+          "href=\"/base-path/second-slug\">second-title</a>"
+        ],
+        [
+          "<a data-track-category=\"contentsClicked\" data-track-action=\"content_item 3\" "\
+          "data-track-label=\"/base-path/third-slug\" "\
+          "data-track-options=\"{&quot;dimension29&quot;:&quot;third-title&quot;}\" "\
+          "href=\"/base-path/third-slug\">third-title</a>",
+          "<a data-track-category=\"contentsClicked\" data-track-action=\"content_item 4\" "\
+          "data-track-label=\"/base-path/fourth-slug\" "\
+          "data-track-options=\"{&quot;dimension29&quot;:&quot;fourth-title&quot;}\" "\
+          "href=\"/base-path/fourth-slug\">fourth-title</a>"
+        ]
       ]
   end
 end

--- a/test/presenters/travel_advice_presenter_test.rb
+++ b/test/presenters/travel_advice_presenter_test.rb
@@ -81,7 +81,7 @@ class TravelAdvicePresenterTest
       assert_equal 'Summary', first_nav_item
     end
 
-    test "navigation items are presented as links unless they are the current part" do
+    test "navigation items are presented as trackable links unless they are the current part" do
       example = schema_item("full-country")
       base_path = example["base_path"]
       current_part = example["details"]["parts"].first
@@ -94,9 +94,17 @@ class TravelAdvicePresenterTest
       current_part_nav_item = navigation_items[0][1]
       another_part_nav_item = navigation_items[0][2]
 
-      assert_equal summary_nav_item, "<a href=\"#{base_path}\">Summary</a>"
+      assert_equal summary_nav_item,
+        "<a data-track-category=\"contentsClicked\" data-track-action=\"content_item 1\" "\
+        "data-track-label=\"/foreign-travel-advice/albania\" "\
+        "data-track-options=\"{&quot;dimension29&quot;:&quot;Summary&quot;}\" "\
+        "href=\"/foreign-travel-advice/albania\">Summary</a>"
       assert_equal current_part_nav_item, current_part['title']
-      assert_equal another_part_nav_item, "<a href=\"#{base_path}/#{another_part['slug']}\">#{another_part['title']}</a>"
+      assert_equal another_part_nav_item,
+        "<a data-track-category=\"contentsClicked\" data-track-action=\"content_item 3\" "\
+        "data-track-label=\"/foreign-travel-advice/albania/terrorism\" "\
+        "data-track-options=\"{&quot;dimension29&quot;:&quot;Terrorism&quot;}\" "\
+        "href=\"/foreign-travel-advice/albania/terrorism\">Terrorism</a>"
     end
 
     test "navigation items link to all parts" do


### PR DESCRIPTION
This is intentionally identical to [contents-list tracking](https://github.com/alphagov/government-frontend/blob/422cf974706b73e2f65f9bd1c1db43e9e4a56047/app/views/components/_contents-list.html.erb#L39-L46) as we want to directly compare the performance of both.

The tests are a little bit horrible because the addition of the tracking in the presenter means that we need to match long strings, but this does make it easier to update the test should the link change in future.