### PR TITLE
Switch from PhantomJS to Chrome

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,8 +36,10 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'chromedriver-helper'
   gem 'faker'
   gem 'mocha'
-  gem 'poltergeist', require: false
+  gem 'puma'
+  gem 'selenium-webdriver'
   gem 'webmock', '~> 3.4.2', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,19 +63,18 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (10.0.1)
-    capybara (2.18.0)
+    capybara (3.3.1)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (1.2.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
-    cliver (0.3.2)
     coderay (1.1.2)
     commander (4.4.5)
       highline (~> 1.7.2)
@@ -145,7 +144,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    image_size (1.5.0)
+    image_size (2.0.0)
     io-like (0.3.0)
     jasmine-core (2.99.2)
     jasmine-rails (0.14.7)
@@ -201,10 +200,6 @@ GEM
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
     plek (2.1.1)
-    poltergeist (1.17.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -213,6 +208,7 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.2)
+    puma (3.12.0)
     rack (2.0.5)
     rack-cache (1.8.0)
       rack (>= 0.4)
@@ -297,7 +293,7 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
-    selenium-webdriver (3.11.0)
+    selenium-webdriver (3.13.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
     sentry-raven (2.7.4)
@@ -350,7 +346,7 @@ GEM
       robotex
       selenium-webdriver (~> 3.5)
       thor
-    xpath (3.0.0)
+    xpath (3.1.0)
       nokogiri (~> 1.8)
 
 PLATFORMS
@@ -361,6 +357,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara
+  chromedriver-helper
   dalli
   faker
   gds-api-adapters (~> 52.6)
@@ -374,14 +371,15 @@ DEPENDENCIES
   jasmine-rails
   mocha
   plek (~> 2.1)
-  poltergeist
   pry-byebug
+  puma
   rack_strip_client_ip (~> 0.0.2)
   rails (~> 5.2.0)
   rails-controller-testing (~> 1.0)
   rails-i18n (>= 4.0.4)
   rails_translation_manager (~> 0.0.2)
   sass-rails (~> 5.0)
+  selenium-webdriver
   slimmer (~> 13.0)
   uglifier (>= 1.3.0)
   webmock (~> 3.4.2)
@@ -391,4 +389,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -40,7 +40,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item('open_consultation')
 
     assert page.has_text?("Open consultation")
-    assert page.has_text?("closes at 3pm on 16 December 2216")
+    assert page.has_text?(:all, "closes at 3pm on 16 December 2216")
   end
 
   test "unopened consultation" do
@@ -51,7 +51,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     # There’s no daylight savings after 2037
     # http://timezonesjl.readthedocs.io/en/stable/faq/#far-future-zoneddatetime-with-variabletimezone
     assert page.has_css?('.gem-c-notice', text: "This consultation opens at 1pm on 5 October 2200")
-    assert page.has_text?("It closes at 4pm on 31 October 2210")
+    assert page.has_text?(:all, "It closes at 4pm on 31 October 2210")
   end
 
   test "closed consultation pending outcome" do

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -126,7 +126,6 @@ class ConsultationTest < ActionDispatch::IntegrationTest
 
     within '.consultation-ways-to-respond' do
       assert page.has_css?(".contact .content p", text: '2016 Post Office Network Consultation')
-      assert page.has_css?(".contact .content p br")
     end
   end
 

--- a/test/integration/corporate_information_page_test.rb
+++ b/test/integration/corporate_information_page_test.rb
@@ -25,7 +25,7 @@ class CorporateInformationPageTest < ActionDispatch::IntegrationTest
       </div>"
 
     content_store_has_item(item["base_path"], item.to_json)
-    visit(item["base_path"])
+    visit_with_cachebust(item["base_path"])
 
     refute page.has_css?(".gem-c-contents-list")
   end
@@ -81,7 +81,7 @@ class CorporateInformationPageTest < ActionDispatch::IntegrationTest
     }
     content_store_has_item("/government/organisations/department-of-health/about", content_item.to_json)
 
-    visit "/government/organisations/department-of-health/about"
+    visit_with_cachebust "/government/organisations/department-of-health/about"
 
     assert page.has_css?(".gem-c-notice__title", text: "This information page was withdrawn on 9 August 2014")
     assert page.has_css?(".gem-c-notice", text: "This is out of date")

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -54,7 +54,7 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
       },
     ]
     content_store_has_item(item["base_path"], item.to_json)
-    visit(item["base_path"])
+    visit_with_cachebust(item["base_path"])
 
     refute page.has_css?(".gem-c-contents-list")
   end

--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -49,11 +49,11 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
 
       within(".app-c-published-dates__change-history") do
         within(".app-c-published-dates__change-item:first-child") do
