### PR TITLE
Contextual footer navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 55.0'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.10'
 gem 'govuk_frontend_toolkit', '~> 8.1.0'
-gem 'govuk_publishing_components', '~> 12.20.0'
+gem 'govuk_publishing_components', '~> 12.21.0'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 13.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       rest-client (~> 2.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    govspeak (5.7.1)
+    govspeak (5.8.0)
       actionview (~> 5.0)
       addressable (>= 2.3.8, < 3)
       commander (~> 4.4)
@@ -129,7 +129,7 @@ GEM
     govuk_frontend_toolkit (8.1.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (12.20.0)
+    govuk_publishing_components (12.21.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -370,7 +370,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.10)
   govuk_frontend_toolkit (~> 8.1.0)
-  govuk_publishing_components (~> 12.20.0)
+  govuk_publishing_components (~> 12.21.0)
   govuk_schemas (~> 3.2)
   htmlentities (~> 4.3)
   jasmine-rails
@@ -394,4 +394,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -10,9 +10,9 @@
 <div class="grid-row responsive-bottom-margin">
   <div class="column-two-thirds">
     <%= render 'govuk_publishing_components/components/govspeak',
-      content: raw(@content_item.body),
-      direction: page_text_direction,
-      disable_youtube_expansions: true %>
+               { direction: page_text_direction, disable_youtube_expansions: true } do %>
+      <%= raw @content_item.body %>
+    <% end %>
 
     <% if @content_item.last_updated && @content_item.schema_name == "help_page" %>
       <%= render "components/published-dates", {

--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -23,3 +23,5 @@
 
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -39,3 +39,5 @@
 
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -185,3 +185,5 @@
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -105,3 +105,5 @@
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -36,3 +36,5 @@
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -41,3 +41,5 @@
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -39,3 +39,5 @@
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -40,3 +40,5 @@
 
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -47,3 +47,5 @@
 
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -37,3 +37,5 @@
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -55,3 +55,5 @@
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -43,3 +43,5 @@
 
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -41,3 +41,5 @@
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -44,6 +44,6 @@
     <% end %>
   </div>
   <div class="column-one-third">
-    <%= render 'govuk_publishing_components/components/related_navigation', @content_item.content_item.parsed_content %>
+    <%= render 'govuk_publishing_components/components/related_navigation', content_item: @content_item.content_item.parsed_content, context: :sidebar %>
   </div>
 </div>

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -26,3 +26,5 @@
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -24,3 +24,5 @@
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -60,3 +60,5 @@
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -48,3 +48,5 @@
 
   <%= render 'shared/sidebar_navigation' %>
 </div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/shared/_footer_navigation.html.erb
+++ b/app/views/shared/_footer_navigation.html.erb
@@ -1,0 +1,12 @@
+<% @contextual_footer = capture do %>
+  <%= render 'govuk_publishing_components/components/contextual_footer',
+             content_item: @content_item.content_item.parsed_content %>
+<% end %>
+
+<% if @contextual_footer.present? %>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <%= @contextual_footer %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
This adds a contextual footer component which contains the following that have been moved from the contextual footer component:

- Mainstream browse pages
- Taxonomy topics
- Topical events
- World locations
- Statistical data sets
- Related external links
- Related contacts

The footer component is rendered in a new grid row so that:

- it sits below the contextual sidebar for narrow device widths
- it sits below the back to content link

See https://trello.com/c/y0AcHMPc

Example URLs:

- https://government-frontend-pr-1136.herokuapp.com/universal-credit
- https://government-frontend-pr-1136.herokuapp.com/pay-dartford-crossing-charge
- https://government-frontend-pr-1136.herokuapp.com/government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees
- https://government-frontend-pr-1136.herokuapp.com/income-tax-rates
---

Visual regression results:
https://government-frontend-pr-1136.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1136.herokuapp.com/component-guide