### PR TITLE
Add tracking for our new taxonomy navigation

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -91,20 +91,39 @@ private
                                .map { |document_collection| document_collection.values_at('base_path', 'title') }
 
       # Fetch link attributes of parent step by steps required to render the top navigation banner
-      @banner_items = @content_item
+      step_by_step_links = @content_item
                         .content_item
                         .dig('links', 'part_of_step_navs')
                         .yield_self { |part_of_step_navs| part_of_step_navs || [] }
                         .sort_by { |step_by_step_nav| step_by_step_nav['title'] }
                         .map { |step_by_step_nav| step_by_step_nav.values_at('title', 'base_path') }
+      @banner_items = format_banner_links(step_by_step_links, "Step by Step")
 
       # Append link attributes of parent taxons to our collections of items for the top navigation banner if the
-      # content item is tagged to more than one taxon. If their is only one taxon a breadcrumb will be used instead.
+      # content item is tagged to more than one taxon. If there is only one taxon a breadcrumb will be used instead.
       if taxons.many?
-        @banner_items += taxons
+        taxon_links = taxons
                            .sort_by { |taxon| taxon[:taxon_name] }
                            .map { |taxon| taxon.values_at('title', 'base_path') }
+        @banner_items += format_banner_links(taxon_links, "Taxon")
       end
+    end
+  end
+
+  def format_banner_links(links, type)
+    links.each.with_index(1).map do |(title, base_path), index|
+      view_context.link_to(
+        title,
+        base_path,
+        data: {
+          "track-category": "relatedTaxonomyLinkClicked",
+          "track-action": "1.#{index} #{type}",
+          "track-label": base_path,
+          "track-options": {
+            dimension29: title
+          }
+        }
+      )
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,23 +60,24 @@
       <% end %>
 
       <% if @banner_items.present? %>
-        <% banner_links = @banner_items.map { |title, path| link_to title, path } %>
-        <div class="taxonomy-navigation__banner" data-module="gem-toggle">
+        <div class="taxonomy-navigation__banner" data-module="track-click">
           <% if @banner_items.size <= 2 %>
-            <p>This page is part of <%= banner_links.take(2).to_sentence.html_safe %></p>
+            <p>This page is part of <%= @banner_items.take(2).to_sentence.html_safe %></p>
           <% else %>
-            <% featured_banner_link, *other_banner_links = banner_links %>
-            <p>
-              This page is part of <%= featured_banner_link %>
-              and <%= pluralize(other_banner_links.size, 'other') %>
-              <a href="#"
-                 data-controls="toggle_taxonomy-navigation__banner-extra"
-                 data-expanded="false"
-                 data-toggled-text="&minus; hide all">+ show all</a>
-            </p>
-            <p id="toggle_taxonomy-navigation__banner-extra" class="js-hidden">
-              <%= other_banner_links.to_sentence.html_safe %>
-            </p>
+            <% featured_banner_link, *other_banner_links = @banner_items %>
+            <div data-module="gem-toggle">
+              <p>
+                This page is part of <%= featured_banner_link %>
+                and <%= pluralize(other_banner_links.size, 'other') %>
+                <a href="#"
+                  data-controls="toggle_taxonomy-navigation__banner-extra"
+                  data-expanded="false"
+                  data-toggled-text="&minus; hide all">+ show all</a>
+              </p>
+              <p id="toggle_taxonomy-navigation__banner-extra" class="js-hidden">
+                <%= other_banner_links.to_sentence.html_safe %>
+              </p>
+            </div>
           <% end %>
         </div>
       <% end %>

--- a/app/views/shared/_taxonomy_navigation.html.erb
+++ b/app/views/shared/_taxonomy_navigation.html.erb
@@ -3,13 +3,25 @@
     <div class="taxonomy-navigation__row">
       <div class="taxonomy-navigation__column">
         <%= render "govuk_publishing_components/components/heading",
