### PR TITLE
Bump govuk_app_config to 1.18.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'uglifier', '>= 1.3.0'
 
 gem 'gds-api-adapters', '~> 59.4'
 gem 'govuk_ab_testing', '~> 2.4'
-gem 'govuk_app_config', '~> 1.16'
+gem 'govuk_app_config', '~> 1.18'
 gem 'govuk_frontend_toolkit', '~> 8.2.0'
 gem 'govuk_publishing_components', '~> 16.26.0'
 gem 'plek', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
       rubocop-rspec (~> 1.28)
       scss_lint
     govuk_ab_testing (2.4.1)
-    govuk_app_config (1.16.1)
+    govuk_app_config (1.18.0)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
@@ -360,7 +360,7 @@ DEPENDENCIES
   gds-api-adapters (~> 59.4)
   govuk-lint
   govuk_ab_testing (~> 2.4)
-  govuk_app_config (~> 1.16)
+  govuk_app_config (~> 1.18)
   govuk_frontend_toolkit (~> 8.2.0)
   govuk_publishing_components (~> 16.26.0)
   govuk_schemas (~> 3.2)


### PR DESCRIPTION
This allows using the Rails DSL for content_security_policy