### PR TITLE
Re-instate regression test info in PR template

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE
+++ b/docs/PULL_REQUEST_TEMPLATE
@@ -1,4 +1,7 @@
 ---
 
+Visual regression results:
+https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html
+
 Component guide for this PR:
 https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide


### PR DESCRIPTION
Visual regression tests on Heroku are working again, see: https://github.com/alphagov/govuk-visual-regression/pull/5

Add a link back into the PR template description for reference.

---

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
