### PR TITLE
Update grid usages to GOV.UK Frontend

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,7 +5,6 @@
 
 // govuk_frontend_toolkit imports
 @import 'colours';
-@import 'measurements';
 @import 'shims';
 @import 'typography';
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,8 @@
 // The main application stylesheet
 
+// Components from govuk_publishing_components gem
+@import 'govuk_publishing_components/all_components';
+
 // govuk_frontend_toolkit imports
 @import 'colours';
 @import 'measurements';
@@ -20,9 +23,6 @@
 
 // Components from this application
 @import 'components/*';
-
-// Components from govuk_publishing_components gem
-@import 'govuk_publishing_components/all_components';
 
 // pages specific view imports
 @import 'views/case-studies';

--- a/app/assets/stylesheets/components/_back-to-top.scss
+++ b/app/assets/stylesheets/components/_back-to-top.scss
@@ -1,9 +1,9 @@
 .app-c-back-to-top {
   @include core-16;
   display: inline-block;
-  margin-bottom: $gutter-half;
-  margin-left: $gutter-half;
-  margin-right: $gutter-half;
+  margin-bottom: govuk-spacing(3);
+  margin-left: govuk-spacing(3);
+  margin-right: govuk-spacing(3);
 }
 
 .app-c-back-to-top__icon {

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,5 +1,3 @@
-@import "grid_layout";
-
 .app-c-banner {
   @include responsive-bottom-margin;
   @include core-19;
@@ -14,7 +12,7 @@
   }
 }
 
-.app-c-banner--grid {
+.app-c-banner--aside {
   @include media(tablet) {
     padding: govuk-spacing(6);
   }

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -6,17 +6,17 @@
   @include white-links;
   background: $govuk-blue;
   color: $white;
-  padding: $gutter-half;
+  padding: govuk-spacing(3);
   clear: both;
 
   @include media(tablet) {
-    padding: $gutter-two-thirds $gutter;
+    padding: govuk-spacing(4) govuk-spacing(6);
   }
 }
 
 .app-c-banner--grid {
   @include media(tablet) {
-    padding: $gutter;
+    padding: govuk-spacing(6);
   }
 }
 
@@ -26,12 +26,12 @@
 
 .app-c-banner__title {
   @include bold-27;
-  margin-bottom: $gutter-one-third;
+  margin-bottom: govuk-spacing(2);
 }
 
 .app-c-banner__desc {
   @include core-19;
   // Ensure the text has a line-length of around 60 characters
   max-width: 30em;
-  padding-top: $gutter-one-third;
+  padding-top: govuk-spacing(2);
 }

--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -13,10 +13,10 @@
 }
 
 .app-c-contents-list-with-body__link-wrapper {
-  padding-bottom: $gutter-one-third;
+  padding-bottom: govuk-spacing(2);
 
   .app-c-back-to-top {
-    padding-bottom: $gutter-one-third;
+    padding-bottom: govuk-spacing(2);
   }
 }
 
@@ -32,17 +32,17 @@
   z-index: 1;
 
   @include media(tablet) {
-    padding-left: $gutter-one-third;
+    padding-left: govuk-spacing(2);
   }
 
   .app-c-back-to-top {
     color: $link-colour;
     margin-bottom: 0;
-    padding: $gutter-half;
+    padding: govuk-spacing(3);
     width: percentage(2 / 3);
 
     @include media(tablet) {
-      padding: $gutter-two-thirds;
+      padding: govuk-spacing(4);
     }
   }
 

--- a/app/assets/stylesheets/components/_download-link.scss
+++ b/app/assets/stylesheets/components/_download-link.scss
@@ -1,11 +1,11 @@
 .app-c-download-link {
   display: inline-block;
   @include bold-19;
-  margin-top: $gutter-half;
-  margin-bottom: $gutter-half;
+  margin-top: govuk-spacing(3);
+  margin-bottom: govuk-spacing(3);
 
   @include media(tablet) {
-    margin-top: $gutter;
+    margin-top: govuk-spacing(6);
   }
 }
 

--- a/app/assets/stylesheets/components/_figure.scss
+++ b/app/assets/stylesheets/components/_figure.scss
@@ -3,7 +3,7 @@
   @include responsive-bottom-margin;
 
   border-top: 1px solid $border-colour;
