### PR TITLE
Rationalise heading levels on contact pages

### DIFF
--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -66,12 +66,12 @@
             </div>
           <% end %>
           <% if phone_group[:opening_times].present? %>
-            <h4 class="normal-weight">Opening times:</h4>
+            <p>Opening times:</p>
             <%= phone_group[:opening_times] %>
           <% end %>
 
           <% if phone_group[:best_time_to_call].present? %>
-            <h4 class="normal-weight">Best time to call:</h4>
+            <p>Best time to call:</p>
             <%= phone_group[:best_time_to_call] %>
           <% end %>
         <% end %>

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -58,11 +58,9 @@
           <%= phone_group[:description] %>
           <% if phone_group[:numbers].any? %>
             <div class="contact">
-              <div class="content">
-                <% phone_group[:numbers].each do |number| %>
-                  <p><%= number[:label] %>:<br /><strong><%= number[:number] %></strong></p>
-                <% end%>
-              </div>
+              <% phone_group[:numbers].each do |number| %>
+                <p><%= number[:label] %>:<br /><strong><%= number[:number] %></strong></p>
+              <% end%>
             </div>
           <% end %>
           <% if phone_group[:opening_times].present? %>

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -86,7 +86,7 @@
         <% @content_item.post.each do |post_group| %>
           <%= post_group[:description] %>
           <div class="contact vcard">
-            <p class="content">
+            <p>
               <% post_group[:v_card].each do |v_card_part| %>
                 <span class="<%= v_card_part[:v_card_class] %>">
                   <%= v_card_part[:value] %>


### PR DESCRIPTION
[Trello](https://trello.com/c/ZgUEa2nB/787-accessibility-issue-on-contact-pages)

This commit primarily removes a redundant and potentially confusing heading level. It also tidies up a couple of pieces of markup that aren't strictly needed for styling the page.

Copying the commit message from the first commit to remove a heading level:

We have some `h4` tags on the page that are unnecessary. Replace them with
`p` tags instead.

Contact pages on goverment-frontend can be represented by the following
pseudo code:

```
<h2>Phone</h2>
  <h3>Phone group title</h3>
    <p>Telephone number</p>
    <h4>Opening times</h4>
    <h4>Best time to call</h4>

  <h3>Phone group title</h3>
    <p>Telephone number</p>
    <h4>Opening times</h4>
    <h4>Best time to call</h4>
```

Some contact pages, however, do not have multiple "Phone groups". In
these cases, the "Phone group title" `h3` is not displayed (there is
(specific logic)[https://github.com/alphagov/government-frontend/blob/6b19d185ae524d0216b3cc9ab9bc49e8c6b893d3/app/views/content_items/contact.html.erb#L55-L57] to only show the titles if more than one exists). 

When we do not display the `h3` on the page, we end up with a heading hierarchy
that skips from an `h2` (Phone) to an `h4` (Opening times).

To add insult to injury, the `h4` rendered markup has
`class="normal-weight"` to override the default bold behaviour of `h4`
tags.

There is very little need for such an explosion of heading levels and
the content still makes sense even without the `h4` tags.

---

You can see two examples of contact pages as follows:

With phone groups:
www.gov.uk/government/organisations/hm-revenue-customs/contact/bereavement-and-deceased-estate

Without phone groups:
www.gov.uk/government/organisations/hm-revenue-customs/contact/agent-dedicated-line-debt-management

## screenshots of current behaviour
### with phone groups showing correct heading hierarchy applied:
<img width="1357" alt="screen shot 2019-02-14 at 08 26 34" src="https://user-images.githubusercontent.com/647311/52793384-83a57680-3065-11e9-9086-f35659b7dbe9.png">

### without phone groups showing skipped heading levels
<img width="1167" alt="screen shot 2019-02-14 at 08 24 08" src="https://user-images.githubusercontent.com/647311/52793437-a6378f80-3065-11e9-8935-9b0935ad6b6e.png">


## screenshots of new behaviour
### with phone groups no longer showing an h4 but still keeping the h2 -> h3 hierarchy
<img width="1335" alt="screen shot 2019-02-14 at 15 22 37" src="https://user-images.githubusercontent.com/647311/52796804-66c07180-306c-11e9-9d41-4c2c2c7fda6e.png">


### without phone groups - no skipped heading levels
<img width="1377" alt="screen shot 2019-02-14 at 15 18 57" src="https://user-images.githubusercontent.com/647311/52796554-f6b1eb80-306b-11e9-8638-b29fc914fd86.png">




---

Visual regression results:
https://government-frontend-pr-1245.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1245.herokuapp.com/component-guide


