### PR TITLE
Use hide_chapter_navigation on guides

### DIFF
--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -41,9 +41,30 @@ class GuidePresenter < ContentItemPresenter
     end
   end
 
+  def show_guide_navigation?
+    multi_page_guide? && !hide_chapter_navigation?
+  end
+
+  def content_title
+    if parts.any?
+      return current_part_title if hide_chapter_navigation?
+    end
+
+    title
+  end
+
 private
 
   def draft_access_token_param
     "token=#{draft_access_token}" if draft_access_token
+  end
+
+  def hide_chapter_navigation?
+    hide_navigation_elements = content_item.parsed_content["details"]["hide_chapter_navigation"]
+    part_of_step_navs? && hide_navigation_elements
+  end
+
+  def part_of_step_navs?
+    content_item.parsed_content["links"]["part_of_step_navs"].present?
   end
 end

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -9,30 +9,34 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', { title: @content_item.title } %>
-    <% if @content_item.multi_page_guide? %>
+    <%= render 'govuk_publishing_components/components/title', { title: @content_item.content_title } %>
+
+    <% if @content_item.show_guide_navigation? %>
       <aside class="part-navigation-container" role="complementary">
         <%= render "govuk_publishing_components/components/contents_list", aria_label: 'Pages in this guide', contents: @content_item.part_link_elements, underline_links: true %>
       </aside>
     <% end %>
   </div>
+
   <div class="column-two-thirds">
     <% if @content_item.has_parts? %>
-      <% if @content_item.multi_page_guide? %>
+      <% if @content_item.show_guide_navigation? %>
         <h1 class="part-title">
           <%= @content_item.current_part_title %>
         </h1>
       <% end %>
+
       <%= render 'govuk_publishing_components/components/govspeak',
           content: @content_item.current_part_body.html_safe,
           direction: page_text_direction,
           disable_youtube_expansions: true %>
-      <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
 
-      <% if @content_item.multi_page_guide? %>
+      <% if @content_item.show_guide_navigation? %>
+        <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
         <%= render 'components/print-link', href: @content_item.print_link, link_text: t("multi_page.print_entire_guide") %>
       <% end %>
     <% end %>
   </div>
-    <%= render 'shared/sidebar_navigation' %>
+
+  <%= render 'shared/sidebar_navigation' %>
 </div>

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -28,4 +28,52 @@ class GuideTest < ActionDispatch::IntegrationTest
     refute page.has_css?('h1', text: @content_item['details']['parts'].first['title'])
     refute page.has_css?('.app-c-print-link')
   end
+
+  test "replaces guide title with part title if in a step by step and hide_chapter_navigation is true" do
+    setup_and_visit_content_item('guide-with-step-navs-and-hide-navigation')
+    title = @content_item['title']
+    part_title = @content_item['details']['parts'][0]['title']
+
+    refute page.has_css?('h1', text: title)
+    assert_has_component_title(part_title)
+  end
+
+  test "does not replace guide title if not in a step by step and hide_chapter_navigation is true" do
+    setup_and_visit_content_item('guide-with-hide-navigation')
+    title = @content_item['title']
+    part_title = @content_item['details']['parts'][0]['title']
+
+    assert_has_component_title(title)
+    assert_has_component_title(part_title)
+  end
+
+  test "shows correct title in a single page guide if in a step by step and hide_chapter_navigation is true" do
+    setup_and_visit_content_item('single-page-guide-with-step-navs-and-hide-navigation')
+    title = @content_item['title']
+    part_title = @content_item['details']['parts'][0]['title']
+
+    refute page.has_css?('h1', text: title)
+    assert_has_component_title(part_title)
+  end
+
+  test "does not show guide navigation and print link if in a step by step and hide_chapter_navigation is true" do
+    setup_and_visit_content_item('guide-with-step-navs-and-hide-navigation')
+
+    refute page.has_css?('.gem-c-pagination')
+    refute page.has_css?('.app-c-print-link')
+  end
+
+  test "shows guide navigation and print link if not in a step by step and hide_chapter_navigation is true" do
+    setup_and_visit_content_item('guide-with-hide-navigation')
+
+    assert page.has_css?('.gem-c-pagination')
+    assert page.has_css?('.app-c-print-link')
+  end
+
+  test "guides with no parts in a step by step with hide_chapter_navigation do not error" do
+    setup_and_visit_content_item('no-part-guide-with-step-navs-and-hide-navigation')
+    title = @content_item['title']
+
+    assert_has_component_title(title)
+  end
 end


### PR DESCRIPTION
- only happens if hide_chapter_navigation is true and the guide is in a step by step
- promotes guide part subtitle to be the page title
- hides guide contents list
- hides next/prev navigation and guide print link

**Before:**

<img width="1108" alt="screen shot 2018-07-31 at 14 10 07" src="https://user-images.githubusercontent.com/861310/43461516-9c3ef6e8-94cb-11e8-8eea-14d7b929ba27.png">

**After:**

<img width="1100" alt="screen shot 2018-07-31 at 14 10 22" src="https://user-images.githubusercontent.com/861310/43461524-a2162398-94cb-11e8-8a36-f77dc68be8d9.png">

Follows on from [this spike](https://github.com/alphagov/government-frontend/pull/1007) done previously.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/809

---

Trello card: https://trello.com/c/RNsA7E4Q/763-hide-chapter-navigation-on-mainstream-guides

Visual regression results:
https://government-frontend-pr-1039.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1039.herokuapp.com/component-guide
