### PR TITLE
Fix toggle behaviour when JS disabled

### DIFF
--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -2,6 +2,14 @@
   @include core-16;
 }
 
+.app-c-published-dates__toggle {
+  display: none;
+
+  .js-enabled & {
+    display: inline-block;
+  }
+}
+
 .app-c-published-dates__change-history {
   margin: 20px 0;
 }

--- a/app/assets/stylesheets/components/_publisher-metadata.scss
+++ b/app/assets/stylesheets/components/_publisher-metadata.scss
@@ -26,3 +26,12 @@
     display: inline-block;
   }
 }
+
+.app-c-publisher-metadata__toggle,
+.app-c-publisher-metadata__definition-others {
+  display: none;
+
+  .js-enabled & {
+    display: inline-block;
+  }
+}

--- a/app/presenters/coming_soon_presenter.rb
+++ b/app/presenters/coming_soon_presenter.rb
@@ -15,7 +15,7 @@ class ComingSoonPresenter < ContentItemPresenter
   end
 
   def formatted_publish_time
-    display_time(DateTime.parse(@publish_time))
+    display_time(Time.parse(@publish_time))
   end
 
   def page_title

--- a/app/presenters/content_item/updatable.rb
+++ b/app/presenters/content_item/updatable.rb
@@ -37,7 +37,7 @@ module ContentItem
     # The direction of change history isn’t guaranteed
     # https://github.com/alphagov/govuk-content-schemas/issues/545
     def reverse_chronological_change_history
-      change_history.sort_by { |item| DateTime.parse(item[:timestamp]) }.reverse
+      change_history.sort_by { |item| Time.parse(item[:timestamp]) }.reverse
     end
 
     def any_updates?

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -89,7 +89,7 @@ class TravelAdvicePresenter < ContentItemPresenter
   end
 
   def atom_public_updated_at
-    DateTime.parse(content_item["public_updated_at"])
+    Time.parse(content_item["public_updated_at"])
   end
 
   def cache_control_max_age(format)

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -17,6 +17,7 @@
       &mdash; <a href="#history"><%= t('components.published_dates.see_all_updates') %></a>
     <% elsif history.any? %>
       <a href="#full-history"
+      class="app-c-published-dates__toggle"
       data-controls="full-history"
       data-expanded="false"
       data-toggled-text="&#45;&nbsp;<%= t('components.published_dates.hide_all_updates') %>">&#43;&nbsp;<%= t('components.published_dates.show_all_updates')

--- a/app/views/components/_publisher-metadata.html.erb
+++ b/app/views/components/_publisher-metadata.html.erb
@@ -33,12 +33,14 @@
                 <% else %>
                   <% featured_value, *other_values = values %>
                   <span class="app-c-publisher-metadata__definition_sentence">
-                    <%= featured_value.html_safe %> and <%= pluralize(other_values.size, 'other') %>
+                    <%= featured_value.html_safe %>,
+                    <span class="app-c-publisher-metadata__definition_others">and <%= pluralize(other_values.size, 'other') %></span>
                   </span>
                   <a href="#"
-                     data-controls="<%= toggle_id %>"
-                     data-expanded="false"
-                     data-toggled-text="&minus; <%= t('components.publisher_metadata.hide_all') %>">
+                    class="app-c-publisher-metadata__toggle"
+                    data-controls="<%= toggle_id %>"
+                    data-expanded="false"
+                    data-toggled-text="&minus; <%= t('components.publisher_metadata.hide_all') %>">
                     + <%= t('components.publisher_metadata.show_all') %>
                   </a>
                   <span id="<%= toggle_id %>" class="js-hidden"><%= other_values.to_sentence.html_safe %></span>

--- a/app/views/components/_publisher-metadata.html.erb
+++ b/app/views/components/_publisher-metadata.html.erb
@@ -27,14 +27,13 @@
             <dd class="app-c-publisher-metadata__definition" data-module="gem-toggle">
               <% if title.to_sym == :collections %>
                 <% if values.size <= 2 %>
-                  <span class="app-c-publisher-metadata__definition_sentence">
+                  <span class="app-c-publisher-metadata__definition-sentence">
                     <%= values.take(2).to_sentence.html_safe %>
                   </span>
                 <% else %>
                   <% featured_value, *other_values = values %>
-                  <span class="app-c-publisher-metadata__definition_sentence">
-                    <%= featured_value.html_safe %>,
-                    <span class="app-c-publisher-metadata__definition_others">and <%= pluralize(other_values.size, 'other') %></span>
+                  <span class="app-c-publisher-metadata__definition-sentence">
+                    <%= featured_value.html_safe %>, <span class="app-c-publisher-metadata__definition-others">and <%= pluralize(other_values.size, 'other') %></span>
                   </span>
                   <a href="#"
                     class="app-c-publisher-metadata__toggle"
@@ -46,7 +45,7 @@
                   <span id="<%= toggle_id %>" class="js-hidden"><%= other_values.to_sentence.html_safe %></span>
                 <% end %>
               <% else %>
-                <span class="app-c-publisher-metadata__definition_sentence">
+                <span class="app-c-publisher-metadata__definition-sentence">
                   <%= values.to_sentence.html_safe %>
                 </span>
               <% end %>

