### PR TITLE
Clean up the world location base path class

### DIFF
--- a/app/services/world_location_base_path.rb
+++ b/app/services/world_location_base_path.rb
@@ -22,7 +22,7 @@
 class WorldLocationBasePath
   EXCEPTIONAL_CASES = {
     "Democratic Republic of Congo" => "democratic-republic-of-congo",
-    "South Georgia and the South Sandwich Islands" => "south-georgia-and-south-sandwich-islands",
+    "South Georgia and the South Sandwich Islands" => "south-georgia-and-the-south-sandwich-islands",
     "St Pierre & Miquelon" => "st-pierre-miquelon"
   }.freeze
 

--- a/app/services/world_location_base_path.rb
+++ b/app/services/world_location_base_path.rb
@@ -1,38 +1,11 @@
-#This is intended as a temporary solution while dependencies on other apps are
-#resolved. We are migrating world locations to a taxonomy based model but the
-#following problems have arisen that this approach temporarily solves:
-#
-# * we require world locations to be associated with content in Whitehall
-#   for email subscriptions to work so we can't just get rid of them
-# * we also need them as not all content will be part of the taxonomy
-#   (e.g. news about the country)
-# * the taxon will take the base path (/world/<country-slug>) and so the
-#   WorldLocation can't occupy that
-# * we need to redirect old /government/world/<country-slug> urls to the new
-#   taxon but if we leave WorldLocation with that path it will a) overwrite
-#   the redirect route every time it is updated and b) we'll be knowingly
-#   linking to a redirect
-#
-#A slightly better solution will be for Whitehall to retrieve the taxon path from
-#publishing API and send that with the world location link as an additional field
-#in the links. We'll need the taxonomy to exist in order to implement this. This
-#will still require frontend code to know about the links but will be similar
-#to prior art we have for some links to be affected by elements with `detail`.
-
 class WorldLocationBasePath
-  EXCEPTIONAL_CASES = {
-    "Democratic Republic of Congo" => "democratic-republic-of-congo",
-    "South Georgia and the South Sandwich Islands" => "south-georgia-and-the-south-sandwich-islands",
-    "St Pierre & Miquelon" => "st-pierre-miquelon"
-  }.freeze
-
   class << self
     def for(world_location_link)
       base_path = world_location_link["base_path"]
       title = world_location_link["title"]
       return base_path if base_path.present?
 
-      slug = EXCEPTIONAL_CASES[title] || title.parameterize
+      slug = title.parameterize
 
       "/world/#{slug}/news"
     end

--- a/test/services/world_location_base_path_test.rb
+++ b/test/services/world_location_base_path_test.rb
@@ -22,7 +22,7 @@ end
 class WorldLocationBasePathForExceptionalCase < ActiveSupport::TestCase
   {
    "Democratic Republic of Congo" => "democratic-republic-of-congo",
-   "South Georgia and the South Sandwich Islands" => "south-georgia-and-south-sandwich-islands",
+   "South Georgia and the South Sandwich Islands" => "south-georgia-and-the-south-sandwich-islands",
    "St Pierre & Miquelon" => "st-pierre-miquelon"
   }.each do |title, expected_slug|
     test "returns /world/#{expected_slug}/news" do


### PR DESCRIPTION
First, revert a ineffective change I made, then attempt to clean this WorldLocationBasePath class up.

As far as I can work out, this is never used. The only document type
that uses the metadata, which is I think where this is possibly used
is travel advice. I checked if any travel advice content is tagged to
world locations, and it isn't.

This is very confusing, as the exceptional cases aren't
exceptional. Looking at the code, the behaviour looks to be the same
with or without them.

I've also removed the comment, as the situation with the migration of
"world locations to a taxonomy based model" is pretty uncertian, as
the Topic Taxonomy doesn't have anything to do with country
classification (it's about subject, not geography), and this
"temporary solution" both as far as I can work out, doesn't do
anything, and has been here for over a year.