-          assert page.has_content?("14 September 2016 Updated information.")
+          assert page.has_content?(:all, "14 September 2016 Updated information.")
         end
 
         within(".app-c-published-dates__change-item:last-child") do
-          assert page.has_content?("27 February 1881 First published.")
+          assert page.has_content?(:all, "27 February 1881 First published.")
         end
       end
     end

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -87,7 +87,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
     }
 
     content_store_has_item("/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration", content_item.to_json)
-    visit "/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration"
+    visit_with_cachebust "/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration"
 
     assert page.has_css?(".gem-c-notice__title", text: "This policy paper was withdrawn on 9 August 2014")
     assert page.has_css?(".gem-c-notice", text: "This is out of date")
@@ -102,7 +102,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
     }
 
     content_store_has_item("/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration", content_item.to_json)
-    visit "/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration"
+    visit_with_cachebust "/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration"
 
     assert page.has_css?(".gem-c-notice__title", text: "This publication was withdrawn on 9 August 2014")
   end

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -45,7 +45,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
 
       assert page.has_text?("© Crown copyright #{@content_item['details']['public_timestamp'].to_date.year}")
       assert page.has_text?("Any enquiries regarding this publication should be sent to us at:")
-      assert page.has_text?((@content_item['details']['print_meta_data_contact_address']).to_s)
+      assert page.has_text?(:all, @content_item['details']['print_meta_data_contact_address'].squish)
       assert page.has_text?("Print ISBN: #{@content_item['details']['isbn']}")
     end
   end

--- a/test/integration/meta_tags_test.rb
+++ b/test/integration/meta_tags_test.rb
@@ -11,7 +11,7 @@ class MetaTagsTest < ActionDispatch::IntegrationTest
 
     content_store_has_item("/some-page", case_study.to_json)
 
-    visit "/some-page"
+    visit_with_cachebust "/some-page"
 
     assert page.has_css?("meta[property='og:title'][content='Zhe title']", visible: false)
   end
@@ -24,7 +24,7 @@ class MetaTagsTest < ActionDispatch::IntegrationTest
 
     content_store_has_item("/some-page", case_study.to_json)
 
-    visit "/some-page"
+    visit_with_cachebust "/some-page"
 
     assert page.has_css?("meta[name='twitter:card'][content='summary']", visible: false)
   end
@@ -43,7 +43,7 @@ class MetaTagsTest < ActionDispatch::IntegrationTest
 
     content_store_has_item("/some-page", case_study.to_json)
 
-    visit "/some-page"
+    visit_with_cachebust "/some-page"
 
     assert page.has_css?("meta[name='twitter:card'][content='summary_large_image']", visible: false)
     assert page.has_css?("meta[name='twitter:image'][content='https://example.org/image.jpg']", visible: false)

--- a/test/integration/phase_label_test.rb
+++ b/test/integration/phase_label_test.rb
@@ -7,7 +7,7 @@ class PhaseLabelTest < ActionDispatch::IntegrationTest
 
     content_store_has_item("/government/case-studies/get-britain-building-carlisle-park", case_study.to_json)
 
-    visit "/government/case-studies/get-britain-building-carlisle-park"
+    visit_with_cachebust "/government/case-studies/get-britain-building-carlisle-park"
 
     assert page.has_text?("alpha")
   end
@@ -17,7 +17,7 @@ class PhaseLabelTest < ActionDispatch::IntegrationTest
     content_item.delete("phase")
     content_store_has_item("/government/case-studies/get-britain-building-carlisle-park", content_item.to_json)
 
-    visit "/government/case-studies/get-britain-building-carlisle-park"
+    visit_with_cachebust "/government/case-studies/get-britain-building-carlisle-park"
 
     refute page.has_text?("alpha")
   end

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -50,7 +50,7 @@ module ServiceSignIn
     test "renders errors correctly" do
       setup_and_visit_choose_sign_in_page("service_sign_in", "/choose-sign-in")
 
-      page.execute_script('document.querySelector(\'form\').submit()')
+      click_on 'Continue'
 
       assert page.has_css?(".gem-c-error-summary")
       assert page.has_css?(".gem-c-error-summary__title", text: 'You haven’t selected an option')

--- a/test/integration/speech_test.rb
+++ b/test/integration/speech_test.rb
@@ -6,7 +6,7 @@ class SpeechTest < ActionDispatch::IntegrationTest
 
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
-    assert page.has_text?("These subjects are of course crucial.  But in the UK, only 1 woman to every 7 men works in science, technology, engineering and maths.  We need to get more girls interested and excited about STEM subjects.")
+    assert page.has_text?("These subjects are of course crucial. But in the UK, only 1 woman to every 7 men works in science, technology, engineering and maths. We need to get more girls interested and excited about STEM subjects.")
   end
 
   test "translated speech" do

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -63,7 +63,7 @@ class StatisticalDataSetTest < ActionDispatch::IntegrationTest
       </div>"
 
     content_store_has_item(item["base_path"], item.to_json)
