### PR TITLE
Check content item is a sign in page before attempting to sign in

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -23,6 +23,8 @@ class ContentItemsController < ApplicationController
   end
 
   def service_sign_in_options
+    return head :not_found unless is_sign_in_content_item_path?
+
     if params[:option].blank?
       @error = true
       show
@@ -34,6 +36,10 @@ class ContentItemsController < ApplicationController
   end
 
 private
+
+  def is_sign_in_content_item_path?
+    content_item_path.include?("sign-in")
+  end
 
   # Allow guides to pass access token to each part to allow
   # fact checking of all content

--- a/test/controllers/service_sign_in_content_item_controller_test.rb
+++ b/test/controllers/service_sign_in_content_item_controller_test.rb
@@ -52,6 +52,11 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
 
+  test "raises a 404 for a content item which isn't a service_sign_in page" do
+    path = "this/is/not/a/sign/in/page"
+    post :service_sign_in_options, params: { path: path }
+    assert_response :not_found
+  end
 
   test "service_sign_in_options with option param set" do
     content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")


### PR DESCRIPTION
This works by checking that the path contains the string 'sign-in'. I was hoping to use a route constraint, but couldn't get it to work on a glob/catch all parameter.

---

Component guide for this PR:
https://government-frontend-pr-842.herokuapp.com/component-guide