### PR TITLE
Add a min-height to stop the back to top link collapsing

### DIFF
--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -16,6 +16,9 @@
   padding-bottom: $gutter-one-third;
 
   .app-c-back-to-top {
+    // This ensures the link doesn't 'collapse' allowing elements
+    // below the link to briefly appear above the link
+    min-height: 1px;
     padding-bottom: $gutter-one-third;
   }
 }


### PR DESCRIPTION
Addresses https://github.com/alphagov/government-frontend/issues/786

A good test page is https://government-frontend-pr-787.herokuapp.com/drug-device-alerts/drug-alert-amoxicillin-sodium-500mg-powder-for-solution-for-injection-additional-reports-of-injection-site-reactions-in-paediatrics-and-adults?cachebust=1519124601

Here's a video of it misbehaving:

![contents-moving](https://user-images.githubusercontent.com/861310/36493263-1a612e9c-1727-11e8-8bd4-70cd74c55ddf.gif)

The elements below the back to top link can briefly
appear above the link as it transitions from an in-body
element to a fixed position, adding a minimum height stops the
element collapsing and causing this flickering element
reordering.

Thanks to @andysellick and @fofr for reporting and explaining this.

---

Component guide for this PR:
https://government-frontend-pr-787.herokuapp.com/component-guide
