### PR TITLE
Enable bold text in govspeak

### DIFF
--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -12,8 +12,7 @@
     <%= render 'govuk_publishing_components/components/govspeak',
       content: raw(@content_item.body),
       direction: page_text_direction,
-      disable_youtube_expansions: true,
-      rich_govspeak: true %>
+      disable_youtube_expansions: true %>
 
     <% if @content_item.last_updated && @content_item.schema_name == "help_page" %>
       <%= render "components/published-dates", {

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -101,7 +101,7 @@
       <% end %>
     <% end %>
 
-    <%= render 'govuk_publishing_components/components/govspeak', content: body, rich_govspeak: true %>
+    <%= render 'govuk_publishing_components/components/govspeak', content: body %>
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -17,8 +17,7 @@
         <%= render 'govuk_publishing_components/components/govspeak',
             content: part['body'].html_safe,
             direction: page_text_direction,
-            disable_youtube_expansions: true,
-            rich_govspeak: true %>
+            disable_youtube_expansions: true %>
       </section>
     <% end %>
   </div>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -26,8 +26,7 @@
       <%= render 'govuk_publishing_components/components/govspeak',
           content: @content_item.current_part_body.html_safe,
           direction: page_text_direction,
-          disable_youtube_expansions: true,
-          rich_govspeak: true %>
+          disable_youtube_expansions: true %>
       <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
 
       <% if @content_item.multi_page_guide? %>


### PR DESCRIPTION
https://trello.com/c/BUij6N3Y/361-turn-on-bold-for-whitehall

Remove the restriction of bold text via `<strong>` tags in Govspeak.


#### Examples 

- https://government-frontend-pr-1014.herokuapp.com/guidance/connect-to-govwifi-using-an-android-device
- https://government-frontend-pr-1014.herokuapp.com/government/news/new-common-sense-code-to-build-greener-homes
- https://government-frontend-pr-1014.herokuapp.com/government/speeches/baroness-warsi-delivers-speech-at-oic-conference
- https://government-frontend-pr-1014.herokuapp.com/guidance/using-nitrogen-fertilisers-in-nitrate-vulnerable-zones
- https://government-frontend-pr-1014.herokuapp.com/government/consultations/rabies-control-strategy
- https://government-frontend-pr-1014.herokuapp.com/government/news/common-clinical-language-for-nhs-will-help-improve-patient-care-and-safety

There are around 5000 content store items with strong tags in the details body, so there's some impact in this change.

Depends on: https://github.com/alphagov/govuk_publishing_components/pull/463

---

Visual regression results:
https://government-frontend-pr-1014.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1014.herokuapp.com/component-guide
