### PR TITLE
Add Contextual comms A/B/C test

### DIFF
--- a/app/assets/stylesheets/components/_blue-box-campaign.scss
+++ b/app/assets/stylesheets/components/_blue-box-campaign.scss
@@ -1,0 +1,43 @@
+.app-c-native-blue-box-campaign__container {
+  border-top: 1px solid $border-colour;
+  padding-top: 20px;
+}
+
+.app-c-native-blue-box-campaign__link {
+  @include bold-24;
+  position: relative;
+  display: block;
+  background: $govuk-blue;
+  width: 100%;
+  min-height: 280px;
+  color: $white;
+  text-decoration: none;
+  text-align: left;
+  box-sizing: border-box;
+  padding: 15px;
+}
+
+.app-c-native-blue-box-campaign__title {
+  display: block;
+  color: $white;
+  font-weight: bold;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.app-c-native-blue-box-campaign__description {
+  @include core-19;
+  display: block;
+  font-weight: normal;
+  padding: 10px 10px 10px 0;
+  color: $white;
+  position: absolute;
+  bottom: 10px;
+}
+
+.app-c-native-blue-box-campaign__link:focus .app-c-native-blue-box-campaign__title,
+.app-c-native-blue-box-campaign__link:focus .app-c-native-blue-box-campaign__description {
+  color: $black;
+}

--- a/app/assets/stylesheets/components/_native-campaign.scss
+++ b/app/assets/stylesheets/components/_native-campaign.scss
@@ -1,0 +1,31 @@
+$dark-grey: #999;
+
+.app-c-native-campaign__container {
+  border-top: 1px solid $border-colour;
+  padding-top: 20px;
+}
+
+.app-c-native-campaign__header {
+  @include core-14;
+  color: $dark-grey;
+  display: inline-block;
+  padding: 4px 6px 1px;
+  border: 1px solid $border-colour;
+  border-radius: 4px;
+}
+
+.app-c-native-campaign__link {
+  margin-top: 15px;
+  display: block;
+  text-decoration: none;
+  @include bold-19;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.app-c-native-campaign__description {
+  @include core-14;
+  padding-top: 5px;
+}

--- a/app/controllers/concerns/contextual_comms_ab_testable.rb
+++ b/app/controllers/concerns/contextual_comms_ab_testable.rb
@@ -84,7 +84,10 @@ module ContextualCommsAbTestable
   end
 
   def campaign_link
-    CAMPAIGN_DATA[campaign_name][:link]
+    CAMPAIGN_DATA[campaign_name][:link] +
+      "?utm_source=#{content_item_path}" +
+      "&utm_content=#{contextual_comms_test_variant.variant_name}" +
+      "&utm_campaign=ukgov-promo&utm_medium=referral"
   end
 
   def campaign_title

--- a/app/controllers/concerns/contextual_comms_ab_testable.rb
+++ b/app/controllers/concerns/contextual_comms_ab_testable.rb
@@ -10,7 +10,12 @@ module ContextualCommsAbTestable
       title: "How healthy is your food?",
       description: "Find out more about calories, the benefits of eating well and simple ways you can make a change.",
       link: "https://www.nhs.uk/oneyou/eating",
-    }
+    },
+    check_your_pay: {
+      title: "Check Your Pay",
+      description: "Are you being underpaid? Find out if your employer is giving you less than the legal minimum.",
+      link: "https://checkyourpay.campaign.gov.uk",
+    },
   }.freeze
 
   def self.included(base)
@@ -66,6 +71,8 @@ module ContextualCommsAbTestable
         :get_in_go_far
       elsif EATING_PAGES.include?(content_item_path)
         :eating
+      elsif CHECK_YOUR_PAY_PAGES.include?(content_item_path)
+        :check_your_pay
       end
   end
 
@@ -113,5 +120,36 @@ module ContextualCommsAbTestable
     /help-with-childcare-costs/tax-free-childcare
     /help-with-childcare-costs/universal-credit
     /school-uniform
