### PR TITLE
Send pageviews at module load time

### DIFF
--- a/app/assets/javascripts/modules/track-radio-group.js
+++ b/app/assets/javascripts/modules/track-radio-group.js
@@ -10,6 +10,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.start = function (element) {
       track(element)
 
+      if (crossDomainTrackingEnabled(element)) {
+        addCrossDomainTracking(element)
+      }
+
       checkVerifyUser(element)
     }
 
@@ -22,10 +26,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
         var $checkedOption = $submittedForm.find('input:checked')
 
-        GOVUK.analytics.trackEvent('Radio button chosen', eventTrackingValue($checkedOption, withHint), options)
+        var eventValue = eventTrackingValue($checkedOption, withHint)
 
-        if (typeof $submittedForm.attr('data-tracking-code') !== 'undefined') {
-          addCrossDomainTracking($submittedForm, $checkedOption, options, withHint)
+        GOVUK.analytics.trackEvent('Radio button chosen', eventValue, options)
+
+        if (crossDomainTrackingEnabled($submittedForm)) {
+          trackCrossDomainEvent($submittedForm, eventValue, options)
         }
       })
     }
@@ -65,15 +71,26 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       return value
     }
 
-    function addCrossDomainTracking(element, $checkedOption, options, withHint) {
-      var code = element.attr('data-tracking-code')
-      var name = element.attr('data-tracking-name')
-      var url = $checkedOption.attr('data-tracking-url')
-      var hostname = $('<a>').prop('href', url).prop('hostname')
-      var eventOptions = $.extend({ 'trackerName': name }, options)
+    function addCrossDomainTracking(element) {
+      var code =   element.attr('data-tracking-code')
+      var domain = element.attr('data-tracking-domain')
+      var name =   element.attr('data-tracking-name')
 
-      GOVUK.analytics.addLinkedTrackerDomain(code, name, hostname)
-      GOVUK.analytics.trackEvent('Radio button chosen', eventTrackingValue($checkedOption, withHint), eventOptions)
+      GOVUK.analytics.addLinkedTrackerDomain(code, name, domain)
+    }
+
+    function trackCrossDomainEvent(element, eventValue, options) {
+      var name = element.attr('data-tracking-name')
+      var eventOptions = $.extend({ 'trackerName': name }, options)
+      GOVUK.analytics.trackEvent('Radio button chosen', eventValue, eventOptions)
+    }
+
+    function crossDomainTrackingEnabled(element) {
+      return (
+        typeof element.attr('data-tracking-code')   !== 'undefined' &&
+        typeof element.attr('data-tracking-domain') !== 'undefined' &&
+        typeof element.attr('data-tracking-name')   !== 'undefined'
+      )
     }
   }
 })(window, window.GOVUK);

--- a/app/presenters/service_sign_in/choose_sign_in_presenter.rb
+++ b/app/presenters/service_sign_in/choose_sign_in_presenter.rb
@@ -18,6 +18,10 @@ module ServiceSignIn
       choose_sign_in["tracking_code"]
     end
 
+    def tracking_domain
+      choose_sign_in["tracking_domain"]
+    end
+
     def tracking_name
       choose_sign_in["tracking_name"]
     end

--- a/spec/javascripts/track-radio-group.spec.js
+++ b/spec/javascripts/track-radio-group.spec.js
@@ -159,24 +159,25 @@ describe('A radio group tracker', function () {
 
       spyOn(GOVUK.analytics, 'addLinkedTrackerDomain')
 
-      var $form = element.find('form')
+      $form = element.find('form')
       $form.attr('data-tracking-code', 'UA-xxxxxx')
+      $form.attr('data-tracking-domain', 'test.service.gov.uk')
       $form.attr('data-tracking-name', 'testTracker')
 
-      var $radioInput = element.find('input[value="govuk-verify"]')
-      $radioInput.attr('data-tracking-url', 'https://test.service.gov.uk')
-
-      $radioInput.trigger('click')
-      $form.trigger('submit')
+      tracker = new GOVUK.Modules.TrackRadioGroup()
+      tracker.start($form)
     })
 
-    it('adds a linked tracker', function () {
+    it('adds a linked tracker as the module is started', function () {
       expect(GOVUK.analytics.addLinkedTrackerDomain).toHaveBeenCalledWith(
         'UA-xxxxxx', 'testTracker', 'test.service.gov.uk'
       )
     })
 
-    it('sends an event to the linked tracker', function() {
+    it('sends an event to the linked tracker when the form is submitted', function() {
+      $form.find('input[value="govuk-verify"]').trigger('click')
+      $form.trigger('submit')
+
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'Radio button chosen', 'govuk-verify-with-hint', { trackerName: 'testTracker', transport: 'beacon' }
       )

--- a/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
+++ b/test/presenters/service_sign_in/choose_sign_in_presenter_test.rb
@@ -55,5 +55,11 @@ class ServiceSignInPresenterTest
     test 'presents the back_link' do
       assert_equal schema_item['links']['parent'].first['base_path'], @presented_item.back_link
     end
+
+    test 'presents the tracking values' do
+      assert_equal @choose_sign_in['tracking_code'], @presented_item.tracking_code
+      assert_equal @choose_sign_in['tracking_domain'], @presented_item.tracking_domain
+      assert_equal @choose_sign_in['tracking_name'], @presented_item.tracking_name
+    end
   end
 end


### PR DESCRIPTION
See https://github.com/alphagov/publisher/pull/962 and https://github.com/alphagov/govuk-content-schemas/pull/823 for context.

- Uses the tracking domain data attribute to configure a cross domain tracker.
- Sends the page view as the tracking module loads, sends the event when the radio group form is submitted.

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
