### PR TITLE
Deduplicate FAQ page schema presentation

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -1,6 +1,8 @@
 <% content_for :extra_head_content do %>
+  <% schema = @content_item.requesting_a_part? ? :article : :faq %>
+
   <%= machine_readable_metadata(
-    schema: :faq,
+    schema: schema,
     canonical_url: @content_item.canonical_url
   ) %>
 <% end %>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -15,7 +15,7 @@ class ApplicationHelperTest < ActionView::TestCase
 
   test "#t_locale_fallback returns nil for a string with a locale translation" do
     fallback = t_locale_fallback("content_item.schema_name.imported", count: 1, locale: :de)
-    assert_equal nil, fallback
+    assert_nil fallback
   end
 
   test "#t_locale_fallback returns default locale for a string with no locale translation" do

--- a/test/models/http_feature_flags_test.rb
+++ b/test/models/http_feature_flags_test.rb
@@ -58,7 +58,7 @@ class HttpFeatureFlagsTest < ActiveSupport::TestCase
 
     feature_flag_value = instance.get_feature_flag('USE_MAGIC')
 
-    assert_equal nil, feature_flag_value
+    assert_nil feature_flag_value
   end
 
   test 'get_feature_flag returns feature flag value when feature flag exists' do

--- a/test/services/request_helper_test.rb
+++ b/test/services/request_helper_test.rb
@@ -4,7 +4,7 @@ class RequestHelperTest < ActiveSupport::TestCase
   test 'get_header returns nil when header does not exist' do
     header_val = RequestHelper.get_header('Govuk-Example-Header', {})
 
-    assert_equal nil, header_val
+    assert_nil header_val
   end
 
   test 'get_header returns header when header exists' do


### PR DESCRIPTION
At present we're showing the same FAQ schema on each page of a guide. This is a bit suboptimal.  We have the option of splitting it up and showing one question and answer per part/chapter in the guide, but it seems much better to present it to Google as a joined up publication, because that's how it's been designed.

To resolve this problem, we present the FAQ page on the default page of the guide, but fall back to the Article schema for chapter pages, so we're still presenting some schema.org content everywhere, but not presenting duplicate content.

[Structured data from /universal-credit](https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Fgovernment-frontend-pr-1478.herokuapp.com%2Funiversal-credit) should show the FAQ schema
[Structured data from /universal-credit/eligibility](https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Fgovernment-frontend-pr-1478.herokuapp.com%2Funiversal-credit%2Feligibility) should show the Article schema

