### PR TITLE
Fix intermittent failing test

### DIFF
--- a/test/integration/links_out_config_test.rb
+++ b/test/integration/links_out_config_test.rb
@@ -33,7 +33,7 @@ class LinksOutConfigTest < ActionDispatch::IntegrationTest
   end
 
   def taxon_config
-    Rails.configuration.taxonomy_navigation_links_out || YAML.load(File.read("config/taxonomy_navigation_links_out.yml"))["default"]
+    Rails.configuration.taxonomy_navigation_links_out || YAML.safe_load(File.read("config/taxonomy_navigation_links_out.yml"))["default"]
   end
 
   def expected_supergroups(rule_level)

--- a/test/integration/links_out_config_test.rb
+++ b/test/integration/links_out_config_test.rb
@@ -32,8 +32,8 @@ class LinksOutConfigTest < ActionDispatch::IntegrationTest
     }
   end
 
-  def config
-    Rails.configuration.taxonomy_navigation_links_out
+  def taxon_config
+    Rails.configuration.taxonomy_navigation_links_out || YAML.load(File.read("config/taxonomy_navigation_links_out.yml"))["default"]
   end
 
   def expected_supergroups(rule_level)
@@ -52,10 +52,10 @@ class LinksOutConfigTest < ActionDispatch::IntegrationTest
     stub_rummager
     setup_variant_b
     using_wait_time 10 do
-      config.each_key do |taxonomy_rule_level|
-        config[taxonomy_rule_level].each_key do |rules_for_taxon|
+      taxon_config.each_key do |taxonomy_rule_level|
+        taxon_config[taxonomy_rule_level].each_key do |rules_for_taxon|
           setup_and_visit_content_item_with_taxonomy_grouping("guide", taxonomy_rule_level => rules_for_taxon)
-          expected_supergroups = expected_supergroups(config[taxonomy_rule_level][rules_for_taxon])
+          expected_supergroups = expected_supergroups(taxon_config[taxonomy_rule_level][rules_for_taxon])
           if expected_supergroups.any?
             assert_has_supergroup_navigation(expected_supergroups)
           else

--- a/test/integration/links_out_config_test.rb
+++ b/test/integration/links_out_config_test.rb
@@ -51,14 +51,16 @@ class LinksOutConfigTest < ActionDispatch::IntegrationTest
   test "links out configuration causes no errors and correct supergroups are displayed for each ruleset" do
     stub_rummager
     setup_variant_b
-    config.each_key do |taxonomy_rule_level|
-      config[taxonomy_rule_level].each_key do |rules_for_taxon|
-        setup_and_visit_content_item_with_taxonomy_grouping("guide", taxonomy_rule_level => rules_for_taxon)
-        expected_supergroups = expected_supergroups(config[taxonomy_rule_level][rules_for_taxon])
-        if expected_supergroups.any?
-          assert_has_supergroup_navigation(expected_supergroups)
-        else
-          refute page.has_css?('taxonomy-navigation')
+    using_wait_time 10 do
+      config.each_key do |taxonomy_rule_level|
+        config[taxonomy_rule_level].each_key do |rules_for_taxon|
+          setup_and_visit_content_item_with_taxonomy_grouping("guide", taxonomy_rule_level => rules_for_taxon)
+          expected_supergroups = expected_supergroups(config[taxonomy_rule_level][rules_for_taxon])
+          if expected_supergroups.any?
+            assert_has_supergroup_navigation(expected_supergroups)
+          else
+            refute page.has_css?('taxonomy-navigation')
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes intermittently failing test. HTML dumps show the content was being rendered but the assertion was still failing. Making capybara wait slightly longer, only in this test, while making an assertion fixes the tests (locally at least). Additionally, fixes occasional error when the rails config isn't loaded

More information on why this occurs:
https://spin.atomicobject.com/2012/04/27/intermittent-test-failures/
In the section entitled "Not waiting long enough"


---

Visual regression results:
https://government-frontend-pr-1052.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1052.herokuapp.com/component-guide
