### PR TITLE
Remove contextual sidebar on variant B for whitehall

### DIFF
--- a/app/controllers/concerns/content_pages_nav_ab_testable.rb
+++ b/app/controllers/concerns/content_pages_nav_ab_testable.rb
@@ -5,7 +5,8 @@ module ContentPagesNavAbTestable
     base.helper_method(
       :content_pages_nav_test_variant,
       :show_new_navigation?,
-      :page_in_scope?
+      :page_in_scope?,
+      :should_show_sidebar?
     )
     base.after_action :set_test_response_header
   end
@@ -47,5 +48,9 @@ module ContentPagesNavAbTestable
   def has_a_live_taxon?
     @content_item.taxons.present? &&
       @content_item.taxons.detect { |taxon| taxon["phase"] == "live" }
+  end
+
+  def should_show_sidebar?
+    content_pages_nav_test_variant.variant?("A") || @content_item.content_item.parsed_content['publishing_app'] != "whitehall"
   end
 end

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -6,6 +6,8 @@
   end
 %>
 
-<div class="column-one-third">
-  <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
-</div>
+<% if should_show_sidebar? %>
+  <div class="column-one-third">
+    <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
+  </div>
+<% end %>

--- a/test/controllers/content_pages_nav_ab_testable_test.rb
+++ b/test/controllers/content_pages_nav_ab_testable_test.rb
@@ -52,6 +52,31 @@ class ContentItemsControllerTest < ActionController::TestCase
     end
   end
 
+  test "should_show_sidebar? is true for variant A" do
+    content_item = content_store_has_schema_example("guide", "single-page-guide")
+    setup_ab_variant("ContentPagesNav", "A")
+    get :show, params: { path: path_for(content_item) }
+    assert @controller.should_show_sidebar?
+  end
+
+  test "should_show_sidebar? is true for variant B if the publishing app is not whitehall" do
+    content_item = content_store_has_schema_example("guide", "single-page-guide")
+    setup_ab_variant("ContentPagesNav", "B")
+    get :show, params: { path: path_for(content_item) }
+
+    assert @controller.should_show_sidebar?
+  end
+
+  test "should_show_sidebar? is false for variant B if the publishing app is whitehall" do
+    content_item = govuk_content_schema_example("guide", "single-page-guide").merge("publishing_app" => "whitehall")
+    content_store_has_item(content_item['base_path'], content_item)
+
+    setup_ab_variant("ContentPagesNav", "B")
+    get :show, params: { path: path_for(content_item) }
+
+    refute @controller.should_show_sidebar?
+  end
+
   def ensure_ab_test_is_correctly_setup(test_variant, content_item)
     content_store_has_item(content_item['base_path'], content_item)
 

--- a/test/integration/content_pages_navigation_test.rb
+++ b/test/integration/content_pages_navigation_test.rb
@@ -59,6 +59,22 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "ContentPagesNav variant A shows sidebar" do
+    stub_rummager
+    setup_sidebar_variant_a
+
+    setup_and_visit_content_from_publishing_app(publishing_app: 'publisher')
+    assert page.has_css?('.gem-c-related-navigation__main-heading', text: 'Related content')
+  end
+
+  test "ContentPagesNav variant B hides sidebar" do
+    stub_rummager
+    setup_sidebar_variant_b
+
+    setup_and_visit_content_from_publishing_app(publishing_app: 'whitehall')
+    refute page.has_css?('.gem-c-related-navigation__main-heading', text: 'Related content')
+  end
+
   test "shows the Services section title and documents with tracking" do
     stub_rummager
     stub_empty_guidance
@@ -243,6 +259,14 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
 
   def setup_variant_b
     ContentItemsController.any_instance.stubs(:show_new_navigation?).returns(true)
+  end
+
+  def setup_sidebar_variant_a
+    ContentItemsController.any_instance.stubs(:should_show_sidebar?).returns(true)
+  end
+
+  def setup_sidebar_variant_b
+    ContentItemsController.any_instance.stubs(:should_show_sidebar?).returns(false)
   end
 
   def schema_type

--- a/test/support/content_pages_nav_test_helper.rb
+++ b/test/support/content_pages_nav_test_helper.rb
@@ -37,6 +37,22 @@ module ContentPagesNavTestHelper
     )
   end
 
+  def setup_and_visit_content_from_publishing_app(publishing_app: nil)
+    content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: schema_type) do |payload|
+      payload.merge('publishing_app' => publishing_app) unless publishing_app.nil?
+      payload
+    end
+
+    content_id = content_item["content_id"]
+    path = content_item["base_path"]
+
+    stub_request(:get, %r{#{path}})
+        .to_return(status: 200, body: content_item.to_json, headers: {})
+    visit path
+
+    assert_selector %{meta[name="govuk:content-id"][content="#{content_id}"}, visible: false
+  end
+
   SINGLE_TAXON = [
     {
       "base_path" => "/education/becoming-an-apprentice",


### PR DESCRIPTION
- Removes sidebar if publishing app is whitehall and in ab test variant B

## Examples:
You will need to have an extension like [ModHeader](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=en) installed in your browser to see the B Variant. The values should be:
Request Header Name: GOVUK-ABTest-ContentPagesNav
Request Header Value: B

- [Tagged to one taxon](https://government-frontend-pr-1009.herokuapp.com/apply-apprenticeship)
- [Tagged to multiple taxons](https://government-frontend-pr-1009.herokuapp.com/government/publications/esfa-update-18-july-2018)
- [Tagged to a taxon without services](https://government-frontend-pr-1009.herokuapp.com/government/publications/working-together-to-safeguard-children--2)
- [Not tagged to any taxons](https://government-frontend-pr-1009.herokuapp.com/government/case-studies/hard-lines)
- [HTML Publication](https://government-frontend-pr-1009.herokuapp.com/government/publications/budget-2016-documents/budget-2016)

Component guide for this PR:
https://government-frontend-pr-1009.herokuapp.com/component-guide