### PR TITLE
Adds missing coming soon translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,6 +128,9 @@ en:
       cma_case:
         one: Competition and Markets Authority case
         other: Competition and Markets Authority cases
+      coming_soon:
+        one: Coming Soon
+        other: Coming Soon
       consultation:
         one: Consultation
         other: Consultations


### PR DESCRIPTION
We're receiving reports on collections of people seeing the message

```
translation missing: en.content_item.schema_name.coming_soon
```

For ex: https://www.gov.uk/government/collections/vat-information-sheets

---

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
