### PR TITLE
Use healthcheck route for Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ ADD . $APP_HOME
 
 RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
 
-HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
+HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck || exit 1
 
 CMD foreman run web


### PR DESCRIPTION
The application has a specific `/healthcheck` endpoint so we should tell Docker to use it too.

---

Visual regression results:
https://government-frontend-pr-959.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-959.herokuapp.com/component-guide