### PR TITLE
Contents list style adjustments

### DIFF
--- a/app/assets/stylesheets/components/_contents-list.scss
+++ b/app/assets/stylesheets/components/_contents-list.scss
@@ -10,40 +10,37 @@
   box-shadow: 0 20px 15px -10px $white;
 }
 
-// Remove underlines from lists of links
-// to improve legibility
 .app-c-contents-list__link {
-  text-decoration: none;
-
-  &:hover,
-  &:focus,
-  &:active {
-    text-decoration: underline;
-  }
-
   .app-c-contents-list__list-item--parent > & {
     font-weight: bold;
   }
 }
 
 .app-c-contents-list__list-item {
-  padding-top: $gutter / 4;
+  padding-top: $gutter-one-third;
   line-height: 1.3;
   list-style-type: none;
+
+  @include media(tablet) {
+    padding-top: $gutter-one-quarter;
+  }
 }
 
 .app-c-contents-list__list-item--dashed {
-  $contents-spacing: $gutter-half + 5;
+  $contents-spacing: $gutter-half + 10;
   margin-left: $contents-spacing;
   padding-right: $contents-spacing;
 
   &:before {
     content: "— ";
     margin-left: -$contents-spacing;
+    padding-right: 5px;
 
     .direction-rtl & {
       margin-left: 0;
       margin-right: -$contents-spacing;
+      padding-right: 0;
+      padding-left: 5px;
     }
   }
 


### PR DESCRIPTION
- restore underline by default, in line with (growing consensus of) link styles across GOV.UK
- slightly increase spacing between links on mobile but leave it as it is on desktop. It's still a bit close on mobile, but any further is going to push the height of longer lists of links too much
- also slightly increase indent spacing on links, to put more space between text and dash

Underline before:

![screen shot 2018-03-28 at 14 54 49](https://user-images.githubusercontent.com/861310/38033496-132c9dd2-3298-11e8-8c81-0a1855b116d7.png)

![screen shot 2018-03-28 at 14 55 21](https://user-images.githubusercontent.com/861310/38033510-1a5cdc66-3298-11e8-8c6f-611d7f8f2b4f.png)

Underline after:

![screen shot 2018-03-28 at 14 55 02](https://user-images.githubusercontent.com/861310/38033523-214eb51c-3298-11e8-8870-9c6faec09d68.png)

![screen shot 2018-03-28 at 14 55 26](https://user-images.githubusercontent.com/861310/38033534-25d9c78e-3298-11e8-994b-cd15efd7902e.png)

Spacing on mobile before:

![screen shot 2018-03-28 at 14 56 31](https://user-images.githubusercontent.com/861310/38033587-49a30504-3298-11e8-8b82-c10e260ba5cf.png)

Spacing on mobile after:

![screen shot 2018-03-28 at 14 56 42](https://user-images.githubusercontent.com/861310/38033602-505d4f80-3298-11e8-8f7b-1fb854d163ad.png)


---

Component guide for this PR:
https://government-frontend-pr-852.herokuapp.com/component-guide
