### PR TITLE
Show taxon breadcrumbs for b variant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 52.6'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.6'
 gem 'govuk_frontend_toolkit', '~> 7.6'
-gem 'govuk_publishing_components', '~> 9.7.0'
+gem 'govuk_publishing_components', '~> 9.8.0'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 13.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
     coderay (1.1.2)
-    commander (4.4.5)
+    commander (4.4.6)
       highline (~> 1.7.2)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
@@ -126,7 +126,7 @@ GEM
     govuk_frontend_toolkit (7.6.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (9.7.0)
+    govuk_publishing_components (9.8.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -365,7 +365,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.6)
   govuk_frontend_toolkit (~> 7.6)
-  govuk_publishing_components (~> 9.7.0)
+  govuk_publishing_components (~> 9.8.0)
   govuk_schemas (~> 3.2)
   htmlentities (~> 4.3)
   jasmine-rails

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
     <% if @content_item.try(:back_link) %>
       <%= render 'govuk_publishing_components/components/back_link', href: @content_item.back_link %>
     <% else %>
-      <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.content_item.parsed_content %>
+      <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.content_item.parsed_content, prioritise_taxon_breadcrumbs: show_new_navigation? %>
     <% end %>
 
     <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">

--- a/test/integration/content_pages_navigation_test.rb
+++ b/test/integration/content_pages_navigation_test.rb
@@ -249,6 +249,31 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
     refute page.has_css?('.gem-c-related-navigation__sub-heading', text: 'Explore the topic')
   end
 
+  test "shows parent-based breadcrumbs if variant a" do
+    stub_empty_rummager
+    taxons = THREE_TAXONS
+    setup_and_visit_content_item_with_taxons('guide', taxons)
+
+    within('.gem-c-contextual-breadcrumbs') do
+      assert page.has_css?('a', text: "Home")
+      assert page.has_css?('a', text: "Childcare and parenting")
+      assert page.has_css?('a', text: "Schools and education")
+    end
+  end
+
+  test "shows taxon breadcrumbs if variant b" do
+    stub_empty_rummager
+    setup_variant_b
+
+    taxons = THREE_TAXONS
+    setup_and_visit_content_item_with_taxons('guide', taxons)
+
+    within('.gem-c-contextual-breadcrumbs') do
+      assert page.has_css?('a', text: "Home")
+      assert page.has_css?('a', text: "Becoming a wizard")
+    end
+  end
+
   def stub_empty_services
     Supergroups::Services.any_instance.stubs(:all_services).returns({})
   end

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -160,7 +160,7 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
   test 'renders no start button when not set' do
     setup_and_visit_content_item('aaib-reports')
 
-    refute page.has_css?('.gem-c-button')
+    refute page.has_css?('.gem-c-button', text: "Find out more")
   end
 
   test 'renders start button' do


### PR DESCRIPTION
Show taxon breadcrumbs if there are live taxons for a content item in variant B

Visual regression results:
https://government-frontend-pr-1013.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1013.herokuapp.com/component-guide

https://trello.com/c/yZfYuiJp/84-use-taxons-breadcrumb-in-b-sample