### PR TITLE
Avoid double breadcrumbs on service sign in pages

### DIFF
--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -1,5 +1,3 @@
-<%= render "govuk_publishing_components/components/back_link", href: @content_item.back_link %>
-
 <% if @error %>
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/views/content_items/service_sign_in/_create_new_account.html.erb
+++ b/app/views/content_items/service_sign_in/_create_new_account.html.erb
@@ -1,5 +1,3 @@
-<%= render "govuk_publishing_components/components/back_link", href: @content_item.back_link %>
-
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', title: @content_item.title %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,13 @@
 
   <div id="wrapper" class="<%= wrapper_class %>">
     <%= render_phase_label @content_item, content_for(:phase_message) %>
-    <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.content_item.parsed_content %>
+
+    <% if @content_item.try(:back_link) %>
+      <%= render 'govuk_publishing_components/components/back_link', href: @content_item.back_link %>
+    <% else %>
+      <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.content_item.parsed_content %>
+    <% end %>
+
     <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">
       <%= yield %>
     </main>


### PR DESCRIPTION
The service sign in pages currently have a back button and a breadcrumb.

https://www.gov.uk/check-income-tax-current-year/sign-in/prove-identity

This shouldn't be done according to the Design System:

https://design-system.service.gov.uk/components/back-link/#when-not-to-use-this-component

## Before

![screen shot 2018-06-20 at 15 15 26](https://user-images.githubusercontent.com/233676/41664097-d91d35c4-749c-11e8-86a7-27451fe5b8fe.png)

## After

![screen shot 2018-06-20 at 15 15 18](https://user-images.githubusercontent.com/233676/41664086-d0cf652c-749c-11e8-9539-941b7b5cf779.png)
