### PR TITLE
Add supergroup sections to taxonomy navigation

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -69,9 +69,13 @@ private
 
       taxon_ids = taxons.map { |taxon| taxon["content_id"] }
       services = Supergroups::Services.new(content_item_path, taxon_ids)
+      guidance_and_regulation = Supergroups::GuidanceAndRegulation.new(content_item_path, taxon_ids)
+      policy_and_engagement = Supergroups::PolicyAndEngagement.new(content_item_path, taxon_ids)
 
       @taxonomy_navigation = {
-        services: (services.all_services if services.any_services?),
+          services: (services.all_services if services.any_services?),
+          guidance_and_regulation: guidance_and_regulation.tagged_content,
+          policy_and_engagement: policy_and_engagement.tagged_content,
       }
 
       @tagged_taxons = taxons.map do |taxon|

--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -1,0 +1,20 @@
+module Supergroups
+  class GuidanceAndRegulation < Supergroup
+    def initialize(current_path, taxon_ids)
+      @current_path = current_path
+      @taxon_ids = taxon_ids
+      @content = fetch_content
+    end
+
+    def tagged_content
+      format_document_data(@content, include_timestamp: false)
+    end
+
+  private
+
+    def fetch_content
+      return [] unless @taxon_ids.any?
+      MostPopularContent.fetch(content_ids: @taxon_ids, current_path: @current_path, filter_content_purpose_supergroup: "guidance_and_regulation")
+    end
+  end
+end

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -1,0 +1,20 @@
+module Supergroups
+  class PolicyAndEngagement < Supergroup
+    def initialize(current_path, taxon_ids)
+      @current_path = current_path
+      @taxon_ids = taxon_ids
+      @content = fetch_content
+    end
+
+    def tagged_content
+      format_document_data(@content)
+    end
+
+  private
+
+    def fetch_content
+      return [] unless @taxon_ids.any?
+      MostRecentContent.fetch(content_ids: @taxon_ids, current_path: @current_path, filter_content_purpose_supergroup: "policy_and_engagement")
+    end
+  end
+end

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -1,0 +1,25 @@
+module Supergroups
+  class Supergroup
+  private
+
+    def format_document_data(documents, include_timestamp: true)
+      documents&.map do |document|
+        data = {
+          link: {
+            text: document["title"],
+            path: document["link"]
+          },
+          metadata: {
+            document_type: document["content_store_document_type"].humanize
+          }
+        }
+
+        if include_timestamp && document["public_timestamp"]
+          data[:metadata][:public_updated_at] = Date.parse(document["public_timestamp"])
+        end
+
+        data
+      end
+    end
+  end
+end

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -2,12 +2,13 @@ module Supergroups
   class Supergroup
   private
 
