### PR TITLE
Fix spacing for notices in consultations

### DIFF
--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -110,6 +110,10 @@ class ConsultationPresenter < ContentItemPresenter
     ways_to_respond["attachment_url"]
   end
 
+  def add_margin?
+    final_outcome? || public_feedback_detail || public_feedback_documents?
+  end
+
 private
 
   def display_date_and_time(date, rollback_midnight = false)

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -31,7 +31,11 @@
       <% content_item_final_outcome = capture do %>
         Visit this page again soon to download the outcome to this public&nbsp;feedback.
       <% end %>
-      <%= render 'govuk_publishing_components/components/notice', title: 'We are analysing your feedback', description_text: content_item_final_outcome, margin_bottom: 0 %>
+      <%= render 'govuk_publishing_components/components/notice',
+        title: 'We are analysing your feedback',
+        description_text: content_item_final_outcome,
+        margin_bottom:(0 unless @content_item.add_margin?)
+      %>
 
     <% elsif @content_item.final_outcome? %>
       <%= render 'govuk_publishing_components/components/notice', title: 'This consultation has concluded' %>


### PR DESCRIPTION
When we replaced this with the notice component in the gem, we removed the bottom margin in all cases. This meant that sometimes, the heading of a section could appear directly underneath a notice with no spacing.

This fix introduces spacing in those cases, but adds a bottom margin when the notice is immediately followed by a banner item (as per the original design)

## Before
<img width="662" alt="screen shot 2018-08-16 at 11 00 21" src="https://user-images.githubusercontent.com/29889908/44202382-b8cb1d80-a143-11e8-8854-a8e45673620e.png">

## After
<img width="661" alt="screen shot 2018-08-16 at 11 00 33" src="https://user-images.githubusercontent.com/29889908/44202375-b5379680-a143-11e8-98fd-cfd84e8de010.png">

Consultation pages:

- [Open Consultation](https://government-frontend-pr-1056.herokuapp.com/government/consultations/fire-safety-clarification-of-statutory-guidance-approved-document-b)
- [Closed Consultation](https://government-frontend-pr-1056.herokuapp.com/government/consultations/home-offices-immigration-statistics-arrivals-data)
- [Closed Consultation with banner](https://government-frontend-pr-1056.herokuapp.com/government/consultations/tackling-the-plastic-problem)
- [Consultation Outcome](https://government-frontend-pr-1056.herokuapp.com/government/consultations/warm-home-discount-scheme-2018-to-2019)