-                   text: t('supergroups.topics'),
-                   heading_level: 2,
-                   font_size: 19 %>
+          text: t('supergroups.topics'),
+          heading_level: 2,
+          font_size: 19
+        %>
         <ul>
-          <% tagged_taxons.each do |tagged_taxon| %>
+          <% tagged_taxons.each_with_index do |tagged_taxon, index| %>
             <li class="taxonomy-navigation__list-item">
-              <%= link_to tagged_taxon[:taxon_name], tagged_taxon[:taxon_link] %>
+              <%= link_to(
+                tagged_taxon[:taxon_name],
+                tagged_taxon[:taxon_link],
+                data: {
+                  "track-category": "relatedTaxonomyLinkClicked",
+                  "track-action": "1.#{index} Topics",
+                  "track-label": tagged_taxon[:taxon_link],
+                  "track-options": {
+                    dimension29: tagged_taxon[:taxon_name]
+                  }
+                }
+              ) %>
             </li>
           <% end %>
         </ul>
@@ -22,9 +34,20 @@
                      heading_level: 2,
                      font_size: 19 %>
           <ul>
-            <% related_collections.each do |base_path, title| %>
+            <% related_collections.each_with_index do |collection, index| %>
               <li class="taxonomy-navigation__list-item">
-                <%= link_to title, base_path %>
+                <%= link_to(
+                  collection[1],
+                  collection[0],
+                  data: {
+                    "track-category": "relatedTaxonomyLinkClicked",
+                    "track-action": "2.#{index} Collections",
+                    "track-label": collection[0],
+                    "track-options": {
+                      dimension29: collection[1]
+                    }
+                  }
+                ) %>
               </li>
             <% end %>
           </ul>

--- a/test/integration/content_pages_navigation_test.rb
+++ b/test/integration/content_pages_navigation_test.rb
@@ -337,7 +337,20 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "ContentPagesNav variant B shows home breadcrumb when a page belongs to a two topics and a step by step" do
+  test "ContentPagesNav variant B has tracking on banner links for single topic and a step by step" do
+    stub_rummager
+    setup_variant_b
+
+    setup_and_visit_content_item_with_taxons('guide-with-step-navs', SINGLE_TAXON)
+
+    within('.taxonomy-navigation__banner') do
+      assert page.has_css?('a[data-track-category="relatedTaxonomyLinkClicked"]', text: 'Learn to drive a car: step by step')
+      assert page.has_css?('a[data-track-action="1.1 Step by Step"]', text: 'Learn to drive a car: step by step')
+      assert page.has_css?('a[data-track-label="/learn-to-drive-a-car"]')
+    end
+  end
+
+  test "ContentPagesNav variant B shows home breadcrumb when a page belongs to two topics and a step by step" do
     stub_rummager
     setup_variant_b
 
@@ -362,6 +375,23 @@ class ContentPagesNavigationTest < ActionDispatch::IntegrationTest
       assert page.has_css?('a', text: 'Learn to drive a car')
       assert page.has_css?('a', text: 'Becoming an apprentice')
       assert page.has_css?('a', text: 'Becoming a wizard')
+    end
+  end
+
+  test "ContentPagesNav variant B has tracking on banner links for two topics and a step by step" do
+    stub_rummager
+    setup_variant_b
+
+    setup_and_visit_content_item_with_taxons('guide-with-step-navs', TWO_TAXONS)
+
+    within('.taxonomy-navigation__banner') do
+      assert page.has_css?('a[data-track-category="relatedTaxonomyLinkClicked"]', text: 'Learn to drive a car: step by step')
+      assert page.has_css?('a[data-track-action="1.1 Step by Step"]', text: 'Learn to drive a car: step by step')
+      assert page.has_css?('a[data-track-label="/learn-to-drive-a-car"]')
+
+      assert page.has_css?('a[data-track-category="relatedTaxonomyLinkClicked"]', text: 'Becoming an apprentice')
+      assert page.has_css?('a[data-track-action="1.1 Taxon"]', text: 'Becoming an apprentice')
+      assert page.has_css?('a[data-track-label="/education/becoming-an-apprentice"]')
     end
   end
 

