### PR TITLE
HUB-167: Fix for a broken reference to the track function

### DIFF
--- a/app/assets/javascripts/modules/track-radio-group.js
+++ b/app/assets/javascripts/modules/track-radio-group.js
@@ -38,14 +38,18 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         dataType: 'jsonp',
         timeout: 3000
       }).then(function(data){
-          GOVUK.Modules.TrackRadioGroup.trackVerifyUser(element, data);
+          reportVerifyUser(element, data);
       }, function(e){console.log("error", e)})
     }
 
     this.trackVerifyUser = function (element, data) {
-        if (data != null && data.value === true) {
-            GOVUK.analytics.trackEvent('verify-hint', 'shown', { transport: 'beacon'});
-            track(element, data.value);
+      reportVerifyUser(element, data);
+    }
+
+    function reportVerifyUser(element, data) {
+      if (data != null && data.value === true) {
+        GOVUK.analytics.trackEvent('verify-hint', 'shown', { transport: 'beacon'});
+        track(element, data.value);
       }
     }
   }


### PR DESCRIPTION
Fixed the undefined function error by extracting the function. Looks a bit ugly but allows
for better unit testing. Refactor suggestions are welcome.

Co-Authored-By: Rachel Smith <rachel.smith@digital.cabinet-office.gov.uk>

---

Visual regression results:
https://government-frontend-pr-1053.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1053.herokuapp.com/component-guide