+  ).freeze
+
+  CHECK_YOUR_PAY_PAGES = %w(
+    /pay-and-work-rights
+    /payslips
+    /report-cash-in-hand-pay
+    /student-jobs-paying-tax
+    /tips-at-work
+    /tips-at-work/tips-and-tax
+    /understanding-your-pay/deductions-from-your-pay
+    /understanding-your-pay/pay-calculations-if-you-work-shifts-or-get-bonuses
+    /understanding-your-pay/working-out-your-pay
+    /employment-contracts-and-conditions
+    /employment-contracts-and-conditions/collective-agreements
+    /employment-contracts-and-conditions/contract-terms
+    /employment-contracts-and-conditions/written-statement-of-employment-particulars
+    /employment-status
+    /employment-status/employee
+    /employment-status/worker
+    /flexible-working
+    /flexible-working/types-of-flexible-working
+    /maximum-weekly-working-hours
+    /maximum-weekly-working-hours/calculating-your-working-hours
+    /maximum-weekly-working-hours/weekly-maximum-working-hours-and-opting-out
+    /night-working-hours
+    /overtime-your-rights
+    /rest-breaks-work
+    /rest-breaks-work/compensatory-rest
+    /rest-breaks-work/exceptions
+    /rest-breaks-work/taking-breaks
+    /rest-breaks-work/young-workers
   ).freeze
 end

--- a/app/controllers/concerns/contextual_comms_ab_testable.rb
+++ b/app/controllers/concerns/contextual_comms_ab_testable.rb
@@ -4,6 +4,8 @@ module ContextualCommsAbTestable
   def self.included(base)
     base.helper_method(
       :contextual_comms_test_variant,
+      :show_blue_box_campaign?,
+      :show_native_campaign?,
     )
     base.after_action :set_test_response_header
   end
@@ -24,5 +26,12 @@ module ContextualCommsAbTestable
   def set_test_response_header
     contextual_comms_test_variant.configure_response(response)
   end
+
+  def show_blue_box_campaign?
+    contextual_comms_test_variant.variant?("BlueBoxCampaign")
+  end
+
+  def show_native_campaign?
+    contextual_comms_test_variant.variant?("NativeCampaign")
   end
 end

--- a/app/controllers/concerns/contextual_comms_ab_testable.rb
+++ b/app/controllers/concerns/contextual_comms_ab_testable.rb
@@ -1,0 +1,2 @@
+module ContextualCommsAbTestable
+end

--- a/app/controllers/concerns/contextual_comms_ab_testable.rb
+++ b/app/controllers/concerns/contextual_comms_ab_testable.rb
@@ -1,8 +1,18 @@
 module ContextualCommsAbTestable
   GOOGLE_ANALYTICS_CUSTOM_DIMENSION = 70
