### PR TITLE
Add related links A/B test

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery except: :service_sign_in_options
 
-  include AATestable
+  include ABTestable
 
 private
 

--- a/app/controllers/concerns/ab_testable.rb
+++ b/app/controllers/concerns/ab_testable.rb
@@ -16,7 +16,7 @@ private
 
   def related_links_test
     @related_links_test ||= GovukAbTesting::AbTest.new(
-      "RelatedLinksABTest",
+      "RelatedLinksABTest1",
       dimension: RELATED_LINKS_DIMENSION,
       allowed_variants: %w(A B),
       control_variant: "A"

--- a/app/controllers/concerns/ab_testable.rb
+++ b/app/controllers/concerns/ab_testable.rb
@@ -1,4 +1,4 @@
-module AATestable
+module ABTestable
   RELATED_LINKS_DIMENSION = 65
 
   def self.included(base)
@@ -16,7 +16,7 @@ private
 
   def related_links_test
     @related_links_test ||= GovukAbTesting::AbTest.new(
-      "RelatedLinksAATest",
+      "RelatedLinksABTest",
       dimension: RELATED_LINKS_DIMENSION,
       allowed_variants: %w(A B),
       control_variant: "A"

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -56,6 +56,11 @@ private
 
   def load_content_item
     content_item = Services.content_store.content_item(content_item_path)
+
+    if related_links_variant.variant?('B') && content_item["links"]["suggested_ordered_related_items"]
+      content_item["links"]["ordered_related_items"] = content_item["links"]["suggested_ordered_related_items"]
+    end
+
     @content_item = PresenterBuilder.new(content_item, content_item_path).presenter
   end
 

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -57,8 +57,8 @@ private
   def load_content_item
     content_item = Services.content_store.content_item(content_item_path)
 
-    if related_links_variant.variant?('B') && content_item.dig('links', 'suggested_ordered_related_items')
-      content_item['links']['ordered_related_items'] = content_item['links']['suggested_ordered_related_items']
+    if related_links_variant.variant?('B')
+      content_item['links']['ordered_related_items'] = content_item['links'].fetch('suggested_ordered_related_items', [])
     end
 
     @content_item = PresenterBuilder.new(content_item, content_item_path).presenter

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -57,7 +57,7 @@ private
   def load_content_item
     content_item = Services.content_store.content_item(content_item_path)
 
-    if related_links_variant.variant?('B')
+    if related_links_variant.variant?('B') && content_item.dig('links')
       content_item['links']['ordered_related_items'] = content_item['links'].fetch('suggested_ordered_related_items', [])
     end
 

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -57,8 +57,8 @@ private
   def load_content_item
     content_item = Services.content_store.content_item(content_item_path)
 
-    if related_links_variant.variant?('B') && content_item["links"]["suggested_ordered_related_items"]
-      content_item["links"]["ordered_related_items"] = content_item["links"]["suggested_ordered_related_items"]
+    if related_links_variant.variant?('B') && content_item.dig('links', 'suggested_ordered_related_items')
+      content_item['links']['ordered_related_items'] = content_item['links']['suggested_ordered_related_items']
     end
 
     @content_item = PresenterBuilder.new(content_item, content_item_path).presenter

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -130,8 +130,8 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_equal content_item['title'], assigns[:content_item].title
   end
 
-  test "gets item from the content store and keeps ordered_related_items when running RelatedLinksABTest control variant" do
-    with_variant RelatedLinksABTest: 'A' do
+  test "gets item from the content store and keeps ordered_related_items when running RelatedLinksABTest1 control variant" do
+    with_variant RelatedLinksABTest1: 'A' do
       content_item = content_store_has_schema_example('case_study', 'case_study')
 
       get :show, params: { path: path_for(content_item) }
@@ -140,13 +140,23 @@ class ContentItemsControllerTest < ActionController::TestCase
     end
   end
 
-  test "gets item from the content store and replaces ordered_related_items when running RelatedLinksABTest test variant" do
-    with_variant RelatedLinksABTest: 'B' do
+  test "gets item from the content store and replaces ordered_related_items when running RelatedLinksABTest1 test variant" do
+    with_variant RelatedLinksABTest1: 'B' do
       content_item = content_store_has_schema_example('case_study', 'case_study')
 
       get :show, params: { path: path_for(content_item) }
       assert_response :success
       assert_equal assigns[:content_item].content_item['links']['ordered_related_items'], assigns[:content_item].content_item['links']['suggested_ordered_related_items']
+    end
+  end
+
+  test "gets item from the content store and replaces ordered_related_items when empty array when RelatedLinksABTest1 test variant has no suggestions" do
+    with_variant RelatedLinksABTest1: 'B' do
+      content_item = content_store_has_schema_example('guide', 'guide')
+
+      get :show, params: { path: path_for(content_item) }
+      assert_response :success
+      assert_equal [], assigns[:content_item].content_item['links']['ordered_related_items']
     end
   end
 

--- a/test/controllers/development_controller_test.rb
+++ b/test/controllers/development_controller_test.rb
@@ -4,8 +4,8 @@ class DevelopmentControllerTest < ActionController::TestCase
   include GovukAbTesting::MinitestHelpers
 
   %w(A B).each do |test_variant|
-    test "RelatedLinksABTest works correctly for each variant (variant: #{test_variant})" do
-      with_variant RelatedLinksABTest: test_variant do
+    test "RelatedLinksABTest1 works correctly for each variant (variant: #{test_variant})" do
+      with_variant RelatedLinksABTest1: test_variant do
         get :index
 
         ab_test = @controller.send(:related_links_test)

--- a/test/controllers/development_controller_test.rb
+++ b/test/controllers/development_controller_test.rb
@@ -4,8 +4,8 @@ class DevelopmentControllerTest < ActionController::TestCase
   include GovukAbTesting::MinitestHelpers
 
   %w(A B).each do |test_variant|
-    test "RelatedLinksAATest works correctly for each variant (variant: #{test_variant})" do
-      with_variant RelatedLinksAATest: test_variant do
+    test "RelatedLinksABTest works correctly for each variant (variant: #{test_variant})" do
+      with_variant RelatedLinksABTest: test_variant do
         get :index
 
         ab_test = @controller.send(:related_links_test)


### PR DESCRIPTION
This PR adds support for the Related Links A/B test, showing a different set of related links on the B variant from the content item's suggested_ordered_related_items, where it exists. It also updates the current RelatedLinksAATest to be RelatedLinksABTest.

Trello: https://trello.com/c/byNrHEMw

---

Visual regression results:
https://government-frontend-pr-1223.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1223.herokuapp.com/component-guide
