### PR TITLE
Update govuk_publishing_components to 6.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 52.2'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.3'
 gem 'govuk_frontend_toolkit', '~> 7.4'
-gem 'govuk_publishing_components', '~> 6.0.0'
+gem 'govuk_publishing_components', '~> 6.1.0'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 12.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
     govuk_frontend_toolkit (7.4.2)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (6.0.0)
+    govuk_publishing_components (6.1.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -361,7 +361,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.3)
   govuk_frontend_toolkit (~> 7.4)
-  govuk_publishing_components (~> 6.0.0)
+  govuk_publishing_components (~> 6.1.0)
   govuk_schemas (~> 3.1)
   htmlentities (~> 4.3)
   jasmine-rails


### PR DESCRIPTION
https://trello.com/c/lOtOV4wU/160-add-taxonomy-sidebar-to-all-pages-tagged-to-live-taxons

Updates `govuk_publishing_components` to `6.1.0` this relaxes the constraint that taxonomy navigation only shows for guidance.

Example:

https://government-frontend-pr-854.herokuapp.com/government/news/ve-day-events-and-general-information

---

Component guide for this PR:
https://government-frontend-pr-854.herokuapp.com/component-guide
