### PR TITLE
Explicitly precompile assets on test

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,8 @@ require 'mocha/minitest'
 require 'capybara/minitest'
 require 'faker'
 
+system('bundle exec rake assets:precompile')
+
 Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 
 Capybara.register_driver :headless_chrome do |app|


### PR DESCRIPTION
When Capybara first runs it triggers an asset compilation. This takes a
very long time at the moment and causes `Net::ReadTimeout` errors when
merged to master. This commit adds an explicit precompile to the test
helper so that assets are already compiled by the time Capybara does its
thing. This will slow down testing on dev environments when first
running tests.

[Trello](https://trello.com/c/AlYnvTTI/804-precompile-assets-during-tests-on-ci-for-government-frontend)

---

Visual regression results:
https://government-frontend-pr-1254.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1254.herokuapp.com/component-guide
