### PR TITLE
Remove reject_link filter and fix tests

### DIFF
--- a/app/services/most_popular_content.rb
+++ b/app/services/most_popular_content.rb
@@ -1,5 +1,3 @@
-require 'gds_api/rummager'
-
 class MostPopularContent
   include RummagerFields
 
@@ -17,7 +15,7 @@ class MostPopularContent
   end
 
   def fetch
-    search_response["results"]
+    search_response
   rescue GdsApi::HTTPErrorResponse => e
     GovukStatsd.increment("govuk_content_pages.most_popular.#{e.class.name.demodulize.downcase}")
     []
@@ -27,16 +25,15 @@ private
 
   def search_response
     params = {
-      start: 0,
-      count: number_of_links,
-      fields: RummagerFields::TAXON_SEARCH_FIELDS,
-      filter_part_of_taxonomy_tree: content_ids,
-      order: '-popularity',
-      reject_link: current_path,
+        start: 0,
+        count: number_of_links + 1,
+        fields: RummagerFields::TAXON_SEARCH_FIELDS,
+        filter_part_of_taxonomy_tree: content_ids,
+        order: '-popularity'
     }
     params[:filter_content_purpose_supergroup] = @filters[:filter_content_purpose_supergroup] if @filters[:filter_content_purpose_supergroup].present?
     params[:filter_content_purpose_subgroup] = @filters[:filter_content_purpose_subgroup] if @filters[:filter_content_purpose_subgroup].present?
 
-    Services.rummager.search(params)
+    Services.rummager.search(params)["results"].delete_if { |result| result["link"] == current_path }[0...number_of_links]
   end
 end

--- a/app/services/most_popular_content.rb
+++ b/app/services/most_popular_content.rb
@@ -34,6 +34,14 @@ private
     params[:filter_content_purpose_supergroup] = @filters[:filter_content_purpose_supergroup] if @filters[:filter_content_purpose_supergroup].present?
     params[:filter_content_purpose_subgroup] = @filters[:filter_content_purpose_subgroup] if @filters[:filter_content_purpose_subgroup].present?
 
-    Services.rummager.search(params)["results"].delete_if { |result| result["link"] == current_path }[0...number_of_links]
+    search_results = Services.rummager.search(params)["results"].delete_if { |result| result["link"] == current_path }[0...number_of_links]
+    if search_results.count < number_of_links
+      GovukStatsd.increment("govuk_content_pages.most_popular.second_rummager_query")
+      params[:reject_link] = current_path
+      params[:count] = number_of_links
+      Services.rummager.search(params)["results"]
+    else
+      search_results
+    end
   end
 end

--- a/app/services/most_recent_content.rb
+++ b/app/services/most_recent_content.rb
@@ -32,6 +32,14 @@ private
     params[:filter_content_purpose_supergroup] = @filters[:filter_content_purpose_supergroup] if @filters[:filter_content_purpose_supergroup].present?
     params[:filter_content_purpose_subgroup] = @filters[:filter_content_purpose_subgroup] if @filters[:filter_content_purpose_subgroup].present?
 
-    Services.rummager.search(params)["results"].delete_if { |result| result["link"] == current_path }[0...number_of_links]
+    search_results = Services.rummager.search(params)["results"].delete_if { |result| result["link"] == current_path }[0...number_of_links]
+    if search_results.count < number_of_links
+      GovukStatsd.increment("govuk_content_pages.most_recent.second_rummager_query")
+      params[:reject_link] = current_path
+      params[:count] = number_of_links
+      Services.rummager.search(params)["results"]
+    else
+      search_results
+    end
   end
 end

--- a/app/services/most_recent_content.rb
+++ b/app/services/most_recent_content.rb
@@ -13,7 +13,7 @@ class MostRecentContent
   end
 
   def fetch
-    search_response["results"]
+    search_response
   rescue GdsApi::HTTPErrorResponse => e
     GovukStatsd.increment("govuk_content_pages.most_recent.#{e.class.name.demodulize.downcase}")
     []
