### PR TITLE
Add noindex for '/help/cookie-details'

### DIFF
--- a/app/views/content_items/help_page.html.erb
+++ b/app/views/content_items/help_page.html.erb
@@ -2,6 +2,9 @@
   <%= machine_readable_metadata(
     schema: :article
   ) %>
+  <% if @content_item.base_path == '/help/cookie-details' %>
+    <meta name="robots" content="noindex">
+  <% end %>
 <% end %>
 
 <%= render 'content_items/body_with_related_links' %>

--- a/test/integration/help_page_test.rb
+++ b/test/integration/help_page_test.rb
@@ -8,4 +8,14 @@ class HelpPageTest < ActionDispatch::IntegrationTest
     assert page.has_text?("GOV.UK puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site.")
     assert_has_published_dates(@content_item["last_updated"])
   end
+
+  test "sets noindex meta tag for '/help/cookie-details'" do
+    @content_item = get_content_example("help_page").tap do |item|
+      item["base_path"] = "/help/cookie-details"
+      content_store_has_item(item["base_path"], item.to_json)
+      visit_with_cachebust(item["base_path"])
+    end
+
+    assert page.has_css?('meta[name="robots"][content="noindex"]', visible: false)
+  end
 end


### PR DESCRIPTION
We don't want to have this page appearing in our search, but instead for
users to see '/help/cookies' as the only result because the details page
is confusing as a landing page. The settings page also links to the
details page.

---

Visual regression results:
https://government-frontend-pr-1394.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1394.herokuapp.com/component-guide
