### PR TITLE
Fix taxonomy navigation (AB) small link font & refactor CSS

### DIFF
--- a/app/assets/stylesheets/helpers/_taxonomy-navigation.scss
+++ b/app/assets/stylesheets/helpers/_taxonomy-navigation.scss
@@ -5,18 +5,6 @@
   border-top: 2px solid $govuk-blue;
 }
 
-.taxonomy-navigation__list-item {
-  margin: $gutter-one-third 0 ($gutter-one-third / 2) 0;
-  padding-bottom: $gutter / 6;
-  list-style: none;
-}
-
-.taxonomy-navigation__section {
-  padding: $gutter-one-third 0 $gutter-two-thirds 0;
-  margin-top: $gutter-half;
-  border-top: 1px solid $black;
-}
-
 .taxonomy-navigation__row {
   display: flex;
   flex-wrap: wrap;
@@ -31,19 +19,31 @@
   @include box-sizing(border-box);
   width: 100%;
   font-size: 16px;
-  padding: ($gutter / 6) $gutter-one-third ($gutter-half + $gutter-one-third) 0;
+  padding: ($gutter-one-third / 2) $gutter-one-third ($gutter-half + $gutter-one-third) 0;
 
   @include media(tablet) {
     width: 50%;
-    padding: ($gutter / 6) ($gutter-half + $gutter-one-third) ($gutter-half + $gutter-one-third) 0;
+    padding: ($gutter-one-third / 2) ($gutter-half + $gutter-one-third) ($gutter-half + $gutter-one-third) 0;
   }
 
   @include media(desktop) {
     width: (1 / 3) * 100%;
-    padding: ($gutter / 6) ($gutter-half + $gutter-one-third) ($gutter-half + $gutter-one-third) 0;
+    padding: ($gutter-one-third / 2) ($gutter-half + $gutter-one-third) ($gutter-half + $gutter-one-third) 0;
   }
 
   .gem-c-heading {
     @include bold-16;
   }
+}
+
+.taxonomy-navigation__list-item {
+  margin: $gutter-one-third 0 ($gutter-one-third / 2) 0;
+  padding-bottom: $gutter-one-third / 2;
+  list-style: none;
+}
+
+.taxonomy-navigation__section {
+  padding: $gutter-one-third 0 $gutter-two-thirds 0;
+  margin-top: $gutter-half;
+  border-top: 1px solid $black;
 }

--- a/app/assets/stylesheets/helpers/_taxonomy-navigation.scss
+++ b/app/assets/stylesheets/helpers/_taxonomy-navigation.scss
@@ -30,10 +30,6 @@
     width: (1 / 3) * 100%;
     padding: ($gutter-one-third / 2) ($gutter-half + $gutter-one-third) ($gutter-half + $gutter-one-third) 0;
   }
-
-  .gem-c-heading {
-    @include bold-16;
-  }
 }
 
 .taxonomy-navigation__list-item {

--- a/app/assets/stylesheets/helpers/_taxonomy-navigation.scss
+++ b/app/assets/stylesheets/helpers/_taxonomy-navigation.scss
@@ -27,9 +27,9 @@
 }
 
 .taxonomy-navigation__column {
-  @include core-16;
   @include box-sizing(border-box);
   width: 100%;
+  font-size: 16px;
   padding: ($gutter / 6) $gutter-one-third ($gutter-half + $gutter-one-third) 0;
 
   @include media(tablet) {

--- a/app/assets/stylesheets/helpers/_taxonomy-navigation.scss
+++ b/app/assets/stylesheets/helpers/_taxonomy-navigation.scss
@@ -6,7 +6,7 @@
 }
 
 .taxonomy-navigation__list-item {
-  margin-bottom: $gutter / 6;
+  margin: $gutter-one-third 0 ($gutter-one-third / 2) 0;
   padding-bottom: $gutter / 6;
   list-style: none;
 }
@@ -20,6 +20,7 @@
 .taxonomy-navigation__row {
   display: flex;
   flex-wrap: wrap;
+  padding-top: $gutter-one-third;
 
   @include media(tablet) {
     margin-right: -25px;

--- a/app/views/shared/_taxonomy_navigation.html.erb
+++ b/app/views/shared/_taxonomy_navigation.html.erb
@@ -4,8 +4,7 @@
       <div class="taxonomy-navigation__column">
         <%= render "govuk_publishing_components/components/heading",
                    text: 'Topics',
-                   heading_level: 2,
-                   padding: true %>
+                   heading_level: 2 %>
         <ul>
           <% tagged_taxons.each do |tagged_taxon| %>
             <li class="taxonomy-navigation__list-item">
@@ -19,8 +18,7 @@
         <div class="taxonomy-navigation__column">
           <%= render "govuk_publishing_components/components/heading",
                      text: 'Collections',
-                     heading_level: 2,
-                     padding: true %>
+                     heading_level: 2 %>
           <ul>
             <% related_collections.each do |base_path, title| %>
               <li class="taxonomy-navigation__list-item">

--- a/app/views/shared/_taxonomy_navigation.html.erb
+++ b/app/views/shared/_taxonomy_navigation.html.erb
@@ -4,7 +4,8 @@
       <div class="taxonomy-navigation__column">
         <%= render "govuk_publishing_components/components/heading",
                    text: 'Topics',
-                   heading_level: 2 %>
+                   heading_level: 2,
+                   font_size: 19 %>
         <ul>
           <% tagged_taxons.each do |tagged_taxon| %>
             <li class="taxonomy-navigation__list-item">
@@ -18,7 +19,8 @@
         <div class="taxonomy-navigation__column">
           <%= render "govuk_publishing_components/components/heading",
                      text: 'Collections',
-                     heading_level: 2 %>
+                     heading_level: 2,
+                     font_size: 19 %>
           <ul>
             <% related_collections.each do |base_path, title| %>
               <li class="taxonomy-navigation__list-item">


### PR DESCRIPTION
Trello: https://trello.com/c/I9TueAJ5/95-font-size-of-topics-collections-on-mobile-is-small

This PR:

- Increases font size of Topic and Collection links on mobile from 14px to 16px.
- Tweaks spacing of links and headings
- Reorders CSS for taxonomy_navigation to make it easier to read/follow
- Remove CSS override for component

## Before (mobile)
<img width="158" alt="screen shot 2018-08-03 at 14 58 23" src="https://user-images.githubusercontent.com/29889908/43646830-debb3a68-972d-11e8-9a3b-92df090b7785.png">

## After (mobile)
<img width="157" alt="screen shot 2018-08-03 at 14 59 19" src="https://user-images.githubusercontent.com/29889908/43646844-e8219c14-972d-11e8-8786-c79a27998783.png">

## Before (desktop)
<img width="587" alt="screen shot 2018-08-03 at 14 58 09" src="https://user-images.githubusercontent.com/29889908/43646867-f0e73e26-972d-11e8-8be6-1d57ec17271f.png">

## After (desktop)
<img width="589" alt="screen shot 2018-08-03 at 14 58 01" src="https://user-images.githubusercontent.com/29889908/43646875-f7aa2d04-972d-11e8-859a-d932e326d26f.png">

Component guide for this PR:
https://government-frontend-pr-1020.herokuapp.com/component-guide

Example:
https://government-frontend-pr-1020.herokuapp.com/government/publications/academies-finance-and-assurance-steering-group-terms-of-reference?ABTest-ContentPagesNav=B