### PR TITLE
Add step navigation dependency

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 //= require_tree ./modules
+//= require current-location
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/step-by-step-nav


### PR DESCRIPTION
Step by step navigation needs this from govuk_publishing_components.  We'll
look at perhaps moving this to a better namespace, but this should be fixed
soon as it causes script errors on pages with step by step navigation if it's
not there. (eg https://www.gov.uk/theory-test )