### PR TITLE
Exclude current page from most popular searches

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -68,7 +68,7 @@ private
       taxons = @content_item.taxons.select { |taxon| taxon["phase"] == "live" }
 
       taxon_ids = taxons.map { |taxon| taxon["content_id"] }
-      services = Supergroups::Services.new(taxon_ids)
+      services = Supergroups::Services.new(content_item_path, taxon_ids)
 
       @taxonomy_navigation = {
         services: (services.all_services if services.any_services?),

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -2,9 +2,13 @@ module Supergroups
   class Services
     attr_reader :content
 
-    def initialize(taxon_ids)
+    def initialize(current_path, taxon_ids)
       @taxon_ids = taxon_ids
-      @content = MostPopularContent.fetch(content_ids: @taxon_ids, filter_content_purpose_supergroup: "services")
+      @content = MostPopularContent.fetch(
+        content_ids: @taxon_ids,
+        current_path: current_path,
+        filter_content_purpose_supergroup: "services"
+      )
     end
 
     def all_services

--- a/app/services/most_popular_content.rb
+++ b/app/services/most_popular_content.rb
@@ -3,16 +3,17 @@ require 'gds_api/rummager'
 class MostPopularContent
   include RummagerFields
 
-  attr_reader :content_ids, :filter_content_purpose_supergroup, :number_of_links
+  attr_reader :content_ids, :current_path, :filter_content_purpose_supergroup, :number_of_links
 
-  def initialize(content_ids:, filter_content_purpose_supergroup:, number_of_links: 5)
+  def initialize(content_ids:, current_path:, filter_content_purpose_supergroup:, number_of_links: 5)
     @content_ids = content_ids
+    @current_path = current_path
     @filter_content_purpose_supergroup = filter_content_purpose_supergroup
     @number_of_links = number_of_links
   end
 
-  def self.fetch(content_ids:, filter_content_purpose_supergroup:)
-    new(content_ids: content_ids, filter_content_purpose_supergroup: filter_content_purpose_supergroup).fetch
+  def self.fetch(content_ids:, current_path:, filter_content_purpose_supergroup:)
+    new(content_ids: content_ids, current_path: current_path, filter_content_purpose_supergroup: filter_content_purpose_supergroup).fetch
   end
 
   def fetch
@@ -28,6 +29,7 @@ private
       fields: RummagerFields::TAXON_SEARCH_FIELDS,
       filter_part_of_taxonomy_tree: content_ids,
       order: '-popularity',
+      reject_link: current_path,
     }
     params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup.present?
 

--- a/test/services/most_popular_content_test.rb
+++ b/test/services/most_popular_content_test.rb
@@ -7,6 +7,7 @@ class MostPopularContentTest < ActiveSupport::TestCase
   def most_popular_content
     @most_popular_content ||= MostPopularContent.new(
       content_ids: taxon_content_ids,
+      current_path: "/how-to-ride-a-bike",
       filter_content_purpose_supergroup: 'guidance_and_regulation'
     )
   end
@@ -65,6 +66,12 @@ class MostPopularContentTest < ActiveSupport::TestCase
 
   test 'filters content by the requested filter_content_purpose_supergroup only' do
     assert_includes_params(filter_content_purpose_supergroup: 'guidance_and_regulation') do
+      most_popular_content.fetch
+    end
+  end
+
+  test 'rejects the originating page from the results' do
+    assert_includes_params(reject_link: '/how-to-ride-a-bike') do
       most_popular_content.fetch
     end
   end


### PR DESCRIPTION
We don't want to show the page that a user is on in any navigation.  It's
confusing and confers no benefit.

An example page with itself in the results is: https://www.gov.uk/government/publications/retiring-teachers-nomination-form-for-official-letter-of-thanks

https://trello.com/c/ljVuTZUL/80-exclude-current-page-from-navigation

## Examples:
You will need to have an extension like [ModHeader](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=en) installed in your browser to see the B Variant. The values should be:
Request Header Name: GOVUK-ABTest-ContentPagesNav
Request Header Value: B

- [Tagged to one taxon](https://government-frontend-pr-997.herokuapp.com/apply-apprenticeship)
- [In its own results set](https://government-frontend-pr-997.herokuapp.com/government/publications/retiring-teachers-nomination-form-for-official-letter-of-thanks)

