### PR TITLE
Switch guides to emit faq structured data

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -1,6 +1,6 @@
 <% content_for :extra_head_content do %>
   <%= machine_readable_metadata(
-    schema: :article,
+    schema: :faq,
     canonical_url: @content_item.canonical_url
   ) %>
 <% end %>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 #
 # To ban all spiders from the entire site uncomment the next two lines:
-User-agent: *
-Disallow: /
+# User-agent: *
+# Disallow: /

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -76,4 +76,14 @@ class GuideTest < ActionDispatch::IntegrationTest
 
     assert_has_component_title(title)
   end
+
+  test "guides show the faq page schema" do
+    setup_and_visit_content_item('guide')
+
+    schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
+    schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }
+
+    qa_page_schema = schemas.detect { |schema| schema["@type"] == "FAQPage" }
+    assert_equal qa_page_schema["headline"], @content_item['title']
+  end
 end


### PR DESCRIPTION
This potentially gives us more control over the presentation of the result in external search applications.

Related to https://github.com/alphagov/govuk_publishing_components/pull/1087

Component guide for this PR:
https://government-frontend-pr-1467.herokuapp.com/component-guide

---

I need to re-allow spidering (reverts part of https://github.com/alphagov/government-frontend/pull/1461) in order to review structured data in checkers such as https://search.google.com/structured-data/testing-tool/u/0/ and https://search.google.com/test/rich-results

This only affects review apps as this robots.txt is not publicly accessible from production-like environments

We noindex, nofollow all the content pages in Heroku review apps, so I think we're safe to allow robots to access these pages.
