### PR TITLE
Fix placeholder image bug

### DIFF
--- a/app/presenters/content_item/news_image.rb
+++ b/app/presenters/content_item/news_image.rb
@@ -12,7 +12,7 @@ module ContentItem
     end
 
     def placeholder_image
-      "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg"
+      { "url" => "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg" }
     end
   end
 end

--- a/test/presenters/content_item/news_image_test.rb
+++ b/test/presenters/content_item/news_image_test.rb
@@ -34,7 +34,7 @@ class ContentItemNewsImageTest < ActiveSupport::TestCase
 
   test "presents a placeholder image if document has no image or default news image" do
     item = DummyContentItem.new
-    placeholder_image = "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg"
+    placeholder_image = { "url" => "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg" }
 
     assert_equal placeholder_image, item.image
   end


### PR DESCRIPTION
It should return a hash instead of a string.