### PR TITLE
Add services frontend

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -71,7 +71,7 @@ private
       services = Supergroups::Services.new(taxon_ids)
 
       @taxonomy_navigation = {
-        services: services.tagged_content,
+        services: services.all_services,
       }
 
       @tagged_taxons = taxons.map do |taxon|

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -71,7 +71,7 @@ private
       services = Supergroups::Services.new(taxon_ids)
 
       @taxonomy_navigation = {
-        services: services.all_services,
+        services: (services.all_services if services.any_services?),
       }
 
       @tagged_taxons = taxons.map do |taxon|

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -6,12 +6,27 @@ module Supergroups
       @taxon_ids = taxon_ids
     end
 
+    def all_services
+      {
+        documents: tagged_content.drop(promoted_content_count),
+        promoted_content: promoted_content,
+      }
+    end
+
     def tagged_content
       @content = MostPopularContent.fetch(content_ids: @taxon_ids, filter_content_purpose_supergroup: "services")
       format_document_data(@content)
     end
 
+    def promoted_content
+      tagged_content.shift(promoted_content_count)
+    end
+
   private
+
+    def promoted_content_count
+      3
+    end
 
     def format_document_data(documents)
       documents&.map do |document|

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -4,22 +4,24 @@ module Supergroups
 
     def initialize(taxon_ids)
       @taxon_ids = taxon_ids
+      @content = MostPopularContent.fetch(content_ids: @taxon_ids, filter_content_purpose_supergroup: "services")
     end
 
     def all_services
       {
-        documents: tagged_content.drop(promoted_content_count),
+        documents: tagged_content,
         promoted_content: promoted_content,
       }
     end
 
     def tagged_content
-      @content = MostPopularContent.fetch(content_ids: @taxon_ids, filter_content_purpose_supergroup: "services")
-      format_document_data(@content)
+      items = @content.drop(promoted_content_count)
+      format_document_data(items)
     end
 
     def promoted_content
-      tagged_content.shift(promoted_content_count)
+      items = @content.shift(promoted_content_count)
+      format_document_data(items, "HighlightBoxClicked")
     end
 
   private
@@ -28,12 +30,20 @@ module Supergroups
       3
     end
 
-    def format_document_data(documents)
-      documents&.map do |document|
+    def format_document_data(documents, data_category = "DocumentListClicked")
+      documents.each.with_index(1)&.map do |document, index|
         data = {
           link: {
             text: document["title"],
-            path: document["link"]
+            path: document["link"],
+            data_attributes: {
+              track_category: "Services" + data_category,
+              track_action: index,
+              track_label: document["link"],
+              track_options: {
+                dimension29: document["title"],
+              }
+            }
           }
         }
 

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -14,6 +14,10 @@ module Supergroups
       }
     end
 
+    def any_services?
+      @content.any?
+    end
+
     def tagged_content
       items = @content.drop(promoted_content_count)
       format_document_data(items)

--- a/app/views/shared/_taxonomy_navigation.html.erb
+++ b/app/views/shared/_taxonomy_navigation.html.erb
@@ -17,7 +17,11 @@
 
         <%= render "govuk_publishing_components/components/highlight_boxes", {
           inverse: true,
-          items: taxonomy_navigation[:services]
+          items: taxonomy_navigation[:services][:promoted_content]
+        } %>
+
+        <%= render "govuk_publishing_components/components/document_list", {
+          items: taxonomy_navigation[:services][:documents]
         } %>
       </div>
     <% end %>

