### PR TITLE
Use organisation logo component from gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 52.5'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.5'
 gem 'govuk_frontend_toolkit', '~> 7.4'
-gem 'govuk_publishing_components', '~> 9.1.0'
+gem 'govuk_publishing_components', '~> 9.2.0'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 12.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
       i18n (>= 0.7)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     gds-api-adapters (52.5.1)
       addressable
       link_header
@@ -127,7 +127,7 @@ GEM
     govuk_frontend_toolkit (7.5.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (9.1.0)
+    govuk_publishing_components (9.2.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -368,7 +368,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.5)
   govuk_frontend_toolkit (~> 7.4)
-  govuk_publishing_components (~> 9.1.0)
+  govuk_publishing_components (~> 9.2.0)
   govuk_schemas (~> 3.1)
   htmlentities (~> 4.3)
   jasmine-rails

--- a/app/presenters/content_item/organisation_branding.rb
+++ b/app/presenters/content_item/organisation_branding.rb
@@ -6,7 +6,7 @@ module ContentItem
       logo = organisation["details"]["logo"]
       logo_component_params = {
         organisation: {
-          name: logo["formatted_title"],
+          name: logo["formatted_title"].html_safe,
           url: organisation["base_path"],
           brand: organisation_brand(organisation),
           crest: logo["crest"],

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -29,7 +29,7 @@
 <div class="<%= @content_item.organisation_brand_class %>">
   <div class="grid-row">
     <div class="column-two-thirds">
-      <%= render 'govuk_component/organisation_logo', @content_item.organisation_logo %>
+      <%= render 'govuk_publishing_components/components/organisation_logo', @content_item.organisation_logo %>
     </div>
   </div>
   <div class="grid-row">

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -12,7 +12,7 @@
   <ol class="organisation-logos">
     <% @content_item.organisations.each do |organisation| %>
       <li class="organisation-logo">
-        <%= render 'govuk_component/organisation_logo', @content_item.organisation_logo(organisation) %>
+        <%= render 'govuk_publishing_components/components/organisation_logo', @content_item.organisation_logo(organisation) %>
       </li>
     <% end %>
   </ol>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -8,15 +8,17 @@
   content_for :simple_header, true
 %>
 
-<div class="publication-external">
-  <ol class="organisation-logos">
-    <% @content_item.organisations.each do |organisation| %>
-      <li class="organisation-logo">
-        <%= render 'govuk_publishing_components/components/organisation_logo', @content_item.organisation_logo(organisation) %>
-      </li>
-    <% end %>
-  </ol>
-</div>
+<% if @content_item.organisations %>
+  <div class="publication-external">
+    <ol class="organisation-logos">
+      <% @content_item.organisations.each do |organisation| %>
+        <li class="organisation-logo">
+          <%= render 'govuk_publishing_components/components/organisation_logo', @content_item.organisation_logo(organisation) %>
+        </li>
+      <% end %>
+    </ol>
+  </div>
+<% end %>
 
 <%= render 'govuk_publishing_components/components/inverse_header', {} do %>
   <%= render 'govuk_publishing_components/components/title',

--- a/test/integration/corporate_information_page_test.rb
+++ b/test/integration/corporate_information_page_test.rb
@@ -65,30 +65,12 @@ class CorporateInformationPageTest < ActionDispatch::IntegrationTest
 
   test "renders an organisation logo" do
     setup_and_visit_content_item('corporate_information_page')
-    assert_has_component_organisation_logo(
-      organisation: {
-        name: 'Department<br/>of Health',
-        url: '/government/organisations/department-of-health',
-        brand: 'department-of-health',
-        crest: 'single-identity'
-      }
-    )
+    assert_has_component_organisation_logo
   end
 
   test "renders a custom organisation logo" do
     setup_and_visit_content_item('corporate_information_page_translated_custom_logo')
-    assert_has_component_organisation_logo(
-      organisation: {
-        name: 'Land Registry',
-        url: '/government/organisations/land-registry',
-        brand: 'department-for-business-innovation-skills',
-        crest: nil,
-        image: {
-          url: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/69/LR_logo_265.png',
-          alt_text: 'Land Registry'
-        }
-      }
-    )
+    assert_has_component_organisation_logo
   end
 
   test 'renders a withdrawal notice on withdrawn page' do

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -20,10 +20,6 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       assert page.has_css?('.gem-c-contents-list')
     end
 
-    within ".organisation-logos" do
-      assert page.has_text?(@content_item["links"]["organisations"][0]["title"])
-    end
-
     assert page.has_text?("The Environment Agency will normally put any responses it receives on the public register. This includes your name and contact details. Tell us if you don’t want your response to be public.")
   end
 
@@ -78,8 +74,8 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   end
 
   def assert_has_component_organisation_logo_with_brand(brand, index = 1)
-    within("li.organisation-logo:nth-of-type(#{index}) #{shared_component_selector('organisation_logo')}") do
-      assert_equal brand, JSON.parse(page.text).fetch("organisation").fetch("brand")
+    within("li.organisation-logo:nth-of-type(#{index})") do
+      assert page.has_css?(".gem-c-organisation-logo.brand--#{brand}")
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -81,10 +81,8 @@ class ActionDispatch::IntegrationTest
     assert page.has_css?('h1', text: title)
   end
 
-  def assert_has_component_organisation_logo(logo, index = 1)
-    within(shared_component_selector("organisation_logo") + ":nth-of-type(#{index})") do
-      assert_equal logo, JSON.parse(page.text).deep_symbolize_keys
-    end
+  def assert_has_component_organisation_logo
+    assert page.has_css?(".gem-c-organisation-logo")
   end
 
   def assert_has_component_government_navigation_active(active)


### PR DESCRIPTION
Uses the organisation logo component added to the gem (https://github.com/alphagov/govuk_publishing_components/pull/365), replacing it with the one from static.

Trello card: https://trello.com/c/jcRtJtvm/32-move-the-organisation-logo-component-to-the-gem
Trello card: https://trello.com/c/EKEwjJ7u/167-modify-component-organisation-logo

---

Visual regression results:
https://government-frontend-pr-931.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-931.herokuapp.com/component-guide
