### PR TITLE
Show step by step navigation for secondary content

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -77,6 +77,31 @@ class ContentItemPresenter
     !content_item.cache_control.private?
   end
 
+  def is_secondary_to_one_step_nav?
+    secondary_to_step_navs.one?
+  end
+
+  def is_secondary_to_multiple_step_navs?
+    secondary_to_step_navs.count > 1
+  end
+
+  def multiple_step_nav_links
+    secondary_to_step_navs.map do |step_by_step|
+      {
+        href: step_by_step['base_path'],
+        text: step_by_step['title']
+      }
+    end
+  end
+
+  def step_by_step_nav
+    secondary_to_step_navs.first['details']['step_by_step_nav'].deep_symbolize_keys
+  end
+
+  def single_step_by_step_header
+    { title: secondary_to_step_navs.first['details']['step_by_step_nav']['title'] }
+  end
+
 private
 
   def display_date(timestamp, format = "%-d %B %Y")
@@ -105,5 +130,9 @@ private
 
   def native_language_name_for(locale)
     I18n.t("language_names.#{locale}", locale: locale)
+  end
+
+  def secondary_to_step_navs
+    @secondary_to_step_navs ||= content_item['links'].fetch('secondary_to_step_navs', []).compact
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,8 @@
 
     <% if @content_item.try(:back_link) %>
       <%= render 'govuk_publishing_components/components/back_link', href: @content_item.back_link %>
+    <% elsif @content_item.is_secondary_to_one_step_nav? %>
+      <%= render 'govuk_publishing_components/components/step_by_step_nav_header', @content_item.single_step_by_step_header %>
     <% else  %>
       <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.content_item.parsed_content %>
     <% end %>

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -1,7 +1,11 @@
-<%
-  content_item = @content_item.content_item.parsed_content
-%>
-
 <div class="govuk-grid-column-one-third">
-  <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
+  <% if @content_item.is_secondary_to_one_step_nav? %>
+    <%= render 'govuk_publishing_components/components/step_by_step_nav', @content_item.step_by_step_nav %>
+  <% elsif @content_item.is_secondary_to_multiple_step_navs? %>
+    <%= render 'govuk_publishing_components/components/step_by_step_nav_related', {
+        links: @content_item.multiple_step_nav_links
+    } %>
+  <% else %>
+    <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item.content_item.parsed_content %>
+  <% end %>
 </div>

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -76,4 +76,42 @@ class PublicationTest < ActionDispatch::IntegrationTest
       }
     )
   end
+
+  test "renders list of steps and uses contextual breadcrumbs if a publication is secondary to multiple step navs" do
+    setup_tap_and_visit_content_item('best-practice-regulation') do |item|
+      # Documents cause additional requests which were troublesome to stub
+      # and are not related to this test
+      item['details']['documents'] = []
+    end
+    assert page.has_text?('Part of')
+    page.assert_selector('a', text: 'Learn to drive a car: step by step')
+    page.assert_selector('a', text: 'Get a divorce: step by step')
+    assert_equal 1, page.find_all('.govuk-breadcrumbs__list-item').count
+    within('.govuk-breadcrumbs__list-item') do
+      assert_selector('a', text: 'Home')
+    end
+  end
+
+  test "renders step nav and step nav header if a publication is secondary to one step navs" do
+    setup_tap_and_visit_content_item('best-practice-guidance') do |item|
+      # Documents cause additional requests which were troublesome to stub
+      # and are not related to this test
+      item['details']['documents'] = []
+    end
+    assert page.has_css?('.gem-c-step-nav')
+
+    within('.gem-c-step-nav') do
+      assert_selector('h2', text: "Check you're allowed to drive")
+      assert_selector('h2', text: "Get a provisional driving licence")
+      assert_selector('h2', text: "Prepare for your theory test")
+      assert_selector('h2', text: "Book and manage your theory test")
+      assert_selector('h2', text: "Book and manage your driving test")
+      assert_selector('h2', text: "When you pass")
+    end
+
+    assert page.has_css?('.gem-c-step-nav-header')
+    within('.gem-c-step-nav-header') do
+      assert_selector('.gem-c-step-nav-header__title', text: 'Learn to drive a car: step by step')
+    end
+  end
 end

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -1,6 +1,21 @@
 require 'test_helper'
 
 class ContentItemPresenterTest < ActiveSupport::TestCase
