### PR TITLE
Render a guide as a single page

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -83,6 +83,8 @@ private
   end
 
   def content_item_template
+    return "guide_single" if @content_item.render_guide_as_single_page?
+
     @content_item.schema_name
   end
 

--- a/app/presenters/content_item/parts.rb
+++ b/app/presenters/content_item/parts.rb
@@ -61,7 +61,9 @@ module ContentItem
 
     def part_link_elements
       parts.map do |part|
-        if part["slug"] != current_part["slug"] || render_guide_as_single_page?
+        if render_guide_as_single_page?
+          { href: "##{part['slug']}", text: part["title"] }
+        elsif part["slug"] != current_part["slug"]
           { href: part["full_path"], text: part["title"] }
         else
           { href: part["full_path"], text: part["title"], active: true }

--- a/app/presenters/content_item/parts.rb
+++ b/app/presenters/content_item/parts.rb
@@ -61,7 +61,7 @@ module ContentItem
 
     def part_link_elements
       parts.map do |part|
-        if part["slug"] != current_part["slug"]
+        if part["slug"] != current_part["slug"] || render_guide_as_single_page?
           { href: part["full_path"], text: part["title"] }
         else
           { href: part["full_path"], text: part["title"], active: true }

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -78,6 +78,11 @@ class ContentItemPresenter
     !content_item.cache_control.private?
   end
 
+  def render_guide_as_single_page?
+    # /voting-in-the-uk
+    content_id == "9315bc67-33e7-42e9-8dea-e022f56dabfa"
+  end
+
 private
 
   def display_date(timestamp, format = "%-d %B %Y")

--- a/app/views/content_items/guide_single.html.erb
+++ b/app/views/content_items/guide_single.html.erb
@@ -1,0 +1,47 @@
+<% content_for :extra_head_content do %>
+  <%= machine_readable_metadata(
+    schema: :article,
+    canonical_url: @content_item.canonical_url,
+    body: @content_item.current_part_body
+  ) %>
+<% end %>
+
+<script type="application/ld+json">
+  <%= raw MachineReadable::GuideFaqPageSchemaPresenter.new(@content_item).structured_data.to_json %>
+</script>
+
+<% content_for :simple_header, true %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'govuk_publishing_components/components/title', { title: @content_item.content_title } %>
+
+    <% if @content_item.show_guide_navigation? %>
+      <aside class="part-navigation-container" role="complementary">
+        <%= render "govuk_publishing_components/components/contents_list", aria_label: 'Pages in this guide', contents: @content_item.part_link_elements, underline_links: true %>
+      </aside>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% if @content_item.has_parts? %>
+
+      <% @content_item.parts.each do |part| %>
+        <h1 id=<%= part["slug"] %> class="part-title">
+          <%= part["title"] %>
+        </h1>
+
+        <%= render 'govuk_publishing_components/components/govspeak',
+          content: part["body"].html_safe,
+          direction: page_text_direction,
+          disable_youtube_expansions: true %>
+
+      <% end %>
+      <%= render 'components/print-link', href: @content_item.print_link, link_text: t("multi_page.print_entire_guide") %>
+    <% end %>
+  </div>
+
+  <%= render 'shared/sidebar_navigation' %>
+</div>
+
+<%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/guide_single.html.erb
+++ b/app/views/content_items/guide_single.html.erb
@@ -42,7 +42,6 @@
           disable_youtube_expansions: true %>
       </section>
       <% end %>
-      <%= render 'components/print-link', href: @content_item.print_link, link_text: t("multi_page.print_entire_guide") %>
     <% end %>
   </div>
 

--- a/app/views/content_items/guide_single.html.erb
+++ b/app/views/content_items/guide_single.html.erb
@@ -27,6 +27,7 @@
     <% if @content_item.has_parts? %>
 
       <% @content_item.parts.each_with_index do |part, index| %>
+      <section class="govuk-!-padding-bottom-9" aria-labelledby="<%= part["slug"] %>">
         <%= render "govuk_publishing_components/components/heading", {
             text: part["title"],
             id: part["slug"],
@@ -39,7 +40,7 @@
           content: part["body"].html_safe,
           direction: page_text_direction,
           disable_youtube_expansions: true %>
-
+      </section>
       <% end %>
       <%= render 'components/print-link', href: @content_item.print_link, link_text: t("multi_page.print_entire_guide") %>
     <% end %>

--- a/app/views/content_items/guide_single.html.erb
+++ b/app/views/content_items/guide_single.html.erb
@@ -26,10 +26,14 @@
   <div class="govuk-grid-column-two-thirds">
     <% if @content_item.has_parts? %>
 
-      <% @content_item.parts.each do |part| %>
-        <h1 id=<%= part["slug"] %> class="part-title">
-          <%= part["title"] %>
-        </h1>
+      <% @content_item.parts.each_with_index do |part, index| %>
+        <%= render "govuk_publishing_components/components/heading", {
+            text: part["title"],
+            id: part["slug"],
+            heading_level: 1,
+            border_top: index.zero? ? 0 : 2,
+            padding: true
+          } %>
 
         <%= render 'govuk_publishing_components/components/govspeak',
           content: part["body"].html_safe,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
 
   get "healthcheck", to: proc { [200, {}, [""]] }
 
+  # Testing guides as a single page so we redirect parts to the default page
+  get "/voting-in-the-uk/:chapter", to: redirect("/voting-in-the-uk#%{chapter}")
+
   get "*path/:variant" => "content_items#show",
       constraints: {
         variant: /print/,


### PR DESCRIPTION
We think it might really help our SEO to have guide content on one page.  The how to vote page is particularly interesting because we have some data about searching intents that might bring people to this page.  We also think that amending this format to a single page might benefit voice answers.

There are some existing issues with guides having multiple h1 tags on a page. This PR doesn't attempt to fix it (and in a way makes it worse) because we have more h1s on the page than we used to (because on the multiple sections).  I'm led to believe that this is not relevant to WCAG by this [trello card on the GOV.UK accessibility backlog](https://trello.com/c/LzxvPjUz/117-fix-multiple-h1-heading-structure).

Other than that, this has been mostly stolen from the existing guide layout, only including all of the parts, and using the heading component for the in page h1s rather than hand-cranked html.

I've added a route to redirect chapters of the guide in question to anchors on the new single page layout

---

Affected page: https://government-frontend-pr-1481.herokuapp.com/voting-in-the-uk
Regular guide: https://government-frontend-pr-1481.herokuapp.com/student-finance
