### PR TITLE
Disable caching of content-store responses

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -2,6 +2,12 @@ require 'gds_api/content_store'
 
 module Services
   def self.content_store
-    @content_store ||= GdsApi::ContentStore.new(Plek.current.find("content-store"))
+    @content_store ||= GdsApi::ContentStore.new(
+      Plek.current.find("content-store"),
+      # Disable caching to avoid caching a stale max-age in the cache control
+      # headers, which would cause this app to set the wrong max-age on its
+      # own responses
+      disable_cache: true,
+    )
   end
 end


### PR DESCRIPTION
By default, gds-api-adapters caches responses based on the `max-age` set in the response's cache control headers. This means that government-frontend can use a very stale max-age when setting cache headers on its own responses.

In the worst case scenario, this means that content changes can take up to 30 minutes to appear on the site.

Disabling this cache should not put much more load on the content store because responses are cached so heavily in Varnish and the CDN, and these handle cache headers correctly.

The plan is to let this run on staging for a day or so to see if it can handle the traffic replay without caching. If not, we can try to improve the caching - it looks like gds-api-adapters can also handle an `expires` header containing an actual date, so we could set that in content-store and use it to set a more accurate `max-age` in government-frontend.

https://trello.com/c/pMHR10Rv/85-2-scheduled-publication-reporting

cc @boffbowsh @gpeng 