+  CAMPAIGN_DATA = {
+    get_in_go_far: {
+      title: "Get In Go Far",
+      description: "Search thousands of apprenticeships from great companies, with more added every day.",
+      link: "https://www.getingofar.gov.uk/",
+    },
+  }.freeze
 
   def self.included(base)
     base.helper_method(
+      :campaign_description,
+      :campaign_link,
+      :campaign_title,
       :contextual_comms_test_variant,
       :show_blue_box_campaign?,
       :show_native_campaign?,
@@ -34,4 +44,39 @@ module ContextualCommsAbTestable
   def show_native_campaign?
     contextual_comms_test_variant.variant?("NativeCampaign")
   end
+
+  def campaign_name
+    @campaign_name ||=
+      if GET_IN_GO_FAR_PAGES.include?(content_item_path)
+        :get_in_go_far
+      end
+  end
+
+  def campaign_link
+    CAMPAIGN_DATA[campaign_name][:link]
+  end
+
+  def campaign_title
+    CAMPAIGN_DATA[campaign_name][:title]
+  end
+
+  def campaign_description
+    CAMPAIGN_DATA[campaign_name][:description]
+  end
+
+  GET_IN_GO_FAR_PAGES = %w(
+    /career-skills-and-training
+    /mature-student-university-funding
+    /higher-education-courses-find-and-apply
+    /what-different-qualification-levels-mean
+    /what-different-qualification-levels-mean/list-of-qualification-levels
+    /what-different-qualification-levels-mean/compare-different-qualification-levels
+    /further-education-courses
+    /improve-english-maths-it-skills
+    /further-education-courses
+    /further-education-courses/financial-help
+    /further-education-courses/find-a-course
+    /looking-for-work-if-disabled
+    /exoffenders-and-employment
+  ).freeze
 end

--- a/app/controllers/concerns/contextual_comms_ab_testable.rb
+++ b/app/controllers/concerns/contextual_comms_ab_testable.rb
@@ -1,2 +1,28 @@
 module ContextualCommsAbTestable
+  GOOGLE_ANALYTICS_CUSTOM_DIMENSION = 70
+
+  def self.included(base)
+    base.helper_method(
+      :contextual_comms_test_variant,
+    )
+    base.after_action :set_test_response_header
+  end
+
+  def contextual_comms_test
+    @contextual_comms_test ||= GovukAbTesting::AbTest.new(
+      "ContextualComms",
+      dimension: GOOGLE_ANALYTICS_CUSTOM_DIMENSION,
+      allowed_variants: %w(NoCampaign BlueBoxCampaign NativeCampaign),
+      control_variant: "NoCampaign"
+    )
+  end
+
+  def contextual_comms_test_variant
+    @contextual_comms_test_variant ||= contextual_comms_test.requested_variant(request.headers)
+  end
+
+  def set_test_response_header
+    contextual_comms_test_variant.configure_response(response)
+  end
+  end
 end

--- a/app/controllers/concerns/contextual_comms_ab_testable.rb
+++ b/app/controllers/concerns/contextual_comms_ab_testable.rb
@@ -20,7 +20,9 @@ module ContextualCommsAbTestable
       :campaign_title,
       :contextual_comms_test_variant,
       :show_blue_box_campaign?,
+      :show_contextual_comms_campaign?,
       :show_native_campaign?,
+      :whitelisted_campaign_page?,
     )
     base.after_action :set_test_response_header
   end
@@ -39,7 +41,11 @@ module ContextualCommsAbTestable
   end
 
   def set_test_response_header
-    contextual_comms_test_variant.configure_response(response)
+    contextual_comms_test_variant.configure_response(response) if whitelisted_campaign_page?
+  end
+
+  def show_contextual_comms_campaign?
+    !contextual_comms_test_variant.variant?("NoCampaign") && whitelisted_campaign_page?
   end
 
   def show_blue_box_campaign?
@@ -48,6 +54,10 @@ module ContextualCommsAbTestable
 
   def show_native_campaign?
     contextual_comms_test_variant.variant?("NativeCampaign")
+  end
+
+  def whitelisted_campaign_page?
+    campaign_name.present?
   end
 
   def campaign_name

--- a/app/controllers/concerns/contextual_comms_ab_testable.rb
+++ b/app/controllers/concerns/contextual_comms_ab_testable.rb
@@ -16,6 +16,11 @@ module ContextualCommsAbTestable
       description: "Are you being underpaid? Find out if your employer is giving you less than the legal minimum.",
       link: "https://checkyourpay.campaign.gov.uk",
     },
+    your_pension: {
+      title: "Get to know your state pension",
+      description: "Get an online forecast to tell you how much you might get, and the earliest you can claim it.",
+      link: "https://www.yourpension.gov.uk/",
+    }
   }.freeze
 
   def self.included(base)
@@ -73,6 +78,8 @@ module ContextualCommsAbTestable
         :eating
       elsif CHECK_YOUR_PAY_PAGES.include?(content_item_path)
         :check_your_pay
+      elsif YOUR_PENSION_PAGES.include?(content_item_path)
+        :your_pension
       end
   end
 
@@ -151,5 +158,18 @@ module ContextualCommsAbTestable
     /rest-breaks-work/exceptions
     /rest-breaks-work/taking-breaks
     /rest-breaks-work/young-workers
+  ).freeze
+
+  YOUR_PENSION_PAGES = %w(
+    /armed-forces-pension-calculator
+    /personal-pensions-your-rights
+    /transferring-your-pension
+    /pension-types
+    /workplace-pensions
+    /employers-workplace-pensions-rules
+    /carers-credit
+    /national-insurance-credits
+    /voluntary-national-insurance-contributions
+    /plan-retirement-income
   ).freeze
 end

