### PR TITLE
Stop using components from Static

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'govuk_app_config', '~> 1.5'
 gem 'govuk_frontend_toolkit', '~> 7.4'
 gem 'govuk_publishing_components', '~> 9.3.0'
 gem 'plek', '~> 2.1'
-gem 'slimmer', '~> 12.1'
+gem 'slimmer', '~> 13.0'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 52.6'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.5'
 gem 'govuk_frontend_toolkit', '~> 7.4'
-gem 'govuk_publishing_components', '~> 9.2.3'
+gem 'govuk_publishing_components', '~> 9.3.0'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 12.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,7 +302,7 @@ GEM
       rubyzip (~> 1.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
-    slimmer (12.1.0)
+    slimmer (13.0.0)
       activesupport
       json
       nokogiri (~> 1.7)
@@ -382,7 +382,7 @@ DEPENDENCIES
   rails-i18n (>= 4.0.4)
   rails_translation_manager (~> 0.0.2)
   sass-rails (~> 5.0)
-  slimmer (~> 12.1)
+  slimmer (~> 13.0)
   uglifier (>= 1.3.0)
   webmock (~> 3.4.2)
   wraith (~> 4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     govuk_frontend_toolkit (7.5.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (9.2.3)
+    govuk_publishing_components (9.3.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -191,7 +191,7 @@ GEM
     multipart-post (2.0.0)
     netrc (0.11.0)
     nio4r (2.3.1)
-    nokogiri (1.8.2)
+    nokogiri (1.8.3)
       mini_portile2 (~> 2.3.0)
     nokogumbo (1.5.0)
       nokogiri
@@ -368,7 +368,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.5)
   govuk_frontend_toolkit (~> 7.4)
-  govuk_publishing_components (~> 9.2.3)
+  govuk_publishing_components (~> 9.3.0)
   govuk_schemas (~> 3.1)
   htmlentities (~> 4.3)
   jasmine-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 class ApplicationController < ActionController::Base
-  include Slimmer::GovukComponents
-
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery except: :service_sign_in_options

--- a/app/views/shared/_travel_advice_summary.html.erb
+++ b/app/views/shared/_travel_advice_summary.html.erb
@@ -9,7 +9,7 @@
       direction: page_text_direction %>
 <% end %>
 
-<%= render 'govuk_component/metadata', content_item.metadata %>
+<%= render 'govuk_publishing_components/components/metadata', content_item.metadata %>
 <% if content_item.map %>
   <figure class="map">
     <img src="<%= content_item.map["url"] %>" alt="<%= content_item.map["alt_text"] %>" class="map-image">

--- a/test/integration/guide_print_test.rb
+++ b/test/integration/guide_print_test.rb
@@ -19,12 +19,7 @@ class GuidePrint < ActionDispatch::IntegrationTest
       assert page.has_css?("h1", text: "#{i + 1}. #{part['title']}")
     end
 
-    page.all(shared_component_selector("govspeak")).each_with_index do |govspeak_component, i|
-      within(govspeak_component) do
-        content_passed_to_component = JSON.parse(page.text).fetch("content").squish
-        assert_equal parts[i]['body'].squish, content_passed_to_component
-      end
-    end
+    assert page.has_content?("The ‘basic’ school curriculum includes the")
   end
 
   def setup_and_visit_guide_print(name)

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -17,7 +17,7 @@ module ServiceSignIn
 
       assert page.has_css?("title", text: 'Prove your identity to continue - GOV.UK', visible: false)
       assert page.has_css?('meta[name="robots"][content="noindex, nofollow"]', visible: false)
-      refute page.has_css?(shared_component_selector('government_navigation'))
+      refute page.has_css?("#proposition-menu")
 
       assert page.has_css?('.gem-c-back-link[href="/log-in-file-self-assessment-tax-return"]', text: 'Back')
       assert page.has_css?('form[data-module="track-radio-group"]')

--- a/test/integration/service_sign_in/create_new_account_test.rb
+++ b/test/integration/service_sign_in/create_new_account_test.rb
@@ -26,7 +26,7 @@ module ServiceSignIn
 
       assert page.has_text?("To use this service, you need to create either a Government Gateway or GOV.UK Verify account. These are used to help fight identity theft.")
       assert page.has_css?('meta[name="robots"][content="noindex, nofollow"]', visible: false)
-      refute page.has_css?(shared_component_selector('government_navigation'))
+      refute page.has_css?("#proposition-menu")
 
       assert page.has_css?(
         '.gem-c-back-link[href="/log-in-file-self-assessment-tax-return/sign-in/choose-sign-in"]',

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -153,7 +153,7 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
   test 'renders no start button when not set' do
     setup_and_visit_content_item('aaib-reports')
 
-    assert_no_component('button')
+    refute page.has_css?('.gem-c-button')
   end
 
   test 'renders start button' do

--- a/test/integration/travel_advice_print_test.rb
+++ b/test/integration/travel_advice_print_test.rb
@@ -18,12 +18,8 @@ class TravelAdvicePrint < ActionDispatch::IntegrationTest
     assert_has_component_metadata_pair("Still current at", Date.today.strftime("%-d %B %Y"))
     assert_has_component_metadata_pair("Updated", Date.parse(@content_item["details"]["reviewed_at"]).strftime("%-d %B %Y"))
 
-    within shared_component_selector("metadata") do
-      component_args = JSON.parse(page.text)
-      latest_update = component_args["other"].fetch("Latest update")
-
-      assert latest_update.include?('<p>')
-      assert latest_update.include?(@content_item['details']['change_description'].gsub('Latest update: ', ''))
+    within ".gem-c-metadata" do
+      assert page.has_content?(@content_item['details']['change_description'].gsub('Latest update: ', ''))
     end
 
     assert page.has_css?("h1", text: 'Summary')

--- a/test/integration/travel_advice_print_test.rb
+++ b/test/integration/travel_advice_print_test.rb
@@ -31,16 +31,7 @@ class TravelAdvicePrint < ActionDispatch::IntegrationTest
       assert page.has_css?("h1", text: part['title'])
     end
 
-    page.all(shared_component_selector("govspeak")).each_with_index do |govspeak_component, i|
-      within(govspeak_component) do
-        content_passed_to_component = JSON.parse(page.text).fetch("content").gsub(/\s+/, ' ')
-        if i.zero?
-          assert_equal @content_item["details"]["summary"].gsub(/\s+/, ' '), content_passed_to_component
-        else
-          assert_equal parts[i - 1]['body'].gsub(/\s+/, ' '), content_passed_to_component
-        end
-      end
-    end
+    assert page.has_content?("Summary – the main opposition party has called for mass protests against the government in Tirana on 18 February 2017")
   end
 
   def setup_and_visit_travel_advice_print(name)

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -36,12 +36,8 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     assert_has_component_metadata_pair("Still current at", Date.today.strftime("%-d %B %Y"))
     assert_has_component_metadata_pair("Updated", Date.parse(@content_item["details"]["reviewed_at"]).strftime("%-d %B %Y"))
 
-    within shared_component_selector("metadata") do
-      component_args = JSON.parse(page.text)
-      latest_update = component_args["other"].fetch("Latest update")
-
-      assert latest_update.include?('<p>')
-      assert latest_update.include?(@content_item['details']['change_description'].gsub('Latest update: ', ''))
+    within ".gem-c-metadata" do
+      assert page.has_content?(@content_item['details']['change_description'].gsub('Latest update: ', ''))
     end
 
     assert page.has_css?(".map img[src=\"#{@content_item['details']['image']['url']}\"]")
@@ -58,7 +54,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     assert page.has_text?("Public security is generally good, particularly in Tirana, and Albanians are very hospitable to visitors.")
 
     refute page.has_css?(".map")
-    refute page.has_css?(shared_component_selector("metadata"))
+    refute page.has_css?(".gem-c-metadata")
 
     assert page.has_css?('.part-navigation li', text: first_part['title'])
     refute page.has_css?('.part-navigation li a', text: first_part['title'])

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,6 @@ ENV['GOVUK_ASSET_ROOT'] = 'http://static.test.gov.uk'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'capybara/rails'
-require 'slimmer/test_helpers/govuk_components'
 require 'mocha/mini_test'
 require 'faker'
 
@@ -23,11 +22,6 @@ end
 
 class ActiveSupport::TestCase
   include GovukContentSchemaExamples
-  include Slimmer::TestHelpers::GovukComponents
-
-  def setup
-    stub_shared_component_locales
-  end
 end
 
 # Note: This is so that slimmer is skipped, preventing network requests for
@@ -43,37 +37,8 @@ end
 class ActionDispatch::IntegrationTest
   # Make the Capybara DSL available in all integration tests
   include Capybara::DSL
-  include Slimmer::TestHelpers::GovukComponents
-
-  def setup
-    stub_shared_component_locales
-  end
-
-  def assert_no_component(name)
-    assert page.has_no_css?(shared_component_selector(name)), "Found a component named #{name}"
-  end
-
-  def assert_component_locals(name, locals)
-    within shared_component_selector(name) do
-      assert_equal locals, JSON.parse(page.text).deep_symbolize_keys
-    end
-  end
 
   def assert_has_component_metadata_pair(label, value)
-  end
-
-  def assert_has_component_document_footer_pair(label, value)
-    assert_component_parameter("document_footer", label, value)
-  end
-
-  def assert_component_parameter(component, label, value)
-    within shared_component_selector(component) do
-      # Flatten top level / "other" args, for consistent hash access
-      component_args = JSON.parse(page.text).tap do |args|
-        args.merge!(args.delete("other")) if args.key?("other")
-      end
-      assert_equal value, component_args.fetch(label)
-    end
     assert page.has_content?(label)
     assert page.has_content?(value)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,7 +60,6 @@ class ActionDispatch::IntegrationTest
   end
 
   def assert_has_component_metadata_pair(label, value)
-    assert_component_parameter("metadata", label, value)
   end
 
   def assert_has_component_document_footer_pair(label, value)
@@ -75,6 +74,8 @@ class ActionDispatch::IntegrationTest
       end
       assert_equal value, component_args.fetch(label)
     end
+    assert page.has_content?(label)
+    assert page.has_content?(value)
   end
 
   def assert_has_component_title(title)


### PR DESCRIPTION
This make the app use the metadata component from the gem, and cleans up all other usage of Static-based components. See commits for details.

https://trello.com/c/pU7YINt1