### PR TITLE
Use default news image on news article pages

### DIFF
--- a/app/presenters/news_article_presenter.rb
+++ b/app/presenters/news_article_presenter.rb
@@ -8,6 +8,13 @@ class NewsArticlePresenter < ContentItemPresenter
   include ContentItem::Metadata
 
   def image
-    content_item["details"]["image"]
+    content_item["details"].dig("image") || default_news_image
+  end
+
+private
+
+  def default_news_image
+    organisation = content_item["links"].dig("primary_publishing_organisation")
+    organisation[0].dig("details", "default_news_image") if organisation.present?
   end
 end

--- a/test/presenters/news_article_presenter_test.rb
+++ b/test/presenters/news_article_presenter_test.rb
@@ -45,6 +45,25 @@ class NewsArticlePresenterTest
     test 'presents the locale' do
       assert_equal schema_item['locale'], presented_item.locale
     end
+
+    test 'presents the document\'s image if present' do
+      assert_equal schema_item['details']['image'], presented_item.image
+    end
+
+    test 'presents the document\'s organisation\'s default_news_image if document\'s image is not present' do
+      default_news_image = { 'url' => 'http://www.test.dev.gov.uk/default_news_image.jpg' }
+      example = schema_item
+      example['details'].delete('image')
+      example['links'] = {
+        'primary_publishing_organisation' => [
+          'details' => {
+            'default_news_image' => default_news_image
+          }
+        ]
+      }
+      presented_item = present_example(example)
+      assert_equal default_news_image, presented_item.image
+    end
   end
 
   class HistoryModePresentedNewsArticle < NewsArticlePresenterTestCase


### PR DESCRIPTION
For https://trello.com/c/UXUxzEv4/512-amend-government-frontend-logic-to-use-default-organisation-image

In cases where a news article doesn't have an image, we use its primary
publishing organisation's default image.