### PR TITLE
Show an error if a strange value is "selected"

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -25,16 +25,26 @@ class ContentItemsController < ApplicationController
     return head :not_found unless is_sign_in_content_item_path?
 
     if params[:option].blank?
-      @error = true
-      show
+      show_error_message
     else
       load_content_item
       selected = @content_item.selected_option(params[:option])
+
+      if selected.nil?
+        show_error_message
+        return
+      end
+
       redirect_to selected[:url]
     end
   end
 
 private
+
+  def show_error_message
+    @error = true
+    show
+  end
 
   def is_sign_in_content_item_path?
     content_item_path.include?("sign-in")

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -43,6 +43,7 @@ module ServiceSignIn
       mapped_options.each do |option|
         return option if option[:value] == selected_value
       end
+      nil
     end
 
   private

--- a/test/controllers/service_sign_in_content_item_controller_test.rb
+++ b/test/controllers/service_sign_in_content_item_controller_test.rb
@@ -86,6 +86,20 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_template :service_sign_in
   end
 
+  test "invalid selected url for service_sign_in page set displays choose_sign_in page with error" do
+    content_item = content_store_has_schema_example("service_sign_in", "service_sign_in")
+    path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
+
+    option = nil
+
+    stub_request(:get, %r{#{path}}).to_return(status: 200, body: content_item.to_json, headers: {})
+
+    post :service_sign_in_options, params: { path: path, option: option }
+
+    assert_not_nil @controller.instance_variable_get(:@error)
+    assert_template :service_sign_in
+  end
+
   def path_for(content_item, locale = nil)
     base_path = content_item['base_path'].sub(/^\//, '')
     base_path.gsub!(/\.#{locale}$/, '') if locale


### PR DESCRIPTION
Errors were reported in Sentry for users on IE6. The value selected on the radio form did not match any of the available values in the radio button list.

Rather than throwing a 500 error, we should show the user an error message.

See: https://sentry.io/govuk/app-government-frontend/issues/540005743/
