### PR TITLE
Temporarily disable "Get in go far" campaign

### DIFF
--- a/app/controllers/concerns/contextual_comms_ab_testable.rb
+++ b/app/controllers/concerns/contextual_comms_ab_testable.rb
@@ -72,9 +72,7 @@ module ContextualCommsAbTestable
 
   def campaign_name
     @campaign_name ||=
-      if GET_IN_GO_FAR_PAGES.include?(content_item_path)
-        :get_in_go_far
-      elsif EATING_PAGES.include?(content_item_path)
+      if EATING_PAGES.include?(content_item_path)
         :eating
       elsif CHECK_YOUR_PAY_PAGES.include?(content_item_path)
         :check_your_pay

--- a/test/controllers/contextual_comms_ab_test_controller_test.rb
+++ b/test/controllers/contextual_comms_ab_test_controller_test.rb
@@ -6,12 +6,12 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   # govuk_base_path is an example page that is eligible to show a campaign.
   CAMPAIGNS = {
-    get_in_go_far: {
-      govuk_base_path: "/career-skills-and-training",
-      title: "Get In Go Far",
-      description: "Search thousands of apprenticeships from great companies, with more added every day.",
-      href: "https://www.getingofar.gov.uk/",
-    },
+    # get_in_go_far: {
+    #   govuk_base_path: "/career-skills-and-training",
+    #   title: "Get In Go Far",
+    #   description: "Search thousands of apprenticeships from great companies, with more added every day.",
+    #   href: "https://www.getingofar.gov.uk/",
+    # },
     eating: {
       govuk_base_path: "/free-school-transport",
       title: "How healthy is your food?",


### PR DESCRIPTION
This campaign is linking to a site with a lapsed certificate, so users are seeing an SSL error.

Talked to Mark (PM) and decided to remove the campaign for now.

cc @emmabeynon 

Related to https://github.com/alphagov/government-frontend/pull/850.