--- a/test/components/publisher_metadata_test.rb
+++ b/test/components/publisher_metadata_test.rb
@@ -67,7 +67,7 @@ class PublisherMetadataTest < ComponentTestCase
   test "renders the first collection and a toggle link when more than two collections are given" do
     render_component(other: { collections: ["<a href='/government/collections/tribunals-statistics'>Tribunals statistics</a>", "<a href='/government/collections/civil-justice-statistics-quarterly'>Civil justice statistics quarterly</a>", "<a href='/government/collections/offender-management-statistics-quarterly'>Offender management statistics quarterly</a>"] })
     assert_select ".app-c-publisher-metadata__other dt", text: 'Collections:'
-    assert_select ".app-c-publisher-metadata__other .app-c-publisher-metadata__definition_sentence", text: 'Tribunals statistics and 2 others'
+    assert_select ".app-c-publisher-metadata__other .app-c-publisher-metadata__definition-sentence", text: 'Tribunals statistics, and 2 others'
     assert_select ".app-c-publisher-metadata__other a", text: '+ show all'
     assert_select ".app-c-publisher-metadata__other a[href='/government/collections/tribunals-statistics']", text: 'Tribunals statistics'
     assert_select ".app-c-publisher-metadata__other a[href='/government/collections/civil-justice-statistics-quarterly']", text: 'Civil justice statistics quarterly'

--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -45,7 +45,6 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
     within(".content-bottom-margin .app-c-published-dates") do
       assert page.has_content?("Published 27 February 1881")
       assert page.has_content?("Last updated 14 September 2016")
-      assert page.has_link?("show all updates", href: "#full-history")
 
       within(".app-c-published-dates__change-history") do
         within(".app-c-published-dates__change-item:first-child") do

--- a/test/integration/travel_advice_atom_feed_test.rb
+++ b/test/integration/travel_advice_atom_feed_test.rb
@@ -8,7 +8,7 @@ class TravelAdviceAtomFeed < ActionDispatch::IntegrationTest
   setup do
     setup_and_parse_travel_advice_atom_feed('full-country')
     @base_path = @content_item['base_path']
-    @updated_at = DateTime.parse(@content_item["public_updated_at"]).rfc3339
+    @updated_at = Time.parse(@content_item["public_updated_at"])
   end
 
   test "it sets the alternative link correctly" do

--- a/test/presenters/case_study_presenter_test.rb
+++ b/test/presenters/case_study_presenter_test.rb
@@ -73,7 +73,7 @@ class CaseStudyPresenterTest < PresenterTestCase
 
   test '#history returns a formatted history if the content item has updates' do
     expected_history = [
-      { display_time: '21 March 2013', note: 'Something changed', timestamp: '2013-03-21T00:00:00+00:00' },
+      { display_time: '21 March 2013', note: 'Something changed', timestamp: '2013-03-21 00:00:00 +0000' },
     ]
 
     assert_equal expected_history, presented_case_study_with_updates.history
@@ -97,7 +97,7 @@ class CaseStudyPresenterTest < PresenterTestCase
   end
 
   def presented_case_study_with_updates
-    updated_date = DateTime.new(2013, 3, 21).to_s
+    updated_date = Time.new(2013, 3, 21).to_s
     with_history = schema_item
     with_history['details']['change_history'] = [{ 'note' => 'Something changed', 'public_timestamp' => updated_date }]
     with_history['public_updated_at'] = updated_date

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -76,7 +76,7 @@ class SpecialistDocumentPresenterTest
       ]
 
       presented = present_example(example)
-      assert DateTime.parse(presented.published) == DateTime.parse("2002-02-02")
+      assert Time.parse(presented.published) == Time.parse("2002-02-02")
     end
 
     test 'has title without context' do
@@ -354,7 +354,7 @@ class SpecialistDocumentPresenterTest
       ]
 
       presented = present_example(example)
-      assert DateTime.parse(presented.published) == DateTime.parse("2010-01-01")
+      assert Time.parse(presented.published) == Time.parse("2010-01-01")
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/LQKpXVSw/186-audit-components-that-use-a-toggle-and-update-to-hide-the-toggle-link-when-js-is-disabled

Previously, these components would auto-expand all contents when JS was disabled (which is good), but also continue to show the toggle link which would be confusing to users. This PR only shows the toggle link if JS is enabled.

## Before (published dates)
<img width="917" alt="screen shot 2018-10-01 at 16 08 18" src="https://user-images.githubusercontent.com/29889908/46297352-5cf21200-c594-11e8-9623-84f34bdc5152.png">

## After (published dates)
<img width="915" alt="screen shot 2018-10-01 at 16 07 28" src="https://user-images.githubusercontent.com/29889908/46297363-61b6c600-c594-11e8-9a65-12870d620254.png">

## Before (publisher metadata)
<img width="904" alt="screen shot 2018-10-01 at 16 08 33" src="https://user-images.githubusercontent.com/29889908/46297377-65e2e380-c594-11e8-8ab4-ff48a9a58a28.png">

## After (publisher metadata)
<img width="808" alt="screen shot 2018-10-01 at 16 07 08" src="https://user-images.githubusercontent.com/29889908/46297384-69766a80-c594-11e8-92be-1f0f1b608d85.png">

Links:
https://government-frontend-pr-1110.herokuapp.com/component-guide/publisher-metadata
https://government-frontend-pr-1110.herokuapp.com/component-guide/published-dates
