### PR TITLE
Add additional variant for Related Links A/B test v3

### DIFF
--- a/app/controllers/concerns/ab_testable.rb
+++ b/app/controllers/concerns/ab_testable.rb
@@ -18,7 +18,7 @@ private
     @related_links_test ||= GovukAbTesting::AbTest.new(
       "RelatedLinksABTest3",
       dimension: RELATED_LINKS_DIMENSION,
-      allowed_variants: %w(A B),
+      allowed_variants: %w(A B C),
       control_variant: "A"
     )
   end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -57,7 +57,7 @@ private
   def load_content_item
     content_item = Services.content_store.content_item(content_item_path)
 
-    if related_links_variant.variant?('B') && content_item.dig('links')
+    if related_links_variant.variant?('C') && content_item.dig('links')
       content_item['links']['ordered_related_items'] = content_item['links'].fetch('suggested_ordered_related_items', [])
     end
 

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -130,7 +130,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_equal content_item['title'], assigns[:content_item].title
   end
 
-  test "gets item from the content store and keeps ordered_related_items when running RelatedLinksABTest3 control variant" do
+  test "gets item from the content store and keeps ordered_related_items when running RelatedLinksABTest3 misclassification variant" do
     with_variant RelatedLinksABTest3: 'A' do
       content_item = content_store_has_schema_example('case_study', 'case_study')
 
@@ -140,8 +140,18 @@ class ContentItemsControllerTest < ActionController::TestCase
     end
   end
 
-  test "gets item from the content store and replaces ordered_related_items when running RelatedLinksABTest3 test variant" do
+  test "gets item from the content store and keeps ordered_related_items when running RelatedLinksABTest3 control variant" do
     with_variant RelatedLinksABTest3: 'B' do
+      content_item = content_store_has_schema_example('case_study', 'case_study')
+
+      get :show, params: { path: path_for(content_item) }
+      assert_response :success
+      assert_equal content_item['links']['ordered_related_items'], assigns[:content_item].content_item['links']['ordered_related_items']
+    end
+  end
+
+  test "gets item from the content store and replaces ordered_related_items when running RelatedLinksABTest3 test variant" do
+    with_variant RelatedLinksABTest3: 'C' do
       content_item = content_store_has_schema_example('case_study', 'case_study')
 
       get :show, params: { path: path_for(content_item) }
@@ -151,7 +161,7 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
   test "gets item from the content store and replaces ordered_related_items when empty array when RelatedLinksABTest3 test variant has no suggestions" do
-    with_variant RelatedLinksABTest3: 'B' do
+    with_variant RelatedLinksABTest3: 'C' do
       content_item = content_store_has_schema_example('guide', 'guide')
 
       get :show, params: { path: path_for(content_item) }

--- a/test/controllers/development_controller_test.rb
+++ b/test/controllers/development_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class DevelopmentControllerTest < ActionController::TestCase
   include GovukAbTesting::MinitestHelpers
 
-  %w(A B).each do |test_variant|
+  %w(A B C).each do |test_variant|
     test "RelatedLinksABTest3 works correctly for each variant (variant: #{test_variant})" do
       with_variant RelatedLinksABTest3: test_variant do
         get :index


### PR DESCRIPTION
This PR adds an additional `C` variant for the upcoming related links A/B test iteration v3. In the previous test we saw some users who had the control variant cookie, yet navigated via the related links which are only shown on the `B` variant.

In order to check if there are any problems with our A/B testing framework, in addition to making the data collection easier for later analysis, we are introducing the new `C` variant which will become our test variant. How the variants now work are as follows:

- `A` variant: No users should ever end up in this variant, as our CDN will be configured it to assign 0% of users. If users do end up in this variant, we may have issues with our A/B testing framework which will require further investigation.
- `B` variant: Our control variant, where related links will not be changed in any way.
- `C` variant: Our test variant, where related links will be changed to use our generated links for the sample involved.

---

Visual regression results:
https://government-frontend-pr-1271.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1271.herokuapp.com/component-guide
