### PR TITLE
Include precompile assets  argument to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,5 @@ REPOSITORY = 'government-frontend'
 
 node {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-government-frontend")
-  govuk.buildProject(publishingE2ETests: true, brakeman: true)
+  govuk.buildProject(publishingE2ETests: true, brakeman: true, precompileAssetsBeforeTests: true)
 }


### PR DESCRIPTION
When Capybara starts during our tests, it causes assets to precompile.
This can be quite slow and often the first request times out during our builds when
merging to master while waiting for asset compilation.

We want to precompile assets before running the tests so we don't hit
this timeout issue and fail our buid.

Pass the precompileAssetsBeforeTests argument to govuk.buildProject
which will trigger a precompile before running tests.

Depends on https://github.com/alphagov/govuk-jenkinslib/pull/49

Supersedes  https://github.com/alphagov/government-frontend/pull/1254

[Trello](https://trello.com/c/AlYnvTTI/804-precompile-assets-during-tests-on-ci-for-government-frontend)

---

Visual regression results:
https://government-frontend-pr-1255.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1255.herokuapp.com/component-guide
