### PR TITLE
Remove image expectation from fatality notice test

### DIFF
--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -40,8 +40,6 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
       'should have image with ministry-of-defence source with alt text'
     )
 
-    assert_has_component_govspeak "<div class=\"govspeak\"><h2 id=\"sir-george-pomeroy-colley\">Sir George Pomeroy Colley</h2><figure class=\"image embedded\"> <div class=\"img\"><img alt=\"Photograph of Sir George Pomeroy Colley posed standing\" src=\"https://assets-origin.integration.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/56271/colley.jpg\"></div> <figcaption>Sir George Pomeroy Colley (All rights reserved.)</figcaption></figure><p>Colley served nearly all of his military and administrative career in British South Africa, but he played a significant part in the Second Anglo-Afghan War as military secretary and then private secretary to the governor-general of India, Lord Lytton. The war began in November 1878 and ended in May 1879 with the Treaty of Gandamak.</p><p>After the war Colley returned to South Africa, became high commissioner for South Eastern Africa in 1880… and died a year later at the Battle of Majuba Hill during the First Boer War.</p><p>A british officer had the following to say</p><blockquote> <p class=\"last-child\">Major General Colley was an exceptional talent, and it is with great sadness that we have learned about this loss. His contribution to Britain through his efforts in the Boer War will not be forgotten.</p></blockquote></div>"
-
     within(".content-bottom-margin .app-c-published-dates") do
       assert page.has_content?("Published 27 February 1881")
       assert page.has_content?("Last updated 14 September 2016")


### PR DESCRIPTION
- other builds are failing because this image cannot be loaded in CI. A separate PR exists to remove this image from govuk-content-schemas

Relates to https://github.com/alphagov/govuk-content-schemas/pull/766