-  padding-top: $gutter-half;
+  padding-top: govuk-spacing(3);
 }
 
 .app-c-figure__image {
@@ -28,12 +28,12 @@
 
     box-sizing: border-box;
     float: left;
-    padding-left: $gutter-half;
+    padding-left: govuk-spacing(3);
     width: 50%;
   }
 
   @include media(mobile) {
-    margin-top: $gutter-one-third;
+    margin-top: govuk-spacing(2);
   }
 }
 
@@ -41,6 +41,6 @@
   margin-bottom: 0;
 
   @include media(desktop, tablet) {
-    margin-bottom: $gutter-one-third;
+    margin-bottom: govuk-spacing(2);
   }
 }

--- a/app/assets/stylesheets/components/_important-metadata.scss
+++ b/app/assets/stylesheets/components/_important-metadata.scss
@@ -3,11 +3,11 @@
   @include white-links;
   background: $govuk-blue;
   color: $white;
-  padding: $gutter-half;
+  padding: govuk-spacing(3);
 
   @include media(tablet) {
     overflow: auto;
-    padding: $gutter-two-thirds $gutter;
+    padding: govuk-spacing(4) govuk-spacing(6);
   }
 }
 
@@ -25,7 +25,7 @@
 
 .app-c-important-metadata__term {
   float: left;
-  padding-right: $gutter-one-third / 2;
+  padding-right: govuk-spacing(1);
 }
 
 .app-c-important-metadata__definition {

--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -25,6 +25,6 @@
 }
 
 .app-c-published-dates--history {
-  padding-top: $gutter-one-third;
+  padding-top: govuk-spacing(2);
   border-top: 1px solid $border-colour;
 }