--- a/app/controllers/concerns/contextual_comms_ab_testable.rb
+++ b/app/controllers/concerns/contextual_comms_ab_testable.rb
@@ -6,6 +6,11 @@ module ContextualCommsAbTestable
       description: "Search thousands of apprenticeships from great companies, with more added every day.",
       link: "https://www.getingofar.gov.uk/",
     },
+    eating: {
+      title: "How healthy is your food?",
+      description: "Find out more about calories, the benefits of eating well and simple ways you can make a change.",
+      link: "https://www.nhs.uk/oneyou/eating",
+    }
   }.freeze
 
   def self.included(base)
@@ -49,6 +54,8 @@ module ContextualCommsAbTestable
     @campaign_name ||=
       if GET_IN_GO_FAR_PAGES.include?(content_item_path)
         :get_in_go_far
+      elsif EATING_PAGES.include?(content_item_path)
+        :eating
       end
   end
 
@@ -78,5 +85,23 @@ module ContextualCommsAbTestable
     /further-education-courses/find-a-course
     /looking-for-work-if-disabled
     /exoffenders-and-employment
+  ).freeze
+
+  EATING_PAGES = %w(
+    /free-school-transport
+    /healthy-start
+    /healthy-start/eligibility
+    /healthy-start/how-to-claim
+    /healthy-start/what-youll-get
+    /help-with-childcare-costs
+    /help-with-childcare-costs/childcare-vouchers
+    /help-with-childcare-costs/free-childcare-2-year-olds
+    /help-with-childcare-costs/free-childcare-2-year-olds-benefits
+    /help-with-childcare-costs/free-childcare-and-education-for-2-to-4-year-olds
+    /help-with-childcare-costs/support-while-you-study
+    /help-with-childcare-costs/tax-credits
+    /help-with-childcare-costs/tax-free-childcare
+    /help-with-childcare-costs/universal-credit
+    /school-uniform
   ).freeze
 end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,4 +1,6 @@
 class ContentItemsController < ApplicationController
+  include ContextualCommsAbTestable
+
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from GdsApi::HTTPNotFound, with: :error_notfound
   rescue_from GdsApi::HTTPGone, with: :error_410

--- a/app/views/components/_blue-box-campaign.html.erb
+++ b/app/views/components/_blue-box-campaign.html.erb
@@ -1,0 +1,6 @@
+<div class="app-c-native-blue-box-campaign__container">
+  <a class="app-c-native-blue-box-campaign__link" href="<%= href %>">
+    <h2 class="app-c-native-blue-box-campaign__title"><%= title %></h2>
+    <span class="app-c-native-blue-box-campaign__description"><%= description %></span>
+  </a>
+</div>

--- a/app/views/components/_native-campaign.html.erb
+++ b/app/views/components/_native-campaign.html.erb
@@ -1,0 +1,5 @@
+<div class="app-c-native-campaign__container">
+  <span class="app-c-native-campaign__header">Campaign</span>
+  <a class="app-c-native-campaign__link" href="<%= href %>"><%= title %></a>
+  <p class="app-c-native-campaign__description"><%= description %></p>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
   <meta name="govuk:content-id" content="<%= @content_item.content_id %>" />
-  <%= contextual_comms_test_variant.analytics_meta_tag.html_safe %>
+  <%= contextual_comms_test_variant.analytics_meta_tag.html_safe if whitelisted_campaign_page? %>
   <%= yield :extra_head_content %>
 </head>
 <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
   <meta name="govuk:content-id" content="<%= @content_item.content_id %>" />
+  <%= contextual_comms_test_variant.analytics_meta_tag.html_safe %>
   <%= yield :extra_head_content %>
 </head>
 <body>

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -1,3 +1,9 @@
 <div class="column-one-third">
   <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item.content_item.parsed_content %>
+  <% if show_blue_box_campaign? %>
+    <%= render 'components/blue-box-campaign', title: "Get In Go Far", description: "Search thousands of apprenticeships from great companies, with more added every day.", href: "https://www.getingofar.gov.uk/" %>
+  <% end %>
+  <% if show_native_campaign? %>
+    <%= render 'components/native-campaign', title: "How healthy is your food?", description: "Find out more about calories, the benefits of eating well and simple ways you can make a change.", href: "https://www.nhs.uk/oneyou/eating" %>
+  <% end %>
 </div>

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -1,10 +1,12 @@
 <div class="column-one-third">
   <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item.content_item.parsed_content %>
   <!-- Rendering the contextual communications campaign test -->
