### PR TITLE
Use rummager results for image_urls

### DIFF
--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -2,7 +2,7 @@ module Supergroups
   class NewsAndCommunications < Supergroup
     attr_reader :content
 
-    PLACEHOLDER_IMAGE = "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg".freeze
+    PLACEHOLDER_IMAGE = "#{Plek.current.asset_root}/government/assets/placeholder.jpg".freeze
 
     def initialize(current_path, taxon_ids, filters)
       super(current_path, taxon_ids, filters, MostRecentContent)

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -9,34 +9,19 @@ module Supergroups
     end
 
     def tagged_content
-      return unless @content.any?
-      {
-        documents: documents,
-        promoted_content: promoted_content,
-      }
+      format_document_data(@content)
     end
 
   private
 
-    def documents
-      items = @content.drop(promoted_content_count)
-      format_document_data(items)
-    end
-
-    def promoted_content
-      items = @content.take(promoted_content_count)
-      format_document_data(items, data_category: "ImageCardClicked")
-    end
-
-  private
-
-    def format_document_data(documents, data_category: nil)
+    def format_document_data(documents)
+      # Start with_index at 1 to help align analytics
       documents.each.with_index(1).map do |document, index|
         data = {
           link: {
             text: document["title"],
             path: document["link"],
-            data_attributes: data_attributes(document["link"], document["title"], index, data_category)
+            data_attributes: data_attributes(document["link"], document["title"], index, "ImageCardClicked")
           },
           metadata: {
             document_type: document_type(document),
@@ -50,10 +35,6 @@ module Supergroups
 
         data
       end
-    end
-
-    def promoted_content_count
-      3
     end
 
     def image_url(document)

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -36,14 +36,7 @@ module Supergroups
           link: {
             text: document["title"],
             path: document["link"],
-            data_attributes: {
-              track_category: "Services" + data_category,
-              track_action: index,
-              track_label: document["link"],
-              track_options: {
-                dimension29: document["title"],
-              }
-            }
+            data_attributes: data_attributes(document["link"], document["title"], index, data_category),
           }
         }
 

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -7,41 +7,7 @@ module Supergroups
     end
 
     def tagged_content
-      return unless @content.any?
-      {
-        documents: documents,
-        promoted_content: promoted_content,
-      }
-    end
-
-  private
-
-    def documents
-      items = @content.drop(promoted_content_count)
-      format_document_data(items)
-    end
-
-    def promoted_content
-      items = @content.take(promoted_content_count)
-      format_document_data(items, "HighlightBoxClicked")
-    end
-
-    def promoted_content_count
-      3
-    end
-
-    def format_document_data(documents, data_category = "DocumentListClicked")
-      documents.each.with_index(1)&.map do |document, index|
-        data = {
-          link: {
-            text: document["title"],
-            path: document["link"],
-            data_attributes: data_attributes(document["link"], document["title"], index, data_category),
-          }
-        }
-
-        data
-      end
+      format_document_data(@content, data_category: "HighlightBoxClicked")
     end
   end
 end

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -14,6 +14,7 @@ module Supergroups
   private
 
     def format_document_data(documents, data_category: nil, include_timestamp: true)
+      # Start with_index at 1 to help align analytics
       documents.each.with_index(1).map do |document, index|
         data = {
           link: {

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -22,16 +22,12 @@ module Supergroups
             data_attributes: data_attributes(document["link"], document["title"], index, data_category)
           },
           metadata: {
-            document_type: document["content_store_document_type"].humanize
+            document_type: document_type(document)
           }
         }
 
         if include_timestamp && document["public_timestamp"]
-          data[:metadata][:public_updated_at] = Date.parse(document["public_timestamp"])
-        end
-
-        if data_category.present?
-          data[:link][:data_attributes][:track_category] = data_module_label + data_category
+          data[:metadata][:public_updated_at] = updated_date(document)
         end
 
         data
@@ -47,6 +43,14 @@ module Supergroups
           dimension29: link_text
         }
       }
+    end
+
+    def document_type(document)
+      document["content_store_document_type"].humanize
+    end
+
+    def updated_date(document)
+      Date.parse(document["public_timestamp"])
     end
 
     def data_module_label

