### PR TITLE
HUB-143: Small style change to description text on service sign in pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,4 +48,5 @@
 @import 'views/specialist-document';
 @import 'views/answer';
 @import 'views/help-page';
-@import "views/guide";
+@import 'views/guide';
+@import 'views/service_sign_in';

--- a/app/assets/stylesheets/views/_service_sign_in.scss
+++ b/app/assets/stylesheets/views/_service_sign_in.scss
@@ -1,0 +1,5 @@
+.service-sign-in {
+  .description {
+    @include core-19;
+  }
+}

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -21,7 +21,8 @@
   <%= render "govuk_publishing_components/components/fieldset", legend_text: legend_text do %>
     <div class="grid-row">
       <div class="column-two-thirds">
-        <%= render 'govuk_component/govspeak', content: @content_item.description %>
+        <div class="description"><%= render 'govuk_component/govspeak', content: @content_item.description %></div>
+        <br/>
         <% if @error %>
           <%= render "components/error-message", text: t('service_sign_in.error.option') %>
         <% end %>


### PR DESCRIPTION
An option to display a text paragraph description under the heading on the service sign in pages has existed for some time but was not being used. We are about to start a base line test to see if having a description here improves through put by increasing understanding. However when testing what this would look like we found that the text was a little small and close to the error text (when shown). This commit contains small changes to change the text size and element spacing.

Note to reviewer: I am less familiar with the Gov.UK code and you seem to use different elements for styling than the ones we use on Verify so please let me know if this is not the right way to set the text size/if there is a better way of doing this that avoids adding a file. I am also not sure if I need to update the wraith tests or if they are just for running locally against the live pages. Please just comment and I can amend accordingly.

solo: @rachelthecodesmith

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