@@ -23,16 +23,15 @@ private
 
   def search_response
     params = {
-      start: 0,
-      count: number_of_links,
-      fields: RummagerFields::TAXON_SEARCH_FIELDS,
-      filter_part_of_taxonomy_tree: @content_ids,
-      order: '-public_timestamp',
-      reject_link: current_path,
+        start: 0,
+        count: number_of_links + 1,
+        fields: RummagerFields::TAXON_SEARCH_FIELDS,
+        filter_part_of_taxonomy_tree: @content_ids,
+        order: '-public_timestamp'
     }
     params[:filter_content_purpose_supergroup] = @filters[:filter_content_purpose_supergroup] if @filters[:filter_content_purpose_supergroup].present?
     params[:filter_content_purpose_subgroup] = @filters[:filter_content_purpose_subgroup] if @filters[:filter_content_purpose_subgroup].present?
 
-    Services.rummager.search(params)
+    Services.rummager.search(params)["results"].delete_if { |result| result["link"] == current_path }[0...number_of_links]
   end
 end

--- a/test/presenters/supergroups/guidance_and_regulation_test.rb
+++ b/test/presenters/supergroups/guidance_and_regulation_test.rb
@@ -4,23 +4,23 @@ class GuidanceAndRegulationTest < ActiveSupport::TestCase
   include RummagerHelpers
 
   test "tagged_content returns empty array if taxon ids is a blank array" do
-    guidance_and_regulation = Supergroups::GuidanceAndRegulation.new("/no-particular-page", [], {})
+    guidance_and_regulation = Supergroups::GuidanceAndRegulation.new("/a-random-path", [], {})
     assert_equal [], guidance_and_regulation.tagged_content
   end
 
   test "tagged_content returns empty array if there are taxon ids but no results" do
     taxon_content_ids = ['any-old-taxon', 'some-other-taxon-id']
 
-    stub_most_popular_content("/no-particular-page", taxon_content_ids, 0, "guidance_and_regulation")
-    guidance_and_regulation = Supergroups::GuidanceAndRegulation.new("/no-particular-page", [], {})
+    stub_most_popular_content("/a-random-path", taxon_content_ids, 0, "guidance_and_regulation")
+    guidance_and_regulation = Supergroups::GuidanceAndRegulation.new("/a-random-path", [], {})
     assert_equal [], guidance_and_regulation.tagged_content
   end
 
   test "tagged_content returns array with 2 items if there are 2 results" do
     taxon_content_ids = ['any-old-taxon', 'some-other-taxon-id']
 
-    stub_most_popular_content("/no-particular-page", taxon_content_ids, 2, "guidance_and_regulation")
-    guidance_and_regulation = Supergroups::GuidanceAndRegulation.new("/no-particular-page", taxon_content_ids, {})
+    stub_most_popular_content("/a-random-path", taxon_content_ids, 2, "guidance_and_regulation")
+    guidance_and_regulation = Supergroups::GuidanceAndRegulation.new("/a-random-path", taxon_content_ids, {})
     assert_equal 2, guidance_and_regulation.tagged_content.count
   end
 end

--- a/test/services/most_popular_content_test.rb
+++ b/test/services/most_popular_content_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class MostPopularContentTest < ActiveSupport::TestCase
-  include RummagerFields
+  include RummagerHelpers
   include GdsApi::TestHelpers::Rummager
 
   def most_popular_content
@@ -16,20 +16,101 @@ class MostPopularContentTest < ActiveSupport::TestCase
     ['something-id-like', 'some-other-id']
   end
 
-  test 'returns the results from search' do
+  test 'returns three results from search by default' do
     search_results = {
-      body: {
-        'results' => [
-          { 'title' => 'Doc 1' },
-          { 'title' => 'A Doc 2' },
-        ]
-      }.to_json
+        body: {
+            'results' => [
+                {
+                  'title' => 'Doc 1',
+                  'link' => 'documents/1'
+                },
+                {
+                  'title' => 'Doc 2',
+                  'link' => 'documents/2'
+                },
+                {
+                  'title' => 'Doc 3',
+                  'link' => 'documents/3'
+                },
+                {
+                  'title' => 'Doc 4',
+                  'link' => 'documents/4'
+                }
+            ]
+        }.to_json
     }
 
     stub_any_rummager_search.to_return(search_results)
 
     results = most_popular_content.fetch
