### PR TITLE
Change feature flag names to represent headers set at the CDN

### DIFF
--- a/app/models/http_feature_flags.rb
+++ b/app/models/http_feature_flags.rb
@@ -3,19 +3,25 @@ class HttpFeatureFlags
     @feature_flags = {}
   end
 
-  def add_http_feature_flag(header_name, val)
-    @feature_flags[header_name] = val
+  def add_http_feature_flag(feature_flag_name, val)
+    @feature_flags[get_header_name(feature_flag_name)] = val
   end
 
-  def get_feature_flag(header_name)
-    @feature_flags[header_name]
+  def get_feature_flag(feature_flag_name)
+    @feature_flags[get_header_name(feature_flag_name)]
   end
 
-  def feature_enabled?(header_name, request_headers)
-    @feature_flags.has_key?(header_name) && @feature_flags[header_name] == request_headers[header_name]
+  def feature_enabled?(feature_flag_name, request_headers)
+    get_feature_flag(feature_flag_name) == request_headers[get_header_name(feature_flag_name)]
   end
 
   def self.instance
     @instance ||= HttpFeatureFlags.new
+  end
+
+private
+
+  def get_header_name(feature_flag_name)
+    "HTTP_#{feature_flag_name.upcase.tr('-', '_')}"
   end
 end

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,6 +1,6 @@
 module FeatureFlagNames
   def self.recommended_related_links
-    'HTTP_GOVUK_USE_RECOMMENDED_RELATED_LINKS'
+    'Govuk-Use-Recommended-Related-Links'
   end
 end
 

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -141,7 +141,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   test "gets item from content store and keep existing ordered_related_items when feature flag header is specified but links already exist" do
     HttpFeatureFlags.instance.add_http_feature_flag(FeatureFlagNames.recommended_related_links, 'true')
-    request.headers[FeatureFlagNames.recommended_related_links] = 'true'
+    request.headers["HTTP_GOVUK_USE_RECOMMENDED_RELATED_LINKS"] = 'true'
 
     content_item = content_store_has_schema_example('guide', 'guide')
 
@@ -154,7 +154,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   test "gets item from content store and keeps ordered_related_items when feature flag header is specified but recommended links turned off" do
     HttpFeatureFlags.instance.add_http_feature_flag(FeatureFlagNames.recommended_related_links, 'false')
-    request.headers[FeatureFlagNames.recommended_related_links] = 'true'
+    request.headers["HTTP_GOVUK_USE_RECOMMENDED_RELATED_LINKS"] = 'true'
 
     content_item = content_store_has_schema_example('case_study', 'case_study')
 
@@ -167,7 +167,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   test "gets item from content store and replaces ordered_related_items when feature flag header is specified and there are no existing links" do
     HttpFeatureFlags.instance.add_http_feature_flag(FeatureFlagNames.recommended_related_links, 'true')
-    request.headers[FeatureFlagNames.recommended_related_links] = 'true'
+    request.headers["HTTP_GOVUK_USE_RECOMMENDED_RELATED_LINKS"] = 'true'
 
     content_item = content_store_has_schema_example('case_study', 'case_study')
 

--- a/test/models/http_feature_flags_test.rb
+++ b/test/models/http_feature_flags_test.rb
@@ -6,7 +6,7 @@ class HttpFeatureFlagsTest < ActiveSupport::TestCase
     instance.add_http_feature_flag('TEST_HEADER', 'show')
 
     new_instance = HttpFeatureFlags.instance
-    feature_enabled = new_instance.feature_enabled?('TEST_HEADER', 'TEST_HEADER' => 'show')
+    feature_enabled = new_instance.feature_enabled?('TEST_HEADER', 'HTTP_TEST_HEADER' => 'show')
 
     assert_equal(true, feature_enabled)
   end
@@ -14,18 +14,18 @@ class HttpFeatureFlagsTest < ActiveSupport::TestCase
   test 'add_http_feature_flag should set a new feature flag' do
     instance = HttpFeatureFlags.new
 
-    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'USE_MAGIC' => 'only_at_weekends')
+    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'HTTP_USE_MAGIC' => 'only_at_weekends')
     assert_equal(false, feature_enabled)
 
     instance.add_http_feature_flag('USE_MAGIC', 'only_at_weekends')
-    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'USE_MAGIC' => 'only_at_weekends')
+    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'HTTP_USE_MAGIC' => 'only_at_weekends')
     assert_equal(true, feature_enabled)
   end
 
   test 'feature_enabled? should return false when feature flag has not been set' do
     instance = HttpFeatureFlags.new
 
-    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'USE_MAGIC' => 'only_at_weekends')
+    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'HTTP_USE_MAGIC' => 'only_at_weekends')
     assert_equal(false, feature_enabled)
   end
 
@@ -41,7 +41,7 @@ class HttpFeatureFlagsTest < ActiveSupport::TestCase
     instance = HttpFeatureFlags.new
 
     instance.add_http_feature_flag('USE_MAGIC', 'only_at_weekends')
-    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'USE_MAGIC' => 'all_the_time')
+    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'HTTP_USE_MAGIC' => 'all_the_time')
     assert_equal(false, feature_enabled)
   end
 
@@ -49,7 +49,7 @@ class HttpFeatureFlagsTest < ActiveSupport::TestCase
     instance = HttpFeatureFlags.new
 
     instance.add_http_feature_flag('USE_MAGIC', 'only_at_weekends')
-    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'USE_MAGIC' => 'only_at_weekends')
+    feature_enabled = instance.feature_enabled?('USE_MAGIC', 'HTTP_USE_MAGIC' => 'only_at_weekends')
     assert_equal(true, feature_enabled)
   end
 


### PR DESCRIPTION
This PR changes the feature flag names used in `FeatureFlagNames` to represent headers as we set them at the CDN. This allows us to output response headers for the feature flags and in the `Vary` header which are consistent with others headers that we set (see below):

**Before (first and last headers)**
<img width="632" alt="Screen Shot 2019-06-27 at 16 56 44" src="https://user-images.githubusercontent.com/5422487/60281529-fae4f400-98fc-11e9-80b2-3bd013aa943d.png">

**After (first and last headers)**
<img width="333" alt="Screen Shot 2019-06-27 at 16 45 15" src="https://user-images.githubusercontent.com/5422487/60281184-5ebaed00-98fc-11e9-9542-44cbcefaa3f0.png">

---

Visual regression results:
https://government-frontend-pr-1398.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1398.herokuapp.com/component-guide
