### PR TITLE
Update `govuk_publishing_components` to 12.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 54.1'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.10'
 gem 'govuk_frontend_toolkit', '~> 8.1.0'
-gem 'govuk_publishing_components', '~> 12.7.1'
+gem 'govuk_publishing_components', '~> 12.8.0'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 13.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     govuk_frontend_toolkit (8.1.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (12.7.1)
+    govuk_publishing_components (12.8.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -370,7 +370,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.10)
   govuk_frontend_toolkit (~> 8.1.0)
-  govuk_publishing_components (~> 12.7.1)
+  govuk_publishing_components (~> 12.8.0)
   govuk_schemas (~> 3.2)
   htmlentities (~> 4.3)
   jasmine-rails


### PR DESCRIPTION
This is needed in order to use the correct styling for `govspeak-html-publication` components.

Trello: https://trello.com/c/wPyyRRfH/634-table-styling-on-2018-budget-query-from-hm-treasury

Related PRs:
 - https://github.com/alphagov/govuk_publishing_components/pull/618
 - https://github.com/alphagov/govuk_publishing_components/pull/622

---

Visual regression results:
https://government-frontend-pr-1156.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1156.herokuapp.com/component-guide