-  <% if show_blue_box_campaign? %>
-    <%= render 'components/blue-box-campaign', title: campaign_title, description: campaign_description, href: campaign_link %>
-  <% end %>
-  <% if show_native_campaign? %>
-    <%= render 'components/native-campaign', title: campaign_title, description: campaign_description, href: campaign_link %>
+  <% if show_contextual_comms_campaign? %>
+    <% if show_blue_box_campaign? %>
+      <%= render 'components/blue-box-campaign', title: campaign_title, description: campaign_description, href: campaign_link %>
+    <% end %>
+    <% if show_native_campaign? %>
+      <%= render 'components/native-campaign', title: campaign_title, description: campaign_description, href: campaign_link %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -1,9 +1,10 @@
 <div class="column-one-third">
   <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item.content_item.parsed_content %>
+  <!-- Rendering the contextual communications campaign test -->
   <% if show_blue_box_campaign? %>
-    <%= render 'components/blue-box-campaign', title: "Get In Go Far", description: "Search thousands of apprenticeships from great companies, with more added every day.", href: "https://www.getingofar.gov.uk/" %>
+    <%= render 'components/blue-box-campaign', title: campaign_title, description: campaign_description, href: campaign_link %>
   <% end %>
   <% if show_native_campaign? %>
-    <%= render 'components/native-campaign', title: "How healthy is your food?", description: "Find out more about calories, the benefits of eating well and simple ways you can make a change.", href: "https://www.nhs.uk/oneyou/eating" %>
+    <%= render 'components/native-campaign', title: campaign_title, description: campaign_description, href: campaign_link %>
   <% end %>
 </div>

--- a/test/components/blue_box_campaign_test.rb
+++ b/test/components/blue_box_campaign_test.rb
@@ -1,0 +1,20 @@
+require 'component_test_helper'
+
+class BlueBoxCampaignTest < ComponentTestCase
+  def component_name
+    "blue-box-campaign"
+  end
+
+  test "fails to render a blue box campaign link when no parameters given" do
+    assert_raise do
+      render_component({})
+    end
+  end
+
+  test "renders a blue box campaign link when required params are given" do
+    render_component(title: "Campaign about things", description: "Look at this campaign about things", href: "https://www.gov.uk/things")
+    assert_select "h2", "Campaign about things"
+    assert_select "a", href: /https:\/\/www.gov.uk\/things/
+    assert_select "span", "Look at this campaign about things"
+  end
+end

--- a/test/components/native_campaign_test.rb
+++ b/test/components/native_campaign_test.rb
@@ -1,0 +1,20 @@
+require 'component_test_helper'
+
+class NativeCampaignTest < ComponentTestCase
+  def component_name
+    "native-campaign"
+  end
+
+  test "fails to render a native campaign link when no parameters given" do
+    assert_raise do
+      render_component({})
+    end
+  end
+
+  test "renders a native campaign link when required params are given" do
+    render_component(title: "Campaign about things", description: "Look at this campaign about things", href: "https://www.gov.uk/things")
+    assert_select "a", "Campaign about things"
+    assert_select "a", href: /https:\/\/www.gov.uk\/things/
+    assert_select "p", "Look at this campaign about things"
+  end
+end

--- a/test/controllers/contextual_comms_ab_test_controller_test.rb
+++ b/test/controllers/contextual_comms_ab_test_controller_test.rb
@@ -18,6 +18,12 @@ class ContentItemsControllerTest < ActionController::TestCase
       description: "Find out more about calories, the benefits of eating well and simple ways you can make a change.",
       href: "<a href=\"https://www.nhs.uk/oneyou/eating\">",
     },
+    check_your_pay: {
+      govuk_base_path: "/pay-and-work-rights",
+      title: "Check Your Pay",
+      description: "Are you being underpaid? Find out if your employer is giving you less than the legal minimum.",
+      href: "<a href=\"https://checkyourpay.campaign.gov.uk\">",
+    },
   }.freeze
 
   test "ContextualComms shows no campaigns for variant 'NoCampaign'" do

