### PR TITLE
Bump govuk_publishing_components from 9.6.0 to 9.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 52.6'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.6'
 gem 'govuk_frontend_toolkit', '~> 7.6'
-gem 'govuk_publishing_components', '~> 9.6.0'
+gem 'govuk_publishing_components', '~> 9.7.0'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 13.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     govuk_frontend_toolkit (7.6.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (9.6.0)
+    govuk_publishing_components (9.7.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -212,7 +212,7 @@ GEM
     rack (2.0.5)
     rack-cache (1.8.0)
       rack (>= 0.4)
-    rack-test (1.0.0)
+    rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rack_strip_client_ip (0.0.2)
     rails (5.2.0)
@@ -275,7 +275,7 @@ GEM
     ruby-progressbar (1.9.0)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
-    sanitize (4.6.5)
+    sanitize (4.6.6)
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
       nokogumbo (~> 1.4)
@@ -325,7 +325,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     unicode-display_width (1.3.0)
-    unicorn (5.4.0)
+    unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     webmock (3.4.2)
@@ -365,7 +365,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.6)
   govuk_frontend_toolkit (~> 7.6)
-  govuk_publishing_components (~> 9.6.0)
+  govuk_publishing_components (~> 9.7.0)
   govuk_schemas (~> 3.2)
   htmlentities (~> 4.3)
   jasmine-rails

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -32,15 +32,15 @@ module ServiceSignIn
             assert page.has_text?("You can't file online until you've activated Government Gateway account using your Unique Taxpayer Reference(UTR).")
           end
 
-          assert page.has_css?(".gem-c-radio__label__text", text: "Use Government Gateway")
-          assert page.has_css?(".gem-c-radio__label__hint", text: "You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.")
+          assert page.has_css?(".gem-c-radio .govuk-label", text: "Use Government Gateway")
+          assert page.has_css?(".gem-c-radio .govuk-hint", text: "You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.")
 
-          assert page.has_css?(".gem-c-radio__label__text", text: "Use GOV.UK Verify")
-          assert page.has_css?(".gem-c-radio__label__hint", text: "You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.")
+          assert page.has_css?(".gem-c-radio .govuk-label", text: "Use GOV.UK Verify")
+          assert page.has_css?(".gem-c-radio .govuk-hint", text: "You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.")
 
-          assert page.has_css?(".gem-c-radio__block-text", text: "or")
+          assert page.has_css?(".govuk-radios__divider", text: "or")
 
-          assert page.has_css?(".gem-c-radio__label__text", text: "Create an account")
+          assert page.has_css?(".gem-c-radio .govuk-label", text: "Create an account")
         end
 
         assert page.has_css?(".gem-c-button", text: "Continue")
@@ -57,7 +57,7 @@ module ServiceSignIn
       assert page.has_css?(".gem-c-error-summary__link[href='#option-0']", text: 'Please select an option')
 
       # Make sure the id is the same as the link href so that they'll link together properly.
-      assert page.has_css?(".gem-c-radio__input[id='option-0'][value='use-government-gateway']", visible: false)
+      assert page.has_css?(".gem-c-radio input[id='option-0'][value='use-government-gateway']", visible: false)
 
       assert page.has_css?(".app-c-error-message", text: 'Please select an option')
     end
@@ -65,13 +65,13 @@ module ServiceSignIn
     test "page less options without an or divider" do
       setup_and_visit_choose_sign_in_page("view_driving_licence", "/choose-sign-in")
 
-      assert page.has_css?(".gem-c-radio__label__text", text: "Use your driving licence and National Insurance number")
-      assert page.has_css?(".gem-c-radio__label__hint", text: "Your driving licence must have been issued in England, Scotland or Wales.")
+      assert page.has_css?(".gem-c-radio .govuk-label", text: "Use your driving licence and National Insurance number")
+      assert page.has_css?(".gem-c-radio .govuk-hint", text: "Your driving licence must have been issued in England, Scotland or Wales.")
 
-      assert page.has_css?(".gem-c-radio__label__text", text: "Use GOV.UK Verify")
-      assert page.has_css?(".gem-c-radio__label__hint", text: "You can use an existing identity account or create a new one. It usually takes about 5 minutes to create an account.")
+      assert page.has_css?(".gem-c-radio .govuk-label", text: "Use GOV.UK Verify")
+      assert page.has_css?(".gem-c-radio .govuk-hint", text: "You can use an existing identity account or create a new one. It usually takes about 5 minutes to create an account.")
 
-      refute page.has_css?(".gem-c-radio__block-text", text: "or")
+      refute page.has_css?(".govuk-radios__divider", text: "or")
     end
 
     test "page renders welsh correctly" do
@@ -90,16 +90,16 @@ module ServiceSignIn
             assert page.has_text?("Os ydych chi’n ffeilio ar-lein am y tro cyntaf, bydd angen i chi gofrestru ar gyfer Hunanasesiad yn gyntaf.")
           end
 
-          assert page.has_css?(".gem-c-radio__label__text", text: "Defnyddio Porth y Llywodraeth")
-          assert page.has_css?(".gem-c-radio__label__hint", text: "Bydd gennych chi ID defnyddiwr os ydych chi wedi cofrestru ar gyfer Hunanasesiad neu wedi ffeilio ffurflen dreth ar-lein yn y gorffennol.")
+          assert page.has_css?(".gem-c-radio .govuk-label", text: "Defnyddio Porth y Llywodraeth")
+          assert page.has_css?(".gem-c-radio .govuk-hint", text: "Bydd gennych chi ID defnyddiwr os ydych chi wedi cofrestru ar gyfer Hunanasesiad neu wedi ffeilio ffurflen dreth ar-lein yn y gorffennol.")
 
-          assert page.has_css?(".gem-c-radio__label__text", text: "Defnyddio GOV.UK Verify")
-          assert page.has_css?(".gem-c-radio__label__hint", text: "Bydd gennych chi gyfrif os ydych chi wedi profi'n barod pwy ydych chi naill ai gyda Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.")
+          assert page.has_css?(".gem-c-radio .govuk-label", text: "Defnyddio GOV.UK Verify")
+          assert page.has_css?(".gem-c-radio .govuk-hint", text: "Bydd gennych chi gyfrif os ydych chi wedi profi'n barod pwy ydych chi naill ai gyda Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.")
 
-          assert page.has_css?(".gem-c-radio__block-text", text: "neu")
+          assert page.has_css?(".govuk-radios__divider", text: "neu")
 
           within ".gem-c-radio:last-of-type" do
-            assert page.has_css?(".gem-c-radio__label__text", text: "Cofrestru ar gyfer Hunanasesiad")
+            assert page.has_css?(".gem-c-radio .govuk-label", text: "Cofrestru ar gyfer Hunanasesiad")
           end
         end
 

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -166,8 +166,8 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
   test 'renders start button' do
     setup_and_visit_content_item('business-finance-support-scheme')
 
-    assert page.has_css?(".gem-c-button.gem-c-button--start[href='http://www.bigissueinvest.com']", text: "Find out more")
-    assert page.has_css?(".gem-c-button__info-text", text: "on the Big Issue Invest website")
+    assert page.has_css?(".gem-c-button[href='http://www.bigissueinvest.com']", text: "Find out more")
+    assert page.has_content?("on the Big Issue Invest website")
   end
 
   test 'does not render a contents list if there are fewer than three items in the contents list' do


### PR DESCRIPTION
After a couple of components have been updated to use GOV.UK Frontend we need to updates the asserts selectors to match the new classes.

This helps [Dependabot passing](https://github.com/alphagov/government-frontend/pull/998).

---

Component guide for this PR:
https://government-frontend-pr-999.herokuapp.com/component-guide
