### PR TITLE
Bump Ruby version in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,7 +380,7 @@ DEPENDENCIES
   wraith (~> 4.2)
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.4.4p296
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
This allows government-frontend to run on Heroku as before