--- a/test/integration/content_pages_related_navigation_test.rb
+++ b/test/integration/content_pages_related_navigation_test.rb
@@ -16,6 +16,21 @@ class ContentPagesRelatedNavigationTest < ActionDispatch::IntegrationTest
     assert page.has_css?('.gem-c-related-navigation__sub-heading', text: 'Collection')
   end
 
+  test "ContentPagesNav variant B shows tagged taxons in the taxonomy navigation" do
+    stub_rummager
+    setup_variant_b
+
+    setup_and_visit_content_item_with_taxons('case_study', SINGLE_TAXON)
+
+    within '.taxonomy-navigation' do
+      assert page.has_css?('.gem-c-heading', text: 'Topics')
+      assert page.has_css?('.taxonomy-navigation__list-item a', text: 'Becoming an apprentice')
+      assert page.has_css?('.taxonomy-navigation__list-item a[data-track-category="relatedTaxonomyLinkClicked"]', text: 'Becoming an apprentice')
+      assert page.has_css?('.taxonomy-navigation__list-item a[data-track-action="1.0 Topics"]', text: 'Becoming an apprentice')
+      assert page.has_css?('.taxonomy-navigation__list-item a[data-track-label="/education/becoming-an-apprentice"]')
+    end
+  end
+
   test "ContentPagesNav variant B shows related collections in the taxonomy navigation" do
     stub_rummager
     setup_variant_b
@@ -24,6 +39,10 @@ class ContentPagesRelatedNavigationTest < ActionDispatch::IntegrationTest
 
     within '.taxonomy-navigation' do
       assert page.has_css?('.gem-c-heading', text: 'Collections')
+      assert page.has_css?('.taxonomy-navigation__list-item a', text: 'Work Programme real life stories')
+      assert page.has_css?('.taxonomy-navigation__list-item a[data-track-category="relatedTaxonomyLinkClicked"]', text: 'Work Programme real life stories')
+      assert page.has_css?('.taxonomy-navigation__list-item a[data-track-action="2.0 Collections"]', text: 'Work Programme real life stories')
+      assert page.has_css?('.taxonomy-navigation__list-item a[data-track-label="/government/collections/work-programme-real-life-stories"]')
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/CALq4uG8/132-add-tracking-for-ab-test

Adds Google Analytics tracking to Topic, Collection, related taxon and step by step links.

Banner with taxon and step by step links:
<img width="973" alt="screen shot 2018-08-15 at 16 01 16" src="https://user-images.githubusercontent.com/29889908/44155171-7994abe4-a0a4-11e8-82c3-f97d2cef0d5f.png">

Topic & Collection links:
<img width="976" alt="screen shot 2018-08-15 at 16 01 21" src="https://user-images.githubusercontent.com/29889908/44155176-7cf22096-a0a4-11e8-8e9a-0803902bafbd.png">

## How to test
You will need to have an extension like ModHeader installed in your browser to see the B Variant. The values should be:
Request Header Name: GOVUK-ABTest-ContentPagesNav
Request Header Value: B

To see Google Analytics events firing in the Dev Tools console, you need an extension like [Google Analytics Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en)

- [Tagged to one taxon](https://government-frontend-pr-1054.herokuapp.com/apply-apprenticeship)

- [Tagged to multiple taxons](https://government-frontend-pr-1054.herokuapp.com/government/publications/esfa-update-18-july-2018)

- [Tagged to a taxon without services](https://government-frontend-pr-1054.herokuapp.com/government/publications/working-together-to-safeguard-children--2)

- [Not tagged to any taxons](https://government-frontend-pr-1054.herokuapp.com/government/case-studies/hard-lines)
