### PR TITLE
Bump components gem to 6.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 52.5'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.4'
 gem 'govuk_frontend_toolkit', '~> 7.4'
-gem 'govuk_publishing_components', '~> 6.2.0'
+gem 'govuk_publishing_components', '~> 6.4.0'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 12.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.3)
+    crass (1.0.4)
     dalli (2.7.7)
     debug_inspector (0.0.3)
     domain_name (0.5.20170404)
@@ -123,7 +123,7 @@ GEM
     govuk_frontend_toolkit (7.4.2)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (6.2.0)
+    govuk_publishing_components (6.4.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -179,8 +179,8 @@ GEM
     minitest (5.11.3)
     mocha (1.5.0)
       metaclass (~> 0.0.1)
-    money (6.10.1)
-      i18n (>= 0.6.4, < 1.0)
+    money (6.11.0)
+      i18n (>= 0.6.4, < 1.1)
     multipart-post (2.0.0)
     netrc (0.11.0)
     nio4r (2.3.0)
@@ -360,7 +360,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.4)
   govuk_frontend_toolkit (~> 7.4)
-  govuk_publishing_components (~> 6.2.0)
+  govuk_publishing_components (~> 6.4.0)
   govuk_schemas (~> 3.1)
   htmlentities (~> 4.3)
   jasmine-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,2 @@
 //= require_tree ./modules
-//= require current-location
-//= require govuk_publishing_components/components/error-summary
-//= require govuk_publishing_components/components/feedback
-//= require govuk_publishing_components/components/step-by-step-nav
+//= require govuk_publishing_components/all_components


### PR DESCRIPTION
Supercedes https://github.com/alphagov/government-frontend/pull/866

---

Visual regression results:
https://government-frontend-pr-871.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-871.herokuapp.com/component-guide
