### PR TITLE
Allow all inline scripts in CSP

### DIFF
--- a/config/initializers/csp.rb
+++ b/config/initializers/csp.rb
@@ -56,17 +56,6 @@ module CSP
       GOVUK_DOMAINS,
       GOOGLE_ANALYTICS_DOMAINS,
 
-      # Allow the script that adds `js-enabled` to the body from govuk_template
-      # https://github.com/alphagov/govuk_template/blob/79340eb91ad8c4279d16da302765d0946d89b1ca/source/views/layouts/govuk_template.html.erb#L40
-      "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
-
-      # The same as above but with leading and trailing whitespace as used by the component guide
-      "'sha256-IWjjekDxqqURWMjVH447fuaAvoZKwpDwLS0ZdcJ+Ey4='",
-
-      # ALlow the script that removes `js-enabled` from body if there's an error
-      # https://github.com/alphagov/govuk_template/blob/79340eb91ad8c4279d16da302765d0946d89b1ca/source/views/layouts/govuk_template.html.erb#L112-L113
-      "'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g='",
-
       # Allow JSONP call to Verify to check whether the user is logged in
       # https://www.staging.publishing.service.gov.uk/log-in-file-self-assessment-tax-return/sign-in/prove-identity
       # https://github.com/alphagov/government-frontend/blob/71aca4df9b74366618a5a93acdb5cd2715f94f49/app/assets/javascripts/modules/track-radio-group.js
@@ -76,8 +65,8 @@ module CSP
       "*.ytimg.com",
       "www.youtube.com",
 
-      # In browsers that don't support the sha256 whitelisting we allow unsafe
-      # inline scripts
+      # Allow all inline scripts until we can conclusively document all the inline scripts we use,
+      # and there's a better way to filter out junk reports
       "'unsafe-inline'"
     ]
 


### PR DESCRIPTION
This commit changes the content security policy to allow all inline scripts, until we can conclusively document all the inline scripts we use, and there's a better way to filter out junk reports.