### PR TITLE
Only pass in safe HTML to govspeak component

### DIFF
--- a/app/presenters/content_item/body.rb
+++ b/app/presenters/content_item/body.rb
@@ -6,7 +6,7 @@ module ContentItem
 
     def govspeak_body
       {
-        content: body,
+        content: body.html_safe,
         direction: text_direction
       }
     end

--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -10,7 +10,7 @@
 <div class="grid-row responsive-bottom-margin">
   <div class="column-two-thirds">
     <%= render 'govuk_publishing_components/components/govspeak',
-      content: @content_item.body,
+      content: raw(@content_item.body),
       direction: page_text_direction,
       disable_youtube_expansions: true,
       rich_govspeak: true %>

--- a/app/views/content_items/_document_collection_body.html.erb
+++ b/app/views/content_items/_document_collection_body.html.erb
@@ -6,7 +6,7 @@
   <%= @content_item.group_heading(group) %>
   <% if group["body"].present? %>
     <%= render 'govuk_publishing_components/components/govspeak',
-        content: group["body"],
+        content: raw(group["body"]),
         direction: page_text_direction %>
   <% end %>
 

--- a/app/views/content_items/_publication_inline_body.html.erb
+++ b/app/views/content_items/_publication_inline_body.html.erb
@@ -5,7 +5,7 @@
 
 <div aria-labelledby="documents-title">
   <%= render 'govuk_publishing_components/components/govspeak',
-             content: @content_item.documents,
+             content: @content_item.documents.html_safe,
              direction: page_text_direction %>
 </div>
 
@@ -16,6 +16,6 @@
 
 <div aria-labelledby="details-title">
   <%= render 'govuk_publishing_components/components/govspeak',
-             content: @content_item.details,
+             content: @content_item.details.html_safe,
              direction: page_text_direction %>
 </div>

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -26,7 +26,7 @@
           caption: @content_item.image["caption"] if @content_item.image %>
 
       <%= render 'govuk_publishing_components/components/govspeak',
-          content: @content_item.body,
+          content: @content_item.body.html_safe,
           direction: page_text_direction %>
     </div>
 

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -40,7 +40,7 @@
         <%= render 'govuk_publishing_components/components/heading', text: "Download the full outcome", mobile_top_margin: true %>
         <div class="consultation-outcome">
           <%= render 'govuk_publishing_components/components/govspeak',
-              content: @content_item.final_outcome_documents,
+              content: @content_item.final_outcome_documents.html_safe,
               direction: page_text_direction %>
         </div>
       <% end %>
@@ -48,7 +48,7 @@
       <%= render 'govuk_publishing_components/components/heading', text: "Detail of outcome", mobile_top_margin: true %>
       <div class="consultation-outcome-detail">
         <%= render 'govuk_publishing_components/components/govspeak',
-            content: @content_item.final_outcome_detail,
+            content: @content_item.final_outcome_detail.html_safe,
             direction: page_text_direction %>
       </div>
     <% end %>
@@ -57,7 +57,7 @@
       <%= render 'govuk_publishing_components/components/heading', text: "Feedback received", mobile_top_margin: true %>
       <div class="consultation-feedback-documents">
         <%= render 'govuk_publishing_components/components/govspeak',
-            content: @content_item.public_feedback_documents,
+            content: @content_item.public_feedback_documents.html_safe,
             direction: page_text_direction %>
       </div >
     <% end %>
@@ -66,7 +66,7 @@
       <%= render 'govuk_publishing_components/components/heading', text: "Detail of feedback received", mobile_top_margin: true %>
       <div class="consultation-feedback">
         <%= render 'govuk_publishing_components/components/govspeak',
-            content: @content_item.public_feedback_detail,
+            content: @content_item.public_feedback_detail.html_safe,
             direction: page_text_direction %>
       </div>
     <% end %>
@@ -115,7 +115,7 @@
         <%= render 'govuk_publishing_components/components/heading', text: "Documents", mobile_top_margin: true %>
         <div class="consultation-documents">
           <%= render 'govuk_publishing_components/components/govspeak',
-              content: @content_item.documents,
+              content: @content_item.documents.html_safe,
               direction: page_text_direction %>
         </div>
       <% end %>

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -47,7 +47,7 @@
     <div class="column-two-thirds">
       <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
         <div class="responsive-bottom-margin">
-          <%= render 'govuk_publishing_components/components/govspeak', content: "#{@content_item.body}#{@additional_body}" %>
+          <%= render 'govuk_publishing_components/components/govspeak', content: "#{@content_item.body}#{@additional_body}".html_safe %>
         </div>
       <% end %>
     </div>

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -27,7 +27,7 @@
           alt: @content_item.image["alt_text"],
           caption: @content_item.image["caption"] if @content_item.image %>
       <%= render 'govuk_publishing_components/components/govspeak',
-          content: @content_item.body,
+          content: @content_item.body.html_safe,
           direction: page_text_direction %>
     </div>
 

--- a/app/views/content_items/gone.html.erb
+++ b/app/views/content_items/gone.html.erb
@@ -6,7 +6,7 @@
       The information on this page has been removed because it was published in error.
     </p>
 
-    <%= render 'govuk_publishing_components/components/govspeak', content: @content_item.explanation %>
+    <%= render 'govuk_publishing_components/components/govspeak', content: @content_item.explanation.html_safe %>
 
     <% if @content_item.alternative_path.present? %>
       <p class="alternative">

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -15,7 +15,7 @@
           <%= "#{index + 1}. #{part['title']}" %>
         </h1>
         <%= render 'govuk_publishing_components/components/govspeak',
