### PR TITLE
Revert "Revert "Remove Webchat section from Construction Industry Scheme contact page""

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -175,7 +175,6 @@ private
       '/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries' => 1034,
       '/government/organisations/hm-revenue-customs/contact/trusts' => 1036,
       '/government/organisations/hm-revenue-customs/contact/employer-enquiries' => 1023,
-      '/government/organisations/hm-revenue-customs/contact/construction-industry-scheme' => 1048,
       '/government/organisations/hm-revenue-customs/contact/online-services-helpdesk' => 1003,
     }
   end


### PR DESCRIPTION
Reverts #800 and reinstate #742 (which means we remove webchat from the Construction Industry Scheme contact page).

We had some crossed wires about which of the two "remove webchat" stories we were doing needed to be reinstated on the 25th Feb.  We shouldn't have reinstated webchat on Construction Industry Scheme - it should be removed forever, we should have reinstated webchat on Self-assessment Online Services Helpdesk as it was a temporary trial from 19th to 25th.  The Self-assessment Online Services Helpdesk webchat removal was handled in #766 and gated so that it reinstated automatically, and, as it turns out, they decided the trial was good enough to keep it removed forever too which was handled in #805.