### PR TITLE
Default to placeholder image for newslike content

### DIFF
--- a/app/presenters/news_article_presenter.rb
+++ b/app/presenters/news_article_presenter.rb
@@ -8,7 +8,7 @@ class NewsArticlePresenter < ContentItemPresenter
   include ContentItem::Metadata
 
   def image
-    content_item["details"].dig("image") || default_news_image
+    content_item["details"].dig("image") || default_news_image || placeholder_image
   end
 
 private
@@ -16,5 +16,9 @@ private
   def default_news_image
     organisation = content_item["links"].dig("primary_publishing_organisation")
     organisation[0].dig("details", "default_news_image") if organisation.present?
+  end
+
+  def placeholder_image
+    "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg"
   end
 end

--- a/app/presenters/world_location_news_article_presenter.rb
+++ b/app/presenters/world_location_news_article_presenter.rb
@@ -8,6 +8,13 @@ class WorldLocationNewsArticlePresenter < ContentItemPresenter
   include ContentItem::Metadata
 
   def image
-    content_item["details"]["image"]
+    content_item["details"].dig("image") || default_news_image 
+  end
+
+private
+
+  def default_news_image
+    organisation = content_item["links"].dig("primary_publishing_organisation")
+    organisation[0].dig("details", "default_news_image") if organisation.present?
   end
 end

--- a/app/presenters/world_location_news_article_presenter.rb
+++ b/app/presenters/world_location_news_article_presenter.rb
@@ -8,7 +8,7 @@ class WorldLocationNewsArticlePresenter < ContentItemPresenter
   include ContentItem::Metadata
 
   def image
-    content_item["details"].dig("image") || default_news_image 
+    content_item["details"].dig("image") || default_news_image || placeholder_image
   end
 
 private
@@ -16,5 +16,9 @@ private
   def default_news_image
     organisation = content_item["links"].dig("primary_publishing_organisation")
     organisation[0].dig("details", "default_news_image") if organisation.present?
+  end
+
+  def placeholder_image
+    "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg"
   end
 end

--- a/test/presenters/news_article_presenter_test.rb
+++ b/test/presenters/news_article_presenter_test.rb
@@ -64,6 +64,15 @@ class NewsArticlePresenterTest
       presented_item = present_example(example)
       assert_equal default_news_image, presented_item.image
     end
+
+    test 'presents a placeholder image if document has no image or default news image' do
+      placeholder_image = "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg"
+      example = schema_item
+      example['details'].delete('image')
+
+      presented_item = present_example(example)
+      assert_equal placeholder_image, presented_item.image
+    end
   end
 
   class HistoryModePresentedNewsArticle < NewsArticlePresenterTestCase

--- a/test/presenters/world_location_news_article_presenter_test.rb
+++ b/test/presenters/world_location_news_article_presenter_test.rb
@@ -76,6 +76,15 @@ class WorldLocationNewsArticlePresenterTest
       presented_item = present_example(example)
       assert_equal default_news_image, presented_item.image
     end
+
+    test 'presents a placeholder image if document has no image or default news image' do
+      placeholder_image = "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg"
+      example = schema_item
+      example['details'].delete('image')
+
+      presented_item = present_example(example)
+      assert_equal placeholder_image, presented_item.image
+    end
   end
 
   class HistoryModePresentedWorldLocationNewsArticle < WorldLocationNewsArticlePresenterTestCase

--- a/test/presenters/world_location_news_article_presenter_test.rb
+++ b/test/presenters/world_location_news_article_presenter_test.rb
@@ -57,6 +57,25 @@ class WorldLocationNewsArticlePresenterTest
     test 'presents world locations as part_of' do
       assert_includes presented_item.part_of[0], schema_item['links']['world_locations'][0]['title']
     end
+
+    test 'presents the document\'s image if present' do
+      assert_equal schema_item['details']['image'], presented_item.image
+    end
+
+    test 'presents the document\'s organisation\'s default_news_image if document\'s image is not present' do
+      default_news_image = { 'url' => 'http://www.test.dev.gov.uk/default_news_image.jpg' }
+      example = schema_item
+      example['details'].delete('image')
+      example['links'] = {
+        'primary_publishing_organisation' => [
+          'details' => {
+            'default_news_image' => default_news_image
+          }
+        ]
+      }
+      presented_item = present_example(example)
+      assert_equal default_news_image, presented_item.image
+    end
   end
 
   class HistoryModePresentedWorldLocationNewsArticle < WorldLocationNewsArticlePresenterTestCase


### PR DESCRIPTION
For https://trello.com/c/UXUxzEv4/512-amend-government-frontend-logic-to-use-default-organisation-image

This ensures that a placeholder image is displays in cases where news-like content does not have an image or a default news image.  We also ensure that world location news articles can display a default news image if they have one in cases where they don't have an image.