### PR TITLE
Better meta tags for third parties

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'govuk_app_config', '~> 1.4'
 gem 'govuk_frontend_toolkit', '~> 7.4'
 gem 'govuk_publishing_components', '~> 6.5.0'
 gem 'plek', '~> 2.1'
-gem 'slimmer', '~> 12.0'
+gem 'slimmer', '~> 12.1'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,7 +302,7 @@ GEM
       rubyzip (~> 1.2)
     sentry-raven (2.7.2)
       faraday (>= 0.7.6, < 1.0)
-    slimmer (12.0.0)
+    slimmer (12.1.0)
       activesupport
       json
       nokogiri (~> 1.7)
@@ -382,7 +382,7 @@ DEPENDENCIES
   rails-i18n (>= 4.0.4)
   rails_translation_manager (~> 0.0.2)
   sass-rails (~> 5.0)
-  slimmer (~> 12.0)
+  slimmer (~> 12.1)
   uglifier (>= 1.3.0)
   webmock (~> 3.3.0)
   wraith (~> 4.2)

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -49,6 +49,10 @@ class ContentItemPresenter
     content_item["content_id"]
   end
 
+  def web_url
+    Plek.current.website_root + content_item["base_path"]
+  end
+
 private
 
   def display_date(timestamp, format = "%-d %B %Y")

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -90,10 +90,6 @@ class TravelAdvicePresenter < ContentItemPresenter
     DateTime.parse(content_item["public_updated_at"])
   end
 
-  def web_url
-    Plek.current.website_root + content_item["base_path"]
-  end
-
 private
 
   # Treat summary as the first part

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,9 +20,28 @@
   <%= javascript_include_tag "application", integrity: true, crossorigin: 'anonymous' %>
   <%= csrf_meta_tags %>
   <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item.content_item } %>
+
   <% if @content_item.description %>
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
+
+  <meta property="og:site_name" content="GOV.UK" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="<%= @content_item.web_url %>" />
+  <meta property="og:title" content="<%= @content_item.page_title %>" />
+  <meta property="og:description" content="<%= strip_tags(@content_item.description) %>" />
+
+  <% if @content_item.respond_to?(:image) && @content_item.image %>
+    <meta property="og:image" content="<%= @content_item.image["url"] %>" />
+    <meta property="og:image:alt" content="<%= @content_item.image["alt_text"] %>" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content="<%= @content_item.image["url"] %>" />
+    <meta name="twitter:image:alt" content="<%= @content_item.image["alt_text"] %>" />
+  <% else %>
+    <meta name="twitter:card" content="summary" />
+  <% end %>
+
   <%= contextual_comms_test_variant.analytics_meta_tag.html_safe if whitelisted_campaign_page? %>
   <%= yield :extra_head_content %>
 </head>

--- a/test/integration/meta_tags_test.rb
+++ b/test/integration/meta_tags_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class MetaTagsTest < ActionDispatch::IntegrationTest
+  test "correct meta tags are displayed for pages" do
+    case_study = GovukSchemas::RandomExample.for_schema(frontend_schema: 'news_article') do |random|
+      random.merge(
+        "title" => "Zhe title",
+        "withdrawn_notice" => {},
+      )
+    end
+
+    content_store_has_item("/some-page", case_study.to_json)
+
+    visit "/some-page"
+
+    assert page.has_css?("meta[property='og:title'][content='Zhe title']", visible: false)
+  end
+
+  test "correct meta tags are displayed for pages without images" do
+    case_study = GovukSchemas::RandomExample.for_schema(frontend_schema: 'news_article') do |random|
+      random["details"].delete("image")
+      random
+    end
+
+    content_store_has_item("/some-page", case_study.to_json)
+
+    visit "/some-page"
+
+    assert page.has_css?("meta[name='twitter:card'][content='summary']", visible: false)
+  end
+
+  test "correct meta tags are displayed for pages with images" do
+    case_study = GovukSchemas::RandomExample.for_schema(frontend_schema: 'news_article') do |random|
+      random["details"] = random["details"].merge(
+        "image" => {
+          "url" => "https://example.org/image.jpg",
+          "alt_text" => "An accessible alt text",
+        }
+      )
+
+      random
+    end
+
+    content_store_has_item("/some-page", case_study.to_json)
+
+    visit "/some-page"
+
+    assert page.has_css?("meta[name='twitter:card'][content='summary_large_image']", visible: false)
+    assert page.has_css?("meta[name='twitter:image'][content='https://example.org/image.jpg']", visible: false)
+    assert page.has_css?("meta[property='og:image'][content='https://example.org/image.jpg']", visible: false)
+  end
+end


### PR DESCRIPTION
This adds a number of new metatags for third parties to use.

It makes the most difference to pages that have images, like news articles and images.

## Facebook

[Linter output](https://developers.facebook.com/tools/debug/sharing/?q=https%3A%2F%2Fgovernment-frontend-pr-878.herokuapp.com%2Fgovernment%2Fnews%2Fhalf-term-fishing-fun-in-cornwall)

Before:

![screen shot 2018-04-18 at 17 49 09](https://user-images.githubusercontent.com/233676/38987930-5cb0a25e-43c9-11e8-8b89-6fb4acb6c81f.png)

After:

![screen shot 2018-04-18 at 17 54 22](https://user-images.githubusercontent.com/233676/38987931-5cc640d2-43c9-11e8-9a25-33a309862130.png)

## Slack

Before:

![before](https://user-images.githubusercontent.com/233676/38988041-b250f13c-43c9-11e8-960e-6c8e3e809d1e.png)

After:

![screen shot 2018-04-19 at 12 02 43](https://user-images.githubusercontent.com/233676/38988036-af2f39fa-43c9-11e8-8f25-370bf1c746b4.png)

## Twitter

Tested with https://cards-dev.twitter.com/validator.

Before:

<img width="998" alt="screen shot 2018-04-19 at 12 08 31" src="https://user-images.githubusercontent.com/233676/38988256-7b79c11a-43ca-11e8-9e78-611b617481c9.png">

After:

<img width="991" alt="screen shot 2018-04-19 at 12 08 59" src="https://user-images.githubusercontent.com/233676/38988258-7b90bf6e-43ca-11e8-8c89-bc739b06a655.png">

## Whatsapp

Before:

![before 2](https://user-images.githubusercontent.com/233676/38988486-3aad8abc-43cb-11e8-83d8-3ebbaa89bbb3.png)

After:

![screen shot 2018-04-19 at 12 13 46](https://user-images.githubusercontent.com/233676/38988489-3d33dcaa-43cb-11e8-8aeb-a560e030ae7e.png)