-    assert_equal(results.count, 2)
+    assert_equal(3, results.count)
+  end
+
+  test 'will use filter_link parameter if more than one results include the current path' do
+    search_results_with_same_path = {
+      'results' => [
+        {
+          'title' => 'Doc 1',
+          'link' => '/how-to-ride-a-bike'
+        },
+        {
+          'title' => 'Doc 2',
+          'link' => '/how-to-ride-a-bike'
+        },
+        {
+          'title' => 'Doc 3',
+          'link' => '/how-to-ride-a-bike'
+        },
+        {
+          'title' => 'Doc 4',
+          'link' => '/how-to-ride-a-bike'
+        }
+      ]
+    }
+
+    search_results_without_same_path = {
+      'results' => [
+        {
+          'title' => 'Doc 1',
+          'link' => 'documents/1'
+        },
+        {
+          'title' => 'Doc 2',
+          'link' => 'documents/2'
+        },
+        {
+          'title' => 'Doc 3',
+          'link' => 'documents/3'
+        }
+      ]
+    }
+
+    parameters = {
+      start: 0,
+      count: 4,
+      fields: RummagerFields::TAXON_SEARCH_FIELDS,
+      filter_part_of_taxonomy_tree: taxon_content_ids,
+      order: '-popularity',
+      filter_content_purpose_supergroup: 'guidance_and_regulation',
+      filter_content_purpose_subgroup: ['guidance']
+    }
+
+    Services.rummager.stubs(:search).with(parameters).returns(search_results_with_same_path)
+
+    filtered_params = parameters.dup
+    filtered_params[:reject_link] = '/how-to-ride-a-bike'
+    filtered_params[:count] = 3
+    Services.rummager.stubs(:search).with(filtered_params).returns(search_results_without_same_path)
+
+    results = most_popular_content.fetch
+
+    assert_equal(3, results.count)
+
+    links = results.map { |result| result["link"] }
+    refute links.include?("/how-to-ride-a-bike")
+    1.upto(3).each do |document_id|
+      assert links.include?("documents/#{document_id}")
+    end
   end
 
   test 'catches api errors' do
@@ -45,7 +126,7 @@ class MostPopularContentTest < ActiveSupport::TestCase
     end
   end
 
-  test 'requests one more than wanted links' do
+  test 'returns number of links plus one' do
     assert_includes_params(count: 4) do
       most_popular_content.fetch
     end
@@ -85,67 +166,28 @@ class MostPopularContentTest < ActiveSupport::TestCase
 
   test 'rejects the originating page from the results' do
     search_results = {
-        'results' => [
-            {
-                'title' => 'Doc 1',
-                'link' => 'documents/1'
-            },
-            {
-                'title' => 'Doc 2',
-                'link' => 'documents/2'
-            },
-            {
-                'title' => 'How to ride a bike',
-                'link' => '/how-to-ride-a-bike'
-            }
-        ]
+      'results' => [
+        {
+          'title' => 'Doc 1',
+          'link' => 'documents/1'
+        },
+        {
+          'title' => 'Doc 2',
+          'link' => 'documents/2'
+        },
+        {
+          'title' => 'How to ride a bike',
+          'link' => '/how-to-ride-a-bike'
+        }
+      ]
     }
 
-    Services.
-      rummager.
-      stubs(:search).
-      returns(search_results)
+    Services.rummager.stubs(:search).returns(search_results)
 
     results = most_popular_content.fetch
     links = results.map { |link| link['link'] }
     refute links.include?('/how-to-ride-a-bike')
     assert links.include?('documents/1')
     assert links.include?('documents/2')
-  end
-
-  def assert_includes_params(expected_params)
-    search_results = {
-      'results' => [
-        {
-          'title' => 'Doc 1'
-        },
-        {
-          'title' => 'Doc 2'
-        }
-      ]
-    }
-
-    Services.
-      rummager.
-      stubs(:search).
-      with { |params| assert_includes_subhash(expected_params, params) }.
-      returns(search_results)
-
-    results = yield
-
-    assert_equal(results.count, 2)
-
-    assert_equal(results.first['title'], 'Doc 1')
-    assert_equal(results.last['title'], 'Doc 2')
-  end
-
-  def assert_includes_subhash(expected_sub_hash, hash)
-    expected_sub_hash.each do |key, value|
-      assert_equal(
-        value,
-        hash[key],
-        "Expected #{hash} to include #{key} => #{value}"
-      )
-    end
   end
 end

