### PR TITLE
Canonical meta tag

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -53,6 +53,14 @@ class ContentItemPresenter
     Plek.current.website_root + content_item["base_path"]
   end
 
+  def canonical_url
+    if requesting_a_part?
+      web_url + "/" + part_slug
+    else
+      web_url
+    end
+  end
+
 private
 
   def display_date(timestamp, format = "%-d %B %Y")

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
 
   <meta property="og:site_name" content="GOV.UK" />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="<%= @content_item.web_url %>" />
+  <meta property="og:url" content="<%= @content_item.canonical_url %>" />
   <meta property="og:title" content="<%= @content_item.page_title %>" />
   <meta property="og:description" content="<%= strip_tags(@content_item.description) %>" />
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,8 @@
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
 
+  <link rel="canonical" href="<%= @content_item.canonical_url %>" />
+
   <meta property="og:site_name" content="GOV.UK" />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= @content_item.web_url %>" />

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -21,6 +21,18 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
     assert_equal "Type", ContentItemPresenter.new("document_type" => "Type").document_type
   end
 
+  test "#canonical_url without a part" do
+    assert_equal "https://www.test.gov.uk/test", ContentItemPresenter.new("base_path" => "/test").canonical_url
+  end
+
+  test "#canonical_url with a part" do
+    example_with_parts = govuk_content_schema_example('travel_advice', 'full-country')
+    request_path = example_with_parts['base_path'] + '/safety-and-security'
+    presented_example = TravelAdvicePresenter.new(example_with_parts, request_path)
+
+    assert_equal "https://www.test.gov.uk/foreign-travel-advice/albania/safety-and-security", presented_example.canonical_url
+  end
+
   test "available_translations sorts languages by locale with English first" do
     translated = govuk_content_schema_example('case_study', 'translated')
     locales = ContentItemPresenter.new(translated).available_translations


### PR DESCRIPTION
This adds a canonical URL `link` tag to all pages. For content items with parts, it makes sure that the part slug is included at the end of the URL.

[Trello Card](https://trello.com/c/J67JSy8r/148-investigate-how-to-implement-canonical-tags-for-government-frontend-to-help-remove-duplicate-urls-2-hour-timebox)

---

Visual regression results:
https://government-frontend-pr-898.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-898.herokuapp.com/component-guide