### PR TITLE
Hub 39 new create account page trial - copy change

### DIFF
--- a/app/presenters/service_sign_in/verify_hub_trial_create_new_account_presenter.rb
+++ b/app/presenters/service_sign_in/verify_hub_trial_create_new_account_presenter.rb
@@ -10,12 +10,20 @@ module ServiceSignIn
     VERIFY_URL_FOR_COMPANY_CAR = "https://www.tax.service.gov.uk/paye/company-car/start-verify".freeze
     VERIFY_URL_FOR_INCOME_TAX = "https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.114080007.145612230.1512381177-373904926.1473694521".freeze
 
+    SERVICE_TEXT_FOR_COMPANY_CAR = "check or update your company car tax".freeze
+    SERVICE_TEXT_FOR_INCOME_TAX = "check your income tax for the current year".freeze
+
     def page_type
       "create_new_account"
     end
 
     def partial_type
       "verify_hub_trial_create_new_account"
+    end
+
+    def service_specific_text
+      return SERVICE_TEXT_FOR_COMPANY_CAR if content_item['base_path'].include?("update-company-car-details")
+      return SERVICE_TEXT_FOR_INCOME_TAX if content_item['base_path'].include?("check-income-tax-current-year")
     end
 
     def govenment_gateway_url

--- a/app/views/content_items/service_sign_in/_verify_hub_trial_create_new_account.html.erb
+++ b/app/views/content_items/service_sign_in/_verify_hub_trial_create_new_account.html.erb
@@ -8,7 +8,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <div class="govuk-govspeak">
-      <p>You can choose to use Government Gateway or GOV.UK Verify. You'll be able to apply for a basic criminal record check with either.</p>
+      <p>You can choose to use Government Gateway or GOV.UK Verify. You'll be able to <%=@content_item.service_specific_text%> with either.</p>
     </div>
   </div>
 </div>
@@ -45,7 +45,7 @@
       <hr>
       <h4>How it works</h4>
 
-      <p>Your details will be shared with the department that runs the 'apply for a basic criminal record check certificate' service.</p>
+      <p>Your details will be shared with the department that runs the '<%=@content_item.service_specific_text%>' service.</p>
   </div>
 
   <div class="column-one-half">

--- a/test/integration/service_sign_in/verify_hub_trial_create_new_account_test.rb
+++ b/test/integration/service_sign_in/verify_hub_trial_create_new_account_test.rb
@@ -18,9 +18,11 @@ module ServiceSignIn
     end
 
     test "page renders correctly for company car details" do
+      SERVICE_TEXT_FOR_COMPANY_CAR = "check or update your company car tax".freeze
       setup_and_visit_create_new_account_page("/update-company-car-details/sign-in")
       assert page.has_text?('Create an account')
-      assert page.has_text?("You can choose to use Government Gateway or GOV.UK Verify. You'll be able to apply for a basic criminal record check with either.")
+      assert page.has_text?(SERVICE_TEXT_FOR_COMPANY_CAR)
+      assert page.has_text?("You can choose to use Government Gateway or GOV.UK Verify.")
       assert page.has_css?(shared_component_selector('button'), text: "Create a Government Gateway account")
       assert page.has_css?(shared_component_selector('button'), text: "Create an account with GOV.UK Verify")
       assert page.has_css?('meta[name="robots"][content="noindex, nofollow"]', visible: false)
@@ -28,9 +30,11 @@ module ServiceSignIn
     end
 
     test "page renders correctly for income tax details" do
+      SERVICE_TEXT_FOR_INCOME_TAX = "check your income tax for the current year".freeze
       setup_and_visit_create_new_account_page("/check-income-tax-current-year/sign-in")
       assert page.has_text?('Create an account')
-      assert page.has_text?("You can choose to use Government Gateway or GOV.UK Verify. You'll be able to apply for a basic criminal record check with either.")
+      assert page.has_text?(SERVICE_TEXT_FOR_INCOME_TAX)
+      assert page.has_text?("You can choose to use Government Gateway or GOV.UK Verify.")
       assert page.has_css?(shared_component_selector('button'), text: "Create a Government Gateway account")
       assert page.has_css?(shared_component_selector('button'), text: "Create an account with GOV.UK Verify")
       assert page.has_css?('meta[name="robots"][content="noindex, nofollow"]', visible: false)

--- a/test/presenters/service_sign_in/verify_hub_trial_create_new_account_presenter_test.rb
+++ b/test/presenters/service_sign_in/verify_hub_trial_create_new_account_presenter_test.rb
@@ -7,6 +7,9 @@ class ServiceSignInPresenterTest
     VERIFY_URL_FOR_COMPANY_CAR = "https://www.tax.service.gov.uk/paye/company-car/start-verify".freeze
     VERIFY_URL_FOR_INCOME_TAX = "https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.114080007.145612230.1512381177-373904926.1473694521".freeze
 
+    SERVICE_TEXT_FOR_COMPANY_CAR = "check or update your company car tax".freeze
+    SERVICE_TEXT_FOR_INCOME_TAX = "check your income tax for the current year".freeze
+
     def schema_name
       "service_sign_in"
     end
@@ -50,6 +53,16 @@ class ServiceSignInPresenterTest
     test 'presents correct url for verify sign up - check income tax' do
       schema_item['base_path'] = "check-income-tax-current-year/sign-in"
       assert_equal VERIFY_URL_FOR_INCOME_TAX, @presented_item.verify_url
+    end
+
+    test 'presents correct service text - update company car details' do
+      schema_item['base_path'] = "update-company-car-details/sign-in"
+      assert_equal SERVICE_TEXT_FOR_COMPANY_CAR, @presented_item.service_specific_text
+    end
+
+    test 'presents correct service text  - check income tax' do
+      schema_item['base_path'] = "check-income-tax-current-year/sign-in"
+      assert_equal SERVICE_TEXT_FOR_INCOME_TAX, @presented_item.service_specific_text
     end
 
     test 'presents the back_link' do


### PR DESCRIPTION
Further to the trial new view for service signing create account page we have found some copy changes that are needed under the Create Account heading and in the Government gateway service section. This text must be set dynamically for each of the two services involved in the trial so for the time being this is being set as a property from the presenter. Should the trial prove successful we will add the copy in publisher as discussed. Tests have been updated.

This amendment has been added as a comment to the original text card: https://govukverify.atlassian.net/browse/HUB-39

<img width="883" alt="screen shot 2018-02-27 at 13 03 53" src="https://user-images.githubusercontent.com/15333080/36730262-b9f71b92-1bbe-11e8-8dad-64d7e06d416a.png">


Screenshots for each of the three services that hit this page are below (run locally)

http://localhost:3090/check-income-tax-current-year/sign-in/create-account 
and
http://localhost:3090/update-company-car-details/sign-in/create-account

<img width="1208" alt="screen shot 2018-02-27 at 14 06 05" src="https://user-images.githubusercontent.com/15333080/36733086-6cf9d5ba-1bc7-11e8-9fa0-ce6b8b0e8668.png">

<img width="1113" alt="screen shot 2018-02-27 at 14 05 51" src="https://user-images.githubusercontent.com/15333080/36733103-741103f0-1bc7-11e8-8b27-cffd601d5b01.png">



Self assessment - should show no change
http://localhost:3090/log-in-file-self-assessment-tax-return/sign-in/register-self-assessment

<img width="1166" alt="screen shot 2018-02-27 at 14 05 07" src="https://user-images.githubusercontent.com/15333080/36733118-7e13ba6e-1bc7-11e8-8b19-474de3f9fb87.png">




---

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
