### PR TITLE
Use `first_published_at`

### DIFF
--- a/app/presenters/content_item/updatable.rb
+++ b/app/presenters/content_item/updatable.rb
@@ -14,7 +14,7 @@ module ContentItem
     end
 
     def first_public_at
-      content_item["details"]["first_public_at"]
+      content_item["details"]["first_public_at"] || content_item["first_published_at"]
     end
 
     def public_updated_at

--- a/test/presenters/content_item/updatable_test.rb
+++ b/test/presenters/content_item/updatable_test.rb
@@ -35,8 +35,8 @@ class ContentItemUpdatableTest < ActiveSupport::TestCase
       def content_item
         {
           'public_updated_at' => '2002-02-02',
+          'first_published_at' => '2001-01-01',
           'details' => {
-            'first_public_at' => '2001-01-01',
             'change_history' => [
               {
                 'note' => 'note',


### PR DESCRIPTION
`details.first_public_at` is deprecated. They should be same, so no frontend changes are intended.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/801.

https://trello.com/c/bMv5Tkgp