### PR TITLE
Fix class: 'govuk-grid-column-third' => 'govuk-grid-column-one-third'

### DIFF
--- a/app/views/shared/_translations.html.erb
+++ b/app/views/shared/_translations.html.erb
@@ -1,5 +1,5 @@
 <% if @content_item.available_translations.length > 1 %>
-  <div class="govuk-grid-column-third">
+  <div class="govuk-grid-column-one-third">
     <%= render 'govuk_publishing_components/components/translation-nav',
         translations: @content_item.available_translations %>
   </div>


### PR DESCRIPTION
'govuk-grid-column-third' isn't defined and thus had no styles being applied. This was causing an issue for Whitehall content with translations when viewed on a mobile device.

Example: https://www.gov.uk/government/news/new-online-service-for-commercial-drivers-to-pay-dvsa-fines

| Before | After |
|--------|------|
|![Screen Shot 2019-08-15 at 14 40 37](https://user-images.githubusercontent.com/5111927/63098621-2d10ea80-bf6b-11e9-9473-018cfc92e836.png)|![Screen Shot 2019-08-15 at 14 42 16](https://user-images.githubusercontent.com/5111927/63098638-38641600-bf6b-11e9-9209-438e5db54b13.png)|

Arises from Zendesk ticket 3771721.

---

Visual regression results:
https://government-frontend-pr-1445.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1445.herokuapp.com/component-guide
