### PR TITLE
Fix deprecated Mocha MiniTest require

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ ENV['GOVUK_ASSET_ROOT'] = 'http://static.test.gov.uk'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'capybara/rails'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'capybara/minitest'
 require 'faker'
 


### PR DESCRIPTION
```
`require 'mocha/mini_test'` has been deprecated. Please use `require 'mocha/minitest' instead.
```

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