--- a/app/assets/stylesheets/components/_publisher-metadata.scss
+++ b/app/assets/stylesheets/components/_publisher-metadata.scss
@@ -1,7 +1,7 @@
 .app-c-publisher-metadata {
   @include responsive-bottom-margin;
   @include core-16;
-  padding-top: $gutter-half;
+  padding-top: govuk-spacing(3);
 }
 
 .app-c-publisher-metadata__other a {
@@ -10,7 +10,7 @@
 
 .app-c-publisher-metadata__term {
   float: left;
-  padding-right: $gutter-one-third / 2;
+  padding-right: govuk-spacing(1);
 
   .direction-rtl & {
     float: none;

--- a/app/assets/stylesheets/helpers/_content-bottom-margin.scss
+++ b/app/assets/stylesheets/helpers/_content-bottom-margin.scss
@@ -1,5 +1,5 @@
 .content-bottom-margin {
-  margin-bottom: $gutter-two-thirds;
+  margin-bottom: govuk-spacing(4);
 
   @include media(tablet) {
     @include responsive-bottom-margin;

--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -1,13 +1,13 @@
 @mixin parts {
   .part-navigation-container {
-    margin-top: $gutter;
-    margin-bottom: $gutter;
-    padding-bottom: $gutter-half;
+    margin-top: govuk-spacing(6);
+    margin-bottom: govuk-spacing(6);
+    padding-bottom: govuk-spacing(3);
 
     @include media(tablet) {
       margin-top: 0;
       margin-bottom: 0;
-      padding-bottom: $gutter-half;
+      padding-bottom: govuk-spacing(3);
     }
 
     border-bottom: 1px solid $grey-2;
@@ -33,12 +33,12 @@
 
   .part-title {
     @include bold-27;
-    margin-bottom: $gutter-half;
-    margin-top: $gutter-half;
+    margin-bottom: govuk-spacing(3);
+    margin-top: govuk-spacing(3);
 
     @include media(tablet) {
-      margin-bottom: $gutter-two-thirds;
-      margin-top: $gutter-two-thirds;
+      margin-bottom: govuk-spacing(4);
+      margin-top: govuk-spacing(4);
     }
   }
 }

--- a/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
+++ b/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
@@ -2,7 +2,7 @@
 // roll out the combination of metadata + logo across
 // formats so they may ultimately become component styles.
 .metadata-logo-wrapper {
-  @extend %contain-floats;
+  @include govuk-clearfix;
   border-top: 1px solid $border-colour;
   margin-left: govuk-spacing(3);
   margin-right: govuk-spacing(3);

--- a/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
+++ b/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
@@ -4,8 +4,8 @@
 .metadata-logo-wrapper {
   @extend %contain-floats;
   border-top: 1px solid $border-colour;
-  margin-left: $gutter-half;
-  margin-right: $gutter-half;
+  margin-left: govuk-spacing(3);
+  margin-right: govuk-spacing(3);
 
   .metadata-column {
     padding-left: 0;
@@ -14,8 +14,8 @@
   .metadata-logo {
     max-height: 90px;
     max-width: 100%;
-    padding-bottom: $gutter-half;
-    padding-top: $gutter-half;
+    padding-bottom: govuk-spacing(3);
+    padding-top: govuk-spacing(3);
 
     @include media(tablet) {
       float: right;

--- a/app/assets/stylesheets/helpers/_sidebar-with-body.scss
+++ b/app/assets/stylesheets/helpers/_sidebar-with-body.scss
@@ -1,6 +1,6 @@
 @mixin sidebar-with-body {
   .sidebar-with-body {
     position: relative;
-    margin-bottom: $gutter * 1.5;
+    margin-bottom: govuk-spacing(8);
   }
 }

--- a/app/assets/stylesheets/mixins/_margins.scss
+++ b/app/assets/stylesheets/mixins/_margins.scss
@@ -1,16 +1,16 @@
 @mixin responsive-bottom-margin {
-  margin-bottom: $gutter-half;
+  margin-bottom: govuk-spacing(3);
 
   @include media(tablet) {
-    margin-bottom: $gutter * 1.5;
+    margin-bottom: govuk-spacing(8);
   }
 }
 
 @mixin responsive-top-margin {
-  margin-top: $gutter-half;
+  margin-top: govuk-spacing(3);
 
   @include media(tablet) {
-    margin-top: $gutter * 1.5;
+    margin-top: govuk-spacing(8);
   }
 }
 

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,5 +1,4 @@
 // govuk_frontend_toolkit imports
-@import 'measurements';
 @import 'typography';
 
 @import 'govuk_publishing_components/all_components_print';

--- a/app/assets/stylesheets/views/_answer.scss
+++ b/app/assets/stylesheets/views/_answer.scss
@@ -2,6 +2,6 @@
   @include add-title-margin;
 
   .last-updated {
-    padding-bottom: $gutter-half;
+    padding-bottom: govuk-spacing(3);
   }
 }

--- a/app/assets/stylesheets/views/_coming-soon.scss
+++ b/app/assets/stylesheets/views/_coming-soon.scss
@@ -1,6 +1,6 @@
 .coming-soon {
   .summary {
     @include core-24;
-    margin-bottom: $gutter-half;
+    margin-bottom: govuk-spacing(3);
   }
 }

--- a/app/assets/stylesheets/views/_consultation.scss
+++ b/app/assets/stylesheets/views/_consultation.scss
@@ -9,7 +9,7 @@
     border-top: 1px solid $border-colour;
 
     @include media(tablet) {
-      padding-top: $gutter;
+      padding-top: govuk-spacing(6);
     }
   }
 }

--- a/app/assets/stylesheets/views/_document-collection.scss
+++ b/app/assets/stylesheets/views/_document-collection.scss
@@ -4,12 +4,12 @@
 
   .group-title {
     @include bold-27;
-    margin-top: $gutter;
-    margin-bottom: $gutter-half;
+    margin-top: govuk-spacing(6);
+    margin-bottom: govuk-spacing(3);
 
     @include media(desktop) {
-      margin-top: $gutter * 1.5;
-      margin-bottom: $gutter-two-thirds;
+      margin-top: govuk-spacing(8);
+      margin-bottom: govuk-spacing(4);
     }
 
     &:first-child {

--- a/app/assets/stylesheets/views/_help-page.scss
+++ b/app/assets/stylesheets/views/_help-page.scss
@@ -2,6 +2,6 @@
   @include add-title-margin;
 
   .last-updated {
-    padding-bottom: $gutter-half;
+    padding-bottom: govuk-spacing(3);
   }
 }

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -9,16 +9,14 @@
   }
 
   .publication-external {
-    @extend %grid-row;
-    margin-bottom: $gutter-two-thirds;
+    margin-bottom: govuk-spacing(4);
     position: relative;
 
     .organisation-logos {
-      @include grid-column(1 / 4);
       list-style-type: none;
 
       .organisation-logo {
-        padding-bottom: $gutter-one-third;
+        padding-bottom: govuk-spacing(2);
       }
     }
 
@@ -30,7 +28,7 @@
 
   .publication-header__last-changed {
     @include core-19;
-    margin-top: $gutter-half;
+    margin-top: govuk-spacing(3);
   }
 
   .column-quarter-desktop-only {

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -1,5 +1,3 @@
-@import "grid_layout";
-
 .html-publication {
   @include sidebar-with-body;
 
@@ -31,36 +29,34 @@
     margin-top: govuk-spacing(3);
   }
 
-  .column-quarter-desktop-only {
-    @include grid-column( 1 / 4, $full-width: desktop );
+  .main-content-container {
+    .direction-rtl & {
+      float: left;
+    }
+  }
 
+  .contents-list-container {
     .direction-rtl & {
       float: right;
     }
   }
 
-  .column-three-quarters-desktop-only {
-    @include grid-column( 3 / 4, $full-width: desktop );
+  .main-content-container {
+    width: 100%;
+    padding: 0 15px;
+    box-sizing: border-box;
 
-    .direction-rtl & {
+    @include media(desktop) {
+      width: 75%;
       float: right;
     }
   }
 
-  .offset-quarter-desktop-only {
-    margin-left: 25%;
+  .offset-empty-contents-list {
+    float: right;
 
     .direction-rtl & {
-      margin-left: 0;
-      margin-right: 25%;
-    }
-
-    @include media(false, $desktop-breakpoint) {
-      margin: 0;
-
-      .direction-rtl & {
-        margin: 0;
-      }
+      float: left;
     }
   }
 

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -3,7 +3,7 @@
   @include add-title-margin;
 
   .part-navigation {
-    margin-bottom: $gutter * 1.5;
+    margin-bottom: govuk-spacing(8);
   }
 
   // TODO: Remove this when components can accept variable unidirectional spacing,
@@ -11,7 +11,7 @@
   .map {
     @include responsive-bottom-margin;
 
-    margin-top: $gutter;
+    margin-top: govuk-spacing(6);
 
     .map-image {
       max-width: 100%;

--- a/app/assets/stylesheets/views/_unpublishing.scss
+++ b/app/assets/stylesheets/views/_unpublishing.scss
@@ -1,10 +1,10 @@
 .unpublishing,
 .gone {
-  margin-bottom: $gutter * 2;
+  margin-bottom: govuk-spacing(9);
 
   .summary,
   .alternative {
     @include core-19;
-    margin-bottom: $gutter-half;
+    margin-bottom: govuk-spacing(3);
   }
 }

--- a/app/views/components/_banner.html.erb
+++ b/app/views/components/_banner.html.erb
@@ -11,7 +11,7 @@
     <%= text %>
   </p>
 <% end %>
-<section class="app-c-banner<% if aside %> app-c-banner--grid<% end %>" aria-label="Notice">
+<section class="app-c-banner<% if aside %> app-c-banner--aside<% end %>" aria-label="Notice">
   <%= content_block %>
   <% if aside %>
     <p class="app-c-banner__desc"><%= aside %></p>

--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -1,14 +1,14 @@
 <% content_for :simple_header, true %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title',
         title: @content_item.title %>
   </div>
 </div>
 
-<div class="grid-row responsive-bottom-margin">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row responsive-bottom-margin">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/govspeak',
                { direction: page_text_direction, disable_youtube_expansions: true } do %>
       <%= raw @content_item.body %>

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -4,12 +4,12 @@
   ) %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds responsive-top-margin">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds responsive-top-margin">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
   <%= render 'shared/translations' %>
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
   </div>
 </div>
@@ -17,8 +17,8 @@
 <%= render 'shared/publisher_metadata_with_logo' %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
-<div class="grid-row">
-  <div class="column-two-thirds content-bottom-margin">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds content-bottom-margin">
     <div class="responsive-bottom-margin">
       <%= render 'components/figure',
           src: @content_item.image["url"],

--- a/app/views/content_items/coming_soon.html.erb
+++ b/app/views/content_items/coming_soon.html.erb
@@ -1,5 +1,5 @@
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', title: 'Coming soon' %>
 
     <p class="summary">

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -4,8 +4,8 @@
   ) %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
   <%= render 'shared/translations' %>
@@ -15,8 +15,8 @@
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'components/important-metadata', items: @content_item.important_metadata %>
 
     <% if @content_item.unopened? %>

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -6,14 +6,14 @@
 
 <% content_for :simple_header, true %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
 </div>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
     <% body = capture do %>
       <% if @content_item.online_form_links.any? %>

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -27,24 +27,24 @@
 <% end %>
 
 <div class="<%= @content_item.organisation_brand_class %>">
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <%= render 'govuk_publishing_components/components/organisation_logo', @content_item.organisation_logo %>
     </div>
   </div>
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <%= render 'govuk_publishing_components/components/title', title: @content_item.title %>
     </div>
     <%= render 'shared/translations' %>
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
       <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
     </div>
   </div>
 
-  <div class="grid-row ">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
         <div class="responsive-bottom-margin">
           <%= render 'govuk_publishing_components/components/govspeak', content: "#{@content_item.body}#{@additional_body}".html_safe %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -4,12 +4,12 @@
   ) %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
   <%= render 'shared/translations' %>
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
   </div>
 </div>
@@ -18,8 +18,8 @@
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'components/important-metadata', items: @content_item.important_metadata %>
 
     <%= render "components/contents-list-with-body", contents: @content_item.contents do %>

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -4,15 +4,15 @@
   ) %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title',
        context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
        title: @content_item.title,
        average_title_length: "long" %>
   </div>
   <%= render 'shared/translations', content_item: @content_item %>
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
     <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
     <%= render 'shared/history_notice', content_item: @content_item %>
@@ -21,8 +21,8 @@
 
 <%= render 'shared/publisher_metadata_with_logo' %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'components/important-metadata',
         items: @content_item.important_metadata %>
 

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -4,12 +4,12 @@
   ) %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
   <%= render 'shared/translations' %>
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
   </div>
 </div>
@@ -17,8 +17,8 @@
 <%= render 'shared/publisher_metadata_with_logo' %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
-<div class="grid-row">
-  <div class="column-two-thirds content-bottom-margin">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds content-bottom-margin">
     <div class="responsive-bottom-margin">
       <%= render 'components/important-metadata',
           items: @content_item.important_metadata %>

--- a/app/views/content_items/gone.html.erb
+++ b/app/views/content_items/gone.html.erb
@@ -1,5 +1,5 @@
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', title: 'The page you\'re looking for is no longer available' %>
 
     <p class="summary">

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -6,8 +6,8 @@
   <script>window.onload = function() { window.print(); }</script>
 <% end %>
 
-<div class="grid-row guide-print">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row guide-print">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', { title: @content_item.title } %>
     <% @content_item.parts.each_with_index do |part, index| %>
       <section>

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -6,7 +6,7 @@
   <script>window.onload = function() { window.print(); }</script>
 <% end %>
 
-<div class="govuk-grid-row guide-print">
+<div class="govuk-grid-row" id="guide-print">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', { title: @content_item.title } %>
     <% @content_item.parts.each_with_index do |part, index| %>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -7,8 +7,8 @@
 
 <% content_for :simple_header, true %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', { title: @content_item.content_title } %>
 
     <% if @content_item.show_guide_navigation? %>
@@ -18,7 +18,7 @@
     <% end %>
   </div>
 
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <% if @content_item.has_parts? %>
       <% if @content_item.show_guide_navigation? %>
         <h1 class="part-title">

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -9,8 +9,8 @@
 %>
 
 <% if @content_item.organisations %>
-  <div class="publication-external">
-    <ol class="organisation-logos">
+  <div class="govuk-grid-row publication-external">
+    <ol class="govuk-grid-column-one-quarter organisation-logos">
       <% @content_item.organisations.each do |organisation| %>
       <% logo_attributes = @content_item.organisation_logo(organisation) %>
       <% next unless logo_attributes %>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -35,12 +35,12 @@
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
 <div
-  class="grid-row sidebar-with-body"
+  class="govuk-grid-row sidebar-with-body"
   data-module="sticky-element-container"
   id="contents"
 >
   <% if @content_item.contents.any? %>
-    <div class="column-quarter-desktop-only">
+    <div class="govuk-grid-column-one-quarter-from-desktop contents-list-container">
       <%= render 'govuk_publishing_components/components/contents_list', contents: @content_item.contents, format_numbers: true %>
     </div>
   <% end %>
@@ -51,7 +51,7 @@
     </div>
   </div>
 
-  <div class="column-three-quarters-desktop-only <% unless @content_item.contents.any? %>offset-quarter-desktop-only<% end %>">
+  <div class="main-content-container<% unless @content_item.contents.any? %> offset-empty-contents-list<% end %>">
     <%= render 'govuk_publishing_components/components/govspeak_html_publication', @content_item.govspeak_body %>
   </div>
 

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -4,12 +4,12 @@
   ) %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
   <%= render 'shared/translations' %>
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
   </div>
 </div>
@@ -18,8 +18,8 @@
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
-<div class="grid-row">
-  <div class="column-two-thirds content-bottom-margin">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds content-bottom-margin">
     <div class="responsive-bottom-margin">
       <%= render 'components/figure',
           src: @content_item.image["url"],

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -4,8 +4,8 @@
   ) %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title',
        context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
        title: @content_item.title,
@@ -13,7 +13,7 @@
   </div>
   <%= render 'shared/translations' %>
 
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
   </div>
 </div>
@@ -22,8 +22,8 @@
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
-<div class="grid-row">
-  <div class="column-two-thirds responsive-bottom-margin">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds responsive-bottom-margin">
     <%= render 'components/important-metadata', items: @content_item.important_metadata %>
     <div class="responsive-bottom-margin">
        <%= render 'publication_inline_body' %>

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -1,6 +1,6 @@
 <% if @error %>
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/error_summary", {
         title: t('service_sign_in.error.title'),
         items: [
@@ -24,8 +24,8 @@
              data: data_attrs) do %>
   <% legend_text = render 'govuk_publishing_components/components/title', title: @content_item.title %>
   <%= render "govuk_publishing_components/components/fieldset", legend_text: legend_text do %>
-    <div class="grid-row">
-      <div class="column-two-thirds">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
         <%= render 'govuk_publishing_components/components/govspeak', content: raw(@content_item.description) %>
         <% if @error %>
           <%= render "components/error-message", text: t('service_sign_in.error.option') %>

--- a/app/views/content_items/service_sign_in/_create_new_account.html.erb
+++ b/app/views/content_items/service_sign_in/_create_new_account.html.erb
@@ -1,5 +1,5 @@
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', title: @content_item.title %>
     <%= render 'govuk_publishing_components/components/govspeak', content: @content_item.body.html_safe %>
   </div>

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -6,20 +6,20 @@
 
 <% content_for :simple_header, true %>
 
-<div class="grid-row">
-  <div class="column-two-thirds responsive-top-margin">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds responsive-top-margin">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
   <%= render 'shared/translations' %>
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
   </div>
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'components/important-metadata',
         items: @content_item.important_metadata %>
 

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -4,12 +4,12 @@
   ) %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
   <%= render 'shared/translations' %>
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
   </div>
 </div>
@@ -18,8 +18,8 @@
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
-<div class="grid-row">
-  <div class="column-two-thirds content-bottom-margin">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds content-bottom-margin">
     <div class="responsive-bottom-margin">
       <%= render 'components/important-metadata',
       items: @content_item.important_metadata %>

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -4,15 +4,15 @@
   ) %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title',
                context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
                title: @content_item.title,
                average_title_length: "long" %>
   </div>
   <%= render 'shared/translations', content_item: @content_item %>
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
     <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
     <%= render 'shared/history_notice', content_item: @content_item %>
@@ -20,8 +20,8 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'components/important-metadata', items: @content_item.important_metadata %>
 
     <%= render "components/contents-list-with-body", contents: @content_item.contents do %>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -4,8 +4,8 @@
   ) %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
   </div>
@@ -13,8 +13,8 @@
 
 <%= render 'shared/publisher_metadata_with_logo' %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render "components/important-metadata",
         items: @content_item.important_metadata,
         margin_bottom: true %>
@@ -43,7 +43,7 @@
           title: nbsp_between_last_two_words(@content_item.forthcoming_notice_title) %>
     <% end %>
   </div>
-  <div class="column-one-third">
+  <div class="govuk-grid-column-one-third">
     <%= render 'govuk_publishing_components/components/related_navigation', content_item: @content_item.content_item.parsed_content, context: :sidebar %>
   </div>
 </div>

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -4,8 +4,8 @@
   ) %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
   </div>
@@ -13,8 +13,8 @@
   <%= render 'shared/translations' %>
 </div>
 
-<div class="grid-row">
-  <div class="column-two-thirds content-bottom-margin">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds content-bottom-margin">
     <%= render 'components/figure',
         src: @content_item.image["url"],
         alt: @content_item.image["alt_text"],

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -6,14 +6,14 @@
 
 <%= render 'shared/title_and_translations', content_item: @content_item %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
   </div>
 </div>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render "components/contents-list-with-body", {
       contents: @content_item.contents,
     } do %>

--- a/app/views/content_items/travel_advice.html+print.erb
+++ b/app/views/content_items/travel_advice.html+print.erb
@@ -6,7 +6,7 @@
   <script>window.onload = function() { window.print(); }</script>
 <% end %>
 
-<div class="govuk-grid-row travel-advice-print">
+<div class="govuk-grid-row" id="travel-advice-print">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
     <% @content_item.parts.each_with_index do |part, i| %>

--- a/app/views/content_items/travel_advice.html+print.erb
+++ b/app/views/content_items/travel_advice.html+print.erb
@@ -6,8 +6,8 @@
   <script>window.onload = function() { window.print(); }</script>
 <% end %>
 
-<div class="grid-row travel-advice-print">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row travel-advice-print">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
     <% @content_item.parts.each_with_index do |part, i| %>
       <section>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -12,15 +12,15 @@
     ) %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
     <aside class="part-navigation-container" role="complementary">
 
-      <nav role="navigation" class="grid-row part-navigation" aria-label="Travel advice pages" data-module="track-click">
+      <nav role="navigation" class="govuk-grid-row part-navigation" aria-label="Travel advice pages" data-module="track-click">
         <%  @content_item.parts_navigation.each_with_index do |part_group, i| %>
           <ol
-            class="column-half"
+            class="govuk-grid-column-one-half"
             <% if i == 1 %>
               start="<%=  @content_item.parts_navigation_second_list_start %>"
             <% end %>
@@ -40,8 +40,8 @@
   </div>
 </div>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="part-title">
       <%= @content_item.current_part_title %>
     </h1>

--- a/app/views/content_items/unpublishing.html.erb
+++ b/app/views/content_items/unpublishing.html.erb
@@ -1,5 +1,5 @@
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', title: 'The page you\'re looking for is no longer available' %>
 
     <p class="summary">

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -20,12 +20,12 @@
   <% end %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds responsive-top-margin">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds responsive-top-margin">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
   <%= render 'shared/translations' %>
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
     <%= render 'components/contents-list-with-body', contents: @content_item.contents do %>
       <%= render 'govuk_publishing_components/components/govspeak',

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -4,12 +4,12 @@
   ) %>
 <% end %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
   <%= render 'shared/translations' %>
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
   </div>
 </div>
@@ -18,8 +18,8 @@
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
-<div class="grid-row">
-  <div class="column-two-thirds content-bottom-margin">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds content-bottom-margin">
     <div class="responsive-bottom-margin">
       <%= render 'components/figure',
           src: @content_item.image["url"],

--- a/app/views/shared/_footer_navigation.html.erb
+++ b/app/views/shared/_footer_navigation.html.erb
@@ -4,8 +4,8 @@
 <% end %>
 
 <% if @contextual_footer.present? %>
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <%= @contextual_footer %>
     </div>
   </div>

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -1,9 +1,9 @@
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if @content_item.try(:logo) %>">
-    <div class="column-two-thirds metadata-column">
+    <div class="govuk-grid-column-two-thirds metadata-column">
       <%= render "components/publisher-metadata", @content_item.publisher_metadata %>
     </div>
-    <div class="column-one-third">
+    <div class="govuk-grid-column-one-third">
       <% if @content_item.try(:logo) %>
         <%= image_tag @content_item.logo[:path],
           alt: @content_item.logo[:alt_text],

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -2,6 +2,6 @@
   content_item = @content_item.content_item.parsed_content
 %>
 
-<div class="column-one-third">
+<div class="govuk-grid-column-one-third">
   <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
 </div>

--- a/app/views/shared/_title_and_translations.html.erb
+++ b/app/views/shared/_title_and_translations.html.erb
@@ -1,5 +1,5 @@
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
   <%= render 'shared/translations' %>

--- a/app/views/shared/_translations.html.erb
+++ b/app/views/shared/_translations.html.erb
@@ -1,5 +1,5 @@
 <% if @content_item.available_translations.length > 1 %>
-  <div class="column-third">
+  <div class="govuk-grid-column-third">
     <%= render 'govuk_publishing_components/components/translation-nav',
         translations: @content_item.available_translations %>
   </div>

--- a/test/components/banner_test.rb
+++ b/test/components/banner_test.rb
@@ -14,7 +14,7 @@ class BannerTest < ComponentTestCase
   test "renders a banner with text correctly" do
     render_component(title: 'Summary', text: 'This was published under the 2010 to 2015 Conservative government')
 
-    assert_select ".app-c-banner--grid", false
+    assert_select ".app-c-banner--aside", false
     assert_select ".app-c-banner__desc", text: 'This was published under the 2010 to 2015 Conservative government'
   end
 
@@ -26,7 +26,7 @@ class BannerTest < ComponentTestCase
   test "renders a banner with title and text correctly" do
     render_component(title: 'Summary', text: 'This was published under the 2010 to 2015 Conservative government')
 
-    assert_select ".app-c-banner--grid", false
+    assert_select ".app-c-banner--aside", false
     assert_select ".app-c-banner__title", text: 'Summary'
     assert_select ".app-c-banner__desc", text: 'This was published under the 2010 to 2015 Conservative government'
   end
@@ -36,7 +36,7 @@ class BannerTest < ComponentTestCase
                       text: 'This was published under the 2010 to 2015 Conservative government',
                       aside: 'This consultation ran from 9:30am on 30 January 2017 to 5pm on 28 February 2017')
 
-    assert_select ".app-c-banner--grid"
+    assert_select ".app-c-banner--aside"
     assert_select ".app-c-banner__title", text: 'Summary'
     assert_select ".app-c-banner__desc", text: 'This was published under the 2010 to 2015 Conservative government'
     assert_select ".app-c-banner__desc", text: 'This consultation ran from 9:30am on 30 January 2017 to 5pm on 28 February 2017'

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -221,7 +221,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_equal request.variant, [:print]
-    assert_select ".travel-advice-print"
+    assert_select "#travel-advice-print"
   end
 
   test "gets item from content store even when url contains multi-byte UTF8 character" do

--- a/test/integration/guide_print_test.rb
+++ b/test/integration/guide_print_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class GuidePrint < ActionDispatch::IntegrationTest
   test "it renders the print view" do
     setup_and_visit_guide_print('guide')
-    assert page.has_css?(".guide-print")
+    assert page.has_css?("#guide-print")
   end
 
   test "it is not indexable by search engines" do

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -26,7 +26,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   test "html publications with meta data" do
     setup_and_visit_content_item("print_with_meta_data")
 
-    within ".grid-row" do
+    within ".govuk-grid-row.sidebar-with-body" do
       assert page.find(".print-meta-data", visible: false)
 
       assert page.has_no_text?("© Crown copyright #{@content_item['details']['public_timestamp'].to_date.year}")
@@ -40,7 +40,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   test "html publications with meta data - print version" do
     setup_and_visit_content_item("print_with_meta_data", "?medium=print")
 
-    within ".grid-row" do
+    within ".govuk-grid-row.sidebar-with-body" do
       assert page.find(".print-meta-data", visible: true)
 
       assert page.has_text?("© Crown copyright #{@content_item['details']['public_timestamp'].to_date.year}")

--- a/test/integration/travel_advice_print_test.rb
+++ b/test/integration/travel_advice_print_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class TravelAdvicePrint < ActionDispatch::IntegrationTest
   test "it renders the print view" do
     setup_and_visit_travel_advice_print('full-country')
-    assert page.has_css?(".travel-advice-print")
+    assert page.has_css?("#travel-advice-print")
   end
 
   test "it is not indexable by search engines" do


### PR DESCRIPTION
Followed the guide here in updating grid usages from GOV.UK Elements to GOV.UK Frontend: https://govuk-design-system-preview.netlify.com/get-started/updating-your-code/

Component guide for this PR:
https://government-frontend-pr-1289.herokuapp.com/component-guide

You can check the various formats here:
https://government-frontend-pr-1289.herokuapp.com/
