### PR TITLE
Track events and pageviews

### DIFF
--- a/app/assets/javascripts/modules/track-radio-group.js
+++ b/app/assets/javascripts/modules/track-radio-group.js
@@ -22,16 +22,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
         var $checkedOption = $submittedForm.find('input:checked')
 
-        var checkedValue = $checkedOption.val();
-
-        if (typeof checkedValue === 'undefined') {
-          checkedValue = 'submitted-without-choosing'
-        }
-
-        GOVUK.analytics.trackEvent('Radio button chosen', checkedValue + (withHint ? '-with-hint' : ''), options)
+        GOVUK.analytics.trackEvent('Radio button chosen', eventTrackingValue($checkedOption, withHint), options)
 
         if (typeof $submittedForm.attr('data-tracking-code') !== 'undefined') {
-          addCrossDomainTracking($submittedForm, $checkedOption, options)
+          addCrossDomainTracking($submittedForm, $checkedOption, options, withHint)
         }
       })
     }
@@ -58,7 +52,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
     }
 
-    function addCrossDomainTracking(element, $checkedOption, options) {
+    function eventTrackingValue(element, withHint) {
+      var value = element.val()
+
+      if (typeof value === 'undefined') {
+        value = 'submitted-without-choosing'
+      }
+
+      if (withHint) {
+        value += '-with-hint'
+      }
+      return value
+    }
+
+    function addCrossDomainTracking(element, $checkedOption, options, withHint) {
       var code = element.attr('data-tracking-code')
       var name = element.attr('data-tracking-name')
       var url = $checkedOption.attr('data-tracking-url')
@@ -66,7 +73,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var eventOptions = $.extend({ 'trackerName': name }, options)
 
       GOVUK.analytics.addLinkedTrackerDomain(code, name, hostname)
-      GOVUK.analytics.trackEvent('Radio button chosen', $checkedOption.val(), eventOptions)
+      GOVUK.analytics.trackEvent('Radio button chosen', eventTrackingValue($checkedOption, withHint), eventOptions)
     }
   }
 })(window, window.GOVUK);

--- a/app/assets/javascripts/modules/track-radio-group.js
+++ b/app/assets/javascripts/modules/track-radio-group.js
@@ -14,7 +14,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     function track (element, withHint) {
-        element.on('submit', function (event) {
+      element.on('submit', function (event) {
 
         var options = { transport: 'beacon' }
 
@@ -30,15 +30,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
         GOVUK.analytics.trackEvent('Radio button chosen', checkedValue + (withHint ? '-with-hint' : ''), options)
 
-        if (typeof element.attr('data-tracking-code') !== 'undefined') {
-          addCrossDomainTracking(element, $checkedOption, options)
+        if (typeof $submittedForm.attr('data-tracking-code') !== 'undefined') {
+          addCrossDomainTracking($submittedForm, $checkedOption, options)
         }
       })
     }
 
     function checkVerifyUser (element) {
       $.ajax({
-        url: 'https://www.signin.service.gov.uk/hint', 
+        url: 'https://www.signin.service.gov.uk/hint',
         cache: false,
         dataType: 'jsonp',
         timeout: 3000
@@ -63,10 +63,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var name = element.attr('data-tracking-name')
       var url = $checkedOption.attr('data-tracking-url')
       var hostname = $('<a>').prop('href', url).prop('hostname')
+      var eventOptions = $.extend({ 'trackerName': name }, options)
 
-      GOVUK.analytics.addLinkedTrackerDomain(code, name, hostname, false)
-      options['trackerName'] = name
-      GOVUK.analytics.trackEvent('Radio button chosen', $checkedOption.val(), options)
+      GOVUK.analytics.addLinkedTrackerDomain(code, name, hostname)
+      GOVUK.analytics.trackEvent('Radio button chosen', $checkedOption.val(), eventOptions)
     }
   }
 })(window, window.GOVUK);

--- a/spec/javascripts/track-radio-group.spec.js
+++ b/spec/javascripts/track-radio-group.spec.js
@@ -155,13 +155,15 @@ describe('A radio group tracker', function () {
     var $form, $radioInput
 
     beforeEach(function () {
+      tracker.trackVerifyUser(element, { status: 'OK', value: true })
+
       spyOn(GOVUK.analytics, 'addLinkedTrackerDomain')
 
       var $form = element.find('form')
       $form.attr('data-tracking-code', 'UA-xxxxxx')
       $form.attr('data-tracking-name', 'testTracker')
 
-      var $radioInput = element.find('input[value="government-gateway"]')
+      var $radioInput = element.find('input[value="govuk-verify"]')
       $radioInput.attr('data-tracking-url', 'https://test.service.gov.uk')
 
       $radioInput.trigger('click')
@@ -176,7 +178,7 @@ describe('A radio group tracker', function () {
 
     it('sends an event to the linked tracker', function() {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'Radio button chosen', 'government-gateway', { trackerName: 'testTracker', transport: 'beacon' }
+        'Radio button chosen', 'govuk-verify-with-hint', { trackerName: 'testTracker', transport: 'beacon' }
       )
     })
   })


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

Track events _and_ pageviews when tracking radio groups across domains.

The pageview data is also required when performing cross domain tracking,
also add some test coverage for radio group tracking.

Also makes a copy of event tracking options so that cross domain config doesn't change the original config object.

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
