### PR TITLE
Upgrade govuk_publishing_components to 13.6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 57.2'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.11'
 gem 'govuk_frontend_toolkit', '~> 8.1.0'
-gem 'govuk_publishing_components', '~> 13.5.2'
+gem 'govuk_publishing_components', '~> 13.6.1'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 13.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     govuk_frontend_toolkit (8.1.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (13.5.2)
+    govuk_publishing_components (13.6.1)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -140,7 +140,7 @@ GEM
     govuk_schemas (3.2.0)
       json-schema (~> 2.8.0)
     hashdiff (0.3.7)
-    highline (2.0.0)
+    highline (2.0.1)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -186,7 +186,7 @@ GEM
     minitest (5.11.3)
     mocha (1.8.0)
       metaclass (~> 0.0.1)
-    money (6.13.1)
+    money (6.13.2)
       i18n (>= 0.6.4, <= 2)
     multipart-post (2.0.0)
     netrc (0.11.0)
@@ -370,7 +370,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.11)
   govuk_frontend_toolkit (~> 8.1.0)
-  govuk_publishing_components (~> 13.5.2)
+  govuk_publishing_components (~> 13.6.1)
   govuk_schemas (~> 3.2)
   htmlentities (~> 4.3)
   jasmine-rails

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -55,9 +55,9 @@ module ServiceSignIn
 
       click_on 'Continue'
 
-      assert page.has_css?(".gem-c-error-summary")
-      assert page.has_css?(".gem-c-error-summary__title", text: 'You haven’t selected an option')
-      assert page.has_css?(".gem-c-error-summary__link[href='#option-0']", text: 'Please select an option')
+      assert page.has_css?(".govuk-error-summary")
+      assert page.has_css?(".govuk-error-summary__title", text: 'You haven’t selected an option')
+      assert page.has_css?("ul li a:first-of-type[href='#option-0']", text: 'Please select an option')
 
       # Make sure the id is the same as the link href so that they'll link together properly.
       assert page.has_css?(".gem-c-radio input[id='option-0'][value='use-government-gateway']", visible: false)

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -55,9 +55,8 @@ module ServiceSignIn
 
       click_on 'Continue'
 
-      assert page.has_css?(".govuk-error-summary")
-      assert page.has_css?(".govuk-error-summary__title", text: 'You haven’t selected an option')
-      assert page.has_css?("ul li a:first-of-type[href='#option-0']", text: 'Please select an option')
+      assert page.has_text?('You haven’t selected an option')
+      assert page.has_text?('Please select an option')
 
       # Make sure the id is the same as the link href so that they'll link together properly.
       assert page.has_css?(".gem-c-radio input[id='option-0'][value='use-government-gateway']", visible: false)


### PR DESCRIPTION
This PR upgrades the govuk_publishing_components gem to version `13.6.1`.

---

Visual regression results:
https://government-frontend-pr-1223.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1223.herokuapp.com/component-guide
