### PR TITLE
Set title lang to match locale of content

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>
+  <title lang="<%= I18n.locale %>">
     <%if content_for?(:title) %>
       <%= yield :title %> - GOV.UK
     <% else %>


### PR DESCRIPTION
See https://github.com/alphagov/govuk_template/issues/342

Currently we set the html level lang to "en" and add a lang attribute to the "main" element with the locale of the content.

This causes screen readers to interpret the page title in english. We should instead markup the title with the same langugage (both the title and main content are in the content item's language).

I think we should also update the core layout in static and/or govuk_template, to allow for a title lang variable to be passed in, but it doesn't seem to be necessary for formats rendered by government frontend (please correct me if I'm wrong).

Government frontend seems like a sensible place to start because it renders news which accounts for most non english content iirc.

---

Visual regression results:
https://government-frontend-pr-862.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-862.herokuapp.com/component-guide
