### PR TITLE
Update related links A/B test variant for test #3

### DIFF
--- a/app/controllers/concerns/ab_testable.rb
+++ b/app/controllers/concerns/ab_testable.rb
@@ -16,7 +16,7 @@ private
 
   def related_links_test
     @related_links_test ||= GovukAbTesting::AbTest.new(
-      "RelatedLinksABTest2",
+      "RelatedLinksABTest3",
       dimension: RELATED_LINKS_DIMENSION,
       allowed_variants: %w(A B),
       control_variant: "A"

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -130,8 +130,8 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_equal content_item['title'], assigns[:content_item].title
   end
 
-  test "gets item from the content store and keeps ordered_related_items when running RelatedLinksABTest2 control variant" do
-    with_variant RelatedLinksABTest2: 'A' do
+  test "gets item from the content store and keeps ordered_related_items when running RelatedLinksABTest3 control variant" do
+    with_variant RelatedLinksABTest3: 'A' do
       content_item = content_store_has_schema_example('case_study', 'case_study')
 
       get :show, params: { path: path_for(content_item) }
@@ -140,8 +140,8 @@ class ContentItemsControllerTest < ActionController::TestCase
     end
   end
 
-  test "gets item from the content store and replaces ordered_related_items when running RelatedLinksABTest2 test variant" do
-    with_variant RelatedLinksABTest2: 'B' do
+  test "gets item from the content store and replaces ordered_related_items when running RelatedLinksABTest3 test variant" do
+    with_variant RelatedLinksABTest3: 'B' do
       content_item = content_store_has_schema_example('case_study', 'case_study')
 
       get :show, params: { path: path_for(content_item) }
@@ -150,8 +150,8 @@ class ContentItemsControllerTest < ActionController::TestCase
     end
   end
 
-  test "gets item from the content store and replaces ordered_related_items when empty array when RelatedLinksABTest2 test variant has no suggestions" do
-    with_variant RelatedLinksABTest2: 'B' do
+  test "gets item from the content store and replaces ordered_related_items when empty array when RelatedLinksABTest3 test variant has no suggestions" do
+    with_variant RelatedLinksABTest3: 'B' do
       content_item = content_store_has_schema_example('guide', 'guide')
 
       get :show, params: { path: path_for(content_item) }

--- a/test/controllers/development_controller_test.rb
+++ b/test/controllers/development_controller_test.rb
@@ -4,8 +4,8 @@ class DevelopmentControllerTest < ActionController::TestCase
   include GovukAbTesting::MinitestHelpers
 
   %w(A B).each do |test_variant|
-    test "RelatedLinksABTest2 works correctly for each variant (variant: #{test_variant})" do
-      with_variant RelatedLinksABTest2: test_variant do
+    test "RelatedLinksABTest3 works correctly for each variant (variant: #{test_variant})" do
+      with_variant RelatedLinksABTest3: test_variant do
         get :index
 
         ab_test = @controller.send(:related_links_test)


### PR DESCRIPTION
This PR updates the A/B test variant for related links from `RelatedLinksABTest2` to `RelatedLinksABTest3`. This is to support the third iteration of the A/B test which is using a new set of related link data.

---

Visual regression results:
https://government-frontend-pr-1269.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1269.herokuapp.com/component-guide
