### PR TITLE
Send cross domain events as final tracking step

### DIFF
--- a/app/assets/javascripts/modules/track-radio-group.js
+++ b/app/assets/javascripts/modules/track-radio-group.js
@@ -27,10 +27,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         if (typeof checkedValue === 'undefined') {
           checkedValue = 'submitted-without-choosing'
         }
+
+        GOVUK.analytics.trackEvent('Radio button chosen', checkedValue + (withHint ? '-with-hint' : ''), options)
+
         if (typeof element.attr('data-tracking-code') !== 'undefined') {
           addCrossDomainTracking(element, $checkedOption, options)
         }
-        GOVUK.analytics.trackEvent('Radio button chosen', checkedValue + (withHint ? '-with-hint' : ''), options)
       })
     }
 


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

We modify the options object for cross domain tracking, this alters the default behaviour.

In any case we should be performing our own event tracking first.

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
