### PR TITLE
Fix component guide inline JS CSP hash

### DIFF
--- a/config/initializers/csp.rb
+++ b/config/initializers/csp.rb
@@ -60,8 +60,8 @@ module CSP
       # https://github.com/alphagov/govuk_template/blob/79340eb91ad8c4279d16da302765d0946d89b1ca/source/views/layouts/govuk_template.html.erb#L40
       "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
 
-      # The same as above but with leading whitespace as used by the component guide
-      "'sha256-+/sukrsYfvM/tHbNll4hTsl0mtvAQUFXZWdCg49lerI='",
+      # The same as above but with leading and trailing whitespace as used by the component guide
+      "'sha256-IWjjekDxqqURWMjVH447fuaAvoZKwpDwLS0ZdcJ+Ey4='",
 
       # ALlow the script that removes `js-enabled` from body if there's an error
       # https://github.com/alphagov/govuk_template/blob/79340eb91ad8c4279d16da302765d0946d89b1ca/source/views/layouts/govuk_template.html.erb#L112-L113


### PR DESCRIPTION
Everything inside the script tags, including both leading and trailing spaces, is important for the hash.