### PR TITLE
Don't show HTTP Basic auth on dev dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ group :development, :test do
   gem 'govuk-lint'
   gem 'govuk_schemas', '~> 3.3'
   gem 'jasmine-rails'
-  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,6 @@ GEM
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
-    byebug (11.0.0)
     capybara (3.26.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -198,12 +197,6 @@ GEM
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
     plek (3.0.0)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    pry-byebug (3.7.0)
-      byebug (~> 11.0)
-      pry (~> 0.10)
     public_suffix (3.1.1)
     puma (4.0.0)
       nio4r (~> 2.0)
@@ -383,7 +376,6 @@ DEPENDENCIES
   minitest-reporters
   mocha
   plek (~> 3.0)
-  pry-byebug
   rack_strip_client_ip (~> 0.0.2)
   rails (~> 5.2.3)
   rails-controller-testing (~> 1.0)

--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -12,4 +12,15 @@ class DevelopmentController < ApplicationController
 
     @paths = YAML.load_file("test/wraith/config.yaml")["paths"]
   end
+
+private
+
+  helper_method :remove_secrets
+
+  def remove_secrets(original_url)
+    parsed_url = URI.parse(original_url)
+    original_url = original_url.gsub(parsed_url.user, "***") if parsed_url.user
+    original_url = original_url.gsub(parsed_url.password, "***") if parsed_url.password
+    original_url
+  end
 end

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -28,15 +28,15 @@
         <table>
           <tr>
             <td>Content store</td>
-            <td><%= link_to Plek.find('content-store'), Plek.find('content-store') %></td>
+            <td><%= link_to remove_secrets(Plek.find('content-store')), remove_secrets(Plek.find('content-store')) %></td>
           </tr>
           <tr>
             <td>Static</td>
-            <td><%= link_to Plek.find('static'), Plek.find('static') %></td>
+            <td><%= link_to remove_secrets(Plek.find('static')), remove_secrets(Plek.find('static')) %></td>
           </tr>
           <tr>
             <td>Search</td>
-            <td><%= link_to Plek.find('search'), Plek.find('search') %></td>
+            <td><%= link_to remove_secrets(Plek.find('search')), remove_secrets(Plek.find('search')) %></td>
           </tr>
         </table>
 

--- a/startup.sh
+++ b/startup.sh
@@ -5,7 +5,7 @@ bundle install
 function set_env() {
   export GOVUK_APP_DOMAIN=www.$1
   export GOVUK_WEBSITE_ROOT=https://www.$1
-  export PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.$1/api}
+  export PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://test:bla@www.$1/api}
   export PLEK_SERVICE_RUMMAGER_URI=${PLEK_SERVICE_RUMMAGER_URI-https://www.$1/api}
   export PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.$1/api}
 }


### PR DESCRIPTION
The dashboard will show the URL for the content store and search, which will contain a username/password combo for integration. This hides the info.