### PR TITLE
Mark withdrawal notice explanation HTML as safe

### DIFF
--- a/app/presenters/content_item/withdrawable.rb
+++ b/app/presenters/content_item/withdrawable.rb
@@ -14,7 +14,7 @@ module ContentItem
       if withdrawn?
         {
           title: withdrawal_notice_title,
-          description_govspeak: withdrawal_notice["explanation"],
+          description_govspeak: withdrawal_notice["explanation"]&.html_safe,
           time: withdrawal_notice_time
         }
       end


### PR DESCRIPTION
The withdrawal notice explanation has been rendered to HTML from Govspeak.
Therefore we can mark the HTML as being safe. This addresses a warning in the notice component.

See https://github.com/alphagov/govuk_publishing_components/commit/106bf9c8b165b86959269108cb684091a945469f

---

Visual regression results:
https://government-frontend-pr-973.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-973.herokuapp.com/component-guide
