### PR TITLE
Remove redundant taxonomy navigation guard conditional

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,7 +44,7 @@
 
     <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">
       <%= yield %>
-      <% if show_new_navigation? && @taxonomy_navigation %>
+      <% if show_new_navigation? %>
         <%= render 'shared/taxonomy_navigation', taxonomy_navigation: @taxonomy_navigation, tagged_taxons: @tagged_taxons %>
       <% end %>
     </main>


### PR DESCRIPTION
`show_new_navigation?` contains the canonical rules, duplicating some of the logic held within `load_taxonomy_navigation` that sets `@taxonomy_navigation` is unnecessary and implies additional complexity.

---

Visual regression results:
https://government-frontend-pr-1004.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1004.herokuapp.com/component-guide
