### PR TITLE
Add a footer link back to Statutory Instruments finder

### DIFF
--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -46,6 +46,12 @@ class SpecialistDocumentPresenter < ContentItemPresenter
       .try(:html_safe)
   end
 
+  def finder_link
+    if finder && statutory_instrument?
+      link_to "See all #{finder['title']}", finder['base_path']
+    end
+  end
+
 private
 
   def nested_headers
@@ -205,5 +211,9 @@ private
   # https://www.gov.uk/aaib-reports/lockheed-l1011-385-1-15-g-bhbr-19-december-1989
   def bulk_published?
     !!facet_values["bulk_published"]
+  end
+
+  def statutory_instrument?
+    content_item["document_type"] == "statutory_instrument"
   end
 end

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -44,6 +44,13 @@
             history: @content_item.history
           } %>
       </div>
+
+      <% if @content_item.finder_link %>
+        <div class="responsive-bottom-margin">
+          <%= @content_item.finder_link %>
+        </div>
+      <% end %>
+
     <% end %>
   </div>
   <%= render 'shared/sidebar_navigation' %>

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -18,6 +18,7 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('employment-appeal-tribunal-decision')
     setup_and_visit_content_item('employment-tribunal-decision')
     setup_and_visit_content_item('european-structural-investment-funds')
+    setup_and_visit_content_item('eu-withdrawal-act-2018-statutory-instruments')
     setup_and_visit_content_item('international-development-funding')
     setup_and_visit_content_item('maib-reports')
     setup_and_visit_content_item('raib-reports')
@@ -167,5 +168,15 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('aaib-reports')
 
     refute page.has_css?('#contents .gem-c-contents-list')
+  end
+
+  test 'renders a link to statutory instruments finder' do
+    # Statutory instruments are tagged to taxonomy so stub rummager request for similar content
+    # which is triggered by the sidebar component.
+    stub_request(:get, /\/search.json/).to_return(status: 200, body: "{}", headers: {})
+    setup_and_visit_content_item('eu-withdrawal-act-2018-statutory-instruments')
+
+    assert page.has_css?("a[href='/eu-withdrawal-act-2018-statutory-instruments']",
+                         text: 'See all EU Withdrawal Act 2018 statutory instruments')
   end
 end


### PR DESCRIPTION
https://trello.com/c/tTKHE3Bx/280-add-a-link-from-statutory-instrument-content-pages-back-to-statutory-instrument-finder

Adds a link back to the EU Withdrawal Act 2018 statutory instruments finder.
This is currently placed at the end of the content body:

![screenshot from 2018-06-28 11-30-17](https://user-images.githubusercontent.com/93511/42029200-abb93670-7ac6-11e8-94d3-018b23ae020e.png)

~Depends on https://github.com/alphagov/govuk-content-schemas/pull/794~

### Example
https://government-frontend-pr-955.herokuapp.com/eu-withdrawal-act-2018-statutory-instruments/eu-exit-guide

---

Visual regression results:
https://government-frontend-pr-955.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-955.herokuapp.com/component-guide
