### PR TITLE
Display image credit for lead images

### DIFF
--- a/app/assets/stylesheets/components/_figure.scss
+++ b/app/assets/stylesheets/components/_figure.scss
@@ -36,3 +36,11 @@
     margin-top: $gutter-one-third;
   }
 }
+
+.app-c-figure__figcaption-text {
+  margin-bottom: 0;
+
+  @include media(desktop, tablet) {
+    margin-bottom: $gutter-one-third;
+  }
+}

--- a/app/views/components/_figure.html.erb
+++ b/app/views/components/_figure.html.erb
@@ -1,12 +1,21 @@
 <%
   alt ||= ''
   caption ||= ''
+  credit ||= ''
 %>
 <figure class="app-c-figure">
   <img class="app-c-figure__image" src="<%= src %>" alt="<%= alt %>">
-  <% unless caption.blank? %>
     <figcaption class="app-c-figure__figcaption">
-      <%= caption %>
+      <% unless caption.blank? %>
+        <p class="app-c-figure__figcaption-text">
+          <%= caption %>
+        </p>
+      <% end %>
+
+      <% if credit.present? %>
+          <p class="app-c-figure__figcaption-credit">
+            Image credit: <%= credit %>
+          </p>
+      <% end %>
     </figcaption>
-  <% end %>
 </figure>

--- a/app/views/components/_figure.html.erb
+++ b/app/views/components/_figure.html.erb
@@ -14,7 +14,7 @@
 
       <% if credit.present? %>
           <p class="app-c-figure__figcaption-credit">
-            Image credit: <%= credit %>
+            <%= I18n.t("components.figure.image_credit", credit: credit) %>
           </p>
       <% end %>
     </figcaption>

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -23,6 +23,7 @@
       <%= render 'components/figure',
           src: @content_item.image["url"],
           alt: @content_item.image["alt_text"],
+          credit: @content_item.image["credit"],
           caption: @content_item.image["caption"] if @content_item.image %>
 
       <%= render 'govuk_publishing_components/components/govspeak',

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -25,6 +25,7 @@
       <%= render 'components/figure',
           src: @content_item.image["url"],
           alt: @content_item.image["alt_text"],
+          credit: @content_item.image["credit"],
           caption: @content_item.image["caption"] if @content_item.image %>
       <%= render 'govuk_publishing_components/components/govspeak',
           content: @content_item.body.html_safe,

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -24,6 +24,7 @@
       <%= render 'components/figure',
           src: @content_item.image["url"],
           alt: @content_item.image["alt_text"],
+          credit: @content_item.image["credit"],
           caption: @content_item.image["caption"] if @content_item.image %>
       <%= render 'govuk_publishing_components/components/govspeak',
           content: @content_item.body.html_safe,

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -27,6 +27,7 @@
       <%= render 'components/figure',
           src: @content_item.image["url"],
           alt: @content_item.image["alt_text"],
+          credit: @content_item.image["credit"],
           caption: @content_item.image["caption"] if @content_item.image %>
 
       <%= render 'govuk_publishing_components/components/govspeak',

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -18,6 +18,7 @@
     <%= render 'components/figure',
         src: @content_item.image["url"],
         alt: @content_item.image["alt_text"],
+        credit: @content_item.image["credit"],
         caption: @content_item.image["caption"] if @content_item.image %>
 
     <%= render 'govuk_publishing_components/components/govspeak',

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -24,6 +24,7 @@
       <%= render 'components/figure',
           src: @content_item.image["url"],
           alt: @content_item.image["alt_text"],
+          credit: @content_item.image["credit"],
           caption: @content_item.image["caption"] if @content_item.image %>
 
       <%= render 'govuk_publishing_components/components/govspeak',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,8 @@ en:
   common:
     last_updated: "Last updated"
   components:
+    figure:
+      image_credit: "Image credit: %{credit}"
     share_links:
       share_this_page: "Share this page"
     publisher_metadata:

--- a/test/components/figure_test.rb
+++ b/test/components/figure_test.rb
@@ -21,6 +21,21 @@ class FigureTest < ComponentTestCase
     render_component(src: '/image', alt: 'image alt text', caption: 'This is a caption')
     assert_select ".app-c-figure__image[src=\"/image\"]"
     assert_select ".app-c-figure__image[alt=\"image alt text\"]"
-    assert_select ".app-c-figure__figcaption", text: 'This is a caption'
+    assert_select ".app-c-figure__figcaption .app-c-figure__figcaption-text", text: 'This is a caption'
+  end
+
+  test "renders a figure with credit correctly" do
+    render_component(src: '/image', alt: 'image alt text', credit: 'Creative Commons')
+    assert_select ".app-c-figure__image[src=\"/image\"]"
+    assert_select ".app-c-figure__image[alt=\"image alt text\"]"
+    assert_select ".app-c-figure__figcaption .app-c-figure__figcaption-credit", text: 'Image credit: Creative Commons'
+  end
+
+  test "renders a figure with caption and credit correctly" do
+    render_component(src: '/image', alt: 'image alt text', caption: 'This is a caption', credit: 'Creative Commons')
+    assert_select ".app-c-figure__image[src=\"/image\"]"
+    assert_select ".app-c-figure__image[alt=\"image alt text\"]"
+    assert_select ".app-c-figure__figcaption .app-c-figure__figcaption-text", text: 'This is a caption'
+    assert_select ".app-c-figure__figcaption .app-c-figure__figcaption-credit", text: 'Image credit: Creative Commons'
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/hGmJ5BfV 
Related to: 
* https://github.com/alphagov/govuk-content-schemas/pull/850
* https://github.com/alphagov/content-publisher/pull/627

## Motivation
Content Publisher allows publishers to add an image credit, but we are not displaying this data on the frontend

## Expected changes
### Desktop
<img width="776" alt="screen shot 2018-12-18 at 15 22 35" src="https://user-images.githubusercontent.com/5793815/50164691-488ffc80-02db-11e9-8ffa-7ba5644df68e.png">

### Mobile
<img width="210" alt="screen shot 2018-12-18 at 16 24 09" src="https://user-images.githubusercontent.com/5793815/50168023-62810d80-02e2-11e9-88f3-0dbdaa02b3c8.png">


Paired with @DilwoarH 