--- a/test/services/most_popular_content_test.rb
+++ b/test/services/most_popular_content_test.rb
@@ -45,8 +45,8 @@ class MostPopularContentTest < ActiveSupport::TestCase
     end
   end
 
-  test 'requests three results by default' do
-    assert_includes_params(count: 3) do
+  test 'requests one more than wanted links' do
+    assert_includes_params(count: 4) do
       most_popular_content.fetch
     end
   end
@@ -84,9 +84,33 @@ class MostPopularContentTest < ActiveSupport::TestCase
   end
 
   test 'rejects the originating page from the results' do
-    assert_includes_params(reject_link: '/how-to-ride-a-bike') do
-      most_popular_content.fetch
-    end
+    search_results = {
+        'results' => [
+            {
+                'title' => 'Doc 1',
+                'link' => 'documents/1'
+            },
+            {
+                'title' => 'Doc 2',
+                'link' => 'documents/2'
+            },
+            {
+                'title' => 'How to ride a bike',
+                'link' => '/how-to-ride-a-bike'
+            }
+        ]
+    }
+
+    Services.
+      rummager.
+      stubs(:search).
+      returns(search_results)
+
+    results = most_popular_content.fetch
+    links = results.map { |link| link['link'] }
+    refute links.include?('/how-to-ride-a-bike')
+    assert links.include?('documents/1')
+    assert links.include?('documents/2')
   end
 
   def assert_includes_params(expected_params)

--- a/test/services/most_recent_content_test.rb
+++ b/test/services/most_recent_content_test.rb
@@ -1,19 +1,115 @@
 require "test_helper"
-require './test/support/custom_assertions.rb'
 
 class MostRecentContentTest < ActiveSupport::TestCase
   include RummagerHelpers
+  include GdsApi::TestHelpers::Rummager
 
   def most_recent_content
     @most_recent_content ||= MostRecentContent.new(
       content_ids: taxon_content_ids,
-      current_path: "/some-path",
-      filters: { filter_content_purpose_supergroup: 'guidance_and_regulation', filter_content_purpose_subgroup: ['guidance'] },
-      number_of_links: 6
+      current_path: "/how-to-ride-a-bike",
+      filters: { filter_content_purpose_supergroup: 'guidance_and_regulation', filter_content_purpose_subgroup: ['guidance'] }
     )
   end
 
-  test 'catches api errors' do
+  test "returns three results from search by default" do
+    search_results = {
+        body: {
+            'results' => [
+                {
+                  'title' => 'Doc 1',
+                  'link' => 'documents/1'
+                },
+                {
+                  'title' => 'Doc 2',
+                  'link' => 'documents/2'
+                },
+                {
+                  'title' => 'Doc 3',
+                  'link' => 'documents/3'
+                },
+                {
+                  'title' => 'Doc 4',
+                  'link' => 'documents/4'
+                }
+            ]
+        }.to_json
+    }
+
+    stub_any_rummager_search.to_return(search_results)
+
+    results = most_recent_content.fetch
+    assert_equal(3, results.count)
+  end
+
+  test "will use filter_link parameter if more than one results include the current path" do
+    search_results_with_same_path = {
+        'results' => [
+            {
+              'title' => 'Doc 1',
+              'link' => '/how-to-ride-a-bike'
+            },
+            {
+              'title' => 'Doc 2',
+              'link' => '/how-to-ride-a-bike'
+            },
+            {
+              'title' => 'Doc 3',
+              'link' => '/how-to-ride-a-bike'
+            },
+            {
+              'title' => 'Doc 4',
+              'link' => '/how-to-ride-a-bike'
+            }
+        ]
+    }
+
+    search_results_without_same_path = {
+        'results' => [
+            {
+              'title' => 'Doc 1',
+              'link' => 'documents/1'
+            },
+            {
+              'title' => 'Doc 2',
+              'link' => 'documents/2'
+            },
+            {
+              'title' => 'Doc 3',
+              'link' => 'documents/3'
+            }
+        ]
+    }
+
+    parameters = {
+        start: 0,
+        count: 4,
+        fields: RummagerFields::TAXON_SEARCH_FIELDS,
+        filter_part_of_taxonomy_tree: taxon_content_ids,
+        order: '-public_timestamp',
+        filter_content_purpose_supergroup: 'guidance_and_regulation',
+        filter_content_purpose_subgroup: ['guidance']
+    }
+
+    Services.rummager.stubs(:search).with(parameters).returns(search_results_with_same_path)
+
+    filtered_params = parameters.dup
+    filtered_params[:reject_link] = '/how-to-ride-a-bike'
+    filtered_params[:count] = 3
+    Services.rummager.stubs(:search).with(filtered_params).returns(search_results_without_same_path)
+
+    results = most_recent_content.fetch
+
+    assert_equal(3, results.count)
+
+    links = results.map { |result| result["link"] }
+    refute links.include?("/how-to-ride-a-bike")
+    1.upto(3).each do |document_id|
+      assert links.include?("documents/#{document_id}")
+    end
+  end
+
+  test "catches api errors" do
     Services.rummager.stubs(:search).raises(GdsApi::HTTPErrorResponse.new(500))
     results = most_recent_content.fetch
 
