### PR TITLE
Add cross domain tracking to service sign in form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 53.1'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.9'
 gem 'govuk_frontend_toolkit', '~> 8.0'
-gem 'govuk_publishing_components', '~> 10.1.0'
+gem 'govuk_publishing_components', '~> 10.2.0'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 13.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     govuk_frontend_toolkit (8.0.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (10.1.0)
+    govuk_publishing_components (10.2.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -367,7 +367,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.9)
   govuk_frontend_toolkit (~> 8.0)
-  govuk_publishing_components (~> 10.1.0)
+  govuk_publishing_components (~> 10.2.0)
   govuk_schemas (~> 3.2)
   htmlentities (~> 4.3)
   jasmine-rails

--- a/app/assets/javascripts/modules/track-radio-group.js
+++ b/app/assets/javascripts/modules/track-radio-group.js
@@ -15,7 +15,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     function track (element, withHint) {
         element.on('submit', function (event) {
-        
+
         var options = { transport: 'beacon' }
 
         var $submittedForm = $(event.target)
@@ -26,6 +26,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
         if (typeof checkedValue === 'undefined') {
           checkedValue = 'submitted-without-choosing'
+        }
+        if (typeof element.attr('data-tracking-code') !== 'undefined') {
+          addCrossDomainTracking(element, $checkedOption)
         }
         GOVUK.analytics.trackEvent('Radio button chosen', checkedValue + (withHint ? '-with-hint' : ''), options)
       })
@@ -51,6 +54,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         GOVUK.analytics.trackEvent('verify-hint', 'shown', { transport: 'beacon'});
         track(element, data.value);
       }
+    }
+
+    function addCrossDomainTracking(element, $checkedOption) {
+      var code = element.attr('data-tracking-code')
+      var name = element.attr('data-tracking-name')
+      var url = $checkedOption.attr('data-tracking-url')
+      var hostname = $('<a>').prop('href', url).prop('hostname')
+
+      GOVUK.analytics.addLinkedTrackerDomain(code, name, hostname)
     }
   }
 })(window, window.GOVUK);

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -14,13 +14,22 @@ module ServiceSignIn
       choose_sign_in["description"]
     end
 
+    def tracking_code
+      choose_sign_in["tracking_code"]
+    end
+
+    def tracking_name
+      choose_sign_in["tracking_name"]
+    end
+
     def options
       radio_options = mapped_options.map do |option|
         {
           text: option[:text],
           value: option[:value],
           hint_text: option[:hint_text],
-          bold: true
+          url: option[:url],
+          bold: true,
         }
       end
       # TODO: Move to decision of when or should be applied to schema

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -13,8 +13,14 @@
     </div>
   </div>
 <% end %>
-
-<%= form_tag({controller: 'content_items', action: 'service_sign_in_options'}, method: "post", data: { module: 'track-radio-group' }) do %>
+<%
+  data_attrs = { module: "track-radio-group" }
+  data_attrs["tracking-code"] = @content_item.tracking_code if @content_item.tracking_code
+  data_attrs["tracking-name"] = @content_item.tracking_name if @content_item.tracking_name
+%>
+<%= form_tag({controller: 'content_items', action: 'service_sign_in_options'},
+             method: "post",
+             data: data_attrs) do %>
   <% legend_text = render 'govuk_publishing_components/components/title', title: @content_item.title %>
   <%= render "govuk_publishing_components/components/fieldset", legend_text: legend_text do %>
     <div class="grid-row">

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -21,6 +21,8 @@ module ServiceSignIn
 
       assert page.has_css?('.gem-c-back-link[href="/log-in-file-self-assessment-tax-return"]', text: 'Back')
       assert page.has_css?('form[data-module="track-radio-group"]')
+      assert page.has_css?("form[data-tracking-code='UA-xxxxxx']")
+      assert page.has_css?("form[data-tracking-name='somethingClicky']")
 
       within "#content form" do
         within ".gem-c-fieldset" do


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

Depends on https://github.com/alphagov/govuk_publishing_components/pull/539 and https://github.com/alphagov/govuk-content-schemas/pull/817

We need to track radio button selection events across domains
so that other departments can monitor the efficacy of changes
and options on the service sign in pages. This commit modifies
the track radio group module to include cross domain tracking
via a tracking code and name. Support is being added for radio
buttons to pass the relevant url so that the hostname can be
identified as part of the tracking.

---

Visual regression results:
https://government-frontend-pr-1102.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1102.herokuapp.com/component-guide
