### PR TITLE
Don't show failed translation message for missing document types

### DIFF
--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -41,7 +41,9 @@ class DocumentCollectionPresenter < ContentItemPresenter
         },
         metadata: {
           public_updated_at: Time.zone.parse(link["public_updated_at"]),
-          document_type: I18n.t("content_item.schema_name.#{link['document_type']}", count: 1)
+          document_type: I18n.t("content_item.schema_name.#{link['document_type']}",
+                                count: 1,
+                                default: nil),
         },
       }
     end

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -73,6 +73,21 @@ class DocumentCollectionPresenterTest
 
       assert_equal documents, presented_item.group_document_links({ "documents" => [document_ids.first] }, 0)
     end
+
+    test 'it handles the document type lacking a translation' do
+      schema_data = schema_item
+
+      document = schema_data["links"]["documents"].first.tap do |link|
+        link["document_type"] = "non-existant"
+      end
+
+      grouped = present_example(schema_data).group_document_links(
+        { "documents" => [document["content_id"]] },
+        0,
+      )
+
+      assert_nil grouped.first[:metadata][:document_type]
+    end
   end
 
   class GroupWithMissingDocument < TestCase


### PR DESCRIPTION
Trello: https://trello.com/c/VdQtNZeV/1122-spike-making-content-publisher-documents-show-up-in-whitehall-document-collections

[With the update to Whitehall that allows adding any GOV.UK page to a
document collection](https://github.com/alphagov/whitehall/pull/4980) there is the potential users could add documents
with types the Government Frontend knows nothing about. For these cases
this will return a nil value rather than raise a failed translation
message.

At this point in time it seems unlikely users would use a document type
that is not known about as the expected usage is Content Publisher
document types. However there is nothing to prevent wider usage of
document types.

This resolves a situation like this:

<img width="714" alt="Screen Shot 2019-08-14 at 12 22 01" src="https://user-images.githubusercontent.com/282717/63017439-42641700-be8e-11e9-9265-d36affafae4c.png">


---

Visual regression results:
https://government-frontend-pr-1443.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1443.herokuapp.com/component-guide
