### PR TITLE
Use h2 if there's no contents list

### DIFF
--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -51,7 +51,8 @@ class DocumentCollectionPresenter < ContentItemPresenter
 
   def group_heading(group)
     title = group["title"]
-    content_tag :h3, title, class: "group-title", id: group_title_id(title)
+    heading_level = show_contents_list? ? :h3 : :h2
+    content_tag heading_level, title, class: "group-title", id: group_title_id(title)
   end
 
 private


### PR DESCRIPTION
When the contents list component doesn't display (if there's 2 groups or less), then the heading level skips from H1 (page title) to H3 (group headings).

Someone raised this issue in a Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3800830

This commit checks whether a contents list will be displayed, and uses a H2 if not.

- Page with contents list: /government/collections/statistics-exclusions
- Page without contents list: /government/collections/statistics-performance-tables
