### PR TITLE
Display new recommended related links

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -56,6 +56,11 @@ private
 
   def load_content_item
     content_item = Services.content_store.content_item(content_item_path)
+
+    if Services.feature_toggler.use_recommended_related_links?(content_item['links'], request.headers)
+      content_item['links']['ordered_related_items'] = content_item['links'].fetch('suggested_ordered_related_items', [])
+    end
+
     @content_item = PresenterBuilder.new(content_item, content_item_path).presenter
   end
 

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -10,4 +10,10 @@ module Services
       disable_cache: true,
     )
   end
+
+  def self.feature_toggler
+    @feature_toggler ||= FeatureToggler.new(
+      HttpFeatureFlags.instance
+    )
+  end
 end

--- a/app/models/feature_toggler.rb
+++ b/app/models/feature_toggler.rb
@@ -1,0 +1,12 @@
+class FeatureToggler
+  def initialize(feature_flags)
+    @feature_flags = feature_flags
+  end
+
+  def use_recommended_related_links?(content_item_links, request_headers)
+    return false if content_item_links.nil?
+
+    content_item_links.fetch('ordered_related_items', []).empty? &&
+      @feature_flags.feature_enabled?(FeatureFlagNames.recommended_related_links, request_headers)
+  end
+end

--- a/app/models/http_feature_flags.rb
+++ b/app/models/http_feature_flags.rb
@@ -1,0 +1,17 @@
+class HttpFeatureFlags
+  def initialize
+    @feature_flags = {}
+  end
+
+  def add_http_feature_flag(header_name, val)
+    @feature_flags[header_name] = val
+  end
+
+  def feature_enabled?(header_name, request_headers)
+    @feature_flags.has_key?(header_name) && @feature_flags[header_name] == request_headers[header_name]
+  end
+
+  def self.instance
+    @instance ||= HttpFeatureFlags.new
+  end
+end

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,0 +1,7 @@
+module FeatureFlagNames
+  def self.recommended_related_links
+    'HTTP_GOVUK_USE_RECOMMENDED_RELATED_LINKS'
+  end
+end
+
+HttpFeatureFlags.instance.add_http_feature_flag(FeatureFlagNames.recommended_related_links, 'true')

--- a/test/models/feature_toggler_test.rb
+++ b/test/models/feature_toggler_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class FeatureTogglerTest < ActiveSupport::TestCase
+  test 'use_recommended_related_links returns false when content item has no links attribute' do
+    content_item = {}
+    instance = setup_feature_toggler_with_feature_enabled(true)
+
+    use_recommended_links = instance.use_recommended_related_links?(content_item['links'], @request_headers)
+
+    assert_equal(false, use_recommended_links)
+  end
+
+  test 'use_recommended_related_links returns false when content item has existing ordered_related_items' do
+    content_item = { "links" => { "ordered_related_items" => [{ "content_id" => "1234" }] } }
+    instance = setup_feature_toggler_with_feature_enabled(true)
+
+    use_recommended_links = instance.use_recommended_related_links?(content_item['links'], @request_headers)
+
+    assert_equal(false, use_recommended_links)
+  end
+
+  test 'use_recommended_related_links returns false when headers are not correct' do
+    content_item = { "links" => {} }
+    instance = setup_feature_toggler_with_feature_enabled(false)
+
+    use_recommended_links = instance.use_recommended_related_links?(content_item['links'], {})
+
+    assert_equal(false, use_recommended_links)
+  end
+
+  test 'use_recommended_related_links returns true when content item has no ordered_related_items attribute and headers are correct' do
+    content_item = { "links" => {} }
+    instance = setup_feature_toggler_with_feature_enabled(true)
+
+    use_recommended_links = instance.use_recommended_related_links?(content_item['links'], @request_headers)
+
+    assert_equal(true, use_recommended_links)
+  end
+
+  test 'use_recommended_related_links returns true when content item has no items in ordered_related_items attribute and headers are correct' do
+    content_item = { "links" => { "ordered_related_items" => [] } }
+    instance = setup_feature_toggler_with_feature_enabled(true)
+
+    use_recommended_links = instance.use_recommended_related_links?(content_item['links'], @request_headers)
+
+    assert_equal(true, use_recommended_links)
+  end
+
+  def setup
+    @request_headers = { 'HTTP_GOVUK_USE_RECOMMENDED_RELATED_LINKS': 'true' }
+  end
+
+  def setup_feature_toggler_with_feature_enabled(feature_enabled)
+    feature_flags = HttpFeatureFlags.new
+    feature_flags.stubs(:feature_enabled?).returns(feature_enabled)
+
+    FeatureToggler.new(feature_flags)
+  end
+end

--- a/test/models/http_feature_flags_test.rb
+++ b/test/models/http_feature_flags_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class HttpFeatureFlagsTest < ActiveSupport::TestCase
+  test 'instance should create a singleton instance' do
+    instance = HttpFeatureFlags.instance
+    instance.add_http_feature_flag('TEST_HEADER', 'show')
+
+    new_instance = HttpFeatureFlags.instance
+    feature_enabled = new_instance.feature_enabled?('TEST_HEADER', 'TEST_HEADER' => 'show')
+
+    assert_equal(true, feature_enabled)
+  end
+
+  test 'add_http_feature_flag should set a new feature flag' do
+    instance = HttpFeatureFlags.new
+
+    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'USE_MAGIC' => 'only_at_weekends')
+    assert_equal(false, feature_enabled)
+
+    instance.add_http_feature_flag('USE_MAGIC', 'only_at_weekends')
+    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'USE_MAGIC' => 'only_at_weekends')
+    assert_equal(true, feature_enabled)
+  end
+
+  test 'feature_enabled? should return false when feature flag has not been set' do
+    instance = HttpFeatureFlags.new
+
+    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'USE_MAGIC' => 'only_at_weekends')
+    assert_equal(false, feature_enabled)
+  end
+
+  test 'feature_enabled? should return false when header has not been set' do
+    instance = HttpFeatureFlags.new
+
+    instance.add_http_feature_flag('USE_MAGIC', 'only_at_weekends')
+    feature_enabled = instance.feature_enabled?('USE_MAGIC', {})
+    assert_equal(false, feature_enabled)
+  end
+
+  test 'feature_enabled? should return false when header has been set but does not match specified value' do
+    instance = HttpFeatureFlags.new
+
+    instance.add_http_feature_flag('USE_MAGIC', 'only_at_weekends')
+    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'USE_MAGIC' => 'all_the_time')
+    assert_equal(false, feature_enabled)
+  end
+
+  test 'feature_enabled? should return true when headers has been set and matches specified value' do
+    instance = HttpFeatureFlags.new
+
+    instance.add_http_feature_flag('USE_MAGIC', 'only_at_weekends')
+    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'USE_MAGIC' => 'only_at_weekends')
+    assert_equal(true, feature_enabled)
+  end
+end


### PR DESCRIPTION
This PR adds support for the new recommended related links to be shown based on the existence of a HTTP header set by our CDN. To achieve this we add support in general for feature flags via a `FeatureToggler` class.

Should the header exist, the new recommended related links will only be shown if there are no existing `ordered_related_items` in the content item, to ensure that we do not override manually curated links.

Dependent on https://github.com/alphagov/govuk-content-schemas/pull/908.

---

Visual regression results:
https://government-frontend-pr-1386.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1386.herokuapp.com/component-guide
