### PR TITLE
Remove Webchat from HMRC Trusts page

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -128,7 +128,6 @@ private
       '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries' => 1016,
       '/government/organisations/hm-revenue-customs/contact/vat-enquiries' => 1028,
       '/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries' => 1034,
-      '/government/organisations/hm-revenue-customs/contact/trusts' => 1036,
       '/government/organisations/hm-revenue-customs/contact/employer-enquiries' => 1023,
       '/government/organisations/hm-revenue-customs/contact/online-services-helpdesk' => 1003,
     }


### PR DESCRIPTION
Requested in Zendesk ticket 2819908