--- a/test/controllers/contextual_comms_ab_test_controller_test.rb
+++ b/test/controllers/contextual_comms_ab_test_controller_test.rb
@@ -24,6 +24,12 @@ class ContentItemsControllerTest < ActionController::TestCase
       description: "Are you being underpaid? Find out if your employer is giving you less than the legal minimum.",
       href: "<a href=\"https://checkyourpay.campaign.gov.uk\">",
     },
+    your_pension: {
+      govuk_base_path: "/armed-forces-pension-calculator",
+      title: "Get to know your state pension",
+      description: "Get an online forecast to tell you how much you might get, and the earliest you can claim it.",
+      href: "<a href=\"https://www.yourpension.gov.uk/\">"
+    }
   }.freeze
 
   test "ContextualComms shows no campaigns for variant 'NoCampaign'" do

--- a/test/controllers/contextual_comms_ab_test_controller_test.rb
+++ b/test/controllers/contextual_comms_ab_test_controller_test.rb
@@ -73,6 +73,17 @@ class ContentItemsControllerTest < ActionController::TestCase
     end
   end
 
+  test "No campaign is shown on pages that haven't been whitelisted" do
+    content_item = set_content_item("/an-answer")
+    content_store_has_item(content_item["base_path"], content_item)
+
+    get :show, params: { path: path_for(content_item) }
+    assert_response 200
+
+    refute_match("native-campaign", response.body)
+    refute_match("blue-box-campaign", response.body)
+  end
+
   def set_content_item(base_path)
     content_item = content_store_has_schema_example("answer", "answer")
     content_item["base_path"] = base_path

--- a/test/controllers/contextual_comms_ab_test_controller_test.rb
+++ b/test/controllers/contextual_comms_ab_test_controller_test.rb
@@ -10,25 +10,25 @@ class ContentItemsControllerTest < ActionController::TestCase
       govuk_base_path: "/career-skills-and-training",
       title: "Get In Go Far",
       description: "Search thousands of apprenticeships from great companies, with more added every day.",
-      href: "<a href=\"https://www.getingofar.gov.uk/\">",
+      href: "https://www.getingofar.gov.uk/",
     },
     eating: {
       govuk_base_path: "/free-school-transport",
       title: "How healthy is your food?",
       description: "Find out more about calories, the benefits of eating well and simple ways you can make a change.",
-      href: "<a href=\"https://www.nhs.uk/oneyou/eating\">",
+      href: "https://www.nhs.uk/oneyou/eating",
     },
     check_your_pay: {
       govuk_base_path: "/pay-and-work-rights",
       title: "Check Your Pay",
       description: "Are you being underpaid? Find out if your employer is giving you less than the legal minimum.",
-      href: "<a href=\"https://checkyourpay.campaign.gov.uk\">",
+      href: "https://checkyourpay.campaign.gov.uk",
     },
     your_pension: {
       govuk_base_path: "/armed-forces-pension-calculator",
       title: "Get to know your state pension",
       description: "Get an online forecast to tell you how much you might get, and the earliest you can claim it.",
-      href: "<a href=\"https://www.yourpension.gov.uk/\">"
+      href: "https://www.yourpension.gov.uk/",
     }
   }.freeze
 
@@ -61,7 +61,7 @@ class ContentItemsControllerTest < ActionController::TestCase
         assert_match("blue-box-campaign", response.body)
         assert_match(value[:title], response.body)
         assert_match(value[:description], response.body)
-        assert_match(value[:href], response.body)
+        assert_select("a:match('href', ?)", value[:href])
       end
     end
   end
@@ -80,7 +80,7 @@ class ContentItemsControllerTest < ActionController::TestCase
         assert_match("native-campaign", response.body)
         assert_match(value[:title], response.body)
         assert_match(value[:description], response.body)
-        assert_match(value[:href], response.body)
+        assert_select("a:match('href', ?)", value[:href])
       end
     end
   end

--- a/test/controllers/contextual_comms_ab_test_controller_test.rb
+++ b/test/controllers/contextual_comms_ab_test_controller_test.rb
@@ -12,6 +12,12 @@ class ContentItemsControllerTest < ActionController::TestCase
       description: "Search thousands of apprenticeships from great companies, with more added every day.",
       href: "<a href=\"https://www.getingofar.gov.uk/\">",
     },
