### PR TITLE
Add logging of variant for navigation test

### DIFF
--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,0 +1,5 @@
+if Object.const_defined?('LogStasher') && LogStasher.enabled
+  LogStasher.add_custom_fields do |fields|
+    fields[:govuk_content_pages_variant] = request.headers['GOVUK-ABTest-ContentPagesNav']
+  end
+end


### PR DESCRIPTION
This will enable us to determine which variant a log entry refers to.  This will help with allowing us to measure performance and track errors.

This is similar to [an equivalent thing in content store](https://github.com/alphagov/content-store/blob/master/config/initializers/logstasher.rb)

https://trello.com/c/CNGGgjcB/129-add-logging-of-ab-test-variant