### PR TITLE
Stop the focus state on in page navigation links from being full width

### DIFF
--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -25,12 +25,8 @@
       list-style: none;
       margin-bottom: 0.75em;
 
-      a {
-        display: block;
-
-        &:focus {
-          @include govuk-template-link-focus-override;
-        }
+      a:focus {
+        @include govuk-template-link-focus-override;
       }
     }
   }


### PR DESCRIPTION
The focus state for links on the in page navigation took up the entire width of the parent element. Stopping the link from displaying like a block element fixes this with no other side effects.

Before:
<img width="483" alt="" src="https://user-images.githubusercontent.com/1732331/64535783-c8e60a00-d30f-11e9-9042-b3b68769e996.png">


After:
<img width="427" alt="" src="https://user-images.githubusercontent.com/1732331/64535792-cc799100-d30f-11e9-933e-4cf709df132d.png">

---

Visual regression results:
https://government-frontend-pr-1474.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1474.herokuapp.com/component-guide
