### PR TITLE
Add detection of contextual title translation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,18 @@ module ApplicationHelper
     I18n.t("i18n.direction", locale: I18n.locale, default: "ltr")
   end
 
+  def t_locale_fallback(key, options = {})
+    options['locale'] = I18n.locale
+    options[:fallback] = nil
+    translation = I18n.t(key, options)
+
+    if translation.nil? || translation.include?("translation missing")
+      I18n.default_locale
+    else
+      return nil
+    end
+  end
+
   def wrapper_class
     "direction-#{page_text_direction}" if page_text_direction
   end

--- a/app/presenters/content_item/title_and_context.rb
+++ b/app/presenters/content_item/title_and_context.rb
@@ -4,6 +4,7 @@ module ContentItem
       {
         title: title,
         context: I18n.t("content_item.schema_name.#{document_type}", count: 1),
+        context_locale: t_locale_fallback("content_item.schema_name.#{document_type}", count: 1),
         average_title_length: "long"
       }
     end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,5 +1,6 @@
 class ContentItemPresenter
   include ContentItem::Withdrawable
+  include ApplicationHelper
 
   attr_reader :content_item,
               :requested_content_item_path,

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -8,6 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title',
        context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
+       context_locale: t_locale_fallback("content_item.schema_name.#{@content_item.document_type}", count: 1),
        title: @content_item.title,
        average_title_length: "long" %>
   </div>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -12,4 +12,23 @@ class ApplicationHelperTest < ActionView::TestCase
     self.stubs(:request).returns(ActionDispatch::TestRequest.create("PATH_INFO" => '/foo/bar', "QUERY_STRING" => 'ham=jam&spam=gram'))
     assert_equal '/foo/bar', current_path_without_query_string
   end
+
+  test "#t_locale_fallback returns nil for a string with a locale translation" do
+    fallback = t_locale_fallback("content_item.schema_name.imported", count: 1, locale: :de)
+    assert_equal nil, fallback
+  end
+
+  test "#t_locale_fallback returns default locale for a string with no locale translation" do
+    I18n.with_locale(:de) do
+      fallback = t_locale_fallback("content_item.schema_name.decision", count: 1, locale: :de)
+      assert_equal :en, fallback
+    end
+  end
+
+  test "#t_locale_fallback returns fallback for irrelevant key" do
+    I18n.with_locale(:de) do
+      fallback = t_locale_fallback("blah", count: 1)
+      assert_equal :en, fallback
+    end
+  end
 end

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -30,7 +30,7 @@ class CorporateInformationPagePresenterTest
 
     test 'has title without context' do
       assert presented_item.is_a?(ContentItem::TitleAndContext)
-      title_component_params = { title: "About us" }
+      title_component_params = { title: "About us", context_locale: :en }
 
       assert_equal title_component_params, presented_item.title_and_context
     end

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -83,7 +83,9 @@ class SpecialistDocumentPresenterTest
       assert presented_item('aaib-reports').is_a?(ContentItem::TitleAndContext)
       title_component_params = {
                                   title: schema_item('aaib-reports')['title'],
-                                  average_title_length: 'long'
+                                  context_locale: nil,
+                                  average_title_length: 'long',
+
                                }
 
       assert_equal title_component_params, presented_item('aaib-reports').title_and_context


### PR DESCRIPTION
https://trello.com/c/iQcgz7lt/25-2-mark-language-on-page-kicker-section-of-page

This adds a helper method which detects whether the string requested
was returned by the current locale's translation file. If not, it returns
the default locale.

This helper is in turn used on the contextual headings, allowing us to
pass the information on to the component that displays the heading, meaning
we will be able to markup the contextual header's actual language, supporting
screenreaders and making the page more semantic.

---

Visual regression results:
https://government-frontend-pr-1447.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1447.herokuapp.com/component-guide
