### PR TITLE
Change the special case to not have the "the"

### DIFF
--- a/app/services/world_location_base_path.rb
+++ b/app/services/world_location_base_path.rb
@@ -22,7 +22,7 @@
 class WorldLocationBasePath
   EXCEPTIONAL_CASES = {
     "Democratic Republic of Congo" => "democratic-republic-of-congo",
-    "South Georgia and the South Sandwich Islands" => "south-georgia-and-the-south-sandwich-islands",
+    "South Georgia and the South Sandwich Islands" => "south-georgia-and-south-sandwich-islands",
     "St Pierre & Miquelon" => "st-pierre-miquelon"
   }.freeze
 

--- a/test/services/world_location_base_path_test.rb
+++ b/test/services/world_location_base_path_test.rb
@@ -22,7 +22,7 @@ end
 class WorldLocationBasePathForExceptionalCase < ActiveSupport::TestCase
   {
    "Democratic Republic of Congo" => "democratic-republic-of-congo",
-   "South Georgia and the South Sandwich Islands" => "south-georgia-and-the-south-sandwich-islands",
+   "South Georgia and the South Sandwich Islands" => "south-georgia-and-south-sandwich-islands",
    "St Pierre & Miquelon" => "st-pierre-miquelon"
   }.each do |title, expected_slug|
     test "returns /world/#{expected_slug}/news" do


### PR DESCRIPTION
This is the working URL [1], so change the special case to use the
working URL.

1: https://www.gov.uk/world/south-georgia-and-south-sandwich-islands/news

---

Visual regression results:
https://government-frontend-pr-1015.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1015.herokuapp.com/component-guide
