### PR TITLE
Add HMRC webchat unavailability message

### DIFF
--- a/app/helpers/webchat_availability_helper.rb
+++ b/app/helpers/webchat_availability_helper.rb
@@ -1,0 +1,20 @@
+module WebchatAvailabilityHelper
+  UNAVAILABILITY_MESSAGE = "This service will be unavailable from 4pm on Saturday 12 May to 9am on Monday 14 May.".freeze
+  HMRC_WEBCHAT_CONTACT_PATHS = %w(
+    /government/organisations/hm-revenue-customs/contact/online-services-helpdesk
+    /government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees
+    /government/organisations/hm-revenue-customs/contact/self-assessment
+    /government/organisations/hm-revenue-customs/contact/tax-credits-enquiries
+  ).freeze
+  UNAVAILABILITY_START = Time.parse("2018-05-12 16:00 BST").freeze
+  UNAVAILABILITY_END = Time.parse("2018-05-14 09:00 BST").freeze
+
+  def webchat_unavailable?(now = Time.zone.now)
+    show_unavailability = now >= UNAVAILABILITY_START && now < UNAVAILABILITY_END
+    show_unavailability && HMRC_WEBCHAT_CONTACT_PATHS.include?(@content_item.base_path)
+  end
+
+  def unavailability_message
+    UNAVAILABILITY_MESSAGE
+  end
+end

--- a/app/views/shared/_webchat.html.erb
+++ b/app/views/shared/_webchat.html.erb
@@ -1,25 +1,29 @@
 <span class="js-webchat"
   data-availability-url="<%= @content_item.webchat_availability_url %>"
   data-open-url="<%= @content_item.webchat_open_url %>">
-  <% if @content_item.base_path == '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries' %>
-    Advisers can only talk to you about Child Tax Credit and Working Tax Credit.
-    They won't be able to transfer you to another webchat team.
-    <br/>
-    <br/>
+  <% if webchat_unavailable? %>
+    <%= unavailability_message %>
+  <% else %>
+    <% if @content_item.base_path == '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries' %>
+      Advisers can only talk to you about Child Tax Credit and Working Tax Credit.
+      They won't be able to transfer you to another webchat team.
+      <br/>
+      <br/>
+    <% end %>
+    <span class="js-webchat-advisers-error">
+      Webchat is unavailable at the moment because of technical problems.
+    </span>
+    <span class="js-webchat-advisers-unavailable hidden">
+      Webchat is closed at the moment.
+    </span>
+    <span class="js-webchat-advisers-busy hidden">
+      All webchat advisers are busy at the moment.
+    </span>
+    <span class="js-webchat-advisers-available hidden">
+      Advisers are available to chat.
+      <a href="#" rel="external" class="js-webchat-open-button">Speak to an adviser now</a>.
+    </span>
   <% end %>
-  <span class="js-webchat-advisers-error">
-    Webchat is unavailable at the moment because of technical problems.
-  </span>
-  <span class="js-webchat-advisers-unavailable hidden">
-    Webchat is closed at the moment.
-  </span>
-  <span class="js-webchat-advisers-busy hidden">
-    All webchat advisers are busy at the moment.
-  </span>
-  <span class="js-webchat-advisers-available hidden">
-    Advisers are available to chat.
-    <a href="#" rel="external" class="js-webchat-open-button">Speak to an adviser now</a>.
-  </span>
 </span>
 <% # This is inline in the source however slimmer will optimize this. %>
 <%= javascript_include_tag "webchat", integrity: true, crossorigin: 'anonymous' %>

--- a/test/helpers/webchat_availability_helper_test.rb
+++ b/test/helpers/webchat_availability_helper_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class WebchatAvailabilityHelperTest < ActionView::TestCase
+  tests WebchatAvailabilityHelper
+
+  setup do
+    @content_item = Object.new
+    @content_item.stubs(:base_path).returns(HMRC_WEBCHAT_CONTACT_PATHS.first)
+  end
+
+  test "webchat_unavailable? indicates unavailability" do
+    refute webchat_unavailable?(Time.parse("2018-05-12 15:59 BST"))
+    assert webchat_unavailable?(Time.parse("2018-05-12 16:00 BST"))
+    assert webchat_unavailable?(Time.parse("2018-05-14 08:59 BST"))
+    refute webchat_unavailable?(Time.parse("2018-05-14 09:00 BST"))
+  end
+end


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/2783996

![screenshot from 2018-05-11 16-32-39](https://user-images.githubusercontent.com/93511/39932769-f331525c-5538-11e8-8fad-04ab297e4e88.png)

eg. https://government-frontend-pr-901.herokuapp.com/government/organisations/hm-revenue-customs/contact/online-services-helpdesk

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