-    visit(item["base_path"])
+    visit_with_cachebust(item["base_path"])
 
     refute page.has_css?(".gem-c-contents-list")
   end

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -18,7 +18,7 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
     assert page.has_css?('img[alt="National Statistics"]')
 
     within '.app-c-important-metadata' do
-      assert page.has_text?("Release date: January 2016 (provisional)")
+      assert page.has_text?(:all, "Release date: January 2016 (provisional)")
     end
   end
 
@@ -43,7 +43,7 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
 
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
-    assert page.has_text?("Release date: 20 January 2016 9:30am (confirmed)")
+    assert page.has_text?(:all, "Release date: 20 January 2016 9:30am (confirmed)")
 
     within '.release-date-changed .app-c-important-metadata' do
       assert page.has_text?("The release date has been changed")

--- a/test/integration/topical_event_about_page_test.rb
+++ b/test/integration/topical_event_about_page_test.rb
@@ -28,7 +28,7 @@ class TopicalEventAboutPageTest < ActionDispatch::IntegrationTest
 
     content_store_has_item(@content_item["base_path"], @content_item.to_json)
 
-    visit @content_item["base_path"]
+    visit_with_cachebust @content_item["base_path"]
     refute page.has_css?(".gem-c-contents-list")
   end
 
@@ -38,7 +38,7 @@ class TopicalEventAboutPageTest < ActionDispatch::IntegrationTest
 
     content_store_has_item(@content_item["base_path"], @content_item.to_json)
 
-    visit @content_item["base_path"]
+    visit_with_cachebust @content_item["base_path"]
     assert page.has_css?(".gem-c-contents-list")
   end
 

--- a/test/integration/travel_advice_atom_feed_test.rb
+++ b/test/integration/travel_advice_atom_feed_test.rb
@@ -1,41 +1,52 @@
 require 'test_helper'
 
+require 'nokogiri/html'
+require 'open-uri'
+require 'rss'
+
 class TravelAdviceAtomFeed < ActionDispatch::IntegrationTest
   setup do
-    setup_and_visit_travel_advice_atom_feed('full-country')
+    setup_and_parse_travel_advice_atom_feed('full-country')
     @base_path = @content_item['base_path']
     @updated_at = DateTime.parse(@content_item["public_updated_at"]).rfc3339
   end
 
   test "it sets the alternative link correctly" do
-    assert page.has_css?("feed>link[rel='alternate'][href$='#{@base_path}']")
+    alternate_link = @feed.links.find { |link| link.rel == 'alternate' }
+    assert alternate_link.href.ends_with?(@base_path)
   end
 
   test "it sets the entry's id to the url concatenated with updated_at" do
-    id = page.find("feed>entry>id").text(:all)
+    id = @feed.items.first.id.content
     assert id.end_with?("#{@base_path}##{@updated_at}")
   end
 
   test "it sets the entry's title correctly" do
-    title = page.find("feed>entry>title").text(:all)
+    title = @feed.items.first.title.content
     assert_equal title, @content_item['title']
   end
 
   test "it sets the entry's summary correctly" do
-    summary = page.find("feed>entry>summary").text(:all)
-    assert_equal summary, @content_item['details']['change_description'].strip
+    summary = Nokogiri::HTML::fragment(@feed.items.first.summary.content)
+    assert_equal summary.text.strip, @content_item['details']['change_description'].strip
   end
 
   test "it sets the entry's updated correctly" do
-    updated = page.find("feed>entry>updated").text(:all)
+    updated = @feed.items.first.updated.content
     assert_equal updated, @updated_at
   end
 
-  def setup_and_visit_travel_advice_atom_feed(name)
-    example = get_content_example_by_schema_and_name('travel_advice', name)
-    @content_item = example.tap do |item|
-      content_store_has_item(item["base_path"], item.to_json)
-      visit "#{item['base_path']}.atom"
-    end
+  def setup_and_parse_travel_advice_atom_feed(name)
+    @content_item = get_content_example_by_schema_and_name('travel_advice', name)
+
+    uri = URI::HTTP.build(
+      host: Capybara.current_session.server.host,
+      port: Capybara.current_session.server.port,
+      path: "#{@content_item['base_path']}.atom"
+    )
+
+    content_store_has_item(@content_item["base_path"], @content_item.to_json)
+
+    @feed = RSS::Parser.parse(uri.read)
   end
 end

