### PR TITLE
Add transparency section

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -71,11 +71,13 @@ private
       services = Supergroups::Services.new(content_item_path, taxon_ids)
       guidance_and_regulation = Supergroups::GuidanceAndRegulation.new(content_item_path, taxon_ids)
       policy_and_engagement = Supergroups::PolicyAndEngagement.new(content_item_path, taxon_ids)
+      transparency = Supergroups::Transparency.new(content_item_path, taxon_ids)
 
       @taxonomy_navigation = {
           services: (services.all_services if services.any_services?),
           guidance_and_regulation: guidance_and_regulation.tagged_content,
           policy_and_engagement: policy_and_engagement.tagged_content,
+          transparency: transparency.tagged_content,
       }
 
       @tagged_taxons = taxons.map do |taxon|

--- a/app/presenters/supergroups/transparency.rb
+++ b/app/presenters/supergroups/transparency.rb
@@ -1,0 +1,20 @@
+module Supergroups
+  class Transparency < Supergroup
+    def initialize(current_path, taxon_ids)
+      @current_path = current_path
+      @taxon_ids = taxon_ids
+      @content = fetch_content
+    end
+
+    def tagged_content
+      format_document_data(@content)
+    end
+
+  private
+
+    def fetch_content
+      return [] unless @taxon_ids.any?
+      MostRecentContent.fetch(content_ids: @taxon_ids, current_path: @current_path, filter_content_purpose_supergroup: "transparency")
+    end
+  end
+end

--- a/app/views/shared/_taxonomy_navigation.html.erb
+++ b/app/views/shared/_taxonomy_navigation.html.erb
@@ -55,5 +55,21 @@
         } %>
       </div>
     <% end %>
+
+    <% if taxonomy_navigation[:transparency].present? %>
+      <div class="taxonomy-navigation__section">
+        <%= render "govuk_publishing_components/components/heading", {
+            text: t('supergroups.transparency'),
+            heading_level: 3,
+            font_size: 24,
+            margin_bottom: 2
+        } %>
+
+        <%= render "govuk_publishing_components/components/document_list", {
+            items: taxonomy_navigation[:transparency]
+        } %>
+      </div>
+    <% end %>
+
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,7 @@ en:
     services: "Services"
     guidance_and_regulation: "Guidance and regulation"
     policy_and_engagement: "Policy and engagement"
+    transparency: "Transparency"
     see_more_supergroups: "See more %{supergroup}"
   language_names:
     ar: Arabic

--- a/test/integration/content_pages_navigation_test.rb
+++ b/test/integration/content_pages_navigation_test.rb
@@ -59,6 +59,7 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
     stub_rummager
     stub_empty_guidance
     stub_empty_policies
+    stub_empty_transparency
     setup_variant_b
 
     taxons = SINGLE_TAXON
@@ -89,8 +90,9 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
 
   test "shows the Policy section title and documents with tracking" do
     stub_rummager
-    stub_empty_services
     stub_empty_guidance
+    stub_empty_services
+    stub_empty_transparency
     setup_variant_b
 
     taxons = SINGLE_TAXON
@@ -117,8 +119,9 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
 
   test "shows the Guidance section title and documents with tracking" do
     stub_rummager
-    stub_empty_services
     stub_empty_policies
+    stub_empty_services
+    stub_empty_transparency
     setup_variant_b
 
     taxons = SINGLE_TAXON
@@ -143,6 +146,36 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
     refute page.has_css?('h3', text: "Guidance and regulation")
   end
 
