### PR TITLE
Mark banner (history notice) as English language and enforce left-to-right flow.

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -2,6 +2,7 @@
   @include responsive-bottom-margin;
   @include core-19;
   @include white-links;
+  direction: ltr;
   background: $govuk-blue;
   color: $white;
   padding: govuk-spacing(3);

--- a/app/views/components/_banner.html.erb
+++ b/app/views/components/_banner.html.erb
@@ -11,7 +11,7 @@
     <%= text %>
   </p>
 <% end %>
-<section class="app-c-banner<% if aside %> app-c-banner--aside<% end %>" aria-label="Notice">
+<section class="app-c-banner<% if aside %> app-c-banner--aside<% end %>" aria-label="Notice" lang="en">
   <%= content_block %>
   <% if aside %>
     <p class="app-c-banner__desc"><%= aside %></p>


### PR DESCRIPTION
https://trello.com/c/lJMjbUEq/22-fix-language-on-history-notice

When pages are translated, the history notice/banner content is not. They should be marked as being in English and left-to-right reading direction should be enforced - this PR addresses this and makes the page work better for screenreaders.

## Before

![Screen Shot 2019-07-16 at 08 01 17](https://user-images.githubusercontent.com/31649453/61273225-e6c84000-a7a0-11e9-92c2-da672e2c6bdf.png)

## After

![Screen Shot 2019-07-16 at 08 01 24](https://user-images.githubusercontent.com/31649453/61273240-ed56b780-a7a0-11e9-81b0-e12278411359.png)



---

Visual regression results:
https://government-frontend-pr-1415.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1415.herokuapp.com/component-guide
