### PR TITLE
Add last_updated timestamp on help_page format

### DIFF
--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -15,8 +15,7 @@
       disable_youtube_expansions: true,
       rich_govspeak: true %>
 
-    <% #https://github.com/alphagov/government-frontend/pull/329#issuecomment-297681738 %>
-    <% if false && @content_item.last_updated %>
+    <% if @content_item.last_updated %>
       <p class="last-updated">
         <%= t 'common.last_updated' %>: <%= @content_item.last_updated %>
       </p>

--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -15,10 +15,10 @@
       disable_youtube_expansions: true,
       rich_govspeak: true %>
 
-    <% if @content_item.last_updated %>
-      <p class="last-updated">
-        <%= t 'common.last_updated' %>: <%= @content_item.last_updated %>
-      </p>
+    <% if @content_item.last_updated && @content_item.schema_name == "help_page" %>
+      <%= render "components/published-dates", {
+        last_updated: @content_item.last_updated
+      } %>
     <% end %>
   </div>
 

--- a/test/integration/help_page_test.rb
+++ b/test/integration/help_page_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class HelpPageTest < ActionDispatch::IntegrationTest
   test "renders title and body" do
     setup_and_visit_content_item('help_page')
-    assert page.has_text?(@content_item["title"])
 
-    assert page.has_text?("Last updated: 16 December 2014")
+    assert page.has_text?(@content_item["title"])
     assert_has_component_govspeak(@content_item["details"]["body"].squish)
+    assert_has_published_dates(@content_item["last_updated"])
   end
 end

--- a/test/integration/help_page_test.rb
+++ b/test/integration/help_page_test.rb
@@ -5,7 +5,7 @@ class HelpPageTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('help_page')
     assert page.has_text?(@content_item["title"])
 
-    # assert page.has_text?("Last updated: 16 December 2014")
+    assert page.has_text?("Last updated: 16 December 2014")
     assert_has_component_govspeak(@content_item["details"]["body"].squish)
   end
 end


### PR DESCRIPTION
To ensure we are GDPR compliant we need to follow the privacy notice template where we have to include an updated timestamp on the privacy page (https://www.gov.uk/help/privacy-policy), which uses the `help_page` document type.

The `last_updated` uses the `public_updated_at` content_item attribute and will affect all `help_page` pages.

![screen shot 2018-05-16 at 16 44 01](https://user-images.githubusercontent.com/19667619/40129713-ec4a2c1e-592c-11e8-8fc1-1324d674f40c.png)

---

Trello card: 
[Enable the 'last updated' timestamp on GOV.UK privacy page / 'help_page' format](https://trello.com/c/f55CKmXD/167-enable-the-last-updated-timestamp-on-govuk-privacy-page-helppage-format-1)

https://government-frontend-pr-907.herokuapp.com/help/privacy-policy

Visual regression results:
https://government-frontend-pr-907.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-907.herokuapp.com/component-guide
