### PR TITLE
Mark coming soons as migrated

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Not all schemas that this app can handle are rendered by it in production.
 |---|---|---|
 | Answer | [View on GOV.UK](https://www.gov.uk/national-minimum-wage-rates) | Migrated |
 | Case study | [View on GOV.UK](https://www.gov.uk/government/case-studies/2013-elections-in-swaziland) | Migrated |
-| Coming soon | | Rendered by Whitehall |
+| Coming soon |  | Migrated |
 | Consultation | [View on GOV.UK](https://www.gov.uk/government/consultations/soft-drinks-industry-levy) | Migrated |
 | Contacts | [View on GOV.UK](https://www.gov.uk/government/organisations/hm-revenue-customs/contact/alcohol-duties-national-registration-unit) | Migrated |
 | Corporate information page | [View on GOV.UK](https://www.gov.uk/government/organisations/government-digital-service/about) | Migrated |


### PR DESCRIPTION
As far as I can tell, these are now rendered by Government Frontend.

https://github.com/alphagov/government-frontend/blob/master/app/views/content_items/coming_soon.html.erb