-    def format_document_data(documents, include_timestamp: true)
-      documents&.map do |document|
+    def format_document_data(documents, data_category: nil, include_timestamp: true)
+      documents.each.with_index(1).map do |document, index|
         data = {
           link: {
             text: document["title"],
-            path: document["link"]
+            path: document["link"],
+            data_attributes: data_attributes(document["link"], document["title"], index)
           },
           metadata: {
             document_type: document["content_store_document_type"].humanize
@@ -18,8 +19,27 @@ module Supergroups
           data[:metadata][:public_updated_at] = Date.parse(document["public_timestamp"])
         end
 
+        if data_category.present?
+          data[:link][:data_attributes][:track_category] = data_module_label + data_category
+        end
+
         data
       end
+    end
+
+    def data_attributes(base_path, link_text, index)
+      {
+        track_category: data_module_label + "DocumentListClicked",
+        track_action: index,
+        track_label: base_path,
+        track_options: {
+          dimension29: link_text
+        }
+      }
+    end
+
+    def data_module_label
+      self.class.name.demodulize.camelize(:lower)
     end
   end
 end

--- a/app/services/most_recent_content.rb
+++ b/app/services/most_recent_content.rb
@@ -1,0 +1,38 @@
+class MostRecentContent
+  attr_reader :content_id, :current_path, :filter_taxon, :number_of_links
+
+  def initialize(content_ids:, current_path:, filter_content_purpose_supergroup:, number_of_links: 5)
+    @content_ids = content_ids
+    @current_path = current_path
+    @filter_content_purpose_supergroup = filter_content_purpose_supergroup
+    @number_of_links = number_of_links
+  end
+
+  def self.fetch(content_ids:, current_path:, filter_content_purpose_supergroup:)
+    new(content_ids: content_ids, current_path: current_path, filter_content_purpose_supergroup: filter_content_purpose_supergroup).fetch
+  end
+
+  def fetch
+    search_response["results"]
+  end
+
+private
+
+  def search_response
+    params = {
+        start: 0,
+        count: number_of_links,
+        fields: %w(title
+                   link
+                   description
+                   content_store_document_type
+                   public_timestamp
+                   organisations),
+        filter_part_of_taxonomy_tree: @content_ids,
+        order: '-public_timestamp',
+        reject_link: current_path,
+    }
+    params[:filter_content_purpose_supergroup] = @filter_content_purpose_supergroup if @filter_content_purpose_supergroup.present?
+    Services.rummager.search(params)
+  end
+end

--- a/app/views/shared/_taxonomy_navigation.html.erb
+++ b/app/views/shared/_taxonomy_navigation.html.erb
@@ -1,12 +1,12 @@
 <% if taxonomy_navigation.values().flatten.any? %>
-  <div class="taxonomy-navigation">
+  <div class="taxonomy-navigation" data-module="track-click">
     <h2>More in
       <% tagged_taxons.each do |tagged_taxon| %>
         <a class="taxonomy-navigation__title-link" href="<%= tagged_taxon[:taxon_link] %>"><%= tagged_taxon[:taxon_name] %></a>
       <% end %>
     </h2>
 
-    <% if taxonomy_navigation[:services].any? %>
+    <% if taxonomy_navigation[:services].present? %>
       <div class="taxonomy-navigation__section">
         <%= render "govuk_publishing_components/components/heading", {
           text: t('supergroups.services'),
@@ -26,7 +26,7 @@
       </div>
     <% end %>
 
-    <% if taxonomy_navigation[:guidance_and_regulation].any? %>
+    <% if taxonomy_navigation[:guidance_and_regulation].present? %>
       <div class="taxonomy-navigation__section">
         <%= render "govuk_publishing_components/components/heading", {
             text: t('supergroups.guidance_and_regulation'),
@@ -41,7 +41,7 @@
       </div>
     <% end %>
 
-    <% if taxonomy_navigation[:policy_and_engagement].any? %>
+    <% if taxonomy_navigation[:policy_and_engagement].present? %>
       <div class="taxonomy-navigation__section">
         <%= render "govuk_publishing_components/components/heading", {
             text: t('supergroups.policy_and_engagement'),

--- a/app/views/shared/_taxonomy_navigation.html.erb
+++ b/app/views/shared/_taxonomy_navigation.html.erb
@@ -25,5 +25,35 @@
         } %>
       </div>
     <% end %>
+
+    <% if taxonomy_navigation[:guidance_and_regulation].any? %>
+      <div class="taxonomy-navigation__section">
+        <%= render "govuk_publishing_components/components/heading", {
+            text: t('supergroups.guidance_and_regulation'),
+            heading_level: 3,
+            font_size: 24,
+            margin_bottom: 2
+        } %>
+
+        <%= render "govuk_publishing_components/components/document_list", {
+            items: taxonomy_navigation[:guidance_and_regulation]
+        } %>
+      </div>
+    <% end %>
+
+    <% if taxonomy_navigation[:policy_and_engagement].any? %>
+      <div class="taxonomy-navigation__section">
+        <%= render "govuk_publishing_components/components/heading", {
+            text: t('supergroups.policy_and_engagement'),
+            heading_level: 3,
+            font_size: 24,
+            margin_bottom: 2
+        } %>
+
+        <%= render "govuk_publishing_components/components/document_list", {
+            items: taxonomy_navigation[:policy_and_engagement]
+        } %>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,8 @@ en:
       see_all_updates: "see all updates"
   supergroups:
     services: "Services"
+    guidance_and_regulation: "Guidance and regulation"
+    policy_and_engagement: "Policy and engagement"
     see_more_supergroups: "See more %{supergroup}"
   language_names:
     ar: Arabic

--- a/test/integration/content_pages_navigation_test.rb
+++ b/test/integration/content_pages_navigation_test.rb
@@ -57,6 +57,8 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
 
   test "shows the Services section title and documents with tracking" do
     stub_rummager
+    stub_empty_guidance
+    stub_empty_policies
     setup_variant_b
 
     taxons = SINGLE_TAXON
@@ -83,6 +85,74 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item_with_taxons('guide', taxons)
 
     refute page.has_css?('h3', text: "Services")
+  end
+
+  test "shows the Policy section title and documents with tracking" do
+    stub_rummager
+    stub_empty_services
+    stub_empty_guidance
+    setup_variant_b
+
+    taxons = SINGLE_TAXON
+
+    setup_and_visit_content_item_with_taxons('guide', taxons)
+
+    assert page.has_css?('h3', text: "Policy and engagement")
+
+    assert page.has_css?('.gem-c-document-list__item a[data-track-category="policyAndEngagementDocumentListClicked"]', text: 'Free school meals form')
+    assert page.has_css?('.gem-c-document-list__item a[data-track-action="1"]', text: 'Free school meals form')
+    assert page.has_css?('.gem-c-document-list__item a[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
+  end
+
+  test "does not show the Policy section if there is no tagged content" do
+    stub_empty_rummager
+    setup_variant_b
+
+    taxons = SINGLE_TAXON
+
+    setup_and_visit_content_item_with_taxons('guide', taxons)
+
+    refute page.has_css?('h3', text: "Policy and engagement")
+  end
+
+  test "shows the Guidance section title and documents with tracking" do
+    stub_rummager
+    stub_empty_services
+    stub_empty_policies
+    setup_variant_b
+
+    taxons = SINGLE_TAXON
+
+    setup_and_visit_content_item_with_taxons('guide', taxons)
+
+    assert page.has_css?('h3', text: "Guidance and regulation")
+
+    assert page.has_css?('.gem-c-document-list__item a[data-track-category="guidanceAndRegulationDocumentListClicked"]', text: 'Free school meals form')
+    assert page.has_css?('.gem-c-document-list__item a[data-track-action="1"]', text: 'Free school meals form')
+    assert page.has_css?('.gem-c-document-list__item a[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
+  end
+
+  test "does not show the Guidance section if there is no tagged content" do
+    stub_empty_rummager
+    setup_variant_b
+
+    taxons = SINGLE_TAXON
+
+    setup_and_visit_content_item_with_taxons('guide', taxons)
+
+    refute page.has_css?('h3', text: "Guidance and regulation")
+  end
+
+  def stub_empty_services
+    Supergroups::Services.any_instance.stubs(:all_services).returns({})
+  end
+
+  def stub_empty_guidance
+    Supergroups::GuidanceAndRegulation.any_instance.stubs(:tagged_content).returns([])
+  end
+
+  def stub_empty_policies
+    Supergroups::PolicyAndEngagement.any_instance.stubs(:tagged_content).returns([])
   end
 
   def setup_variant_a

--- a/test/presenters/supergroups/guidance_and_regulation_test.rb
+++ b/test/presenters/supergroups/guidance_and_regulation_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class GuidanceAndRegulationTest < ActiveSupport::TestCase
+  include RummagerHelpers
+
+  def taxon_content_ids
+    ['c3c860fc-a271-4114-b512-1c48c0f82564', 'ff0e8e1f-4dea-42ff-b1d5-f1ae37807af2']
+  end
+
+  test "tagged_content returns empty array if taxon ids is a blank array" do
+    guidance_and_regulation = Supergroups::GuidanceAndRegulation.new("/no-particular-page", [])
+    assert_equal [], guidance_and_regulation.tagged_content
+  end
+
+  test "tagged_content returns empty array if there are taxon ids but no results" do
+    stub_most_popular_content("/no-particular-page", [], 0, "guidance_and_regulation")
+    guidance_and_regulation = Supergroups::GuidanceAndRegulation.new("/no-particular-page", [])
+    assert_equal [], guidance_and_regulation.tagged_content
+  end
+
+  test "tagged_content returns array with 2 items if there are 2 results" do
+    stub_most_popular_content("/no-particular-page", taxon_content_ids, 2, "guidance_and_regulation")
+    guidance_and_regulation = Supergroups::GuidanceAndRegulation.new("/no-particular-page", taxon_content_ids)
+    assert_equal 2, guidance_and_regulation.tagged_content.count
+  end
+end

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class PolicyAndEngagementTest < ActiveSupport::TestCase
+  include RummagerHelpers
+
+  def taxon_content_ids
+    ['c3c860fc-a271-4114-b512-1c48c0f82564', 'ff0e8e1f-4dea-42ff-b1d5-f1ae37807af2']
+  end
+
+  test "tagged_content returns empty array if taxon ids is a blank array" do
+    policy_and_engagement = Supergroups::PolicyAndEngagement.new("/a-random-path", [])
+    assert_equal [], policy_and_engagement.tagged_content
+  end
+
+  test "tagged_content returns empty array if there are taxon ids but no results" do
+    stub_most_recent_content("/a-random-path", [], 0, "policy_and_engagement")
+    policy_and_engagement = Supergroups::PolicyAndEngagement.new("/a-random-path", [])
+    assert_equal [], policy_and_engagement.tagged_content
+  end
+
+  test "tagged_content returns array with 2 items if there are 2 results" do
+    stub_most_recent_content("/a-random-path", taxon_content_ids, 2, "policy_and_engagement")
+    policy_and_engagement = Supergroups::PolicyAndEngagement.new("/a-random-path", taxon_content_ids)
+    assert_equal 2, policy_and_engagement.tagged_content.count
+  end
+end

--- a/test/services/most_recent_content_test.rb
+++ b/test/services/most_recent_content_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+require './test/support/custom_assertions.rb'
+
+class MostRecentContentTest < ActiveSupport::TestCase
+  include RummagerHelpers
+
+  def most_recent_content
+    @most_recent_content ||= MostRecentContent.new(
+      content_ids: taxon_content_ids,
+      current_path: "/some-path",
+      filter_content_purpose_supergroup: "guidance_and_regulation",
+      number_of_links: 6
+    )
+  end
+
+  def taxon_content_ids
+    ['c3c860fc-a271-4114-b512-1c48c0f82564', 'ff0e8e1f-4dea-42ff-b1d5-f1ae37807af2']
+  end
+
+  test "orders the results by popularity in descending order" do
+    assert_includes_params(order: '-public_timestamp') do
+      most_recent_content.fetch
+    end
+  end
+
+  test "includes taxon ids" do
+    assert_includes_params(filter_part_of_taxonomy_tree: taxon_content_ids) do
+      most_recent_content.fetch
+    end
+  end
+
+  test "returns number of links" do
+    assert_includes_params(count: 6) do
+      most_recent_content.fetch
+    end
+  end
+
+  test "excludes current page" do
+    assert_includes_params(reject_link: "/some-path") do
+      most_recent_content.fetch
+    end
+  end
+end

--- a/test/support/custom_assertions.rb
+++ b/test/support/custom_assertions.rb
@@ -1,0 +1,15 @@
+module MiniTest::Assertions
+  # Behaves a bit like `hash_including`.
+  # Given a slice of the original hash, it verifies that the original hash
+  # includes the sub-hash given. Useful when testing partial arguments/params to
+  # methods.
+  def assert_includes_subhash(expected_sub_hash, hash)
+    expected_sub_hash.each do |key, value|
+      assert_equal(
+        value,
+        hash[key],
+        "Expected #{hash} to include #{key}=#{value}"
+      )
+    end
+  end
+end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -1,0 +1,81 @@
+module RummagerHelpers
+  def stub_most_recent_content(reject_link, taxon_content_ids, content_link_count, supergroup)
+    results = generate_search_results(content_link_count, supergroup)
+    stub_for_taxon_and_supergroup(reject_link, taxon_content_ids, results, supergroup, "-public_timestamp")
+  end
+
+  def stub_most_popular_content(reject_link, taxon_content_ids, content_link_count, supergroup)
+    results = generate_search_results(content_link_count, supergroup)
+    stub_for_taxon_and_supergroup(reject_link, taxon_content_ids, results, supergroup, "-popularity")
+  end
+
+  def stub_for_taxon_and_supergroup(reject_link, content_ids, results, filter_content_purpose_supergroup, order_by)
+    fields = %w(title
+                link
+                description
+                content_store_document_type
+                public_timestamp
+                organisations)
+
+    params = {
+        start: 0,
+        count: 5,
+        fields: fields,
+        filter_part_of_taxonomy_tree: content_ids,
+        order: order_by,
+        filter_content_purpose_supergroup: filter_content_purpose_supergroup,
+        reject_link: reject_link,
+    }
+
+    Services.rummager.stubs(:search)
+        .with(params)
+        .returns(
+          "results" => results,
+          "start" => 0,
+          "total" => results.size
+        )
+  end
+
+  def generate_search_results(count, supergroup)
+    count.times.map do |number|
+      rummager_document_for_supergroup_section("content-item-#{number}", supergroup)
+    end
+  end
+
+  def rummager_document_for_supergroup_section(slug, content_store_document_type)
+    {
+        'title'                       => slug.titleize.humanize.to_s,
+        'link'                        => "/#{slug}",
+        'description'                 => 'A discription about tagged content',
+        'content_store_document_type' => content_store_document_type,
+        'public_timestamp'            => 1.hour.ago.iso8601,
+        'organisations'               => [{ 'title' => "#{content_store_document_type.humanize} Organisation Title" }]
+    }
+  end
+
+  def assert_includes_params(expected_params)
+    search_results = {
+        'results' => [
+          {
+              'title' => 'Doc 1'
+          },
+          {
+              'title' => 'Doc 2'
+          }
+        ]
+    }
+
+    Services.
+        rummager.
+        stubs(:search).
+        with { |params| assert_includes_subhash(expected_params, params) }.
+        returns(search_results)
+
+    results = yield
+
+    assert_equal(results.count, 2)
+
+    assert_equal(results.first["title"], 'Doc 1')
+    assert_equal(results.last["title"], 'Doc 2')
+  end
+end


### PR DESCRIPTION
Adds guidance and regulation, and policy and engagement sections to the nav section at the footer of content pages.

- Policy and engagement content:
  - configured to get latest content
  - shows public updated at date
  - document type
- Guidance and regulation
  - retrieved by popularity (as determined by rummager)
  - shows document type (but not date)

They're both displayed as lists of items rather than highlight boxes.

The content page will show this navigation if they are tagged to a live taxonomy, be rendered by this application and not be an HTML publication (and have results to show)

This PR is to get things generally close to the desired outcome and then we'll polish after testing and a further design review.

![screen shot 2018-07-27 at 11 43 18](https://user-images.githubusercontent.com/773037/43316796-5bfbc142-9192-11e8-9653-062330b76027.png)

## Examples:
You will need to have an extension like [ModHeader](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=en) installed in your browser to see the B Variant. The values should be:
Request Header Name: GOVUK-ABTest-ContentPagesNav
Request Header Value: B

- [Tagged to one taxon](https://government-frontend-pr-994.herokuapp.com/apply-apprenticeship)
- [Tagged to multiple taxons](https://government-frontend-pr-994.herokuapp.com/government/publications/esfa-update-18-july-2018)
- [Tagged to a taxon without services](https://government-frontend-pr-994.herokuapp.com/government/publications/working-together-to-safeguard-children--2)
- [Not tagged to any taxons](https://government-frontend-pr-994.herokuapp.com/government/case-studies/hard-lines)
- [HTML Publication](https://government-frontend-pr-994.herokuapp.com/government/publications/budget-2016-documents/budget-2016)

Component guide for this PR:
https://government-frontend-pr-994.herokuapp.com/component-guide
