### PR TITLE
Add more schemas

### DIFF
--- a/app/helpers/machine_readable_metadata_helper.rb
+++ b/app/helpers/machine_readable_metadata_helper.rb
@@ -1,0 +1,6 @@
+module MachineReadableMetadataHelper
+  def machine_readable_metadata(args)
+    locals = { content_item: @content_item.content_item }.merge(args)
+    render('govuk_publishing_components/components/machine_readable_metadata', locals)
+  end
+end

--- a/app/views/content_items/answer.html.erb
+++ b/app/views/content_items/answer.html.erb
@@ -1,7 +1,7 @@
 <% content_for :extra_head_content do %>
-  <%= render 'govuk_publishing_components/components/machine_readable_metadata',
-    schema: :article,
-    content_item: @content_item.content_item %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
 <% end %>
 
 <%= render 'content_items/body_with_related_links' %>

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <div class="grid-row">
   <div class="column-two-thirds responsive-top-margin">
     <%= render 'govuk_component/title', @content_item.title_and_context %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <% content_for :simple_header, true %>
 
 <div class="grid-row">

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <% @additional_body = capture do %>
   <% if @content_item.corporate_information? %>
     <%= @content_item.corporate_information_heading_tag %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -1,11 +1,12 @@
 <% content_for :extra_head_content do %>
-  <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+  <%= machine_readable_metadata(
     schema: :article,
-    content_item: @content_item.content_item,
-    canonical_url: @content_item.canonical_url %>
+    canonical_url: @content_item.canonical_url
+  ) %>
 <% end %>
 
 <% content_for :simple_header, true %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', { title: @content_item.title } %>

--- a/app/views/content_items/help_page.html.erb
+++ b/app/views/content_items/help_page.html.erb
@@ -1,1 +1,7 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <%= render 'content_items/body_with_related_links' %>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <%
   content_for :simple_header, true
 %>

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -1,7 +1,7 @@
 <% content_for :extra_head_content do %>
-  <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+  <%= machine_readable_metadata(
     schema: :news_article,
-    content_item: @content_item.content_item %>
+  ) %>
 <% end %>
 
 <div class="grid-row">

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <% content_for :simple_header, true %>
 
 <div class="grid-row">

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :news_article
+  ) %>
+<% end %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title',

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 
 <div class="grid-row">

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -4,12 +4,12 @@
   <%= auto_discovery_link_tag :atom, @content_item.feed_link,
     title: "Recent updates for #{@content_item.country_name}" %>
 
-  <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+  <%= machine_readable_metadata(
     schema: :article,
-    content_item: @content_item.content_item,
     canonical_url: @content_item.canonical_url,
     title: @content_item.page_title,
-    body: @content_item.current_part_body %>
+    body: @content_item.current_part_body
+    ) %>
 <% end %>
 
 <div class="grid-row">

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article
+  ) %>
+<% end %>
+
 <% @additional_body = capture do %>
   <% if @content_item.policies.any? %>
     <h2 id="policies">Policies</h2>

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :news_article
+  ) %>
+<% end %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_component/title', @content_item.title_and_context %>


### PR DESCRIPTION
This adds the baseline structured data to all remaining formats in the app.

Everything is an article, except speech and world_location_news_article, which are news articles.

I think there are a bunch of improvements we could make with this, like marking up statistical datasets as
https://developers.google.com/search/docs/data-types/dataset, but that's for future PRs.

https://trello.com/c/RLQI1IUV/23-add-structured-data-to-the-top-500-pages