### PR TITLE
Bump to most recent version of `govuk_publishing_components`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 53.1'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.9'
 gem 'govuk_frontend_toolkit', '~> 7.6'
-gem 'govuk_publishing_components', '~> 9.26.1'
+gem 'govuk_publishing_components', '~> 9.27.0'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 13.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     govuk_frontend_toolkit (7.6.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (9.26.1)
+    govuk_publishing_components (9.27.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -367,7 +367,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.9)
   govuk_frontend_toolkit (~> 7.6)
-  govuk_publishing_components (~> 9.26.1)
+  govuk_publishing_components (~> 9.27.0)
   govuk_schemas (~> 3.2)
   htmlentities (~> 4.3)
   jasmine-rails


### PR DESCRIPTION
Trello:
https://trello.com/c/e27ECoMb/209-remove-the-policies-link-from-the-content-page-header-applies-to-some-pages

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
