### PR TITLE
Display withdrawal notices on translated editions in English

### DIFF
--- a/app/presenters/content_item/withdrawable.rb
+++ b/app/presenters/content_item/withdrawable.rb
@@ -31,11 +31,15 @@ module ContentItem
     end
 
     def withdrawal_notice_context
-      I18n.t("content_item.schema_name.#{schema_name}", count: 1)
+      I18n.t("content_item.schema_name.#{schema_name}", count: 1, locale: :en)
     end
 
     def withdrawal_notice_time
-      content_tag(:time, display_date(withdrawal_notice["withdrawn_at"]), datetime: withdrawal_notice["withdrawn_at"])
+      content_tag(:time, english_display_date(withdrawal_notice["withdrawn_at"]), datetime: withdrawal_notice["withdrawn_at"])
+    end
+
+    def english_display_date(timestamp, format = "%-d %B %Y")
+      I18n.l(Time.zone.parse(timestamp), format: format, locale: :en) if timestamp
     end
   end
 end

--- a/test/presenters/content_item/withdrawable_test.rb
+++ b/test/presenters/content_item/withdrawable_test.rb
@@ -4,6 +4,11 @@ class ContentItemWithdrawableTest < ActiveSupport::TestCase
   def setup
     @withdrawable = Object.new
     @withdrawable.extend(ContentItem::Withdrawable)
+    I18n.locale = :cy
+  end
+
+  def teardown
+    I18n.locale = I18n.default_locale
   end
 
   test 'content item is withdrawn' do
@@ -60,7 +65,30 @@ class ContentItemWithdrawableTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal @withdrawable.withdrawal_notice_component[:title], "This news article was withdrawn on <time datetime=\"2016-07-12T09:47:15Z\">2016-07-12T09:47:15Z</time>"
+    assert_equal @withdrawable.withdrawal_notice_component[:title], "This news article was withdrawn on <time datetime=\"2016-07-12T09:47:15Z\">12 July 2016</time>"
     assert_equal @withdrawable.withdrawal_notice_component[:description_govspeak], "<div class='govspeak'><p>It has been superseded by <a href='https://www.gov.uk/government/statistics/local-area-walking-and-cycling-in-england-2014-to-2015'>Local area walking and cycling in England: 2014 to 2015</a>.</p>\\n</div>"
+  end
+
+  test 'notice title presents only in English, even if locale is set to another language' do
+  # This is to prevent the withdrawal notices on translated editions
+  # displaying a combination of languages in their titles.
+    class << @withdrawable
+      def schema_name
+        'publication'
+      end
+
+      def content_item
+        {
+          'title' => 'Proportion of residents who do any walking or cycling (at local authority level) (CW010)',
+          'withdrawn_notice' => {
+            'explanation' => '<div class=\'govspeak\'><p>It has been superseded by <a href=\'https://www.gov.uk/government/statistics/local-area-walking-and-cycling-in-england-2014-to-2015\'>Local area walking and cycling in England: 2014 to 2015</a>.</p>\n</div>',
+            'withdrawn_at' => '2016-07-12T09:47:15Z'
+          },
+          'locale': 'cy'
+        }
+      end
+    end
+
+    assert_equal @withdrawable.withdrawal_notice_component[:title], "This publication was withdrawn on <time datetime=\"2016-07-12T09:47:15Z\">12 July 2016</time>"
   end
 end


### PR DESCRIPTION
Currently a withdrawn translated edition may display the majority of the
withdrawal notice title in English, but with dates and publication type
in the chosen locale.

Until withdrawal notices are also available via I18n, this PR will ensure
only English is displayed.

### before
<img width="933" alt="Welsh - new behaviour" src="https://user-images.githubusercontent.com/13475227/56354380-79ba0400-61cb-11e9-8458-79be55077555.png">

### after
<img width="933" alt="Welsh - new behaviour with translation" src="https://user-images.githubusercontent.com/13475227/56354394-80487b80-61cb-11e9-8562-49eaec60fb87.png">





---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
