### PR TITLE
Prevent errors for missing public_updated_at

### DIFF
--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -40,7 +40,7 @@ class DocumentCollectionPresenter < ContentItemPresenter
           }
         },
         metadata: {
-          public_updated_at: Time.zone.parse(link["public_updated_at"]),
+          public_updated_at: link["public_updated_at"]&.then { |time| Time.zone.parse(time) },
           document_type: I18n.t("content_item.schema_name.#{link['document_type']}",
                                 count: 1,
                                 default: nil),

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -88,6 +88,21 @@ class DocumentCollectionPresenterTest
 
       assert_nil grouped.first[:metadata][:document_type]
     end
+
+    test 'it handles public_updated_at not being specified' do
+      schema_data = schema_item
+
+      document = schema_data["links"]["documents"].first.tap do |link|
+        link.delete("public_updated_at")
+      end
+
+      grouped = present_example(schema_data).group_document_links(
+        { "documents" => [document["content_id"]] },
+        0,
+      )
+
+      assert_nil grouped.first[:metadata][:public_updated_at]
+    end
   end
 
   class GroupWithMissingDocument < TestCase


### PR DESCRIPTION
This stops document collections raising errors when a public_updated_at
value is not set on a document. This is often the case with draft GOV.UK
documents, however Whitehall tends to fill in this field which is why
this error hasn't been seen before.

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide
