### PR TITLE
Use base path to exclude current page from tax nav

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -66,13 +66,14 @@ private
   def load_taxonomy_navigation
     if @content_item.taxons.present?
       taxons = @content_item.taxons.select { |taxon| taxon["phase"] == "live" }
+      current_base_path = @content_item.base_path
 
       taxon_ids = taxons.map { |taxon| taxon["content_id"] }
-      services = Supergroups::Services.new(content_item_path, taxon_ids)
-      guidance_and_regulation = Supergroups::GuidanceAndRegulation.new(content_item_path, taxon_ids)
-      news = Supergroups::NewsAndCommunications.new(content_item_path, taxon_ids)
-      policy_and_engagement = Supergroups::PolicyAndEngagement.new(content_item_path, taxon_ids)
-      transparency = Supergroups::Transparency.new(content_item_path, taxon_ids)
+      services = Supergroups::Services.new(current_base_path, taxon_ids)
+      guidance_and_regulation = Supergroups::GuidanceAndRegulation.new(current_base_path, taxon_ids)
+      news = Supergroups::NewsAndCommunications.new(current_base_path, taxon_ids)
+      policy_and_engagement = Supergroups::PolicyAndEngagement.new(current_base_path, taxon_ids)
+      transparency = Supergroups::Transparency.new(current_base_path, taxon_ids)
 
       @taxonomy_navigation = {
         services: (services.all_services if services.any_services?),


### PR DESCRIPTION
Trello: https://trello.com/c/AbYDeU6N/99-dont-show-current-item-in-taxonomy-navigation-continued

Extend the logic we added to exclude the current page from the taxonomy navigation, to also apply to multi-page formats like guides.

## Before
<img width="993" alt="screen shot 2018-08-06 at 13 30 30" src="https://user-images.githubusercontent.com/29889908/43716702-024e2ca0-997d-11e8-8eb3-7a7625b47642.png">

## After
<img width="985" alt="screen shot 2018-08-06 at 13 30 41" src="https://user-images.githubusercontent.com/29889908/43716706-07686520-997d-11e8-9efb-a1c958de5b68.png">

Examples:

- https://government-frontend-pr-1026.herokuapp.com/student-finance/new-fulltime-students
- https://government-frontend-pr-1026.herokuapp.com/change-address-driving-licence/apply-by-post
