### PR TITLE
Upgrade govuk_publishing_components to 13.8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-api-adapters', '~> 57.2'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 1.11'
 gem 'govuk_frontend_toolkit', '~> 8.1.0'
-gem 'govuk_publishing_components', '~> 13.6.1'
+gem 'govuk_publishing_components', '~> 13.8.1'
 gem 'plek', '~> 2.1'
 gem 'slimmer', '~> 13.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     govuk_frontend_toolkit (8.1.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (13.6.1)
+    govuk_publishing_components (13.8.1)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -370,7 +370,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 1.11)
   govuk_frontend_toolkit (~> 8.1.0)
-  govuk_publishing_components (~> 13.6.1)
+  govuk_publishing_components (~> 13.8.1)
   govuk_schemas (~> 3.2)
   htmlentities (~> 4.3)
   jasmine-rails


### PR DESCRIPTION
This commit upgrades the govuk_publishing_components gem to version `13.8.1`.

---

Visual regression results:
https://government-frontend-pr-1234.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1234.herokuapp.com/component-guide
