### PR TITLE
Set language within navigation sections

### DIFF
--- a/app/views/shared/_taxonomy_navigation.html.erb
+++ b/app/views/shared/_taxonomy_navigation.html.erb
@@ -1,5 +1,5 @@
 <% if taxonomy_navigation.values().flatten.any? %>
-  <div class="taxonomy-navigation" data-module="track-click">
+  <div class="taxonomy-navigation" data-module="track-click" lang="en">
     <div class="taxonomy-navigation__row">
       <div class="taxonomy-navigation__column">
         <%= render "govuk_publishing_components/components/heading",

--- a/test/integration/content_pages_navigation_test.rb
+++ b/test/integration/content_pages_navigation_test.rb
@@ -426,6 +426,15 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "ContentPagesNav variant B language is set to en" do
+    stub_rummager
+    setup_variant_b
+
+    setup_and_visit_content_item_with_taxons('guide', SINGLE_TAXON)
+
+    assert page.has_css?('.taxonomy-navigation[lang="en"]')
+  end
+
   def stub_empty_services
     Supergroups::Services.any_instance.stubs(:tagged_content).returns({})
   end


### PR DESCRIPTION
- Taxonomy Navigation language is set to English
- Rummager search result is mostly English
