### PR TITLE
Thread content item links out and amend stubs

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -67,15 +67,9 @@ private
   def load_taxonomy_navigation
     if @content_item.taxons.present?
       current_base_path = @content_item.base_path
+      @taxonomy_navigation = @content_item.taxonomy_navigation(current_base_path)
+
       taxons = @content_item.taxons.select { |taxon| taxon["phase"] == "live" }
-      taxon_ids = taxons.map { |taxon| taxon["content_id"] }
-
-      @taxonomy_navigation = {}
-      @content_item.links_out_supergroups.each do |supergroup|
-        supergroup_taxon_links = "Supergroups::#{supergroup.camelcase}".constantize.new(current_base_path, taxon_ids, filter_content_purpose_subgroup: @content_item.links_out_subgroups)
-        @taxonomy_navigation[supergroup.to_sym] = supergroup_taxon_links.tagged_content
-      end
-
       @tagged_taxons = taxons.map do |taxon|
         {
           taxon_id: taxon["content_id"],

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -13,7 +13,7 @@ module Services
   end
 
   def self.rummager
-    @rummager ||= GdsApi::Rummager.new(Plek.new.find("rummager"),
+    GdsApi::Rummager.new(Plek.new.find("rummager"),
       timeout: 2)
   end
 end

--- a/app/presenters/content_item/taxonomy_navigation.rb
+++ b/app/presenters/content_item/taxonomy_navigation.rb
@@ -1,0 +1,28 @@
+module ContentItem
+  module TaxonomyNavigation
+    include LinksOut
+
+    def taxonomy_navigation(current_base_path)
+      taxons = @taxons.select { |taxon| taxon["phase"] == "live" }
+      taxon_ids = taxons.map { |taxon| taxon["content_id"] }
+      supergroup_taxon_links = []
+
+      links_out_supergroups.each do |supergroup|
+        content = "Supergroups::#{supergroup.camelcase}".constantize.new(current_base_path, taxon_ids, filter_content_purpose_subgroup: links_out_subgroups)
+        supergroup_taxon_link = { supergroup: supergroup.to_sym, content: content }
+        supergroup_taxon_links << supergroup_taxon_link
+      end
+
+      supergroup_taxon_links_threads = {}
+      supergroup_taxon_links.each do |supergroup_taxon_link|
+        supergroup_taxon_links_threads[supergroup_taxon_link[:supergroup]] = Thread.new { supergroup_taxon_link[:content].tagged_content }
+      end
+
+      taxonomy_navigation = {}
+      supergroup_taxon_links_threads.each_pair do |supergroup, content_thread|
+        taxonomy_navigation[supergroup] = content_thread.join.value
+      end
+      taxonomy_navigation
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,6 +1,6 @@
 class ContentItemPresenter
   include ContentItem::Withdrawable
-  include ContentItem::LinksOut
+  include ContentItem::TaxonomyNavigation
 
   attr_reader :content_item,
               :requested_content_item_path,

--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -1,11 +1,15 @@
 module Supergroups
   class GuidanceAndRegulation < Supergroup
-    def initialize(current_path, taxon_ids, filters)
-      super(current_path, taxon_ids, filters, MostPopularContent)
+    def tagged_content
+      content = fetch_content
+      format_document_data(content, include_timestamp: false)
     end
 
-    def tagged_content
-      format_document_data(@content, include_timestamp: false)
+  private
+
+    def fetch_content
+      return [] unless @taxon_ids.any?
+      MostPopularContent.fetch(content_ids: @taxon_ids, current_path: @current_path, filters: @filters)
     end
   end
 end

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -1,15 +1,11 @@
 module Supergroups
   class NewsAndCommunications < Supergroup
-    attr_reader :content
 
     PLACEHOLDER_IMAGE = "#{Plek.current.asset_root}/government/assets/placeholder.jpg".freeze
 
-    def initialize(current_path, taxon_ids, filters)
-      super(current_path, taxon_ids, filters, MostRecentContent)
-    end
-
     def tagged_content
-      format_document_data(@content)
+      content = fetch_content
+      format_document_data(content)
     end
 
   private
@@ -43,6 +39,11 @@ module Supergroups
 
     def context(document)
       "#{document_type(document)} - #{updated_date(document).strftime('%e %B %Y')}"
+    end
+
+    def fetch_content
+      return [] unless @taxon_ids.any?
+      MostRecentContent.fetch(content_ids: @taxon_ids, current_path: @current_path, filters: @filters)
     end
   end
 end

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -1,7 +1,10 @@
 module Supergroups
   class PolicyAndEngagement < Supergroup
-    def initialize(current_path, taxon_ids, filters)
-      super(current_path, taxon_ids, filters, MostRecentContent)
+  private
+
+    def fetch_content
+      return [] unless @taxon_ids.any?
+      MostRecentContent.fetch(content_ids: @taxon_ids, current_path: @current_path, filters: @filters)
     end
   end
 end

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -1,13 +1,15 @@
 module Supergroups
   class Services < Supergroup
-    attr_reader :content
-
-    def initialize(current_path, taxon_ids, filters)
-      super(current_path, taxon_ids, filters, MostPopularContent)
+    def tagged_content
+      content = fetch_content
+      format_document_data(content, data_category: "HighlightBoxClicked")
     end
 
-    def tagged_content
-      format_document_data(@content, data_category: "HighlightBoxClicked")
+  private
+
+    def fetch_content
+      return [] unless @taxon_ids.any?
+      MostPopularContent.fetch(content_ids: @taxon_ids, current_path: @current_path, filters: @filters)
     end
   end
 end

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -1,14 +1,17 @@
+require_relative "../../services/most_popular_content"
+require_relative "../../services/most_recent_content"
+
 module Supergroups
   class Supergroup
-    def initialize(current_path, taxon_ids, filters, content_order_class)
+    def initialize(current_path, taxon_ids, filters)
       @current_path = current_path
       @taxon_ids = taxon_ids
       @filters = default_filters.merge(filters)
-      @content = fetch_content(content_order_class)
     end
 
     def tagged_content
-      format_document_data(@content)
+      content = fetch_content
+      format_document_data(content)
     end
 
   private
@@ -60,11 +63,6 @@ module Supergroups
 
     def default_filters
       { filter_content_purpose_supergroup: self.class.name.demodulize.underscore }
-    end
-
-    def fetch_content(content_order_class)
-      return [] unless @taxon_ids.any?
-      content_order_class.fetch(content_ids: @taxon_ids, current_path: @current_path, filters: @filters)
     end
   end
 end

--- a/app/presenters/supergroups/transparency.rb
+++ b/app/presenters/supergroups/transparency.rb
@@ -1,7 +1,10 @@
 module Supergroups
   class Transparency < Supergroup
-    def initialize(current_path, taxon_ids, filters)
-      super(current_path, taxon_ids, filters, MostRecentContent)
+  private
+
+    def fetch_content
+      return [] unless @taxon_ids.any?
+      MostRecentContent.fetch(content_ids: @taxon_ids, current_path: @current_path, filters: @filters)
     end
   end
 end

--- a/app/services/most_popular_content.rb
+++ b/app/services/most_popular_content.rb
@@ -1,4 +1,4 @@
-require 'gds_api/rummager'
+require 'services'
 
 class MostPopularContent
   include RummagerFields

--- a/app/services/most_recent_content.rb
+++ b/app/services/most_recent_content.rb
@@ -1,3 +1,5 @@
+require 'services'
+
 class MostRecentContent
   attr_reader :content_id, :current_path, :filters, :number_of_links
 

--- a/test/presenters/content_item/taxonomy_navigation_test.rb
+++ b/test/presenters/content_item/taxonomy_navigation_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class TaxonomyNavigationTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::Rummager
+  include ContentPagesNavTestHelper
+
+  def setup
+    @taxonomy_navigation = Object.new
+    @taxonomy_navigation.extend(ContentItem::TaxonomyNavigation)
+    class << @taxonomy_navigation
+      def content_item
+        {
+            "content_purpose_supergroup" => "guidance_and_regulation",
+            "content_purpose_subgroup" => "guidance",
+            "document_type" => "guide",
+        }
+      end
+    end
+    @taxonomy_navigation.instance_variable_set(:@taxons, SINGLE_TAXON)
+    stub_rummager
+  end
+
+  def rule_one_supergroup
+    {
+        "content_purpose_supergroup" => {
+            "guidance_and_regulation" => [
+                {
+                    "title" => "link_to_guidance_and_regulation",
+                    "type" => "content_purpose_supergroup",
+                    "supergroup" => "services"
+                }
+            ]
+        }
+    }
+  end
+
+  def rule_all_supergroups
+    {
+        "content_purpose_supergroup" => {
+            "guidance_and_regulation" => [
+                {
+                    "title" => "link_to_guidance_and_regulation",
+                    "type" => "content_purpose_supergroup",
+                    "supergroup" => "guidance_and_regulation"
+                },
+                {
+                    "title" => "link_to_guidance_and_regulation",
+                    "type" => "content_purpose_supergroup",
+                    "supergroup" => "transparency"
+                },
+                {
+                    "title" => "link_to_guidance_and_regulation",
+                    "type" => "content_purpose_supergroup",
+                    "supergroup" => "news_and_communications"
+                },
+                {
+                    "title" => "link_to_guidance_and_regulation",
+                    "type" => "content_purpose_supergroup",
+                    "supergroup" => "policy_and_engagement"
+                },
+                {
+                    "title" => "link_to_guidance_and_regulation",
+                    "type" => "content_purpose_supergroup",
+                    "supergroup" => "services"
+                }
+            ]
+        }
+    }
+  end
+
+  def stub_load_rules(rules)
+    Rails.configuration.stubs(:taxonomy_navigation_links_out).returns(rules)
+  end
+
+  test 'links_out_supergroups returns empty hash if there are no rules' do
+    stub_load_rules({})
+    assert_equal Hash.new, @taxonomy_navigation.taxonomy_navigation("some/path")
+  end
+
+  test 'links_out_supergroups returns hash with only services if the rules has only services' do
+    stub_load_rules(rule_one_supergroup)
+    assert_equal [:services], @taxonomy_navigation.taxonomy_navigation("some/path").keys
+    assert_equal 4, @taxonomy_navigation.taxonomy_navigation("some/path")[:services].count
+  end
+
+  test 'links_out_supergroups returns hash with all supergroups if the rules has all supergroups' do
+    stub_load_rules(rule_all_supergroups)
+    taxonomy_navigation = @taxonomy_navigation.taxonomy_navigation("some/path")
+    assert_equal %i(guidance_and_regulation transparency news_and_communications policy_and_engagement services), taxonomy_navigation.keys
+    supergroups.each do |supergroup|
+      assert_equal 4, taxonomy_navigation[supergroup.to_sym].count
+    end
+  end
+end

--- a/test/services/most_popular_content_test.rb
+++ b/test/services/most_popular_content_test.rb
@@ -33,7 +33,7 @@ class MostPopularContentTest < ActiveSupport::TestCase
   end
 
   test 'catches api errors' do
-    Services.rummager.stubs(:search).raises(GdsApi::HTTPErrorResponse.new(500))
+    GdsApi::Rummager.any_instance.stubs(:search).raises(GdsApi::HTTPErrorResponse.new(500))
     results = most_popular_content.fetch
 
     assert_equal(results, [])
@@ -101,8 +101,8 @@ class MostPopularContentTest < ActiveSupport::TestCase
       ]
     }
 
