### PR TITLE
[DO NOT MERGE] Spike: change guide pages if in a step by step

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -6,34 +6,55 @@
 <% end %>
 
 <% content_for :simple_header, true %>
+<%
+  step_navs = @content_item.content_item.parsed_content["links"]["part_of_step_navs"]
+  part_of_step_navs = false
+  part_of_step_navs = step_navs.length if step_navs
+  page_title = @content_item.title
+
+  if part_of_step_navs and @content_item.multi_page_guide?
+    page_title = @content_item.current_part_title
+  end
+%>
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', { title: @content_item.title } %>
-    <% if @content_item.multi_page_guide? %>
-      <aside class="part-navigation-container" role="complementary">
-        <%= render "govuk_publishing_components/components/contents_list", aria_label: 'Pages in this guide', contents: @content_item.part_link_elements, underline_links: true %>
-      </aside>
+    <%= render 'govuk_publishing_components/components/title', { title: page_title } %>
+
+    <% if not part_of_step_navs %>
+      <% if @content_item.multi_page_guide? %>
+        <aside class="part-navigation-container" role="complementary">
+          <%= render "govuk_publishing_components/components/contents_list", aria_label: 'Pages in this guide', contents: @content_item.part_link_elements, underline_links: true %>
+        </aside>
+      <% end %>
     <% end %>
   </div>
+
   <div class="column-two-thirds">
     <% if @content_item.has_parts? %>
-      <% if @content_item.multi_page_guide? %>
-        <h1 class="part-title">
-          <%= @content_item.current_part_title %>
-        </h1>
+      <% if not part_of_step_navs %>
+        <% if @content_item.multi_page_guide? %>
+          <h1 class="part-title">
+            <%= @content_item.current_part_title %>
+          </h1>
+        <% end %>
       <% end %>
+
       <%= render 'govuk_publishing_components/components/govspeak',
           content: @content_item.current_part_body.html_safe,
           direction: page_text_direction,
           disable_youtube_expansions: true,
           rich_govspeak: true %>
-      <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
+
+      <% if not part_of_step_navs %>
+        <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
+      <% end %>
 
       <% if @content_item.multi_page_guide? %>
         <%= render 'components/print-link', href: @content_item.print_link, link_text: t("multi_page.print_entire_guide") %>
       <% end %>
     <% end %>
   </div>
-    <%= render 'shared/sidebar_navigation' %>
+
+  <%= render 'shared/sidebar_navigation' %>
 </div>


### PR DESCRIPTION
Some guides are showing a contents list that closely mirrors the step by step navigation it is part of, but do not provide an as accurate representation of the journey as the step by step does. We therefore want to be able to modify some guides as follows, in order to help users navigate more easily.

- remove contents list
- remove next/prev navigation
- move title from beneath contents list and put it in place of the guide title

Example: https://government-frontend-pr-1007.herokuapp.com/take-pet-abroad/microchip

**DO NOT MERGE** - this is not production ready. Required additions:

- logic is currently based on 'if guide has a step nav', this should be replaced with an option set through the publishing interface, so that these changes can be applied on a per-guide basis
- probably need to move this logic out of the view
- should also perhaps remove the 'print entire guide' option at the bottom?

**Before:**

<img width="1108" alt="screen shot 2018-07-31 at 14 10 07" src="https://user-images.githubusercontent.com/861310/43461516-9c3ef6e8-94cb-11e8-8eea-14d7b929ba27.png">

**After:**

<img width="1100" alt="screen shot 2018-07-31 at 14 10 22" src="https://user-images.githubusercontent.com/861310/43461524-a2162398-94cb-11e8-8a36-f77dc68be8d9.png">


---

Trello card: https://trello.com/c/jrEitsjh/752-spike-hiding-mainstream-guide-chapters-and-arrows-s