### PR TITLE
Link to people instead of ministers

### DIFF
--- a/app/presenters/content_item/linkable.rb
+++ b/app/presenters/content_item/linkable.rb
@@ -3,7 +3,7 @@ module ContentItem
     include ActionView::Helpers::UrlHelper
 
     def from
-      organisations_ordered_by_importance + links_group(%w{worldwide_organisations ministers speaker})
+      organisations_ordered_by_importance + links_group(%w{worldwide_organisations people speaker})
     end
 
     def part_of
@@ -21,9 +21,9 @@ module ContentItem
   private
 
     def links(type)
-      expanded_links_from_content_item(type).map do |link|
-        link_for_type(type, link)
-      end
+      expanded_links_from_content_item(type)
+        .select { |link| link["base_path"] || type == "world_locations" }
+        .map { |link| link_for_type(type, link) }
     end
 
     def expanded_links_from_content_item(type)

--- a/test/presenters/content_item/linkable_test.rb
+++ b/test/presenters/content_item/linkable_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class ContentItemLinkableTest < ActiveSupport::TestCase
+  class DummyContentItem
+    include ContentItem::Linkable
+    attr_accessor :content_item, :title
+
+    def initialize
+      @content_item = {
+        "base_path" => "/a/base/path",
+        "links" => {},
+      }
+      @title = "A Title"
+    end
+  end
+
+  test "when people links have base_paths they are linked to" do
+    item = DummyContentItem.new
+    item.content_item["links"]["people"] = [
+      {
+        "title" => "Winston Churchill",
+        "base_path" => "/government/people/winston-churchill",
+      }
+    ]
+
+    expected_from_links = [
+      %{<a href="/government/people/winston-churchill">Winston Churchill</a>}
+    ]
+    assert_equal expected_from_links, item.from
+  end
+
+  test "when people links don't have base_paths they are skipped" do
+    item = DummyContentItem.new
+    item.content_item["links"]["people"] = [
+      {
+        "title" => "Winston Churchill",
+        "base_path" => nil,
+      }
+    ]
+
+    expected_from_links = []
+    assert_equal expected_from_links, item.from
+  end
+end

--- a/test/presenters/content_item/linkable_test.rb
+++ b/test/presenters/content_item/linkable_test.rb
@@ -41,4 +41,22 @@ class ContentItemLinkableTest < ActiveSupport::TestCase
     expected_from_links = []
     assert_equal expected_from_links, item.from
   end
+
+  # World locations don't have links in the Publishing API payload
+  # This weird situation is explained here:
+  # - https://github.com/alphagov/government-frontend/pull/386
+  test "when a world location is linked to" do
+    item = DummyContentItem.new
+    item.content_item["links"]["world_locations"] = [
+      {
+        "title" => "Germany",
+        "base_path" => nil,
+      }
+    ]
+
+    expected_from_links = [
+      %{<a href="/world/germany/news">Germany</a>}
+    ]
+    assert_equal expected_from_links, item.part_of
+  end
 end

--- a/test/presenters/content_item/shareable_test.rb
+++ b/test/presenters/content_item/shareable_test.rb
@@ -1,18 +1,18 @@
 require 'test_helper'
 include ERB::Util
 
-class DummyContentItem
-  include ContentItem::Shareable
-  attr_accessor :content_item, :title
-
-  def initialize
-    @content_item = {}
-    @content_item["base_path"] = "/a/base/path"
-    @title = "A Title"
-  end
-end
-
 class ContentItemShareableTest < ActiveSupport::TestCase
+  class DummyContentItem
+    include ContentItem::Shareable
+    attr_accessor :content_item, :title
+
+    def initialize
+      @content_item = {}
+      @content_item["base_path"] = "/a/base/path"
+      @title = "A Title"
+    end
+  end
+
   def expected_path
     url_encode(Plek.current.website_root + "/a/base/path")
   end

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -35,8 +35,8 @@ class PublicationPresenterTest < PresenterTestCase
     assert presented.historically_political?
   end
 
-  test '#from presents ministers' do
-    minister = schema_item["links"]["ministers"][0]
+  test '#from presents people' do
+    minister = schema_item["links"]["people"][0]
     assert presented_item.from.include?("<a href=\"#{minister['base_path']}\">#{minister['title']}</a>")
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/3GT17tkH/211-associate-content-with-ministers-l

This is marked as not to be merged due to requiring this: https://github.com/alphagov/govuk-content-schemas/pull/816

The ministers link type is now [deprecated](https://github.com/alphagov/govuk-content-schemas/blob/76fe9441a2b9ec6f030735f012347dbe8eb6e331/formats/news_article.jsonnet#L47) as it serves the same purpose as people links and these contain the same data. This allows widening up to link to people with other role appointments.

As people document_types don't require a base_path it also does a check that those actually have links (this is something that can affect pretty much all links so there should probably be more checks across this app - but I'm not opening up that rabbit hole just yet)