-            content: part['body'],
+            content: part['body'].html_safe,
             direction: page_text_direction,
             disable_youtube_expansions: true,
             rich_govspeak: true %>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -24,7 +24,7 @@
         </h1>
       <% end %>
       <%= render 'govuk_publishing_components/components/govspeak',
-          content: @content_item.current_part_body,
+          content: @content_item.current_part_body.html_safe,
           direction: page_text_direction,
           disable_youtube_expansions: true,
           rich_govspeak: true %>

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -26,7 +26,7 @@
           alt: @content_item.image["alt_text"],
           caption: @content_item.image["caption"] if @content_item.image %>
       <%= render 'govuk_publishing_components/components/govspeak',
-          content: @content_item.body,
+          content: @content_item.body.html_safe,
           direction: page_text_direction %>
     </div>
 

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -21,7 +21,7 @@
   <%= render "govuk_publishing_components/components/fieldset", legend_text: legend_text do %>
     <div class="grid-row">
       <div class="column-two-thirds">
-        <%= render 'govuk_publishing_components/components/govspeak', content: @content_item.description %>
+        <%= render 'govuk_publishing_components/components/govspeak', content: raw(@content_item.description) %>
         <% if @error %>
           <%= render "components/error-message", text: t('service_sign_in.error.option') %>
         <% end %>

--- a/app/views/content_items/service_sign_in/_create_new_account.html.erb
+++ b/app/views/content_items/service_sign_in/_create_new_account.html.erb
@@ -3,6 +3,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', title: @content_item.title %>
-    <%= render 'govuk_publishing_components/components/govspeak', content: @content_item.body %>
+    <%= render 'govuk_publishing_components/components/govspeak', content: @content_item.body.html_safe %>
   </div>
 </div>

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -30,7 +30,7 @@
           caption: @content_item.image["caption"] if @content_item.image %>
 
       <%= render 'govuk_publishing_components/components/govspeak',
-          content: @content_item.body,
+          content: @content_item.body.html_safe,
           direction: page_text_direction %>
     </div>
 

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -27,7 +27,7 @@
     <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
     <div class="responsive-bottom-margin">
       <%= render 'govuk_publishing_components/components/govspeak',
-                 content: @content_item.body,
+                 content: @content_item.body.html_safe,
                  direction: page_text_direction %>
     </div>
     <div class="responsive-bottom-margin">

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -21,7 +21,7 @@
         caption: @content_item.image["caption"] if @content_item.image %>
 
     <%= render 'govuk_publishing_components/components/govspeak',
-      content: @content_item.body,
+      content: @content_item.body.html_safe,
       direction: page_text_direction %>
   </div>
   <%= render 'shared/sidebar_navigation' %>

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -18,7 +18,7 @@
       contents: @content_item.contents,
     } do %>
       <%= render 'govuk_publishing_components/components/govspeak',
-          content: @content_item.body,
+          content: @content_item.body.html_safe,
           direction: page_text_direction %>
     <% end %>
   </div>

--- a/app/views/content_items/travel_advice.html+print.erb
+++ b/app/views/content_items/travel_advice.html+print.erb
@@ -18,7 +18,7 @@
         <%= render 'shared/travel_advice_summary', content_item: @content_item if i == 0 %>
 
         <%= render 'govuk_publishing_components/components/govspeak',
-            content: part['body'],
+            content: part['body'].html_safe,
             direction: page_text_direction %>
       </section>
     <% end %>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -51,7 +51,7 @@
     <% end %>
 
     <%= render 'govuk_publishing_components/components/govspeak',
-        content: @content_item.current_part_body,
+        content: @content_item.current_part_body.html_safe,
         direction: page_text_direction %>
 
     <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>

--- a/app/views/content_items/unpublishing.html.erb
+++ b/app/views/content_items/unpublishing.html.erb
@@ -6,7 +6,7 @@
       The information on this page has been removed because it was published in error.
     </p>
 
-    <%= render 'govuk_publishing_components/components/govspeak', content: @content_item.explanation %>
+    <%= render 'govuk_publishing_components/components/govspeak', content: @content_item.explanation.html_safe %>
 
     <% if @content_item.alternative_url.present? %>
       <p class="alternative">

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -29,7 +29,7 @@
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
     <%= render 'components/contents-list-with-body', contents: @content_item.contents do %>
       <%= render 'govuk_publishing_components/components/govspeak',
-            content: "#{@content_item.body} #{@additional_body}",
+            content: "#{@content_item.body} #{@additional_body}".html_safe,
             direction: page_text_direction %>
     <% end %>
   </div>

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -27,7 +27,7 @@
           caption: @content_item.image["caption"] if @content_item.image %>
 
       <%= render 'govuk_publishing_components/components/govspeak',
-        content: @content_item.body,
+        content: @content_item.body.html_safe,
         direction: page_text_direction %>
     </div>
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -178,6 +178,8 @@ class ActionDispatch::IntegrationTest
     stub_request(:get, %r{#{path}})
       .to_return(status: 200, body: content_item.to_json, headers: {})
     visit path
+
+    assert_equal 200, page.status_code
   end
 
   def get_content_example(name)


### PR DESCRIPTION
This makes sure that we only pass in safe HTML to the govspeak component, because in the future the component won't call `html_safe` on it for us (https://github.com/alphagov/govuk_publishing_components/pull/356).

In some cases I've used `raw` because the input may be nil.

https://trello.com/c/ZMVwIyj5