### PR TITLE
Add tracking domain to service sign in form

### DIFF
--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -16,6 +16,7 @@
 <%
   data_attrs = { module: "track-radio-group" }
   data_attrs["tracking-code"] = @content_item.tracking_code if @content_item.tracking_code
+  data_attrs["tracking-domain"] = @content_item.tracking_domain if @content_item.tracking_domain
   data_attrs["tracking-name"] = @content_item.tracking_name if @content_item.tracking_name
 %>
 <%= form_tag({controller: 'content_items', action: 'service_sign_in_options'},

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -22,6 +22,7 @@ module ServiceSignIn
       assert page.has_css?('.gem-c-back-link[href="/log-in-file-self-assessment-tax-return"]', text: 'Back')
       assert page.has_css?('form[data-module="track-radio-group"]')
       assert page.has_css?("form[data-tracking-code='UA-xxxxxx']")
+      assert page.has_css?("form[data-tracking-domain='tax.service.gov.uk']")
       assert page.has_css?("form[data-tracking-name='somethingClicky']")
 
       within "#content form" do


### PR DESCRIPTION
This adds the tracking domain to the service sign in form when provided. Used in check-state-pension pages.

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
