### PR TITLE
Remove explore the topic from the sidebar

### DIFF
--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -2,7 +2,8 @@
   content_item = @content_item.content_item.parsed_content
 
   if show_new_navigation?
-    content_item['links'].yield_self { |links| links.except!('document_collections') }
+    content_item['links']
+        .yield_self { |links| links.except!('document_collections', 'mainstream_browse_pages', 'topics') }
   end
 %>
 

--- a/test/integration/content_pages_navigation_test.rb
+++ b/test/integration/content_pages_navigation_test.rb
@@ -217,6 +217,22 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
     refute page.has_css?('h3', text: "News and communications")
   end
 
+  test "ContentPagesNav variant A shows explore the topic in the sidebar" do
+    setup_variant_a
+
+    setup_and_visit_content_item('guide')
+
+    assert page.has_css?('.gem-c-related-navigation__sub-heading', text: 'Explore the topic')
+  end
+
+  test "ContentPagesNav variant B does not show explore the topic in the sidebar" do
+    setup_variant_b
+
+    setup_and_visit_content_item('guide')
+
+    refute page.has_css?('.gem-c-related-navigation__sub-heading', text: 'Explore the topic')
+  end
+
   def stub_empty_services
     Supergroups::Services.any_instance.stubs(:all_services).returns({})
   end


### PR DESCRIPTION
Removes explore the topic from the sidebar when the taxonomy navigation is shown.

This is achieved by stripping out the mainstream browse page and topic links that the component depends on:

https://github.com/alphagov/govuk_publishing_components/blob/5fed4505deef99ad447779029ffac46d62041a39/lib/govuk_publishing_components/presenters/related_navigation_helper.rb#L119-L128

https://trello.com/c/fFxBHBQm

---

Visual regression results:
https://government-frontend-pr-1010.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1010.herokuapp.com/component-guide