--- a/test/integration/content_pages_navigation_test.rb
+++ b/test/integration/content_pages_navigation_test.rb
@@ -74,6 +74,17 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
     assert page.has_css?('.gem-c-document-list__item a[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
   end
 
+  test "does not show the Services section if there is no tagged content" do
+    stub_empty_rummager
+    setup_variant_b
+
+    taxons = SINGLE_TAXON
+
+    setup_and_visit_content_item_with_taxons('guide', taxons)
+
+    refute page.has_css?('h3', text: "Services")
+  end
+
   def setup_variant_a
     ContentItemsController.any_instance.stubs(:show_new_navigation?).returns(false)
   end

--- a/test/integration/content_pages_navigation_test.rb
+++ b/test/integration/content_pages_navigation_test.rb
@@ -27,7 +27,7 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item_with_taxons('guide', SINGLE_TAXON)
 
     assert page.has_css?('.taxonomy-navigation h2', text: 'Becoming an apprentice')
-    assert page.has_css?('.gem-c-highlight-boxes__title', text: 'Apprenticeship agreement: template')
+    assert page.has_css?('.gem-c-highlight-boxes__title', text: 'Free school meals form')
   end
 
   test "ContentPagesNav variant B renders many taxons nicely" do
@@ -40,7 +40,7 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
     assert page.has_css?('.taxonomy-navigation h2 a[href="/education/becoming-a-wizard"]', text: 'Becoming a wizard')
     assert page.has_css?('.taxonomy-navigation h2 a[href="/education/becoming-the-sorceror-supreme"]', text: 'Becoming the sorceror supreme')
 
-    assert page.has_css?('.gem-c-highlight-boxes__title', text: 'Apprenticeship agreement: template')
+    assert page.has_css?('.gem-c-highlight-boxes__title', text: 'Free school meals form')
   end
 
   test "ContentPagesNav variant B only includes live taxons" do
@@ -53,8 +53,25 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
 
     assert page.has_css?('.taxonomy-navigation h2 a[href="/education/becoming-an-apprentice"]', text: 'Becoming an apprentice')
     refute page.has_css?('.taxonomy-navigation h2 a[href="/education/becoming-a-ghostbuster"]', text: 'Becoming a ghostbuster')
+  end
 
-    assert page.has_css?('.gem-c-highlight-boxes__title', text: 'Apprenticeship agreement: template')
+  test "shows the Services section title and documents with tracking" do
+    stub_rummager
+    setup_variant_b
+
+    taxons = SINGLE_TAXON
+
+    setup_and_visit_content_item_with_taxons('guide', taxons)
+
+    assert page.has_css?('h3', text: "Services")
+    assert page.has_css?('.gem-c-highlight-boxes__title', text: 'Free school meals form')
+    assert page.has_css?('.gem-c-highlight-boxes__title[data-track-category="ServicesHighlightBoxClicked"]', text: 'Free school meals form')
+    assert page.has_css?('.gem-c-highlight-boxes__title[data-track-action="1"]', text: 'Free school meals form')
+    assert page.has_css?('.gem-c-highlight-boxes__title[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
+
+    assert page.has_css?('.gem-c-document-list__item a[data-track-category="ServicesDocumentListClicked"]', text: 'Free school meals form')
+    assert page.has_css?('.gem-c-document-list__item a[data-track-action="1"]', text: 'Free school meals form')
+    assert page.has_css?('.gem-c-document-list__item a[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
   end
 
   def setup_variant_a

--- a/test/integration/content_pages_navigation_test.rb
+++ b/test/integration/content_pages_navigation_test.rb
@@ -36,9 +36,9 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
 
     setup_and_visit_content_item_with_taxons('guide', THREE_TAXONS)
 
-    assert page.has_css?('.taxonomy-navigation h2', text: 'Becoming an apprentice')
-    assert page.has_css?('.taxonomy-navigation h2', text: 'Becoming a wizard')
-    assert page.has_css?('.taxonomy-navigation h2', text: 'Becoming the sorceror supreme')
+    assert page.has_css?('.taxonomy-navigation h2 a[href="/education/becoming-an-apprentice"]', text: 'Becoming an apprentice')
+    assert page.has_css?('.taxonomy-navigation h2 a[href="/education/becoming-a-wizard"]', text: 'Becoming a wizard')
+    assert page.has_css?('.taxonomy-navigation h2 a[href="/education/becoming-the-sorceror-supreme"]', text: 'Becoming the sorceror supreme')
 
     assert page.has_css?('.gem-c-highlight-boxes__title', text: 'Apprenticeship agreement: template')
   end
@@ -51,8 +51,8 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
 
     setup_and_visit_content_item_with_taxons('guide', taxons)
 
-    assert page.has_css?('.taxonomy-navigation h2', text: 'Becoming an apprentice')
-    refute page.has_css?('.taxonomy-navigation h2', text: 'Becoming a ghostbuster')
+    assert page.has_css?('.taxonomy-navigation h2 a[href="/education/becoming-an-apprentice"]', text: 'Becoming an apprentice')
+    refute page.has_css?('.taxonomy-navigation h2 a[href="/education/becoming-a-ghostbuster"]', text: 'Becoming a ghostbuster')
 
     assert page.has_css?('.gem-c-highlight-boxes__title', text: 'Apprenticeship agreement: template')
   end

--- a/test/support/content_pages_nav_test_helper.rb
+++ b/test/support/content_pages_nav_test_helper.rb
@@ -1,27 +1,24 @@
 module ContentPagesNavTestHelper
   def stub_rummager
-    stub_any_rummager_search
-          .to_return(
-            body: {
-              "results": [
-                {
-                  "content_store_document_type": "form",
-                  "description": "This agreement must be signed by the apprentice and the employer at the start of the apprenticeship.",
-                  "link": "/government/publications/apprenticeship-agreement-template",
-                  "public_timestamp": "2012-08-28T00:00:00.000+01:00",
-                  "title": "Apprenticeship agreement: template",
-                  "index": "government",
-                  "_id": "/government/publications/apprenticeship-agreement-template",
-                  "elasticsearch_type": "edition",
-                  "document_type": "edition"
-                }
-              ],
-              "total": 1,
-              "start": 0,
-              "aggregates": {},
-              "suggested_queries": []
-            }.to_json
-          )
+    results = []
+
+    4.times do
+      results.push(
+        "content_store_document_type": "form",
+        "link": "/government/publications/meals",
+        "title": "Free school meals form",
+      )
+    end
+
+    stub_any_rummager_search.to_return(
+      body: {
+        "results": results,
+        "total": 1,
+        "start": 0,
+        "aggregates": {},
+        "suggested_queries": []
+      }.to_json
+    )
   end
 
   SINGLE_TAXON = [

--- a/test/support/content_pages_nav_test_helper.rb
+++ b/test/support/content_pages_nav_test_helper.rb
@@ -21,6 +21,20 @@ module ContentPagesNavTestHelper
     )
   end
 
+  def stub_empty_rummager
+    results = []
+
+    stub_any_rummager_search.to_return(
+      body: {
+        "results": results,
+        "total": 1,
+        "start": 0,
+        "aggregates": {},
+        "suggested_queries": []
+      }.to_json
+    )
+  end
+
   SINGLE_TAXON = [
     {
       "base_path" => "/education/becoming-an-apprentice",


### PR DESCRIPTION
**Note: base branch is add-services-ab-2 for now, while that hasn't been merged in yet.**

Trello: https://trello.com/c/ac5YHBcd/54-use-live-data-in-services-section

<img width="996" alt="screen shot 2018-07-24 at 16 34 20" src="https://user-images.githubusercontent.com/29889908/43149733-22dace1e-8f60-11e8-9626-7ff66de85c54.png">

Example pages:

- https://government-frontend-pr-988.herokuapp.com/government/publications/l-plate-size-rules
- https://government-frontend-pr-988.herokuapp.com/student-finance
- https://government-frontend-pr-988.herokuapp.com/help-with-childcare-costs


Component guide for this PR:
https://government-frontend-pr-988.herokuapp.com/component-guide
