### PR TITLE
Force English for metadata

### DIFF
--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -1,5 +1,6 @@
 .app-c-published-dates {
   @include core-16;
+  direction: ltr;
 }
 
 .app-c-published-dates__toggle {

--- a/app/assets/stylesheets/components/_publisher-metadata.scss
+++ b/app/assets/stylesheets/components/_publisher-metadata.scss
@@ -1,6 +1,7 @@
 .app-c-publisher-metadata {
   @include responsive-bottom-margin;
   @include core-16;
+  direction: ltr;
   padding-top: govuk-spacing(3);
 }
 
@@ -11,20 +12,6 @@
 .app-c-publisher-metadata__term {
   float: left;
   padding-right: govuk-spacing(1);
-
-  .direction-rtl & {
-    float: none;
-    display: inline-block;
-    padding-right: 0;
-    padding-left: 5px;
-  }
-}
-
-.app-c-publisher-metadata__definition {
-  .direction-rtl & {
-    float: none;
-    display: inline-block;
-  }
 }
 
 .app-c-publisher-metadata__toggle,

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -80,7 +80,7 @@ class ContentItemPresenter
 private
 
   def display_date(timestamp, format = "%-d %B %Y")
-    I18n.l(Time.zone.parse(timestamp), format: format) if timestamp
+    I18n.l(Time.zone.parse(timestamp), format: format, locale: 'en') if timestamp
   end
 
   def sorted_locales(translations)

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -7,21 +7,20 @@
   history_class = "app-c-published-dates--history" if history.any?
 %>
 <% if published || last_updated %>
-<div class="app-c-published-dates <%= history_class %>" <% if history.any? %>id="history" data-module="toggle"<% end %>>
+<div class="app-c-published-dates <%= history_class %>" <% if history.any? %>id="history" data-module="toggle"<% end %> lang="en">
   <% if published %>
-    <%= t('components.published_dates.published', date: published) %>
+    Published <%= published %>
   <% end %>
   <% if last_updated %>
-    <% if published %><br /><% end %><%= t('components.published_dates.last_updated', date: last_updated) %>
+    <% if published %><br /><% end %>Last updated <%= last_updated %>
     <% if link_to_history && history.empty? %>
-      &mdash; <a href="#history"><%= t('components.published_dates.see_all_updates') %></a>
+      &mdash; <a href="#history"><%= t('components.published_dates.see_all_updates', locale: :en) %></a>
     <% elsif history.any? %>
       <a href="#full-history"
       class="app-c-published-dates__toggle"
       data-controls="full-history"
       data-expanded="false"
-      data-toggled-text="&#45;&nbsp;<%= t('components.published_dates.hide_all_updates') %>">&#43;&nbsp;<%= t('components.published_dates.show_all_updates')
-       %></a>
+      data-toggled-text="&#45;&nbsp;<%= t('components.published_dates.hide_all_updates', locale: :en) %>">&#43;&nbsp;<%= t('components.published_dates.show_all_updates', locale: :en) %></a>
       <div class="app-c-published-dates__change-history js-hidden" id="full-history">
         <ol>
           <% history.each do |change| %>

--- a/app/views/components/_publisher-metadata.html.erb
+++ b/app/views/components/_publisher-metadata.html.erb
@@ -7,7 +7,7 @@
   metadata = [published, last_updated]
 %>
 <% if metadata.any? || other_has_values %>
-  <div class="app-c-publisher-metadata">
+  <div class="app-c-publisher-metadata" lang="en">
     <%= render 'components/published-dates', published: published, last_updated: last_updated, link_to_history: link_to_history %>
     <% if other_has_values %>
       <div class="app-c-publisher-metadata__other">
@@ -20,15 +20,13 @@
           %>
           <% if values.any? %>
             <dt class="app-c-publisher-metadata__term">
-              <%= t(title.to_s.parameterize(separator: '_'),
-                    scope: 'components.publisher_metadata',
-                    default: title.to_s.humanize) %>:
+              <%= title.to_s.humanize %>:
             </dt>
             <dd class="app-c-publisher-metadata__definition" data-module="gem-toggle">
               <% if title.to_sym == :collections %>
                 <% if values.size <= 2 %>
                   <span class="app-c-publisher-metadata__definition-sentence">
-                    <%= values.take(2).to_sentence.html_safe %>
+                    <%= values.take(2).to_sentence(locale: :en).html_safe %>
                   </span>
                 <% else %>
                   <% featured_value, *other_values = values %>
@@ -42,11 +40,11 @@
                     data-toggled-text="&minus; <%= t('components.publisher_metadata.hide_all') %>">
                     + <%= t('components.publisher_metadata.show_all') %>
                   </a>
-                  <span id="<%= toggle_id %>" class="js-hidden"><%= other_values.to_sentence.html_safe %></span>
+                  <span id="<%= toggle_id %>" class="js-hidden"><%= other_values.to_sentence(locale: :en).html_safe %></span>
                 <% end %>
               <% else %>
                 <span class="app-c-publisher-metadata__definition-sentence">
-                  <%= values.to_sentence.html_safe %>
+                  <%= values.to_sentence(locale: :en).html_safe %>
                 </span>
               <% end %>
             </dd>


### PR DESCRIPTION
https://trello.com/c/YjWKQe6Z/12-update-metadata-component-for-language

On translated pages we are largely failing to translate the metadata,
leading to messy strings where the only translated content is the month
or the word "and" amongst otherwise English sentences.

This change sets the locale to English for the dates, and reverts attempts
to translate other sections of the page, and it marks the components
as being in English. It removes classnames that aren't used from the CSS
and forces the text direction to be left-to-right for these components.

This marks the page up more semantically, and supports a better experience
for screenreader users as they can now context switch the language
appropriately.

## Relevant urls:
https://www.gov.uk/government/news/death-of-former-prime-minister-lady-thatcher.ar
https://www.gov.uk/government/news/death-of-former-prime-minister-lady-thatcher.es
https://www.gov.uk/government/news/death-of-former-prime-minister-lady-thatcher.ur
https://www.gov.uk/government/news/ambassador-hobbs-inaugurates-social-projects-in-the-department-of-san-pedro.es-419

# Screenshots
## Before 
![Screen Shot 2019-07-16 at 13 37 59](https://user-images.githubusercontent.com/31649453/61295062-26a61c00-a7cf-11e9-8ac0-6f59c8965e19.png)
![Screen Shot 2019-07-16 at 13 38 08](https://user-images.githubusercontent.com/31649453/61295063-26a61c00-a7cf-11e9-89c3-c678915031f3.png)
![Screen Shot 2019-07-16 at 13 38 15](https://user-images.githubusercontent.com/31649453/61295064-26a61c00-a7cf-11e9-8766-192f7d1d90b0.png)

## After
![Screen Shot 2019-07-16 at 13 37 28](https://user-images.githubusercontent.com/31649453/61295121-40dffa00-a7cf-11e9-89f0-fc05b0474378.png)
![Screen Shot 2019-07-16 at 13 37 35](https://user-images.githubusercontent.com/31649453/61295122-40dffa00-a7cf-11e9-9a3e-7bc2cb880e83.png)
![Screen Shot 2019-07-16 at 13 37 48](https://user-images.githubusercontent.com/31649453/61295123-40dffa00-a7cf-11e9-8fda-875c0ed24dca.png)


