### PR TITLE
HUB-73 Add new sign-in page design to Personal Tax Account service

### DIFF
--- a/app/presenters/service_sign_in/verify_hub_trial_create_new_account_presenter.rb
+++ b/app/presenters/service_sign_in/verify_hub_trial_create_new_account_presenter.rb
@@ -1,5 +1,5 @@
 # Trial new start page payout for update company car details and income tax services (by verify hub improvements team)
-# Due for teardown/review on 8th March 2018 - Jira card HUB-39
+# Due for teardown/review on 23rd March 2018 - Jira card HUB-39
 
 module ServiceSignIn
   class VerifyHubTrialCreateNewAccountPresenter < ContentItemPresenter
@@ -7,11 +7,15 @@ module ServiceSignIn
 
     GOV_GATE_URL_FOR_COMPANY_CAR = "https://www.tax.service.gov.uk/paye/company-car/start-government-gateway".freeze
     GOV_GATE_URL_FOR_INCOME_TAX = "https://www.tax.service.gov.uk/check-income-tax/start-government-gateway?_ga=2.114080007.145612230.1512381177-373904926.147".freeze
+    GOV_GATE_URL_FOR_PERSONAL_TAX = "https://www.tax.service.gov.uk/personal-account/start-government-gateway".freeze
     VERIFY_URL_FOR_COMPANY_CAR = "https://www.tax.service.gov.uk/paye/company-car/start-verify".freeze
     VERIFY_URL_FOR_INCOME_TAX = "https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.114080007.145612230.1512381177-373904926.1473694521".freeze
+    VERIFY_URL_FOR_PERSONAL_TAX = "https://www.tax.service.gov.uk/personal-account/start-verify".freeze
+
 
     SERVICE_TEXT_FOR_COMPANY_CAR = "check or update your company car tax".freeze
     SERVICE_TEXT_FOR_INCOME_TAX = "check your income tax for the current year".freeze
+    SERVICE_TEXT_FOR_PERSONAL_TAX = "access your personal tax account".freeze
 
     def page_type
       "create_new_account"
@@ -24,16 +28,19 @@ module ServiceSignIn
     def service_specific_text
       return SERVICE_TEXT_FOR_COMPANY_CAR if content_item['base_path'].include?("update-company-car-details")
       return SERVICE_TEXT_FOR_INCOME_TAX if content_item['base_path'].include?("check-income-tax-current-year")
+      return SERVICE_TEXT_FOR_PERSONAL_TAX if content_item['base_path'].include?("personal-tax-account")
     end
 
     def govenment_gateway_url
       return GOV_GATE_URL_FOR_COMPANY_CAR if content_item['base_path'].include?("update-company-car-details")
       return GOV_GATE_URL_FOR_INCOME_TAX if content_item['base_path'].include?("check-income-tax-current-year")
+      return GOV_GATE_URL_FOR_PERSONAL_TAX if content_item['base_path'].include?("personal-tax-account")
     end
 
     def verify_url
       return VERIFY_URL_FOR_COMPANY_CAR if content_item['base_path'].include?("update-company-car-details")
       return VERIFY_URL_FOR_INCOME_TAX if content_item['base_path'].include?("check-income-tax-current-year")
+      return VERIFY_URL_FOR_PERSONAL_TAX if content_item['base_path'].include?("personal-tax-account")
     end
 
     def back_link

--- a/app/services/presenter_builder.rb
+++ b/app/services/presenter_builder.rb
@@ -50,7 +50,9 @@ private
   end
 
   def service_included_for_trial?
-    content_item_path.include?("update-company-car-details") || content_item_path.include?("check-income-tax-current-year")
+    content_item_path.include?("update-company-car-details") ||
+      content_item_path.include?("check-income-tax-current-year") ||
+      content_item_path.include?("personal-tax-account")
   end
 
   def content_path_create_account?

