### PR TITLE
Remove outdated CSS

### DIFF
--- a/app/assets/stylesheets/application-ie6.scss
+++ b/app/assets/stylesheets/application-ie6.scss
@@ -1,7 +1,0 @@
-// BASE STYLESHEET FOR IE 6 COMPILER
-
-$is-ie: true;
-$ie-version: 6;
-$mobile-ie6: false;
-
-@import "application";

--- a/app/assets/stylesheets/application-ie7.scss
+++ b/app/assets/stylesheets/application-ie7.scss
@@ -1,6 +1,0 @@
-// BASE STYLESHEET FOR IE 7 COMPILER
-
-$is-ie: true;
-$ie-version: 7;
-
-@import "application";

--- a/app/assets/stylesheets/application-ie8.scss
+++ b/app/assets/stylesheets/application-ie8.scss
@@ -1,6 +1,0 @@
-// BASE STYLESHEET FOR IE 8 COMPILER
-
-$is-ie: true;
-$ie-version: 8;
-
-@import "application";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,10 +8,7 @@
       <%= @content_item.page_title %> - GOV.UK
     <% end %>
   </title>
-  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %><!--<![endif]-->
-  <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><script>var ieVersion = 6;</script><![endif]-->
-  <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><script>var ieVersion = 7;</script><![endif]-->
-  <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><script>var ieVersion = 8;</script><![endif]-->
+  <%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %>
   <% if Rails.env.test? && params[:medium] == 'print' %>
     <%= stylesheet_link_tag "print.css", :media => "screen", integrity: true, crossorigin: 'anonymous' %>
   <% else %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,10 +9,6 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 Rails.application.config.assets.precompile += %w(
-  application-ie6.css
-  application-ie6.css
-  application-ie7.css
-  application-ie8.css
   print.css
   webchat.js
 )


### PR DESCRIPTION
We no longer support IE6 and IE7 to the extent where specific stylesheets are
necessary and the IE8 stylesheet was doing nothing helpful. Removing these
improves the compile time and makes the dev environment more useable.

---

Visual regression results:
https://government-frontend-pr-1450.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1450.herokuapp.com/component-guide
