### PR TITLE
Use request header for related links to determine response header

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -115,7 +115,10 @@ private
 
   def set_use_recommended_related_links_header
     response.headers['Vary'] = [response.headers['Vary'], FeatureFlagNames.recommended_related_links].compact.join(', ')
-    response.headers[FeatureFlagNames.recommended_related_links] = Services.feature_toggler.feature_flags.get_feature_flag(FeatureFlagNames.recommended_related_links)
+
+    related_links_request_header = RequestHelper.get_header(FeatureFlagNames.recommended_related_links, request.headers)
+    required_header_value = Services.feature_toggler.feature_flags.get_feature_flag(FeatureFlagNames.recommended_related_links)
+    response.headers[FeatureFlagNames.recommended_related_links] = (related_links_request_header == required_header_value).to_s
   end
 
   def set_expiry

--- a/app/lib/request_helper.rb
+++ b/app/lib/request_helper.rb
@@ -1,0 +1,9 @@
+module RequestHelper
+  def self.get_header(header_name, request_headers)
+    request_headers[headerise(header_name)]
+  end
+
+  def self.headerise(header_name)
+    "HTTP_#{header_name.upcase.tr('-', '_')}"
+  end
+end

--- a/app/models/http_feature_flags.rb
+++ b/app/models/http_feature_flags.rb
@@ -4,24 +4,18 @@ class HttpFeatureFlags
   end
 
   def add_http_feature_flag(feature_flag_name, val)
-    @feature_flags[get_header_name(feature_flag_name)] = val
+    @feature_flags[RequestHelper.headerise(feature_flag_name)] = val
   end
 
   def get_feature_flag(feature_flag_name)
-    @feature_flags[get_header_name(feature_flag_name)]
+    @feature_flags[RequestHelper.headerise(feature_flag_name)]
   end
 
   def feature_enabled?(feature_flag_name, request_headers)
-    get_feature_flag(feature_flag_name) == request_headers[get_header_name(feature_flag_name)]
+    get_feature_flag(feature_flag_name) == RequestHelper.get_header(feature_flag_name, request_headers)
   end
 
   def self.instance
     @instance ||= HttpFeatureFlags.new
-  end
-
-private
-
-  def get_header_name(feature_flag_name)
-    "HTTP_#{feature_flag_name.upcase.tr('-', '_')}"
   end
 end

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -178,24 +178,36 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_equal assigns[:content_item].content_item['links']['ordered_related_items'], content_item['links']['suggested_ordered_related_items']
   end
 
-  test "sets the Govuk-Use-Recommended-Links header to true when using recommended links" do
+  test "sets the Govuk-Use-Recommended-Links response header to false when request header is not set" do
     HttpFeatureFlags.instance.add_http_feature_flag(FeatureFlagNames.recommended_related_links, 'true')
     content_item = content_store_has_schema_example('case_study', 'case_study')
 
     get :show, params: { path: path_for(content_item) }
 
     assert_includes response.headers['Vary'], FeatureFlagNames.recommended_related_links
-    assert_equal 'true', response.headers[FeatureFlagNames.recommended_related_links]
+    assert_equal 'false', response.headers[FeatureFlagNames.recommended_related_links]
   end
 
-  test "sets the Govuk-Use-Recommended-Links header to false when not using recommended links" do
-    HttpFeatureFlags.instance.add_http_feature_flag(FeatureFlagNames.recommended_related_links, 'false')
+  test "sets the Govuk-Use-Recommended-Links response header to false when request header is set to false" do
+    HttpFeatureFlags.instance.add_http_feature_flag(FeatureFlagNames.recommended_related_links, 'true')
+    request.headers["HTTP_GOVUK_USE_RECOMMENDED_RELATED_LINKS"] = 'false'
     content_item = content_store_has_schema_example('case_study', 'case_study')
 
     get :show, params: { path: path_for(content_item) }
 
     assert_includes response.headers['Vary'], FeatureFlagNames.recommended_related_links
     assert_equal 'false', response.headers[FeatureFlagNames.recommended_related_links]
+  end
+
+  test "sets the Govuk-Use-Recommended-Links response header to true when request header is set to true" do
+    HttpFeatureFlags.instance.add_http_feature_flag(FeatureFlagNames.recommended_related_links, 'true')
+    request.headers["HTTP_GOVUK_USE_RECOMMENDED_RELATED_LINKS"] = 'true'
+    content_item = content_store_has_schema_example('case_study', 'case_study')
+
+    get :show, params: { path: path_for(content_item) }
+
+    assert_includes response.headers['Vary'], FeatureFlagNames.recommended_related_links
+    assert_equal 'true', response.headers[FeatureFlagNames.recommended_related_links]
   end
 
   test "sets the expiry as sent by content-store" do

--- a/test/services/request_helper_test.rb
+++ b/test/services/request_helper_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class RequestHelperTest < ActiveSupport::TestCase
+  test 'get_header returns nil when header does not exist' do
+    header_val = RequestHelper.get_header('Govuk-Example-Header', {})
+
+    assert_equal nil, header_val
+  end
+
+  test 'get_header returns header when header exists' do
+    header_val = RequestHelper.get_header('Govuk-Example-Header', 'HTTP_GOVUK_EXAMPLE_HEADER' => 'this_is_a_test')
+
+    assert_equal 'this_is_a_test', header_val
+  end
+
+  test 'headerise returns header with HTTP prefix, no dashes and all uppercase' do
+    header_name = 'Govuk-Example-Header'
+
+    transformed_header_name = RequestHelper.headerise(header_name)
+
+    assert_equal 'HTTP_GOVUK_EXAMPLE_HEADER', transformed_header_name
+  end
+end


### PR DESCRIPTION
This PR fixes the related links response header to be determined by the request header. If the request header is not set or does not match the required value as defined by the `feature_flags` initializer, we set the response header to `false`; if the request header is set and matches the required value, it's set to `true`.

This will enable us to change the request header at CDN level if we need to change related links.

---

Visual regression results:
https://government-frontend-pr-1400.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1400.herokuapp.com/component-guide
