### PR TITLE
Bump govuk_publishing_components to 9.9.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 52.7'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.8'
 gem 'govuk_frontend_toolkit', '~> 7.6'
-gem 'govuk_publishing_components', '~> 9.9.0'
+gem 'govuk_publishing_components', '~> 9.9.1'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 13.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     govuk_frontend_toolkit (7.6.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (9.9.0)
+    govuk_publishing_components (9.9.1)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -365,7 +365,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.8)
   govuk_frontend_toolkit (~> 7.6)
-  govuk_publishing_components (~> 9.9.0)
+  govuk_publishing_components (~> 9.9.1)
   govuk_schemas (~> 3.2)
   htmlentities (~> 4.3)
   jasmine-rails

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -79,7 +79,7 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
     documents = @content_item["links"]["documents"]
 
     documents.each do |doc|
-      assert page.has_css?('.gem-c-document-list__item-title a', text: doc["title"])
+      assert page.has_css?('.gem-c-document-list__item-title', text: doc["title"])
     end
 
     assert page.has_css?('.gem-c-document-list .gem-c-document-list__item', count: documents.count)
@@ -101,7 +101,7 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
     groups = page.all('.gem-c-document-list')
     assert page.has_css?('[data-module="track-click"]'), count: groups.length
 
-    first_section_links = groups.first.all('.gem-c-document-list__item-title a')
+    first_section_links = groups.first.all('.gem-c-document-list__item-title')
     first_link = first_section_links.first
 
     assert_equal(


### PR DESCRIPTION
This version removes headings from the document list component. This caused a couple of tests to fail which have also been fixed in this commit.

There should be no visible difference between how the document list renders.

## Before
<img width="649" alt="screen shot 2018-08-06 at 10 52 40" src="https://user-images.githubusercontent.com/29889908/43710197-ddf26a3a-9966-11e8-80bf-feb08d9205cc.png">

## After
<img width="644" alt="screen shot 2018-08-06 at 10 55 38" src="https://user-images.githubusercontent.com/29889908/43710343-4627ac64-9967-11e8-9e1b-20f8de01ae61.png">

---

Component guide for this PR:
https://government-frontend-pr-1025.herokuapp.com/component-guide
