### PR TITLE
Make HTML publication page more robust

### DIFF
--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -12,8 +12,10 @@
   <div class="publication-external">
     <ol class="organisation-logos">
       <% @content_item.organisations.each do |organisation| %>
+      <% logo_attributes = @content_item.organisation_logo(organisation) %>
+      <% next unless logo_attributes %>
         <li class="organisation-logo">
-          <%= render 'govuk_publishing_components/components/organisation_logo', @content_item.organisation_logo(organisation) %>
+          <%= render 'govuk_publishing_components/components/organisation_logo', logo_attributes %>
         </li>
       <% end %>
     </ol>


### PR DESCRIPTION
Since moving the organisation logo to the gem we're seeing intermittent test failures. This happens in cases where the random content generator in `HtmlPublicationTest` generates an organisation item without a logo in the details. This makes [`OrganisationBranding#organisation_logo` return nil][1], which is passed into the component, which subsequently crashes with a nil-error.

This makes the page more robust by only displaying logos that exist.

[1]: https://github.com/alphagov/government-frontend/blob/fc0f75cd16f4e1f126690cf5f9aee005af504186/app/presenters/content_item/organisation_branding.rb#L4