### PR TITLE
Add missing taxonomy_navigation component ar and ru translations

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -14,6 +14,11 @@ ar:
       topical_events: "أحداث ذات صلة بالموضوع"
       topics: "المواضيع"
       world_locations: "العالم"
+    taxonomy_navigation:
+      collections: "مجموعات"
+      related_content: "محتوى ذو صلة"
+      topical_events: "أحداث ذات صلة بالموضوع"
+      world_locations: "العالم"
     published_dates:
       published: "تاريخ النشر %{date}"
     publisher_metadata:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -10,6 +10,11 @@ ru:
       topical_events: "Актуальные события"
       topics: "Темы"
       world_locations: "Страны, регионы, организации"
+    taxonomy_navigation:
+      collections: "Коллекции"
+      related_content: "На эту тему"
+      topical_events: "Актуальные события"
+      world_locations: "Страны, регионы, организации"
   content_item:
     schema_name:
       announcement:


### PR DESCRIPTION
These got missed from #1055 somehow.

Examples:

- https://government-frontend-pr-1072.herokuapp.com/government/news/foreign-secretary-statement-israels-right-to-defend-itself.ar
- https://government-frontend-pr-1072.herokuapp.com/government/news/foreign-secretary-statement-israels-right-to-defend-itself.ru

---

[Trello card](https://trello.com/c/y8CzrRHI/400-add-the-language-translations-into-the-universal-layout-template)