### PR TITLE
Get webchat info from content item

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -8,6 +8,10 @@ class ContactPresenter < ContentItemPresenter
     end
   end
 
+  def webchat_body
+    content_item.dig("details", "more_info_webchat").try(:html_safe)
+  end
+
   def online_form_links
     contact_form_links = content_item["details"]["contact_form_links"] || []
     contact_form_links.map do |link|

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -46,7 +46,7 @@
 
       <% if @content_item.show_webchat? %>
         <h2 id="webchat-title">Webchat</h2>
-        <p><%= render 'shared/webchat' %></p>
+        <%= render 'shared/webchat' %>
       <% end %>
 
       <% if @content_item.phone.any? %>

--- a/app/views/shared/_webchat.html.erb
+++ b/app/views/shared/_webchat.html.erb
@@ -1,29 +1,27 @@
-<span class="js-webchat"
-  data-availability-url="<%= @content_item.webchat_availability_url %>"
-  data-open-url="<%= @content_item.webchat_open_url %>">
-  <% if webchat_unavailable? %>
-    <%= unavailability_message %>
-  <% else %>
-    <% if @content_item.base_path == '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries' %>
-      Advisers can only talk to you about Child Tax Credit and Working Tax Credit.
-      They won't be able to transfer you to another webchat team.
-      <br/>
-      <br/>
+<%= @content_item.webchat_body %>
+
+<p>
+  <span class="js-webchat"
+    data-availability-url="<%= @content_item.webchat_availability_url %>"
+    data-open-url="<%= @content_item.webchat_open_url %>">
+    <% if webchat_unavailable? %>
+      <%= unavailability_message %>
+    <% else %>
+      <span class="js-webchat-advisers-error">
+        Webchat is unavailable at the moment because of technical problems.
+      </span>
+      <span class="js-webchat-advisers-unavailable hidden">
+        Webchat is closed at the moment.
+      </span>
+      <span class="js-webchat-advisers-busy hidden">
+        All webchat advisers are busy at the moment.
+      </span>
+      <span class="js-webchat-advisers-available hidden">
+        Advisers are available to chat.
+        <a href="#" rel="external" class="js-webchat-open-button">Speak to an adviser now</a>.
+      </span>
     <% end %>
-    <span class="js-webchat-advisers-error">
-      Webchat is unavailable at the moment because of technical problems.
-    </span>
-    <span class="js-webchat-advisers-unavailable hidden">
-      Webchat is closed at the moment.
-    </span>
-    <span class="js-webchat-advisers-busy hidden">
-      All webchat advisers are busy at the moment.
-    </span>
-    <span class="js-webchat-advisers-available hidden">
-      Advisers are available to chat.
-      <a href="#" rel="external" class="js-webchat-open-button">Speak to an adviser now</a>.
-    </span>
-  <% end %>
-</span>
+  </span>
+</p>
 <% # This is inline in the source however slimmer will optimize this. %>
 <%= javascript_include_tag "webchat", integrity: true, crossorigin: 'anonymous' %>


### PR DESCRIPTION
This commit replaces the existing hardcoded webchat info for one page with the relevant content item field, to allow editors to specify this text using contacts-admin.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/798 and https://github.com/alphagov/contacts-admin/pull/446.

Trello: https://trello.com/c/kcGo8LWv/331-webchats-changes-to-dynamic-text

---

Visual regression results:
https://government-frontend-pr-982.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-982.herokuapp.com/component-guide
