### PR TITLE
Render news items within a list

### DIFF
--- a/app/views/shared/_taxonomy_navigation.html.erb
+++ b/app/views/shared/_taxonomy_navigation.html.erb
@@ -72,9 +72,9 @@
           margin_bottom: 2
         } %>
 
-        <div class="grid-row">
+        <ul class="grid-row">
           <% taxonomy_navigation[:news_and_communications].each do |promo| %>
-            <div class="column-one-third">
+            <li class="column-one-third taxonomy-navigation__list-item">
               <%= render "govuk_publishing_components/components/image_card", {
                 context: promo[:image][:context],
                 href: promo[:link][:path],
@@ -83,9 +83,9 @@
                 heading_level: 0,
                 href_data_attributes: promo[:link][:data_attributes]
                 } %>
-            </div>
+            </li>
           <% end %>
-        </div>
+        </ul>
       </div>
     <% end %>
 

--- a/test/support/content_pages_nav_test_helper.rb
+++ b/test/support/content_pages_nav_test_helper.rb
@@ -169,9 +169,9 @@ module ContentPagesNavTestHelper
 
   def assert_has_news_and_communications_section
     assert page.has_css?('h3', text: "News and communications")
-    assert page.has_css?('.gem-c-image-card__title', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-image-card__title-link[data-track-category="newsAndCommunicationsImageCardClicked"]', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-image-card__title-link[data-track-action="1"]', text: 'Free school meals form')
-    assert page.has_css?('.gem-c-image-card__title-link[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
+    assert page.has_css?('ul li .gem-c-image-card__title', text: 'Free school meals form')
+    assert page.has_css?('ul li .gem-c-image-card__title-link[data-track-category="newsAndCommunicationsImageCardClicked"]', text: 'Free school meals form')
+    assert page.has_css?('ul li .gem-c-image-card__title-link[data-track-action="1"]', text: 'Free school meals form')
+    assert page.has_css?('ul li .gem-c-image-card__title-link[data-track-label="/government/publications/meals"]', text: 'Free school meals form')
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/kstnTmJZ/131-render-news-items-in-a-list

We should be rendering the News and Communication items within a list, not a div. This is semantically correct and more accessible. This shouldn't change how the items render visually:

<img width="998" alt="screen shot 2018-08-15 at 11 12 25" src="https://user-images.githubusercontent.com/29889908/44144014-d477101e-a07d-11e8-8cf8-434a12198be4.png">

Examples:
You will need to have an extension like ModHeader installed in your browser to see the B Variant. The values should be:
Request Header Name: GOVUK-ABTest-ContentPagesNav
Request Header Value: B

- [Tagged to one taxon](https://government-frontend-pr-1048.herokuapp.com/apply-apprenticeship)

- [Tagged to multiple taxons](https://government-frontend-pr-1048.herokuapp.com/government/publications/esfa-update-18-july-2018)

- [Tagged to a taxon without services](https://government-frontend-pr-1048.herokuapp.com/government/publications/working-together-to-safeguard-children--2)


