### PR TITLE
Add minitest reporters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :test do
   gem 'capybara'
   gem 'chromedriver-helper'
   gem 'faker'
+  gem 'minitest-reporters'
   gem 'mocha'
   gem 'puma'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     anemone (0.7.2)
       nokogiri (>= 1.3.0)
       robotex (>= 1.0.0)
+    ansi (1.5.0)
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
@@ -180,6 +181,11 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    minitest-reporters (1.3.6)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     mocha (1.8.0)
       metaclass (~> 0.0.1)
     money (6.13.2)
@@ -370,6 +376,7 @@ DEPENDENCIES
   govuk_schemas (~> 3.2)
   htmlentities (~> 4.3)
   jasmine-rails
+  minitest-reporters
   mocha
   plek (~> 2.1)
   pry-byebug
@@ -390,4 +397,4 @@ RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,8 +8,11 @@ require 'capybara/rails'
 require 'mocha/minitest'
 require 'capybara/minitest'
 require 'faker'
+require "minitest/reporters"
 
 Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
+
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(


### PR DESCRIPTION
This helps troubleshoot flaky tests by printing the name and duration of each
test as it runs.
