### PR TITLE
Rename helper module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.2'
 gem 'govuk_frontend_toolkit', '~> 7.4'
 gem 'govuk_navigation_helpers', '~> 9.0'
-gem 'govuk_publishing_components', '~> 5.1.3'
+gem 'govuk_publishing_components', '~> 5.2'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 12.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       rest-client (~> 2.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    govspeak (5.4.0)
+    govspeak (5.5.0)
       actionview (>= 4.1, < 6)
       addressable (>= 2.3.8, < 3)
       commander (~> 4.4)
@@ -129,7 +129,7 @@ GEM
       activesupport (~> 5.1)
       gds-api-adapters (>= 43.0)
       govuk_ab_testing (~> 2.4)
-    govuk_publishing_components (5.1.3)
+    govuk_publishing_components (5.2.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
@@ -364,7 +364,7 @@ DEPENDENCIES
   govuk_app_config (~> 1.2)
   govuk_frontend_toolkit (~> 7.4)
   govuk_navigation_helpers (~> 9.0)
-  govuk_publishing_components (~> 5.1.3)
+  govuk_publishing_components (~> 5.2)
   govuk_schemas (~> 3.1)
   htmlentities (~> 4.3)
   jasmine-rails

--- a/app/helpers/related_navigation_sidebar_helper.rb
+++ b/app/helpers/related_navigation_sidebar_helper.rb
@@ -1,4 +1,4 @@
-module RelatedNavigationHelper
+module RelatedNavigationSidebarHelper
   MAX_SECTION_LENGTH = 5
   DEFINED_SECTIONS = %w(
     related_guides


### PR DESCRIPTION
Addresses problems spotted here https://github.com/alphagov/government-frontend/pull/781

Rename a helper (module) so that it won't collide with a class with the same name introduced in v5.2.0 of the govuk_publishing_components gem.

cc @tijmenb @emmabeynon 
---

Component guide for this PR:
https://government-frontend-pr-790.herokuapp.com/component-guide
