### PR TITLE
Add related links A/A test to all routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery except: :service_sign_in_options
 
+  include AATestable
+
 private
 
   def content_item_path

--- a/app/controllers/concerns/aa_testable.rb
+++ b/app/controllers/concerns/aa_testable.rb
@@ -1,0 +1,29 @@
+module AATestable
+  RELATED_LINKS_DIMENSION = 65
+
+  def self.included(base)
+    base.helper_method(
+      :related_links_variant
+    )
+    base.after_action :set_test_response_header
+  end
+
+  def related_links_variant
+    @related_links_variant ||= related_links_test.requested_variant(request.headers)
+  end
+
+private
+
+  def related_links_test
+    @related_links_test ||= GovukAbTesting::AbTest.new(
+      "RelatedLinksAATest",
+      dimension: RELATED_LINKS_DIMENSION,
+      allowed_variants: %w(A B),
+      control_variant: "A"
+    )
+  end
+
+  def set_test_response_header
+    related_links_variant.configure_response(response)
+  end
+end

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -4,6 +4,7 @@
   <title>
     government-frontend development page
   </title>
+  <%= related_links_variant.analytics_meta_tag.html_safe %>
 </head>
 <body>
   <div id="wrapper">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,8 @@
   <%= csrf_meta_tags %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item.content_item %>
 
+  <%= related_links_variant.analytics_meta_tag.html_safe %>
+
   <% if @content_item.description %>
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>

--- a/test/controllers/development_controller_test.rb
+++ b/test/controllers/development_controller_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class DevelopmentControllerTest < ActionController::TestCase
+  include GovukAbTesting::MinitestHelpers
+
+  %w(A B).each do |test_variant|
+    test "RelatedLinksAATest works correctly for each variant (variant: #{test_variant})" do
+      with_variant RelatedLinksAATest: test_variant do
+        get :index
+
+        ab_test = @controller.send(:related_links_test)
+        requested = ab_test.requested_variant(request.headers)
+        assert requested.variant?(test_variant)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new concern `AATestable`, which will be used to run an A/A test to determine
variance in our metrics and help guide metrics to use for upcoming A/B tests on related links.

Solo: @karlbaker02

---

Visual regression results:
https://government-frontend-pr-1211.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1211.herokuapp.com/component-guide
