### PR TITLE
Use button component from gem

### DIFF
--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -30,5 +30,5 @@
     </div>
   <% end %>
 
-  <%= render 'govuk_component/button', text: t('service_sign_in.continue'), margin_bottom: true %>
+  <%= render 'govuk_publishing_components/components/button', text: t('service_sign_in.continue'), margin_bottom: true %>
 <% end %>

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -22,7 +22,7 @@
         <%= render 'govuk_component/govspeak', @content_item.govspeak_body %>
         <% if @content_item.continuation_link %>
           <%= render(
-              'govuk_component/button',
+              'govuk_publishing_components/components/button',
               start: true,
               href: @content_item.continuation_link,
               text: "Find out more",

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -50,7 +50,7 @@ module ServiceSignIn
             assert page.has_css?(".gem-c-radio__label__text", text: "Create an account")
           end
         end
-        assert page.has_css?(shared_component_selector('button'), text: "Continue")
+        assert page.has_css?(".gem-c-button", text: "Continue")
       end
     end
 
@@ -120,7 +120,7 @@ module ServiceSignIn
           end
         end
 
-        assert page.has_css?(shared_component_selector('button'), text: "Bwrw ymlaen")
+        assert page.has_css?(".gem-c-button", text: "Bwrw ymlaen")
       end
     end
 

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -159,13 +159,8 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
   test 'renders start button' do
     setup_and_visit_content_item('business-finance-support-scheme')
 
-    assert_component_locals(
-      'button',
-      start: true,
-      href: 'http://www.bigissueinvest.com',
-      info_text: 'on the Big Issue Invest website',
-      text: 'Find out more'
-    )
+    assert page.has_css?(".gem-c-button.gem-c-button--start[href='http://www.bigissueinvest.com']", text: "Find out more")
+    assert page.has_css?(".gem-c-button__info-text", text: "on the Big Issue Invest website")
   end
 
   test 'does not render a contents list if there are fewer than three items in the contents list' do


### PR DESCRIPTION
Button component is now in the gem, not static. Updating to use the gem.


Visual regression results:
https://government-frontend-pr-883.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-883.herokuapp.com/component-guide
