### PR TITLE
Add clarification message for tax credit webchat

### DIFF
--- a/app/views/shared/_webchat.html.erb
+++ b/app/views/shared/_webchat.html.erb
@@ -1,6 +1,12 @@
 <span class="js-webchat"
   data-availability-url="<%= @content_item.webchat_availability_url %>"
   data-open-url="<%= @content_item.webchat_open_url %>">
+  <% if @content_item.base_path == '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries' %>
+    Advisers can only talk to you about Child Tax Credit and Working Tax Credit.
+    They won't be able to transfer you to another webchat team.
+    <br/>
+    <br/>
+  <% end %>
   <span class="js-webchat-advisers-error">
     Webchat is unavailable at the moment because of technical problems.
   </span>


### PR DESCRIPTION
Message to try and avoid people incorrectly using the webchat when they want a
different department.

This only appears for the specific webchat instance:

<img width="647" alt="screenshot 2018-03-09 14 11 27" src="https://user-images.githubusercontent.com/63736/37217046-5f815684-23b4-11e8-96e5-0cb09dcf2644.png">

https://trello.com/c/6Gt4ON2h/100-2-text-change-to-webchat