### PR TITLE
Increase Capybara driver timeout

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,13 +15,17 @@ Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w(headless disable-gpu no-sandbox) }
   )
+  client = Selenium::WebDriver::Remote::Http::Default.new
+  client.timeout = 90 # Asset compilation can result in a timeout on the first request hence the increase.
 
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    desired_capabilities: capabilities
+    desired_capabilities: capabilities,
+    http_client: client
   )
 end
+
 Capybara.default_driver = :headless_chrome
 Capybara.javascript_driver = :headless_chrome
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,8 +11,19 @@ require 'faker'
 
 Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 
-Capybara.default_driver = :selenium_chrome_headless
-Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless disable-gpu no-sandbox) }
+  )
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    desired_capabilities: capabilities
+  )
+end
+Capybara.default_driver = :headless_chrome
+Capybara.javascript_driver = :headless_chrome
 
 GovukAbTesting.configure do |config|
   config.acceptance_test_framework = :active_support


### PR DESCRIPTION
[Master branch is failing on CI](https://ci.integration.publishing.service.gov.uk/job/government-frontend/job/master/931/console) because

```
[build] Error:
[build] ServiceSignIn::ChooseSignInTest#test_renders_errors_correctly:
[build] Net::ReadTimeout: Net::ReadTimeout
[build]     test/integration/service_sign_in/choose_sign_in_test.rb:116:in `setup_and_visit_choose_sign_in_page'
[build]     test/integration/service_sign_in/choose_sign_in_test.rb:53:in `block in <class:ChooseSignInTest>'
[build] 
[build] bin/rails test test/integration/service_sign_in/choose_sign_in_test.rb:52
```

Looking at previous fails it can be any test, but always the first to call `#visit`.
https://github.com/teamcapybara/capybara/issues/1305 implies the problem may be asset compilation.
I've increased the timeout and this seems to allow builds to pass.

![These go up to eleven](https://upload.wikimedia.org/wikipedia/en/thumb/0/06/Spinal_Tap_-_Up_to_Eleven.jpg/330px-Spinal_Tap_-_Up_to_Eleven.jpg)

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
