### PR TITLE
Remove unused stubbing

### DIFF
--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -291,10 +291,6 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
   test "shows the taxonomy-navigation if tagged to taxonomy" do
-    GovukNavigationHelpers::ContentItem
-      .stubs(:whitelisted_root_taxon_content_ids)
-      .returns(["aaaa-bbbb"])
-
     content_item = content_store_has_schema_example("document_collection", "document_collection")
     path = "government/abtest/document_collection"
     content_item['base_path'] = "/#{path}"


### PR DESCRIPTION
The "whitelisted taxons" thing has been removed in https://github.com/alphagov/govuk_navigation_helpers/pull/120.