+  test "shows the Transparency section title and documents with tracking" do
+    stub_rummager
+    stub_empty_guidance
+    stub_empty_policies
+    stub_empty_services
+    setup_variant_b
+
+    taxons = SINGLE_TAXON
+
+    setup_and_visit_content_item_with_taxons('guide', taxons)
+
+    assert page.has_css?('h3', text: "Transparency")
+
+    assert page.has_css?('.gem-c-document-list__item a[data-track-category="transparencyDocumentListClicked"]', text: 'Free school meals form')
+    assert page.has_css?('.gem-c-document-list__item a[data-track-action="1"]', text: 'Free school meals form')
+    assert page.has_css?('.gem-c-document-list__item a[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
+  end
+
+  test "does not show the Transparency section if there is no tagged content" do
+    stub_empty_rummager
+    setup_variant_b
+
+    taxons = SINGLE_TAXON
+
+    setup_and_visit_content_item_with_taxons('guide', taxons)
+
+    refute page.has_css?('h3', text: "Guidance and regulation")
+  end
+
+
   def stub_empty_services
     Supergroups::Services.any_instance.stubs(:all_services).returns({})
   end
@@ -153,6 +186,10 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
 
   def stub_empty_policies
     Supergroups::PolicyAndEngagement.any_instance.stubs(:tagged_content).returns([])
+  end
+
+  def stub_empty_transparency
+    Supergroups::Transparency.any_instance.stubs(:tagged_content).returns([])
   end
 
   def setup_variant_a

--- a/test/presenters/supergroups/transparency_test.rb
+++ b/test/presenters/supergroups/transparency_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class TransparencyTest < ActiveSupport::TestCase
+  include RummagerHelpers
+
+  def taxon_content_ids
+    ['c3c860fc-a271-4114-b512-1c48c0f82564', 'ff0e8e1f-4dea-42ff-b1d5-f1ae37807af2']
+  end
+
+  test "tagged_content returns empty array if taxon ids is a blank array" do
+    policy_and_engagement = Supergroups::Transparency.new("/a-random-path", [])
+    assert_equal [], policy_and_engagement.tagged_content
+  end
+
+  test "tagged_content returns empty array if there are taxon ids but no results" do
+    stub_most_recent_content("/a-random-path", [], 0, "transparency")
+    policy_and_engagement = Supergroups::Transparency.new("/a-random-path", [])
+    assert_equal [], policy_and_engagement.tagged_content
+  end
+
+  test "tagged_content returns array with 2 items if there are 2 results" do
+    stub_most_recent_content("/a-random-path", taxon_content_ids, 2, "transparency")
+    policy_and_engagement = Supergroups::Transparency.new("/a-random-path", taxon_content_ids)
+    assert_equal 2, policy_and_engagement.tagged_content.count
+  end
+end


### PR DESCRIPTION
Adds the transparency supergroup to the taxonomy navigation section.

As per the other PRs, this is currently behind an AB test and is not seen by general access.

Transparency docs are displayed as lists of items rather than highlight boxes.

The content page will show this navigation if they are tagged to a live taxonomy, be rendered by this application and not be an HTML publication (and  have results to show)

![screen shot 2018-07-27 at 15 50 32](https://user-images.githubusercontent.com/773037/43328317-8ef8504c-91b5-11e8-952d-2df69c86b1e2.png)

## Examples:
You will need to have an extension like [ModHeader](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=en) installed in your browser to see the B Variant. The values should be:
Request Header Name: GOVUK-ABTest-ContentPagesNav
Request Header Value: B

- [Tagged to one taxon](https://government-frontend-pr-1000.herokuapp.com/apply-apprenticeship)
- [Tagged to multiple taxons](https://government-frontend-pr-1000.herokuapp.com/government/publications/esfa-update-18-july-2018)
- [Tagged to a taxon without services](https://government-frontend-pr-1000.herokuapp.com/government/publications/working-together-to-safeguard-children--2)
- [Not tagged to any taxons](https://government-frontend-pr-1000.herokuapp.com/government/case-studies/hard-lines)
- [HTML Publication](https://government-frontend-pr-1000.herokuapp.com/government/publications/budget-2016-documents/budget-2016)

Component guide for this PR:
https://government-frontend-pr-1000.herokuapp.com/component-guide


https://trello.com/c/A1x3YnId/51-get-most-recent-transparency-data

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
