### PR TITLE
Show step by step sidebar on Whitehall content

### DIFF
--- a/app/controllers/concerns/content_pages_nav_ab_testable.rb
+++ b/app/controllers/concerns/content_pages_nav_ab_testable.rb
@@ -51,6 +51,8 @@ module ContentPagesNavAbTestable
   end
 
   def should_show_sidebar?
-    content_pages_nav_test_variant.variant?("A") || @content_item.content_item.parsed_content['publishing_app'] != "whitehall"
+    content_pages_nav_test_variant.variant?("A") ||
+      @content_item.step_by_steps.present? ||
+      @content_item.content_item.parsed_content['publishing_app'] != "whitehall"
   end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -12,6 +12,7 @@ class ContentItemPresenter
               :phase,
               :part_slug,
               :document_type,
+              :step_by_steps,
               :taxons
 
   attr_accessor :include_collections_in_other_publisher_metadata
@@ -27,6 +28,7 @@ class ContentItemPresenter
     @phase = content_item["phase"]
     @document_type = content_item["document_type"]
     @taxons = content_item["links"]["taxons"] if content_item["links"]
+    @step_by_steps = content_item["links"]["part_of_step_navs"] if content_item["links"]
     @part_slug = requesting_a_part? ? requested_content_item_path.split('/').last : nil
   end
 

--- a/test/controllers/content_pages_nav_ab_testable_test.rb
+++ b/test/controllers/content_pages_nav_ab_testable_test.rb
@@ -77,6 +77,14 @@ class ContentItemsControllerTest < ActionController::TestCase
     refute @controller.should_show_sidebar?
   end
 
+  test "should_show_sidebar? is true when tagged to a step by step even for whitehall content" do
+    content_item = content_store_has_schema_example("guide", "guide-with-step-navs").merge("publishing_app" => "whitehall")
+    setup_ab_variant("ContentPagesNav", "B")
+    get :show, params: { path: path_for(content_item) }
+
+    assert @controller.should_show_sidebar?
+  end
+
   def ensure_ab_test_is_correctly_setup(test_variant, content_item)
     content_store_has_item(content_item['base_path'], content_item)
 


### PR DESCRIPTION
We're hiding the sidebar on whitehall content in the AB test. The exception to
this is when it's a step by step.

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