+    eating: {
+      govuk_base_path: "/free-school-transport",
+      title: "How healthy is your food?",
+      description: "Find out more about calories, the benefits of eating well and simple ways you can make a change.",
+      href: "<a href=\"https://www.nhs.uk/oneyou/eating\">",
+    },
   }.freeze
 
   test "ContextualComms shows no campaigns for variant 'NoCampaign'" do

--- a/test/controllers/contextual_comms_ab_test_controller_test.rb
+++ b/test/controllers/contextual_comms_ab_test_controller_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class ContentItemsControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::ContentStore
+  include GovukAbTesting::MinitestHelpers
+
+  test "ContextualComms shows no campaigns for variant 'NoCampaign'" do
+    content_store_has_item(content_item["base_path"], content_item)
+
+    with_variant ContextualComms: "NoCampaign" do
+      get :show, params: { path: path_for(content_item) }
+      assert_response 200
+
+      refute_match("native-campaign", response.body)
+      refute_match("blue-box-campaign", response.body)
+    end
+  end
+
+  test "ContextualComms shows a blue box campaign for variant 'BlueBoxCampaign'" do
+    content_store_has_item(content_item["base_path"], content_item)
+
+    with_variant ContextualComms: "BlueBoxCampaign" do
+      get :show, params: { path: path_for(content_item) }
+      assert_response 200
+
+      assert_match("blue-box-campaign", response.body)
+      assert_match("Get In Go Far", response.body)
+      assert_match("Search thousands of apprenticeships from great companies, with more added every day.", response.body)
+      assert_match("<a href=\"https://www.getingofar.gov.uk/\">", response.body)
+    end
+  end
+
+  test "ContextualComms shows a native campaign for variant 'NativeCampaign'" do
+    content_store_has_item(content_item["base_path"], content_item)
+
+    with_variant ContextualComms: "NativeCampaign" do
+      get :show, params: { path: path_for(content_item) }
+      assert_response 200
+
+      assert_match("native-campaign", response.body)
+      assert_match("How healthy is your food?", response.body)
+      assert_match("Find out more about calories, the benefits of eating well and simple ways you can make a change.", response.body)
+      assert_match("<a href=\"https://www.nhs.uk/oneyou/eating\">", response.body)
+    end
+  end
+
+  def content_item
+    content_item = content_store_has_schema_example("answer", "answer")
+    content_item["base_path"] = "/career-skills-and-training"
+    content_item
+  end
+
+  def path_for(content_item, locale = nil)
+    base_path = content_item['base_path'].sub(/^\//, '')
+    base_path.gsub!(/\.#{locale}$/, '') if locale
+    base_path
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/h0AKz5g2/55-overview-card-for-building-the-experiment-on-govuk

This adds an A/B/C test for the contextual comms experiment.  We are testing two campaign formats (Native and Blue Box) against a control of no campaign displayed.  We have four campaigns to promote and have selected a group of pages for each campaign on which the test will be conducted. After this test has concluded we intend to tear this code out.

To view the test variations in the browser, navigate to https://government-frontend-pr-850.herokuapp.com/armed-forces-pension-calculator and use the ModHeader Chrome extension to set a Request Header:
- Name: `GOVUK-ABTest-ContextualComms`
- Value: `BlueBoxCampaign`, `NativeCampaign` or `NoCampaign`.

**Page with variation "NoCampaign"**
<img width="1007" alt="nocampaign" src="https://user-images.githubusercontent.com/13434452/37959844-ffb0b776-31ab-11e8-91b1-8eecbdb4a550.png">

**Page with variation "NativeCampaign"**
<img width="986" alt="nativecampaign" src="https://user-images.githubusercontent.com/13434452/37959871-121dec6c-31ac-11e8-9e88-e934d059c412.png">

**Page with variation "BlueBoxCampaign"**
<img width="982" alt="blueboxcampaign" src="https://user-images.githubusercontent.com/13434452/37959886-1c0fa2ba-31ac-11e8-8330-6c661d6abd13.png">

---

Component guide for this PR:
https://government-frontend-pr-850.herokuapp.com/component-guide
