### PR TITLE
[Do not merge] Show taxonomy navigation for non-guidance formats

### DIFF
--- a/app/models/navigation_type.rb
+++ b/app/models/navigation_type.rb
@@ -1,15 +1,11 @@
 class NavigationType
-  GUIDANCE_SCHEMAS =
-    %w{answer contact guide detailed_guide document_collection publication}.freeze
-
   def initialize(content_item)
     @content_item = content_item
   end
 
   def should_present_taxonomy_navigation?
     !content_is_tagged_to_browse_pages? &&
-      content_is_tagged_to_a_taxon? &&
-      content_schema_is_guidance?
+      content_is_tagged_to_a_taxon?
   end
 
 private
@@ -20,9 +16,5 @@ private
 
   def content_is_tagged_to_browse_pages?
     @content_item.dig("links", "mainstream_browse_pages").present?
-  end
-
-  def content_schema_is_guidance?
-    GUIDANCE_SCHEMAS.include? @content_item["schema_name"]
   end
 end

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -318,7 +318,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_match(/A Taxon/, taxonomy_sidebar)
   end
 
-  test "Case Studies don't have the taxonomy-navigation" do
+  test "Case Studies have the taxonomy-navigation" do
     content_item = content_store_has_schema_example('case_study', 'case_study')
     path = 'government/test/case-study'
     content_item['base_path'] = "/#{path}"
@@ -334,7 +334,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     content_store_has_item(content_item['base_path'], content_item)
 
     get :show, params: { path: path_for(content_item) }
-    assert_equal [], @request.variant
+    assert_equal [:taxonomy_navigation], @request.variant
     refute_match(/A Taxon/, taxonomy_sidebar)
   end
 


### PR DESCRIPTION
Demonstrates how navigation might work for non-guidance formats tagged to taxonomy.

##### Eg.
https://government-frontend-pr-814.herokuapp.com/government/collections/statistics-vocational-qualifications

---

Component guide for this PR:
https://government-frontend-pr-814.herokuapp.com/component-guide
