### PR TITLE
Label figure component as English

### DIFF
--- a/app/views/components/_figure.html.erb
+++ b/app/views/components/_figure.html.erb
@@ -3,7 +3,7 @@
   caption ||= ''
   credit ||= ''
 %>
-<figure class="app-c-figure">
+<figure class="app-c-figure" lang="en">
   <img class="app-c-figure__image" src="<%= src %>" alt="<%= alt %>">
     <figcaption class="app-c-figure__figcaption">
       <% unless caption.blank? %>


### PR DESCRIPTION
https://trello.com/c/APajl08R/4-where-alt-text-is-presented-mark-as-english
When pages are translated, there is no translation on the alt
text or the caption attached to an image, so they need to be
semantically labelled as being in English.

## Example page:

![Screen Shot 2019-07-17 at 10 08 33](https://user-images.githubusercontent.com/31649453/61363000-1f3c4c80-a87b-11e9-9f1e-270be0262a03.png)
