### PR TITLE
Change Plek(rummager) to Plek(search)

### DIFF
--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -36,8 +36,8 @@
             <td><%= link_to Plek.find('static'), Plek.find('static') %></td>
           </tr>
           <tr>
-            <td>Rummager (search)</td>
-            <td><%= link_to Plek.find('rummager'), Plek.find('rummager') %></td>
+            <td>Search</td>
+            <td><%= link_to Plek.find('search'), Plek.find('search') %></td>
           </tr>
         </table>
 


### PR DESCRIPTION
For the migration to search-api we're going to re-target the 'search'
alias to search-api.

---

[Trello card](https://trello.com/c/yrq9hZmU/77-point-the-search-alias-to-search-api-if-rummager-is-disabled)