### PR TITLE
Fix sidebar taxon showing

### DIFF
--- a/app/models/navigation_type.rb
+++ b/app/models/navigation_type.rb
@@ -8,14 +8,14 @@ class NavigationType
 
   def should_present_taxonomy_navigation?
     !content_is_tagged_to_browse_pages? &&
-      content_is_tagged_to_a_taxon? &&
+      content_is_tagged_to_a_live_taxon? &&
       content_schema_is_guidance?
   end
 
 private
 
-  def content_is_tagged_to_a_taxon?
-    @content_item.dig("links", "taxons").present?
+  def content_is_tagged_to_a_live_taxon?
+    @content_item.dig("links", "taxons").to_a.any? { |taxon| taxon["phase"] == "live" }
   end
 
   def content_is_tagged_to_browse_pages?

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -1,10 +1,13 @@
 <% if step_nav_helper.show_related_links? %>
+  <!-- Rendering the step by step -->
   <%= render 'shared/sidebar_step_nav', no_margin: true %>
 <% else %>
   <div class="column-third">
   <% if @navigation.should_present_taxonomy_navigation? %>
+    <!-- Rendering the taxonomy based sidebar -->
     <%= render partial: 'govuk_component/taxonomy_sidebar', locals: @content_item.taxonomy_sidebar %>
   <% else %>
+    <!-- Rendering the related navigation -->
     <%= render 'govuk_publishing_components/components/related_navigation', @content_item.content_item.parsed_content %>
   <% end %>
   </div>


### PR DESCRIPTION
The recent changes to the taxonomy exposed that we have duplicated logic between this application and the components. At the moment this app thinks that there are taxons, so it tries to show the sidebar. However, the `govuk_component/taxonomy_sidebar` component *doesn't* think there are taxons, because it only looks at the live ones.

This is a temporary fix, we will re-architect this so that the logic is simple and in only one place. I'm also sad about the lack of failing tests for this.

## Before

![screen shot 2018-03-14 at 15 35 00](https://user-images.githubusercontent.com/233676/37412700-578812b4-279d-11e8-8cfb-7250ed9f8f1f.png)

## After

![screen shot 2018-03-14 at 15 34 49](https://user-images.githubusercontent.com/233676/37412704-5ae1584e-279d-11e8-9f10-69404974c910.png)