--- a/app/services/most_recent_content.rb
+++ b/app/services/most_recent_content.rb
@@ -20,17 +20,12 @@ private
 
   def search_response
     params = {
-        start: 0,
-        count: number_of_links,
-        fields: %w(title
-                   link
-                   description
-                   content_store_document_type
-                   public_timestamp
-                   organisations),
-        filter_part_of_taxonomy_tree: @content_ids,
-        order: '-public_timestamp',
-        reject_link: current_path,
+      start: 0,
+      count: number_of_links,
+      fields: RummagerFields::TAXON_SEARCH_FIELDS,
+      filter_part_of_taxonomy_tree: @content_ids,
+      order: '-public_timestamp',
+      reject_link: current_path,
     }
     params[:filter_content_purpose_supergroup] = @filters[:filter_content_purpose_supergroup] if @filters[:filter_content_purpose_supergroup].present?
     params[:filter_content_purpose_subgroup] = @filters[:filter_content_purpose_subgroup] if @filters[:filter_content_purpose_subgroup].present?

--- a/app/services/rummager_fields.rb
+++ b/app/services/rummager_fields.rb
@@ -1,10 +1,11 @@
 module RummagerFields
-  TAXON_SEARCH_FIELDS = %w(title
-                           link
+  TAXON_SEARCH_FIELDS = %w(content_store_document_type
                            description
-                           content_store_document_type
+                           image_url
+                           link
+                           organisations
                            public_timestamp
-                           organisations).freeze
+                           title).freeze
 
   FEED_SEARCH_FIELDS = %w(title
                           link

--- a/app/views/shared/_taxonomy_navigation.html.erb
+++ b/app/views/shared/_taxonomy_navigation.html.erb
@@ -3,7 +3,7 @@
     <div class="taxonomy-navigation__row">
       <div class="taxonomy-navigation__column">
         <%= render "govuk_publishing_components/components/heading",
-                   text: 'Topics',
+                   text: t('supergroups.topics'),
                    heading_level: 2,
                    font_size: 19 %>
         <ul>
@@ -18,7 +18,7 @@
       <% if related_collections.any? %>
         <div class="taxonomy-navigation__column">
           <%= render "govuk_publishing_components/components/heading",
-                     text: 'Collections',
+                     text: t('supergroups.collections'),
                      heading_level: 2,
                      font_size: 19 %>
           <ul>

--- a/app/views/shared/_taxonomy_navigation.html.erb
+++ b/app/views/shared/_taxonomy_navigation.html.erb
@@ -81,7 +81,6 @@
                 href: promo[:link][:path],
                 heading_text: promo[:link][:text],
                 image_src: promo[:image][:url],
-                image_alt: promo[:image][:alt],
                 heading_level: 0,
                 href_data_attributes: promo[:link][:data_attributes]
                 } %>

--- a/app/views/shared/_taxonomy_navigation.html.erb
+++ b/app/views/shared/_taxonomy_navigation.html.erb
@@ -43,7 +43,7 @@
 
         <%= render "govuk_publishing_components/components/highlight_boxes", {
           inverse: true,
-          items: taxonomy_navigation[:services][:promoted_content]
+          items: taxonomy_navigation[:services]
         } %>
       </div>
     <% end %>
@@ -72,9 +72,8 @@
           margin_bottom: 2
         } %>
 
-        <% taxonomy_navigation[:news_and_communications][:promoted_content].in_groups_of(3, false) do |promo_group| %>
-          <div class="grid-row">
-          <% promo_group.each do |promo| %>
+        <div class="grid-row">
+          <% taxonomy_navigation[:news_and_communications].each do |promo| %>
             <div class="column-one-third">
               <%= render "govuk_publishing_components/components/image_card", {
                 context: promo[:image][:context],
@@ -86,11 +85,7 @@
                 } %>
             </div>
           <% end %>
-          </div>
-        <% end %>
-        <%= render "govuk_publishing_components/components/document_list", {
-          items: taxonomy_navigation[:news_and_communications][:documents]
-        } %>
+        </div>
       </div>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,8 @@ en:
     policy_and_engagement: "Policy and engagement"
     transparency: "Transparency"
     see_more_supergroups: "See more %{supergroup}"
+    topics: "Topics"
+    collections: "Collections"
   language_names:
     ar: Arabic
     de: German

--- a/test/integration/content_pages_navigation_test.rb
+++ b/test/integration/content_pages_navigation_test.rb
@@ -203,11 +203,6 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
 
     setup_and_visit_content_item_with_taxons('guide', taxons)
 