@@ -24,20 +120,40 @@ class MostRecentContentTest < ActiveSupport::TestCase
     ['c3c860fc-a271-4114-b512-1c48c0f82564', 'ff0e8e1f-4dea-42ff-b1d5-f1ae37807af2']
   end
 
+  test "starts from the first page" do
+    assert_includes_params(start: 0) do
+      most_recent_content.fetch
+    end
+  end
+
+  test "returns number of links plus one" do
+    assert_includes_params(count: 4) do
+      most_recent_content.fetch
+    end
+  end
+
+  test "requests a limited number of fields" do
+    fields = RummagerFields::TAXON_SEARCH_FIELDS
+
+    assert_includes_params(fields: fields) do
+      most_recent_content.fetch
+    end
+  end
+
   test "orders the results by popularity in descending order" do
     assert_includes_params(order: '-public_timestamp') do
       most_recent_content.fetch
     end
   end
 
-  test "includes taxon ids" do
+  test "scopes the results to the current taxon" do
     assert_includes_params(filter_part_of_taxonomy_tree: taxon_content_ids) do
       most_recent_content.fetch
     end
   end
 
-  test "returns number of links plus one" do
-    assert_includes_params(count: 7) do
+  test "filters content by the requested filter_content_purpose_supergroup" do
+    assert_includes_params(filter_content_purpose_supergroup: 'guidance_and_regulation') do
       most_recent_content.fetch
     end
   end
@@ -52,28 +168,25 @@ class MostRecentContentTest < ActiveSupport::TestCase
     search_results = {
         'results' => [
             {
-                'title' => 'Doc 1',
-                'link' => 'documents/1'
+              'title' => 'Doc 1',
+              'link' => 'documents/1'
             },
             {
-                'title' => 'Doc 2',
-                'link' => 'documents/2'
+              'title' => 'Doc 2',
+              'link' => 'documents/2'
             },
             {
-                'title' => 'Some path',
-                'link' => '/some-path'
+              'title' => 'Some path',
+              'link' => '/how-to-ride-a-bike'
             }
         ]
     }
 
-    Services.
-        rummager.
-        stubs(:search).
-        returns(search_results)
+    Services.rummager.stubs(:search).returns(search_results)
 
     results = most_recent_content.fetch
     links = results.map { |link| link['link'] }
-    refute links.include?('/some-path')
+    refute links.include?('/how-to-ride-a-bike')
     assert links.include?('documents/1')
     assert links.include?('documents/2')
   end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -31,22 +31,21 @@ module RummagerHelpers
     )
 
     params = {
-        start: 0,
-        count: 3,
-        fields: fields,
-        filter_part_of_taxonomy_tree: content_ids,
-        order: order_by,
-        filter_content_purpose_supergroup: filter_content_purpose_supergroup,
-        reject_link: reject_link,
+      start: 0,
+      count: 4,
+      fields: fields,
+      filter_part_of_taxonomy_tree: content_ids,
+      order: order_by,
+      filter_content_purpose_supergroup: filter_content_purpose_supergroup
     }
 
     Services.rummager.stubs(:search)
