### PR TITLE
Add initial content pages nav AB testing code

### DIFF
--- a/app/controllers/concerns/content_pages_nav_ab_testable.rb
+++ b/app/controllers/concerns/content_pages_nav_ab_testable.rb
@@ -1,0 +1,38 @@
+module ContentPagesNavAbTestable
+  CUSTOM_DIMENSION = 65
+
+  def self.included(base)
+    base.helper_method(
+      :content_pages_nav_test_variant,
+      :show_new_navigation?,
+      :page_in_scope?
+    )
+    base.after_action :set_test_response_header
+  end
+
+  def content_pages_nav_test
+    @content_pages_nav_test ||= GovukAbTesting::AbTest.new(
+      "ContentPagesNav",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: %w(A B),
+      control_variant: "A"
+    )
+  end
+
+  def content_pages_nav_test_variant
+    @content_pages_nav_test_variant ||= content_pages_nav_test.requested_variant(request.headers)
+  end
+
+  def set_test_response_header
+    content_pages_nav_test_variant.configure_response(response) if page_in_scope?
+  end
+
+  def show_new_navigation?
+    !content_pages_nav_test_variant.variant?("B") && page_in_scope?
+  end
+
+  def page_in_scope?
+    #TODO Page is tagged to a taxon
+    false
+  end
+end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,4 +1,5 @@
 class ContentItemsController < ApplicationController
+  include ContentPagesNavAbTestable
 
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from GdsApi::HTTPNotFound, with: :error_notfound
@@ -13,6 +14,8 @@ class ContentItemsController < ApplicationController
 
   def show
     load_content_item
+
+    load_taxonomy_navigation if page_in_scope?
 
     set_expiry
     set_access_control_allow_origin_header if request.format.atom?
@@ -58,6 +61,10 @@ private
   def load_content_item
     content_item = Services.content_store.content_item(content_item_path)
     @content_item = PresenterBuilder.new(content_item, content_item_path).presenter
+  end
+
+  def load_taxonomy_navigation
+    # to be fleshed out with the content pages topic taxon navigation
   end
 
   def content_item_template

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
   <% if @content_item.description %>
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
+  <%= content_pages_nav_test_variant.analytics_meta_tag.html_safe if page_in_scope? %>
 
   <%= yield :extra_head_content %>
 </head>

--- a/test/controllers/content_pages_nav_ab_testable_test.rb
+++ b/test/controllers/content_pages_nav_ab_testable_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class ContentItemsControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::ContentStore
+  include GovukAbTesting::MinitestHelpers
+
+  %w(A B).each do |test_variant|
+    test "ContentPagesNav variant #{test_variant} works" do
+      #this sample guide is not part of the education taxon
+      content_item = content_store_has_schema_example("guide", "single-page-guide")
+      content_store_has_item(content_item['base_path'], content_item)
+
+      @controller.stubs(:page_in_scope?).returns(true)
+
+      with_variant ContentPagesNav: test_variant do
+        get :show, params: { path: path_for(content_item) }
+        assert_response 200
+
+        ab_test = GovukAbTesting::AbTest.new("ContentPagesNav", dimension: 65)
+        requested = ab_test.requested_variant(request.headers)
+        assert requested.variant?(test_variant)
+      end
+    end
+  end
+
+  def path_for(content_item, locale = nil)
+    base_path = content_item['base_path'].sub(/^\//, '')
+    base_path.gsub!(/\.#{locale}$/, '') if locale
+    base_path
+  end
+end


### PR DESCRIPTION
At present we don't want to show any difference.  This commit is to add the
AB testing code so we can hook into it wih subsequent work.  We will be showing
topic taxonomy based navigation on variant B.

https://trello.com/c/sbDytyen/75-set-up-ab-test-in-government-frontend

https://trello.com/c/wIy1dXTj/82-epic-get-data-for-taxonomy-navigation
