### PR TITLE
Catch rummager errors for navigation

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -13,6 +13,7 @@ module Services
   end
 
   def self.rummager
-    @rummager ||= GdsApi::Rummager.new(Plek.new.find("rummager"))
+    @rummager ||= GdsApi::Rummager.new(Plek.new.find("rummager"),
+      timeout: 2)
   end
 end

--- a/app/services/most_popular_content.rb
+++ b/app/services/most_popular_content.rb
@@ -18,6 +18,9 @@ class MostPopularContent
 
   def fetch
     search_response["results"]
+  rescue GdsApi::HTTPErrorResponse => e
+    GovukStatsd.increment("govuk_content_pages.most_popular.#{e.class.name.demodulize.downcase}")
+    []
   end
 
 private

--- a/app/services/most_recent_content.rb
+++ b/app/services/most_recent_content.rb
@@ -14,6 +14,9 @@ class MostRecentContent
 
   def fetch
     search_response["results"]
+  rescue GdsApi::HTTPErrorResponse => e
+    GovukStatsd.increment("govuk_content_pages.most_recent.#{e.class.name.demodulize.downcase}")
+    []
   end
 
 private

--- a/test/services/most_popular_content_test.rb
+++ b/test/services/most_popular_content_test.rb
@@ -32,6 +32,13 @@ class MostPopularContentTest < ActiveSupport::TestCase
     assert_equal(results.count, 2)
   end
 
+  test 'catches api errors' do
+    Services.rummager.stubs(:search).raises(GdsApi::HTTPErrorResponse.new(500))
+    results = most_popular_content.fetch
+
+    assert_equal(results, [])
+  end
+
   test 'starts from the first page' do
     assert_includes_params(start: 0) do
       most_popular_content.fetch

--- a/test/services/most_recent_content_test.rb
+++ b/test/services/most_recent_content_test.rb
@@ -13,6 +13,13 @@ class MostRecentContentTest < ActiveSupport::TestCase
     )
   end
 
+  test 'catches api errors' do
+    Services.rummager.stubs(:search).raises(GdsApi::HTTPErrorResponse.new(500))
+    results = most_recent_content.fetch
+
+    assert_equal(results, [])
+  end
+
   def taxon_content_ids
     ['c3c860fc-a271-4114-b512-1c48c0f82564', 'ff0e8e1f-4dea-42ff-b1d5-f1ae37807af2']
   end


### PR DESCRIPTION
We reduce the timeout for rummager queries to 2 seconds.  If they go above 2 secs for all of the queries we risk timing out the whole page which is not good. (They are generally well below this 99th %ile is at 300ms, 50th %ile is at 21ms when running on staging at double our expected load)

In addition, we catch any errors returned from the api call and set the results to empty so that we can render what we need to.

We send metrics of these errors to Graphite so we can analyse them later.

https://trello.com/c/CNGGgjcB/129-add-logging-of-ab-test-variant