### PR TITLE
Fix intermittent failing tests

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -50,8 +50,7 @@ module GovernmentFrontend
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true
 
-    config.before_initialize do
-      config.taxonomy_navigation_links_out = config_for(:taxonomy_navigation_links_out)
-    end
+    # Load links out configuration for taxonomy navigation
+    config.taxonomy_navigation_links_out = config_for(:taxonomy_navigation_links_out)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,8 @@ module GovernmentFrontend
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true
 
-    config.taxonomy_navigation_links_out = config_for(:taxonomy_navigation_links_out)
+    config.before_initialize do
+      config.taxonomy_navigation_links_out = config_for(:taxonomy_navigation_links_out)
+    end
   end
 end

--- a/test/integration/links_out_config_test.rb
+++ b/test/integration/links_out_config_test.rb
@@ -3,66 +3,41 @@ require 'test_helper'
 class LinksOutConfigTest < ActionDispatch::IntegrationTest
   include ContentPagesNavTestHelper
   include GdsApi::TestHelpers::Rummager
+  include Capybara::Minitest::Assertions
 
-  def schema_type
-    "guide"
-  end
+  Rails.configuration.taxonomy_navigation_links_out.each do |name, group|
+    group.each do |level, rules|
+      test "links out configuration for #{name} #{level}" do
+        stub_rummager
+        setup_variant_b
 
-  def setup_variant_b
-    ContentItemsController.any_instance.stubs(:show_new_navigation?).returns(true)
-  end
+        content_example = get_example_guide_with_single_taxon
+        content_example[name] = level
 
-  def setup_and_visit_content_item_with_taxonomy_grouping(name, taxonomy_grouping)
-    taxonomy_grouping = default_taxonomy_grouping.merge(taxonomy_grouping)
-    @content_item = get_content_example(name).tap do |item|
-      item["links"]["taxons"] = SINGLE_TAXON
-      item["content_purpose_supergroup"] = taxonomy_grouping["content_purpose_supergroup"]
-      item["content_purpose_subgroup"] = taxonomy_grouping["content_purpose_subgroup"]
-      item["document_type"] = taxonomy_grouping["document_type"]
-      content_store_has_item(item["base_path"], item.to_json)
-      visit_with_cachebust(item["base_path"])
-    end
-  end
+        content_store_has_item content_example['base_path'], content_example.to_json
+        visit_with_cachebust content_example['base_path']
 
-  def default_taxonomy_grouping
-    {
-        "content_purpose_supergroup" => "guidance_and_regulation",
-        "content_purpose_subgroup" => "guidance",
-        "document_type" => "guide"
-    }
-  end
-
-  def taxon_config
-    Rails.configuration.taxonomy_navigation_links_out
-  end
-
-  def expected_supergroups(rule_level)
-    rule_level.map { |rules| rules["supergroup"].humanize }
-  end
-
-  def assert_has_supergroup_navigation(expected_supergroups)
-    within('.taxonomy-navigation') do
-      expected_supergroups.each do |supergroup|
-        assert page.has_css?('.gem-c-heading', text: supergroup)
-      end
-    end
-  end
-
-  test "links out configuration causes no errors and correct supergroups are displayed for each ruleset" do
-    stub_rummager
-    setup_variant_b
-    using_wait_time 30 do
-      taxon_config.each_key do |taxonomy_rule_level|
-        taxon_config[taxonomy_rule_level].each_key do |rules_for_taxon|
-          setup_and_visit_content_item_with_taxonomy_grouping("guide", taxonomy_rule_level => rules_for_taxon)
-          expected_supergroups = expected_supergroups(taxon_config[taxonomy_rule_level][rules_for_taxon])
-          if expected_supergroups.any?
-            assert_has_supergroup_navigation(expected_supergroups)
-          else
-            refute page.has_css?('.taxonomy-navigation')
+        if rules.empty?
+          refute_css '.taxonomy-navigation'
+        else
+          rules.each do |rule|
+            assert_css '.taxonomy-navigation .gem-c-heading', text: rule['supergroup'].humanize
           end
         end
       end
     end
+  end
+
+  def get_example_guide_with_single_taxon
+    get_content_example_by_schema_and_name('guide', 'guide').tap do |item|
+      item['content_purpose_subgroup'] = 'guidance'
+      item['content_purpose_supergroup'] = 'guidance_and_regulation'
+      item['document_type'] = 'guide'
+      item['links']['taxons'] = SINGLE_TAXON
+    end
+  end
+
+  def setup_variant_b
+    ContentItemsController.any_instance.stubs(:show_new_navigation?).returns(true)
   end
 end

--- a/test/integration/links_out_config_test.rb
+++ b/test/integration/links_out_config_test.rb
@@ -33,7 +33,7 @@ class LinksOutConfigTest < ActionDispatch::IntegrationTest
   end
 
   def taxon_config
-    Rails.configuration.taxonomy_navigation_links_out || YAML.safe_load(File.read("config/taxonomy_navigation_links_out.yml"))["default"]
+    Rails.configuration.taxonomy_navigation_links_out
   end
 
   def expected_supergroups(rule_level)
@@ -59,7 +59,7 @@ class LinksOutConfigTest < ActionDispatch::IntegrationTest
           if expected_supergroups.any?
             assert_has_supergroup_navigation(expected_supergroups)
           else
-            refute page.has_css?('taxonomy-navigation')
+            refute page.has_css?('.taxonomy-navigation')
           end
         end
       end

--- a/test/integration/links_out_config_test.rb
+++ b/test/integration/links_out_config_test.rb
@@ -51,7 +51,7 @@ class LinksOutConfigTest < ActionDispatch::IntegrationTest
   test "links out configuration causes no errors and correct supergroups are displayed for each ruleset" do
     stub_rummager
     setup_variant_b
-    using_wait_time 10 do
+    using_wait_time 30 do
       taxon_config.each_key do |taxonomy_rule_level|
         taxon_config[taxonomy_rule_level].each_key do |rules_for_taxon|
           setup_and_visit_content_item_with_taxonomy_grouping("guide", taxonomy_rule_level => rules_for_taxon)

--- a/test/presenters/content_item/links_out_test.rb
+++ b/test/presenters/content_item/links_out_test.rb
@@ -80,7 +80,7 @@ class LinksOutTest < ActiveSupport::TestCase
   end
 
   def stub_load_rules(rules)
-    Rails.configuration.taxonomy_navigation_links_out = rules
+    Rails.configuration.stubs(:taxonomy_navigation_links_out).returns(rules)
   end
 
   def assert_has_supergroup_rule(rule_set)


### PR DESCRIPTION

Improves further on PR #1052. Moved custom configuration to a before_initialize block which seems to solve a problem with the config not being available in test environment. Based on the following stackoverflow post

https://stackoverflow.com/a/44770663

![screenshot-stackoverflow com-2018 08 16-14-06-26](https://user-images.githubusercontent.com/41049800/44211053-02296600-a160-11e8-941b-c192df9d8887.png)

Trello: https://trello.com/c/toblYkmD/133-investigate-and-fix-failing-tests-on-government-frontend

---

Visual regression results:
https://government-frontend-pr-1057.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1057.herokuapp.com/component-guide
