### PR TITLE
Cache travel advice atom feeds for 5 minutes.

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -92,9 +92,8 @@ private
   end
 
   def set_expiry
-    max_age = @content_item.content_item.cache_control.max_age
-    cache_private = @content_item.content_item.cache_control.private?
-    expires_in(max_age, public: !cache_private)
+    expires_in(@content_item.cache_control_max_age(request.format),
+               public: @content_item.cache_control_public?)
   end
 
   def with_locale

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -61,6 +61,16 @@ class ContentItemPresenter
     end
   end
 
+  # The default behaviour to is honour the max_age
+  # from the content-store response.
+  def cache_control_max_age(_format)
+    content_item.cache_control.max_age
+  end
+
+  def cache_control_public?
+    !content_item.cache_control.private?
+  end
+
 private
 
   def display_date(timestamp, format = "%-d %B %Y")

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -2,6 +2,8 @@ class TravelAdvicePresenter < ContentItemPresenter
   include ContentItem::Parts
   include ActionView::Helpers::TextHelper
 
+  ATOM_CACHE_CONTROL_MAX_AGE = 300
+
   def page_title
     if is_summary?
       super
@@ -88,6 +90,11 @@ class TravelAdvicePresenter < ContentItemPresenter
 
   def atom_public_updated_at
     DateTime.parse(content_item["public_updated_at"])
+  end
+
+  def cache_control_max_age(format)
+    return ATOM_CACHE_CONTROL_MAX_AGE if format == "atom"
+    content_item.cache_control.max_age
   end
 
 private

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -136,6 +136,14 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_equal "max-age=20, public", @response.headers['Cache-Control']
   end
 
+  test "sets a longer cache-control header for travel advice atom feeds" do
+    content_item = content_store_has_schema_example('travel_advice', 'full-country')
+    get :show, params: { path: path_for(content_item), format: 'atom' }
+
+    assert_response :success
+    assert_equal "max-age=300, public", @response.headers['Cache-Control']
+  end
+
   test "honours cache-control private items" do
     content_item = content_store_has_schema_example('coming_soon', 'coming_soon')
     content_store_has_item(content_item['base_path'], content_item, private: true)


### PR DESCRIPTION
https://trello.com/c/5GRfTtMR/233-make-atom-feeds-more-resilient

![screenshot from 2018-06-18 16-49-08](https://user-images.githubusercontent.com/93511/41547243-96f3d3e6-7317-11e8-8ece-399335f13a61.png)


---

Visual regression results:
https://government-frontend-pr-941.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-941.herokuapp.com/component-guide
