### PR TITLE
Update govuk_publishing_components gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 52.5'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.5'
 gem 'govuk_frontend_toolkit', '~> 7.4'
-gem 'govuk_publishing_components', '~> 8.1.0'
+gem 'govuk_publishing_components', '~> 8.2.0'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 12.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       nokogiri (~> 1.8)
     cliver (0.3.2)
     coderay (1.1.2)
-    commander (4.4.4)
+    commander (4.4.5)
       highline (~> 1.7.2)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
@@ -127,7 +127,7 @@ GEM
     govuk_frontend_toolkit (7.5.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (8.1.0)
+    govuk_publishing_components (8.2.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -368,7 +368,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.5)
   govuk_frontend_toolkit (~> 7.4)
-  govuk_publishing_components (~> 8.1.0)
+  govuk_publishing_components (~> 8.2.0)
   govuk_schemas (~> 3.1)
   htmlentities (~> 4.3)
   jasmine-rails

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,25 +25,6 @@
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
 
-  <link rel="canonical" href="<%= @content_item.canonical_url %>" />
-
-  <meta property="og:site_name" content="GOV.UK" />
-  <meta property="og:type" content="article" />
-  <meta property="og:url" content="<%= @content_item.canonical_url %>" />
-  <meta property="og:title" content="<%= @content_item.page_title %>" />
-  <meta property="og:description" content="<%= strip_tags(@content_item.description) %>" />
-
-  <% if @content_item.respond_to?(:image) && @content_item.image %>
-    <meta property="og:image" content="<%= @content_item.image["url"] %>" />
-    <meta property="og:image:alt" content="<%= @content_item.image["alt_text"] %>" />
-
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:image" content="<%= @content_item.image["url"] %>" />
-    <meta name="twitter:image:alt" content="<%= @content_item.image["alt_text"] %>" />
-  <% else %>
-    <meta name="twitter:card" content="summary" />
-  <% end %>
-
   <%= yield :extra_head_content %>
 </head>
 <body>


### PR DESCRIPTION
The meta tags are now done by the Machine readable metadata component (https://github.com/alphagov/govuk_publishing_components/pull/335). 

There's more to do to use the new features in 8.2.0, but that will be done in future PRs.