### PR TITLE
Reduce number of related links to 3 as default

### DIFF
--- a/app/services/most_popular_content.rb
+++ b/app/services/most_popular_content.rb
@@ -5,7 +5,7 @@ class MostPopularContent
 
   attr_reader :content_ids, :current_path, :filter_content_purpose_supergroup, :number_of_links
 
-  def initialize(content_ids:, current_path:, filter_content_purpose_supergroup:, number_of_links: 5)
+  def initialize(content_ids:, current_path:, filter_content_purpose_supergroup:, number_of_links: 3)
     @content_ids = content_ids
     @current_path = current_path
     @filter_content_purpose_supergroup = filter_content_purpose_supergroup

--- a/app/services/most_recent_content.rb
+++ b/app/services/most_recent_content.rb
@@ -1,7 +1,7 @@
 class MostRecentContent
   attr_reader :content_id, :current_path, :filter_taxon, :number_of_links
 
-  def initialize(content_ids:, current_path:, filter_content_purpose_supergroup:, number_of_links: 5)
+  def initialize(content_ids:, current_path:, filter_content_purpose_supergroup:, number_of_links: 3)
     @content_ids = content_ids
     @current_path = current_path
     @filter_content_purpose_supergroup = filter_content_purpose_supergroup

--- a/app/views/shared/_taxonomy_navigation.html.erb
+++ b/app/views/shared/_taxonomy_navigation.html.erb
@@ -45,10 +45,6 @@
           inverse: true,
           items: taxonomy_navigation[:services][:promoted_content]
         } %>
-
-        <%= render "govuk_publishing_components/components/document_list", {
-          items: taxonomy_navigation[:services][:documents]
-        } %>
       </div>
     <% end %>
 
@@ -93,10 +89,6 @@
           <% end %>
           </div>
         <% end %>
-
-        <%= render "govuk_publishing_components/components/document_list", {
-          items: taxonomy_navigation[:news_and_communication][:documents]
-        } %>
       </div>
     <% end %>
 

--- a/test/integration/content_pages_navigation_test.rb
+++ b/test/integration/content_pages_navigation_test.rb
@@ -92,10 +92,6 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
     assert page.has_css?('.gem-c-highlight-boxes__title[data-track-category="ServicesHighlightBoxClicked"]', text: 'Free school meals form')
     assert page.has_css?('.gem-c-highlight-boxes__title[data-track-action="1"]', text: 'Free school meals form')
     assert page.has_css?('.gem-c-highlight-boxes__title[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
-
-    assert page.has_css?('.gem-c-document-list__item a[data-track-category="ServicesDocumentListClicked"]', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-document-list__item a[data-track-action="1"]', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-document-list__item a[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
   end
 
   test "does not show the Services section if there is no tagged content" do
@@ -216,10 +212,6 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
     assert page.has_css?('.gem-c-image-card__title-link[data-track-category="newsAndCommunicationsImageCardClicked"]', text: 'Free school meals form')
     assert page.has_css?('.gem-c-image-card__title-link[data-track-action="1"]', text: 'Free school meals form')
     assert page.has_css?('.gem-c-image-card__title-link[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
-
-    assert page.has_css?('.gem-c-document-list__item a[data-track-category="newsAndCommunicationsDocumentListClicked"]', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-document-list__item a[data-track-action="1"]', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-document-list__item a[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
   end
 
   test "does not show the News and comms section if there is no tagged content" do

--- a/test/services/most_popular_content_test.rb
+++ b/test/services/most_popular_content_test.rb
@@ -38,8 +38,8 @@ class MostPopularContentTest < ActiveSupport::TestCase
     end
   end
 
-  test 'requests five results by default' do
-    assert_includes_params(count: 5) do
+  test 'requests three results by default' do
+    assert_includes_params(count: 3) do
       most_popular_content.fetch
     end
   end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -19,7 +19,7 @@ module RummagerHelpers
 
     params = {
         start: 0,
-        count: 5,
+        count: 3,
         fields: fields,
         filter_part_of_taxonomy_tree: content_ids,
         order: order_by,


### PR DESCRIPTION
**Previously default was 5, now changed to 3**

---

![screen shot 2018-08-14 at 09 53 29](https://user-images.githubusercontent.com/6651749/44082006-0cf6d162-9fa8-11e8-8e38-0c1f8c4ac508.png)

Examples:
You will need to have an extension like ModHeader installed in your browser to see the B Variant. The values should be:
Request Header Name: GOVUK-ABTest-ContentPagesNav
Request Header Value: B

- [Tagged to one taxon](https://government-frontend-pr-1043.herokuapp.com/apply-apprenticeship)

- [Tagged to multiple taxons](https://government-frontend-pr-1043.herokuapp.com/government/publications/esfa-update-18-july-2018)

- [Tagged to a taxon without services](https://government-frontend-pr-1043.herokuapp.com/government/publications/working-together-to-safeguard-children--2)

- [Not tagged to any taxons](https://government-frontend-pr-1043.herokuapp.com/government/case-studies/hard-lines)

- [HTML Publication](https://government-frontend-pr-1043.herokuapp.com/government/publications/budget-2016-documents/budget-2016)

Component guide for this PR:
https://government-frontend-pr-1043.herokuapp.com/component-guide

https://trello.com/c/75LmThvF
