### PR TITLE
Use govuk_test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,11 +36,9 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'chromedriver-helper'
+  gem 'govuk_test'
   gem 'faker'
   gem 'minitest-reporters'
   gem 'mocha'
-  gem 'puma'
-  gem 'selenium-webdriver'
   gem 'webmock', '~> 3.6.0', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,11 @@ GEM
       sassc-rails (>= 2.0.1)
     govuk_schemas (3.2.0)
       json-schema (~> 2.8.0)
+    govuk_test (1.0.0)
+      capybara
+      puma
+      selenium-webdriver (>= 3.142)
+      webdrivers
     hashdiff (0.4.0)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
@@ -209,7 +214,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     public_suffix (3.1.1)
-    puma (3.12.1)
+    puma (4.0.0)
+      nio4r (~> 2.0)
     rack (2.0.7)
     rack-cache (1.9.0)
       rack (>= 0.4)
@@ -352,6 +358,10 @@ GEM
     unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    webdrivers (4.0.1)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.6.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -381,7 +391,6 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara
-  chromedriver-helper
   dalli
   faker
   gds-api-adapters (~> 59.5)
@@ -391,20 +400,19 @@ DEPENDENCIES
   govuk_frontend_toolkit (~> 8.2.0)
   govuk_publishing_components (~> 17.10.0)
   govuk_schemas (~> 3.2)
+  govuk_test
   htmlentities (~> 4.3)
   jasmine-rails
   minitest-reporters
   mocha
   plek (~> 3.0)
   pry-byebug
-  puma
   rack_strip_client_ip (~> 0.0.2)
   rails (~> 5.2.3)
   rails-controller-testing (~> 1.0)
   rails-i18n (>= 4.0.4)
   rails_translation_manager (~> 0.1.0)
   sass-rails (~> 5.0)
-  selenium-webdriver
   slimmer (~> 13.1)
   uglifier (>= 1.3.0)
   webmock (~> 3.6.0)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,23 +14,9 @@ Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
-Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu no-sandbox) }
-  )
-  client = Selenium::WebDriver::Remote::Http::Default.new
-  client.read_timeout = 120 # Asset compilation can result in a timeout on the first request hence the increase.
-
-  Capybara::Selenium::Driver.new(
-    app,
-    browser: :chrome,
-    desired_capabilities: capabilities,
-    http_client: client
-  )
-end
+GovukTest.configure
 
 Capybara.default_driver = :headless_chrome
-Capybara.javascript_driver = :headless_chrome
 
 GovukAbTesting.configure do |config|
   config.acceptance_test_framework = :active_support


### PR DESCRIPTION
Trello: https://trello.com/c/hwMoAOau/3-%F0%9F%90%B3-get-all-apps-working-on-docker

This replaces the manual for headless chrome with that provided by
govuk_test and allows removing the chromedriver version pinning in
govuk_docker [1]

[1]: https://github.com/alphagov/govuk-docker/blob/1503800b0c5ac5a9385456ff08286a840493a025/government-frontend/chromedriver-version