### PR TITLE
Render step by step navigation from content items

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     debug_inspector (0.0.3)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    erubi (1.7.0)
+    erubi (1.7.1)
     execjs (2.7.0)
     faker (1.8.7)
       i18n (>= 0.7)
@@ -250,7 +250,7 @@ GEM
       rake
     raindrops (0.19.0)
     rake (12.3.0)
-    rb-fsevent (0.10.2)
+    rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     request_store (1.4.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,15 +7,10 @@ class ApplicationController < ActionController::Base
 
 private
 
-  def current_step_nav
-    @step_nav ||= GovukNavigationHelpers::StepNavContent.current_step_nav(request.path)
+  def step_nav_helper
+    @step_nav_helpers ||= GovukPublishingComponents::StepNavHelper.new(content_item.content_item, request.path)
   end
-  helper_method :current_step_nav
-
-  def show_step_nav?
-    current_step_nav && current_step_nav.show_step_nav?
-  end
-  helper_method :show_step_nav?
+  helper_method :step_nav_helper
 
   def content_item_path
     path_and_optional_locale = params

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :no_breadcrumbs, show_step_nav? %>
+<%= content_for :no_breadcrumbs, step_nav_helper.show_header? %>
 <%= content_for :simple_header, @navigation.should_present_taxonomy_navigation? %>
 
 <div class="grid-row">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,8 +34,8 @@
 
   <div id="wrapper" class="<%= wrapper_class %>">
     <%= render_phase_label @content_item, content_for(:phase_message) %>
-    <% if show_step_nav?%>
-      <%= render 'shared/step_nav_header', step_nav_content: current_step_nav %>
+    <% if step_nav_helper.show_header? %>
+      <%= render 'shared/step_nav_header' %>
     <% else %>
       <% if !content_for(:no_breadcrumbs) %>
         <%= render 'shared/breadcrumbs' %>

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -1,4 +1,4 @@
-<% if show_step_nav? %>
+<% if step_nav_helper.show_related_links? %>
   <%= render 'shared/sidebar_step_nav', no_margin: true %>
 <% else %>
   <div class="column-third">

--- a/app/views/shared/_sidebar_step_nav.html.erb
+++ b/app/views/shared/_sidebar_step_nav.html.erb
@@ -2,9 +2,8 @@
   no_margin ||= false
 %>
 <nav class="column-third <%= "step-by-step-nav-sidebar" unless no_margin %>">
-  <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: [{
-      href: current_step_nav.base_path,
-      text: current_step_nav.title
-  }] %>
-  <%= render 'govuk_publishing_components/components/step_by_step_nav', current_step_nav.set_current_step %>
+  <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: step_nav_helper.related_links %>
+  <% if step_nav_helper.show_sidebar? && step_nav_helper %>
+    <%= render 'govuk_publishing_components/components/step_by_step_nav', step_nav_helper.sidebar %>
+  <% end %>
 </nav>

--- a/app/views/shared/_step_nav_header.html.erb
+++ b/app/views/shared/_step_nav_header.html.erb
@@ -1,5 +1,3 @@
-<%= render "govuk_publishing_components/components/step_by_step_nav_header",
-  title: current_step_nav.title,
-  path: current_step_nav.base_path,
-  skip_link: current_step_nav.skip_link
-  %>
+<% if step_nav_helper.show_header? %>
+  <%= render 'govuk_publishing_components/components/step_by_step_nav_header', step_nav_helper.header %>
+<% end %>

--- a/test/controllers/step_navigation_controller_test.rb
+++ b/test/controllers/step_navigation_controller_test.rb
@@ -6,7 +6,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   %w(guide answer publication).each do |schema_name|
     test "#{schema_name} shows step by step navigation where relevant" do
-      content_item = content_store_has_schema_example(schema_name, schema_name)
+      content_item = content_store_has_schema_example(schema_name, "#{schema_name}-with-step-navs")
       content_item['base_path'] = "/pass-plus"
       path = content_item['base_path'][1..-1]
 


### PR DESCRIPTION
We've moved the step by step navigation helpers to the publishing components, so we need to update the frontend apps.

This now reads the step by step navigation content from the content item rather than it being hardcoded in the govuk_navigation_helpers gem.

https://trello.com/c/ESb3nINX/442-government-frontend-renders-step-by-step-navigation-from-content-item