-        .with(params)
-        .returns(
-          "results" => results,
-          "start" => 0,
-          "total" => results.size
-        )
+      .with(params)
+      .returns(
+        "results" => results,
+        "start" => 0,
+        "total" => results.size
+      )
   end
 
   def generate_search_results(count, supergroup)
@@ -70,14 +69,14 @@ module RummagerHelpers
 
   def assert_includes_params(expected_params)
     search_results = {
-        'results' => [
-          {
-              'title' => 'Doc 1'
-          },
-          {
-              'title' => 'Doc 2'
-          }
-        ]
+      'results' => [
+        {
+            'title' => 'Doc 1'
+        },
+        {
+            'title' => 'Doc 2'
+        }
+      ]
     }
 
     Services.

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -1,12 +1,10 @@
 module RummagerHelpers
   def stub_most_recent_content(reject_link, taxon_content_ids, content_link_count, supergroup)
-    results = generate_search_results(content_link_count, supergroup)
-    stub_for_taxon_and_supergroup(reject_link, taxon_content_ids, results, supergroup, "-public_timestamp")
+    stub_for_taxon_and_supergroup(reject_link, content_link_count, taxon_content_ids, supergroup, "-public_timestamp")
   end
 
   def stub_most_popular_content(reject_link, taxon_content_ids, content_link_count, supergroup)
-    results = generate_search_results(content_link_count, supergroup)
-    stub_for_taxon_and_supergroup(reject_link, taxon_content_ids, results, supergroup, "-popularity")
+    stub_for_taxon_and_supergroup(reject_link, content_link_count, taxon_content_ids, supergroup, "-popularity")
   end
 
   def stub_rummager_document_without_image_url
@@ -19,7 +17,7 @@ module RummagerHelpers
       )
   end
 
-  def stub_for_taxon_and_supergroup(reject_link, content_ids, results, filter_content_purpose_supergroup, order_by)
+  def stub_for_taxon_and_supergroup(reject_link, content_link_count, content_ids, filter_content_purpose_supergroup, order_by)
     fields = %w(
       content_store_document_type
       description
@@ -39,6 +37,8 @@ module RummagerHelpers
       filter_content_purpose_supergroup: filter_content_purpose_supergroup
     }
 
+    results = generate_search_results(content_link_count, filter_content_purpose_supergroup)
+
     Services.rummager.stubs(:search)
       .with(params)
       .returns(
@@ -46,6 +46,17 @@ module RummagerHelpers
         "start" => 0,
         "total" => results.size
       )
+
+    filtered_params = params.dup
+    filtered_params[:reject_link] = reject_link
+    filtered_params[:count] = 3
+    Services.rummager.stubs(:search)
+        .with(filtered_params)
+        .returns(
+          "results" => results,
+          "start" => 0,
+          "total" => results.size
+        )
   end
 
   def generate_search_results(count, supergroup)
@@ -75,6 +86,9 @@ module RummagerHelpers
         },
         {
             'title' => 'Doc 2'
+        },
+        {
+            'title' => 'Doc 3'
         }
       ]
     }
@@ -87,9 +101,9 @@ module RummagerHelpers
 
     results = yield
 
-    assert_equal(results.count, 2)
+    assert_equal(results.count, 3)
 
     assert_equal(results.first["title"], 'Doc 1')
-    assert_equal(results.last["title"], 'Doc 2')
+    assert_equal(results.last["title"], 'Doc 3')
   end
 end


### PR DESCRIPTION
Refactors most_recent_content and most_popular_content to remove filter_link in Rummager queries and instead filter out any content item with the current path afterwards. This means Rummager is more able to cache results with the same taxonomy for different pages. Benchmarking with 50 random paths showed an improvement in average query time from 0.1276s to 0.0015s.

Following a review request, if there are not enough results after filtering out any results with the same link, it will make a second rummager query which includes the reject_link parameter to ensure it gets enough results. As this will make the overall page load time longer, it is monitored so if we're getting a high number of requests where this is happening we'll be able to make the initial rummager query request more than one extra link thereby mitigating the problem

Additionally refactored some tests to make them slightly more consistent

---

Visual regression results:
https://government-frontend-pr-1066.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1066.herokuapp.com/component-guide

Trello card:
https://trello.com/c/xh5YnCze/136-spike-improve-navigation-performance