+  def presenter_with_content_secondary_to_one_step_by_step
+    one_step_by_step = govuk_content_schema_example('publication', 'best-practice-guidance')
+    ContentItemPresenter.new(one_step_by_step, one_step_by_step['base_path'])
+  end
+
+  def presenter_with_content_secondary_to_multiple_step_by_steps
+    multiple_step_by_step = govuk_content_schema_example('publication', 'best-practice-regulation')
+    ContentItemPresenter.new(multiple_step_by_step, multiple_step_by_step['base_path'])
+  end
+
+  def presenter_with_content_secondary_to_no_step_by_steps
+    no_step_by_step = govuk_content_schema_example('publication', 'best-practice-research')
+    ContentItemPresenter.new(no_step_by_step, no_step_by_step['base_path'])
+  end
+
   test "#title" do
     assert_equal "Title", ContentItemPresenter.new("title" => "Title").title
   end
@@ -52,5 +67,49 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
 
     refute presented_example.requesting_a_part?
     assert presented_example.part_slug.nil?
+  end
+
+  test "is_secondary_to_one_step_nav? returns true if tagged as secondary to a single step_by_step" do
+    assert presenter_with_content_secondary_to_one_step_by_step.is_secondary_to_one_step_nav?
+  end
+
+  test "is_secondary_to_one_step_nav? returns false if not tagged to a step_by_step" do
+    refute presenter_with_content_secondary_to_no_step_by_steps.is_secondary_to_one_step_nav?
+  end
+
+  test "is_secondary_to_one_step_nav? returns false if tagged to more than one step_by_step" do
+    refute presenter_with_content_secondary_to_multiple_step_by_steps.is_secondary_to_one_step_nav?
+  end
+
+  test "is_secondary_to_multiple_step_navs? returns true if tagged to more than one step_by_step" do
+    assert presenter_with_content_secondary_to_multiple_step_by_steps.is_secondary_to_multiple_step_navs?
+  end
+
+  test "is_secondary_to_multiple_step_navs? returns false if not tagged to a step_by_step" do
+    refute presenter_with_content_secondary_to_one_step_by_step.is_secondary_to_multiple_step_navs?
+  end
+
+  test "is_secondary_to_multiple_step_navs? returns false if tagged as secondary to a single step_by_step" do
+    refute presenter_with_content_secondary_to_one_step_by_step.is_secondary_to_multiple_step_navs?
+  end
+
+  test "multiple_step_nav_links contains correct href and text values" do
+    expected_result = [
+                        { href: "/learn-to-drive-a-car", text: "Learn to drive a car: step by step" },
+                        { href: "/get-a-divorce", text: "Get a divorce: step by step" }
+                      ]
+    assert_equal expected_result, presenter_with_content_secondary_to_multiple_step_by_steps.multiple_step_nav_links
+  end
+
+  test "step_by_step_nav is correct for content secondary to a single step by step" do
+    step_by_step_nav = presenter_with_content_secondary_to_one_step_by_step.step_by_step_nav
+    assert step_by_step_nav.keys.include?(:steps)
+    assert_equal %i(title contents), step_by_step_nav[:steps].first.keys
+  end
+
+  test "single_step_by_step_header is correct for content secondary to a single step by step" do
+    single_step_by_step_header = presenter_with_content_secondary_to_one_step_by_step.single_step_by_step_header
+    expected_header = { title: 'Learn to drive a car: step by step' }
+    assert_equal expected_header, single_step_by_step_header
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -161,6 +161,14 @@ class ActionDispatch::IntegrationTest
     end
   end
 
+  def setup_tap_and_visit_content_item(name, parameter_string = '')
+    @content_item = get_content_example(name).tap do |item|
+      yield(item)
+      content_store_has_item(item["base_path"], item.to_json)
+      visit_with_cachebust("#{item['base_path']}#{parameter_string}")
+    end
+  end
+
   def setup_and_visit_random_content_item(document_type: nil)
     content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: schema_type) do |payload|
       payload.merge('document_type' => document_type) unless document_type.nil?


### PR DESCRIPTION
Makes it possible for the step by step side bar to
appear in the side navigation for all content that
uses the contextual navigation.
Behaves differently for content that is secondary
to more than one step by steps - instead just
listing the step by steps and not using the step
nav header

**Single step by step**
![single_step_by_step](https://user-images.githubusercontent.com/41049800/58095286-94b4d500-7bca-11e9-9555-599d9f6bae64.png)

**Multiple step by steps**
![multiple_step_by_step](https://user-images.githubusercontent.com/41049800/58095308-a4341e00-7bca-11e9-9378-9816e79fbd36.png)

Trello: https://trello.com/c/eC8EXI21/120-step-by-step-add-the-closed-step-by-step-to-the-side-nav-for-secondary-content
---

Visual regression results:
https://government-frontend-pr-1348.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1348.herokuapp.com/component-guide