-    assert page.has_css?('h3', text: "News and communications")
-    assert page.has_css?('.gem-c-image-card__title', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-image-card__title-link[data-track-category="newsAndCommunicationsImageCardClicked"]', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-image-card__title-link[data-track-action="1"]', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-image-card__title-link[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
     assert_has_news_and_communications_section
   end
 

--- a/test/integration/content_pages_navigation_test.rb
+++ b/test/integration/content_pages_navigation_test.rb
@@ -93,7 +93,7 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
 
     assert page.has_css?('h3', text: "Services")
     assert page.has_css?('.gem-c-highlight-boxes__title', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-highlight-boxes__title[data-track-category="ServicesHighlightBoxClicked"]', text: 'Free school meals form')
+    assert page.has_css?('.gem-c-highlight-boxes__title[data-track-category="servicesHighlightBoxClicked"]', text: 'Free school meals form')
     assert page.has_css?('.gem-c-highlight-boxes__title[data-track-action="1"]', text: 'Free school meals form')
     assert page.has_css?('.gem-c-highlight-boxes__title[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
   end

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -5,7 +5,7 @@ class NewsAndCommunicationsTest < ActiveSupport::TestCase
 
   test "finds no results if taxon ids is a blank array" do
     news_and_comms = Supergroups::NewsAndCommunications.new("/a-random-path", [], {})
-    assert_nil news_and_comms.tagged_content
+    assert_equal [], news_and_comms.tagged_content
   end
 
   test "finds no results if there are taxon ids but no results" do
@@ -13,41 +13,24 @@ class NewsAndCommunicationsTest < ActiveSupport::TestCase
 
     stub_most_recent_content("/a-random-path", taxon_content_ids, 0, "news_and_communications")
     news_and_comms = Supergroups::NewsAndCommunications.new("/a-random-path", taxon_content_ids, {})
-    assert_nil news_and_comms.tagged_content
+    assert_equal [], news_and_comms.tagged_content
   end
 
-  test "finds 2 featured items and 0 normal items with 2 results" do
+  test "Presents 2 items with 2 results" do
     taxon_content_ids = ['any-old-taxon', 'some-other-taxon-id']
     stub_most_recent_content("/a-random-path", taxon_content_ids, 2, "news_and_communications")
-    stub_content_store_items(2)
 
     news_and_comms = Supergroups::NewsAndCommunications.new("/a-random-path", taxon_content_ids, {})
 
-    assert_equal 0, news_and_comms.tagged_content[:documents].count
-    assert_equal 2, news_and_comms.tagged_content[:promoted_content].count
-  end
-
-  test "finds 3 promoted items and 2 normal items if there are enough results" do
-    taxon_content_ids = ['any-old-taxon', 'some-other-taxon-id']
-    stub_most_recent_content("/a-random-path", taxon_content_ids, 5, "news_and_communications")
-    stub_content_store_items(3)
-
-    news_and_comms = Supergroups::NewsAndCommunications.new("/a-random-path", taxon_content_ids, {})
-
-    assert_equal 2, news_and_comms.tagged_content[:documents].count
-    assert_equal 3, news_and_comms.tagged_content[:promoted_content].count
+    assert_equal 2, news_and_comms.tagged_content.count
   end
 
   test "promoted content includes placeholder images if the content doesn't have one" do
-    placeholder_image = "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg"
-
-    taxon_content_ids = ['any-old-taxon']
-    stub_most_recent_content("/a-random-path", taxon_content_ids, 1, "news_and_communications")
+    placeholder_image = "http://static.test.gov.uk/government/assets/placeholder.jpg"
     stub_rummager_document_without_image_url
 
-    news_and_comms = Supergroups::NewsAndCommunications.new("/a-random-path", taxon_content_ids, {})
-
-    news_item = news_and_comms.tagged_content[:promoted_content].first
+    news_and_comms = Supergroups::NewsAndCommunications.new("/a-random-path", ['any-old-taxon'], {})
+    news_item = news_and_comms.tagged_content.first
 
     assert_equal news_item[:image][:url], placeholder_image
   end
@@ -57,14 +40,8 @@ class NewsAndCommunicationsTest < ActiveSupport::TestCase
     stub_most_recent_content("/a-random-path", taxon_content_ids, 1, "news_and_communications")
 
     news_and_comms = Supergroups::NewsAndCommunications.new("/a-random-path", taxon_content_ids, {})
-    news_item = news_and_comms.tagged_content[:promoted_content].first
+    news_item = news_and_comms.tagged_content.first
 
     assert_equal news_item[:image][:url], "https://assets.testing.gov.uk/awesome-pic.jpg"
-  end
-
-  def stub_content_store_items(count)
-    count.times.map do |i|
-      content_store_has_item("/content-item-#{i}")
-    end
   end
 end

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -40,9 +40,10 @@ class NewsAndCommunicationsTest < ActiveSupport::TestCase
 
   test "promoted content includes placeholder images if the content doesn't have one" do
     placeholder_image = "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg"
+
     taxon_content_ids = ['any-old-taxon']
     stub_most_recent_content("/a-random-path", taxon_content_ids, 1, "news_and_communications")
-    stub_content_store_items(1)
+    stub_rummager_document_without_image_url
 
     news_and_comms = Supergroups::NewsAndCommunications.new("/a-random-path", taxon_content_ids, {})
 
@@ -55,21 +56,10 @@ class NewsAndCommunicationsTest < ActiveSupport::TestCase
     taxon_content_ids = ['any-old-taxon']
     stub_most_recent_content("/a-random-path", taxon_content_ids, 1, "news_and_communications")
 
-    content = content_item_for_base_path("/content-item-0").merge(
-      "details": {
-        "image": {
-          "url": "an/image/path",
-          "alt_text": "some alt text"
-        }
-      }
-    )
-    content_store_has_item("/content-item-0", content)
-
     news_and_comms = Supergroups::NewsAndCommunications.new("/a-random-path", taxon_content_ids, {})
-
     news_item = news_and_comms.tagged_content[:promoted_content].first
 
-    assert_equal news_item[:image][:url], "an/image/path"
+    assert_equal news_item[:image][:url], "https://assets.testing.gov.uk/awesome-pic.jpg"
   end
 
   def stub_content_store_items(count)

--- a/test/presenters/supergroups/services_test.rb
+++ b/test/presenters/supergroups/services_test.rb
@@ -5,7 +5,7 @@ class ServicesTest < ActiveSupport::TestCase
 
   test "services returns no results if taxon ids is a blank array" do
     services = Supergroups::Services.new("/a-random-path", [], {})
-    assert_nil services.tagged_content
+    assert_equal [], services.tagged_content
   end
 
   test "services returns no results if there are taxon ids but no results" do
@@ -13,7 +13,7 @@ class ServicesTest < ActiveSupport::TestCase
 
     stub_most_popular_content("/a-random-path", taxon_content_ids, 0, "services")
     services = Supergroups::Services.new("/a-random-path", taxon_content_ids, {})
-    assert_nil services.tagged_content
+    assert_equal [], services.tagged_content
   end
 
   test "tagged_content returns hash with with 2 featured items and 0 normal items with 2 results" do
@@ -23,18 +23,16 @@ class ServicesTest < ActiveSupport::TestCase
 
     services = Supergroups::Services.new("/a-random-path", taxon_content_ids, {})
 
-    assert_equal 0, services.tagged_content[:documents].count
-    assert_equal 2, services.tagged_content[:promoted_content].count
+    assert_equal 2, services.tagged_content.count
   end
 
   test "tagged_content returns hash with with 3 featured items and 2 normal items if there are enough results" do
     taxon_content_ids = ['any-old-taxon', 'some-other-taxon-id']
 
-    stub_most_popular_content("/a-random-path", taxon_content_ids, 5, "services")
+    stub_most_popular_content("/a-random-path", taxon_content_ids, 3, "services")
 
     services = Supergroups::Services.new("/a-random-path", taxon_content_ids, {})
 
-    assert_equal 2, services.tagged_content[:documents].count
-    assert_equal 3, services.tagged_content[:promoted_content].count
+    assert_equal 3, services.tagged_content.count
   end
 end

--- a/test/support/content_pages_nav_test_helper.rb
+++ b/test/support/content_pages_nav_test_helper.rb
@@ -154,9 +154,5 @@ module ContentPagesNavTestHelper
     assert page.has_css?('.gem-c-image-card__title-link[data-track-category="newsAndCommunicationsImageCardClicked"]', text: 'Free school meals form')
     assert page.has_css?('.gem-c-image-card__title-link[data-track-action="1"]', text: 'Free school meals form')
     assert page.has_css?('.gem-c-image-card__title-link[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
-
-    assert page.has_css?('.gem-c-document-list__item a[data-track-category="newsAndCommunicationsDocumentListClicked"]', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-document-list__item a[data-track-action="1"]', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-document-list__item a[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
   end
 end

--- a/test/support/content_pages_nav_test_helper.rb
+++ b/test/support/content_pages_nav_test_helper.rb
@@ -7,6 +7,8 @@ module ContentPagesNavTestHelper
         "content_store_document_type": "form",
         "link": "/government/publications/meals",
         "title": "Free school meals form",
+        "public_timestamp": "2018-01-02T03:04:05Z",
+        "image_url": "https://assets.gov.uk/pertinent-image.gif",
       )
     end
 
@@ -117,7 +119,7 @@ module ContentPagesNavTestHelper
   def assert_has_services_section
     assert page.has_css?('h3', text: "Services")
     assert page.has_css?('.gem-c-highlight-boxes__title', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-highlight-boxes__title[data-track-category="ServicesHighlightBoxClicked"]', text: 'Free school meals form')
+    assert page.has_css?('.gem-c-highlight-boxes__title[data-track-category="servicesHighlightBoxClicked"]', text: 'Free school meals form')
     assert page.has_css?('.gem-c-highlight-boxes__title[data-track-action="1"]', text: 'Free school meals form')
     assert page.has_css?('.gem-c-highlight-boxes__title[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
   end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -9,13 +9,26 @@ module RummagerHelpers
     stub_for_taxon_and_supergroup(reject_link, taxon_content_ids, results, supergroup, "-popularity")
   end
 
+  def stub_rummager_document_without_image_url
+    result = rummager_document_for_supergroup_section("doc-with-no-url", "news_story", false)
+    Services.rummager.stubs(:search)
+      .returns(
+        "results" => [result],
+        "start" => 0,
+        "total" => 1
+      )
+  end
+
   def stub_for_taxon_and_supergroup(reject_link, content_ids, results, filter_content_purpose_supergroup, order_by)
-    fields = %w(title
-                link
-                description
-                content_store_document_type
-                public_timestamp
-                organisations)
+    fields = %w(
+      content_store_document_type
+      description
+      image_url
+      link
+      organisations
+      public_timestamp
+      title
+    )
 
     params = {
         start: 0,
@@ -42,15 +55,17 @@ module RummagerHelpers
     end
   end
 
-  def rummager_document_for_supergroup_section(slug, content_store_document_type)
-    {
-        'title'                       => slug.titleize.humanize.to_s,
-        'link'                        => "/#{slug}",
-        'description'                 => 'A discription about tagged content',
-        'content_store_document_type' => content_store_document_type,
-        'public_timestamp'            => 1.hour.ago.iso8601,
-        'organisations'               => [{ 'title' => "#{content_store_document_type.humanize} Organisation Title" }]
+  def rummager_document_for_supergroup_section(slug, content_store_document_type, with_image_url = true)
+    document = {
+      'title'                       => slug.titleize.humanize.to_s,
+      'link'                        => "/#{slug}",
+      'description'                 => 'A description about tagged content',
+      'content_store_document_type' => content_store_document_type,
+      'public_timestamp'            => 1.hour.ago.iso8601,
+      'organisations'               => [{ 'title' => "#{content_store_document_type.humanize} Organisation Title" }]
     }
+    document['image_url'] = 'https://assets.testing.gov.uk/awesome-pic.jpg' if with_image_url
+    document
   end
 
   def assert_includes_params(expected_params)


### PR DESCRIPTION
This eliminates up to three calls to content store for each page's navigation.

To do this we need to add image_url to the fields that rummager returns.

We can remove the alt text for images that are links because the link text is more relevant (and is preferred by browsers anyway).

We then need a default image in case the content doesn't have an image (not all do).

After rebasing on top of https://github.com/alphagov/government-frontend/pull/1043 and https://github.com/alphagov/government-frontend/pull/1032 it became clear that we can remove some things from the `news_and_communications` and `services` as they don't need to have content split into `promoted` and `tagged` content any more as they only display it in one form now.

I've therefore removed the `promoted` sections from these presenters which allows us to simplify some things and delete a bunch of code.

---

https://government-frontend-pr-1042.herokuapp.com/apply-apprenticeship