-    Services.
-      rummager.
+    GdsApi::Rummager.
+      any_instance.
       stubs(:search).
       with { |params| assert_includes_subhash(expected_params, params) }.
       returns(search_results)

--- a/test/services/most_recent_content_test.rb
+++ b/test/services/most_recent_content_test.rb
@@ -14,7 +14,7 @@ class MostRecentContentTest < ActiveSupport::TestCase
   end
 
   test 'catches api errors' do
-    Services.rummager.stubs(:search).raises(GdsApi::HTTPErrorResponse.new(500))
+    GdsApi::Rummager.any_instance.stubs(:search).raises(GdsApi::HTTPErrorResponse.new(500))
     results = most_recent_content.fetch
 
     assert_equal(results, [])

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -11,7 +11,7 @@ module RummagerHelpers
 
   def stub_rummager_document_without_image_url
     result = rummager_document_for_supergroup_section("doc-with-no-url", "news_story", false)
-    Services.rummager.stubs(:search)
+    GdsApi::Rummager.any_instance.stubs(:search)
       .returns(
         "results" => [result],
         "start" => 0,
@@ -40,7 +40,7 @@ module RummagerHelpers
         reject_link: reject_link,
     }
 
-    Services.rummager.stubs(:search)
+    GdsApi::Rummager.any_instance.stubs(:search)
         .with(params)
         .returns(
           "results" => results,
@@ -70,18 +70,18 @@ module RummagerHelpers
 
   def assert_includes_params(expected_params)
     search_results = {
-        'results' => [
-          {
-              'title' => 'Doc 1'
-          },
-          {
-              'title' => 'Doc 2'
-          }
-        ]
+      'results' => [
+        {
+            'title' => 'Doc 1'
+        },
+        {
+            'title' => 'Doc 2'
+        }
+      ]
     }
 
-    Services.
-        rummager.
+    GdsApi::Rummager.
+        any_instance.
         stubs(:search).
         with { |params| assert_includes_subhash(expected_params, params) }.
         returns(search_results)


### PR DESCRIPTION
Threads calls to rummager for taxonomy navigation links so they are fetched concurrently rather than consecutively. Benchmarking indicates this reduces the average time for 10 requests from 1.24s to 0.89s

Trello:
https://trello.com/c/xh5YnCze/136-spike-improve-navigation-performance
---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
