### PR TITLE
Revert "Bump govuk_app_config from 1.16.1 to 1.16.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
       rubocop-rspec (~> 1.28)
       scss_lint
     govuk_ab_testing (2.4.1)
-    govuk_app_config (1.16.2)
+    govuk_app_config (1.16.1)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)


### PR DESCRIPTION
Reverts alphagov/government-frontend#1352

https://github.com/alphagov/govuk_app_config/pull/93