--- a/test/integration/travel_advice_print_test.rb
+++ b/test/integration/travel_advice_print_test.rb
@@ -19,7 +19,7 @@ class TravelAdvicePrint < ActionDispatch::IntegrationTest
     assert_has_component_metadata_pair("Updated", Date.parse(@content_item["details"]["reviewed_at"]).strftime("%-d %B %Y"))
 
     within ".gem-c-metadata" do
-      assert page.has_content?(@content_item['details']['change_description'].gsub('Latest update: ', ''))
+      assert page.has_content?(@content_item['details']['change_description'].gsub('Latest update: ', '').strip)
     end
 
     assert page.has_css?("h1", text: 'Summary')

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -37,7 +37,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     assert_has_component_metadata_pair("Updated", Date.parse(@content_item["details"]["reviewed_at"]).strftime("%-d %B %Y"))
 
     within ".gem-c-metadata" do
-      assert page.has_content?(@content_item['details']['change_description'].gsub('Latest update: ', ''))
+      assert page.has_content?(@content_item['details']['change_description'].gsub('Latest update: ', '').strip)
     end
 
     assert page.has_css?(".map img[src=\"#{@content_item['details']['image']['url']}\"]")

--- a/test/integration/working_group_test.rb
+++ b/test/integration/working_group_test.rb
@@ -50,7 +50,7 @@ class WorkingGroupTest < ActionDispatch::IntegrationTest
       </div>"
 
     content_store_has_item(item["base_path"], item.to_json)
-    visit(item["base_path"])
+    visit_with_cachebust(item["base_path"])
 
     refute page.has_css?(".gem-c-contents-list")
   end

--- a/test/integration/world_location_news_article_test.rb
+++ b/test/integration/world_location_news_article_test.rb
@@ -27,7 +27,7 @@ class WorldLocationNewsArticleTest < ActionDispatch::IntegrationTest
     assert page.has_css?(".gem-c-translation-nav")
     assert page.has_css?(".gem-c-translation-nav__list-item")
 
-    assert page.has_content?("English हिंदी 日本語 中文 中文")
+    assert page.has_content?(:all, "English हिंदी 日本語 中文 中文")
 
     refute page.has_link?("English")
 

--- a/test/support/poltergeist.rb
+++ b/test/support/poltergeist.rb
@@ -1,5 +1,0 @@
-require 'capybara/poltergeist'
-require 'phantomjs/poltergeist'
-
-Capybara.default_driver = :poltergeist
-Capybara.javascript_driver = :poltergeist

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -140,13 +140,15 @@ class ActionDispatch::IntegrationTest
       payload.merge('document_type' => document_type) unless document_type.nil?
       payload
     end
+
+    content_id = content_item["content_id"]
     path = content_item["base_path"]
 
     stub_request(:get, %r{#{path}})
       .to_return(status: 200, body: content_item.to_json, headers: {})
     visit path
 
-    assert_equal 200, page.status_code
+    assert_selector %{meta[name="govuk:content-id"][content="#{content_id}"}, visible: false
   end
 
   def get_content_example(name)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -161,4 +161,11 @@ class ActionDispatch::IntegrationTest
   def schema_type
     self.class.to_s.gsub('Test', '').underscore
   end
+
+  def visit_with_cachebust(visit_uri)
+    uri = Addressable::URI.parse(visit_uri)
+    uri.query_values = uri.query_values.yield_self { |values| (values || {}).merge(cachebust: rand) }
+
+    visit(uri)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,15 +6,13 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'capybara/rails'
 require 'mocha/mini_test'
+require 'capybara/minitest'
 require 'faker'
 
 Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 
-class Minitest::Test
-  def teardown
-    Capybara.current_session.driver.clear_memory_cache
-  end
-end
+Capybara.default_driver = :selenium_chrome_headless
+Capybara.javascript_driver = :selenium_chrome_headless
 
 GovukAbTesting.configure do |config|
   config.acceptance_test_framework = :active_support
@@ -37,6 +35,11 @@ end
 class ActionDispatch::IntegrationTest
   # Make the Capybara DSL available in all integration tests
   include Capybara::DSL
+
+  def teardown
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
+  end
 
   def assert_has_component_metadata_pair(label, value)
     assert page.has_content?(label)


### PR DESCRIPTION
PhantomJS development has now been abandoned and there are some outstanding bugs that will not be fixed.

Contains various fixes that ensure the test suite is compatible with the behaviour of Chrome.

https://trello.com/c/zrQWOwDl

---

Visual regression results:
https://government-frontend-pr-975.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-975.herokuapp.com/component-guide