--- a/test/presenters/service_sign_in/verify_hub_trial_create_new_account_presenter_test.rb
+++ b/test/presenters/service_sign_in/verify_hub_trial_create_new_account_presenter_test.rb
@@ -4,11 +4,14 @@ class ServiceSignInPresenterTest
   class VerifyHubTrialCreateNewAccount < ActiveSupport::TestCase
     GOV_GATE_URL_FOR_COMPANY_CAR = "https://www.tax.service.gov.uk/paye/company-car/start-government-gateway".freeze
     GOV_GATE_URL_FOR_INCOME_TAX = "https://www.tax.service.gov.uk/check-income-tax/start-government-gateway?_ga=2.114080007.145612230.1512381177-373904926.147".freeze
+    GOV_GATE_URL_FOR_PERSONAL_TAX = "https://www.tax.service.gov.uk/personal-account/start-government-gateway".freeze
     VERIFY_URL_FOR_COMPANY_CAR = "https://www.tax.service.gov.uk/paye/company-car/start-verify".freeze
     VERIFY_URL_FOR_INCOME_TAX = "https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.114080007.145612230.1512381177-373904926.1473694521".freeze
+    VERIFY_URL_FOR_PERSONAL_TAX = "https://www.tax.service.gov.uk/personal-account/start-verify".freeze
 
     SERVICE_TEXT_FOR_COMPANY_CAR = "check or update your company car tax".freeze
     SERVICE_TEXT_FOR_INCOME_TAX = "check your income tax for the current year".freeze
+    SERVICE_TEXT_FOR_PERSONAL_TAX = "access your personal tax account".freeze
 
     def schema_name
       "service_sign_in"
@@ -55,14 +58,29 @@ class ServiceSignInPresenterTest
       assert_equal VERIFY_URL_FOR_INCOME_TAX, @presented_item.verify_url
     end
 
+    test 'presents correct url for gateway sign up - personal tax account' do
+      schema_item['base_path'] = "personal-tax-account/sign-in"
+      assert_equal GOV_GATE_URL_FOR_PERSONAL_TAX, @presented_item.govenment_gateway_url
+    end
+
+    test 'presents correct url for verify sign up - personal tax account' do
+      schema_item['base_path'] = "personal-tax-account/sign-in"
+      assert_equal VERIFY_URL_FOR_PERSONAL_TAX, @presented_item.verify_url
+    end
+
     test 'presents correct service text - update company car details' do
       schema_item['base_path'] = "update-company-car-details/sign-in"
       assert_equal SERVICE_TEXT_FOR_COMPANY_CAR, @presented_item.service_specific_text
     end
 
-    test 'presents correct service text  - check income tax' do
+    test 'presents correct service text - check income tax' do
       schema_item['base_path'] = "check-income-tax-current-year/sign-in"
       assert_equal SERVICE_TEXT_FOR_INCOME_TAX, @presented_item.service_specific_text
+    end
+
+    test 'presents correct service text - personal tax account' do
+      schema_item['base_path'] = "personal-tax-account/sign-in"
+      assert_equal SERVICE_TEXT_FOR_PERSONAL_TAX, @presented_item.service_specific_text
     end
 
     test 'presents the back_link' do


### PR DESCRIPTION
The Personal Tax Account service start page is moving to the new start page/interstitial page/create account pattern deployed in Q3 for Self Assessment, Company Car Tax and Check This Year's Tax. As with the other two services in the trial, the intention is to give people more information to help them make a more informed choice between Gateway and Verify. In the past we've seen similar changes drive more people to Verify.

Our Jira ticket: https://govukverify.atlassian.net/browse/HUB-73

This PR is to add the new trial design of the _create account_ page to the Personal Tax account Service. The change adds the new service route to the existing trial presenter and view.

There will be corresponding changes in publisher to move this service to the new start page and add the interstitial page. We believe this PR is safe to merge and deploy on its own and won't be accessible to the public until the page type is changed in publisher.

Since we've just added a new service we expect the trial to continue for around another two weeks, so we've updated the nominal trial end date accordingly to 23rd March. 

Screenshot of the page for the Personal Tax Service (running locally):

![image](https://user-images.githubusercontent.com/24547183/37215418-c69964ec-23af-11e8-8774-4042c0312379.png)

---

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
