### PR TITLE
Fix content out links for content pages AB

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -72,7 +72,7 @@ private
 
       @taxonomy_navigation = {}
       @content_item.links_out_supergroups.each do |supergroup|
-        supergroup_taxon_links = "Supergroups::#{supergroup.camelcase}".constantize.new(current_base_path, taxon_ids, filter_content_purpose_subgroup: @content_item.links_out_subgroups)
+        supergroup_taxon_links = "Supergroups::#{supergroup.camelcase}".constantize.new(current_base_path, taxon_ids, filter_content_purpose_subgroup: @content_item.links_out_subgroups(supergroup))
         @taxonomy_navigation[supergroup.to_sym] = supergroup_taxon_links.tagged_content
       end
 

--- a/app/presenters/content_item/links_out.rb
+++ b/app/presenters/content_item/links_out.rb
@@ -4,8 +4,8 @@ module ContentItem
       @links_out_supergroups ||= fetch_links_out_supergroups
     end
 
-    def links_out_subgroups
-      @links_out_subgroups ||= fetch_links_out_subgroups
+    def links_out_subgroups(supergroup)
+      fetch_links_out_subgroups(supergroup)
     end
 
   private
@@ -14,10 +14,10 @@ module ContentItem
       links_out.map { |link| link["supergroup"] }.uniq
     end
 
-    def fetch_links_out_subgroups
+    def fetch_links_out_subgroups(supergroup)
       subgroups = []
       links_out.each do |link|
-        if link["type"] == "content_purpose_subgroup"
+        if link["type"] == "content_purpose_subgroup" && link["supergroup"] == supergroup
           subgroups << link["title"]
         end
       end

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -3,7 +3,7 @@ module Supergroups
     def initialize(current_path, taxon_ids, filters, content_order_class)
       @current_path = current_path
       @taxon_ids = taxon_ids
-      @filters = default_filters.merge(filters)
+      @filters = filters.merge(default_filters)
       @content = fetch_content(content_order_class)
     end
 

--- a/test/presenters/content_item/links_out_test.rb
+++ b/test/presenters/content_item/links_out_test.rb
@@ -223,13 +223,22 @@ class LinksOutTest < ActiveSupport::TestCase
     assert_equal %w(link_to_news), @links_out.links_out_subgroups("news_and_communications")
   end
 
+  test 'links_out_subgroups returns no subgroup names if content_purpose_subgroup is not a subgroup of the supergroup' do
+    amended_rules = rules
+    amended_rules["content_purpose_subgroup"]["guidance"] << news_rule
+    amended_rules["document_type"] = nil
+
+    stub_load_rules(amended_rules)
+    assert_equal [], @links_out.links_out_subgroups("guidance_and_regulation")
+  end
+
   test 'links_out_subgroups returns correct subgroup names for content_purpose_subgroup rules' do
     amended_rules = rules
     amended_rules["content_purpose_subgroup"]["guidance"] << news_rule
     amended_rules["document_type"] = nil
 
     stub_load_rules(amended_rules)
-    assert_equal %w(link_to_guidance), @links_out.links_out_subgroups("guidance_and_regulation")
+    assert_equal %w(link_to_news), @links_out.links_out_subgroups("news_and_communications")
   end
 
   test 'links_out_subgroups returns correct subgroup names for document_type rules' do

--- a/test/presenters/content_item/links_out_test.rb
+++ b/test/presenters/content_item/links_out_test.rb
@@ -100,7 +100,7 @@ class LinksOutTest < ActiveSupport::TestCase
   end
 
   def assert_returns_guidance
-    assert_equal %w(guidance), @links_out.links_out_subgroups
+    assert_equal %w(guidance), @links_out.links_out_subgroups("guidance_and_regulation")
   end
 
   def assert_returns_guidance_and_regulation
@@ -220,7 +220,7 @@ class LinksOutTest < ActiveSupport::TestCase
     amended_rules["document_type"] = nil
 
     stub_load_rules(amended_rules)
-    assert_equal %w(link_to_news), @links_out.links_out_subgroups
+    assert_equal %w(link_to_news), @links_out.links_out_subgroups("news_and_communications")
   end
 
   test 'links_out_subgroups returns correct subgroup names for content_purpose_subgroup rules' do
@@ -229,7 +229,7 @@ class LinksOutTest < ActiveSupport::TestCase
     amended_rules["document_type"] = nil
 
     stub_load_rules(amended_rules)
-    assert_equal %w(link_to_guidance link_to_news), @links_out.links_out_subgroups
+    assert_equal %w(link_to_guidance), @links_out.links_out_subgroups("guidance_and_regulation")
   end
 
   test 'links_out_subgroups returns correct subgroup names for document_type rules' do
@@ -237,6 +237,6 @@ class LinksOutTest < ActiveSupport::TestCase
     amended_rules["document_type"]["guide"] << news_rule
 
     stub_load_rules(amended_rules)
-    assert_equal %w(link_to_news), @links_out.links_out_subgroups
+    assert_equal %w(link_to_news), @links_out.links_out_subgroups("news_and_communications")
   end
 end


### PR DESCRIPTION
Previous calls to rummager were always being filtered by subgroups, regardless of the supergroup. This meant some supergroups were not displaying at all.

This commit changes the retrieval of subgroups to link them to the current supergroup for that search. Only subgroups relevant to that supergroup are returned. If there are no subgroup filters for that supergroup, all content is retrieved.

## Before (missing services)
<img width="978" alt="screen shot 2018-08-31 at 12 58 27" src="https://user-images.githubusercontent.com/29889908/44911104-9cbba480-ad1d-11e8-99ba-98391b60eeeb.png">

## After
<img width="979" alt="screen shot 2018-08-31 at 12 58 35" src="https://user-images.githubusercontent.com/29889908/44911107-a1805880-ad1d-11e8-8746-1cd3150ba6ad.png">

---

Examples:
https://government-frontend-pr-1068.herokuapp.com/student-finance?ABTest-ContentPagesNav=B
https://government-frontend-pr-1068.herokuapp.com/apply-uk-visa?ABTest-ContentPagesNav=B
