### PR TITLE
Use the meta tags component from the gem

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
   <% end %>
   <%= javascript_include_tag "application", integrity: true, crossorigin: 'anonymous' %>
   <%= csrf_meta_tags %>
-  <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item.content_item } %>
+  <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item.content_item %>
 
   <% if @content_item.description %>
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />


### PR DESCRIPTION
This replaces the analytics meta tags component from Static with the new [meta tags component](https://github.com/alphagov/govuk_publishing_components/pull/278) in the gem. There should be no changes in behaviour.

https://trello.com/c/2w1AKyuW