### PR TITLE
Increase Capybara timeouts

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ Capybara.register_driver :headless_chrome do |app|
     chromeOptions: { args: %w(headless disable-gpu no-sandbox) }
   )
   client = Selenium::WebDriver::Remote::Http::Default.new
-  client.timeout = 90 # Asset compilation can result in a timeout on the first request hence the increase.
+  client.read_timeout = 120 # Asset compilation can result in a timeout on the first request hence the increase.
 
   Capybara::Selenium::Driver.new(
     app,


### PR DESCRIPTION
Master is failing with Net::ReadTimeout errors. We have
[previously](https://github.com/alphagov/government-frontend/pull/1121)
increased timeouts which seemed to solve the problem. Let's hope the
magic works again.

At the same time, we are getting a deprecation warning:

```
WARN Selenium [DEPRECATION] :timeout= is deprecated. Use #read_timeout= and #open_timeout= instead.
```

so I have changed `timeout` to `read_timeout` instead.

---

Visual regression results:
https://government-frontend-pr-1249.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1249.herokuapp.com/component-guide
