### PR TITLE
Ensure we always pluralise the translation for 'Documents'

### DIFF
--- a/app/views/content_items/_publication_inline_body.html.erb
+++ b/app/views/content_items/_publication_inline_body.html.erb
@@ -1,4 +1,6 @@
-<%= render 'components/heading', text: t("publication.documents", count: @content_item.documents_count), id: "documents-title" %>
+<%= render 'components/heading',
+  text: t("publication.documents", count: 5), # This should always be pluralised.
+  id: "documents-title" %>
 
 <div aria-labelledby="documents-title">
   <%= render 'govuk_component/govspeak',


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/2583792
https://trello.com/c/aPpXYR8h/294-translation-of-related-navigation-component

Fixes a pluralisation problem for publications 'Documents' heading.
We don't need a variable heading based on the number of documents attached to a publication, the heading should always be pluralised.

Production
![screenshot from 2018-02-28 11-18-32](https://user-images.githubusercontent.com/93511/36785216-fcc51044-1c79-11e8-9452-bd00144c9e4a.png)

PR
![screenshot from 2018-02-28 11-18-55](https://user-images.githubusercontent.com/93511/36785226-08a1f9c2-1c7a-11e8-8bb0-f8e48fa0936f.png)

#### Example

https://government-frontend-pr-804.herokuapp.com/government/publications/tb-restricted-cattle-application-to-hold-a-market-gathering-or-dedicated-sale.cy

---

Component guide for this PR:
https://government-frontend-pr-804.herokuapp.com/component-guide
