### PR TITLE
Remove related_links_variant from index

### DIFF
--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -4,7 +4,6 @@
   <title>
     government-frontend development page
   </title>
-  <%= related_links_variant.analytics_meta_tag.html_safe %>
 </head>
 <body>
   <div id="wrapper">


### PR DESCRIPTION
This was missed from a previous [PR](https://github.com/alphagov/government-frontend/pull/1354) when an AB test had finished.

