### PR TITLE
Updated version for `govuk_publishing_components` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 52.5'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.5'
 gem 'govuk_frontend_toolkit', '~> 7.4'
-gem 'govuk_publishing_components', '~> 9.0.0'
+gem 'govuk_publishing_components', '~> 9.1.0'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 12.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     govuk_frontend_toolkit (7.5.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (9.0.0)
+    govuk_publishing_components (9.1.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -368,7 +368,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.5)
   govuk_frontend_toolkit (~> 7.4)
-  govuk_publishing_components (~> 9.0.0)
+  govuk_publishing_components (~> 9.1.0)
   govuk_schemas (~> 3.1)
   htmlentities (~> 4.3)
   jasmine-rails


### PR DESCRIPTION
Removes policy links from the taxonomy sidebar;
https://github.com/alphagov/govuk_publishing_components/pull/357

This will accomodate changes relating to this card;
https://trello.com/c/3xOhZgEJ/127-removing-policy-links-from-the-taxonomy-sidebar

---

Visual regression results:
https://government-frontend-pr-927.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-927.herokuapp.com/component-guide
