### PR TITLE
Pass _ga client id to external signon services

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,2 +1,11 @@
 //= require_tree ./modules
 //= require govuk_publishing_components/all_components
+//= require set-ga-client-id-on-form
+
+jQuery(function ($) {
+  var $form = $('.js-service-sign-in-form')
+
+  if ($form.length) {
+    new GOVUK.SetGaClientIdOnForm({ $form: $form })
+  }
+})

--- a/app/assets/javascripts/set-ga-client-id-on-form.js
+++ b/app/assets/javascripts/set-ga-client-id-on-form.js
@@ -1,0 +1,20 @@
+(function () {
+  'use strict'
+
+  window.GOVUK = window.GOVUK || {}
+  var GOVUK = window.GOVUK
+
+  function SetGaClientIdOnForm (options) {
+    if (!options.$form || !window.ga) { return }
+
+    var form = options.$form
+
+    window.ga(function(tracker) {
+      var clientId = tracker.get('clientId')
+      var action = form.attr('action')
+      form.attr('action', action + "?_ga=" + clientId)
+    });
+  }
+
+  GOVUK.SetGaClientIdOnForm = SetGaClientIdOnForm
+})(window, window.GOVUK);

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -34,7 +34,7 @@ class ContentItemsController < ApplicationController
         return
       end
 
-      redirect_to selected[:url]
+      redirect_to service_url(selected[:url])
     end
   end
 
@@ -124,6 +124,16 @@ private
   def set_expiry
     expires_in(@content_item.cache_control_max_age(request.format),
                public: @content_item.cache_control_public?)
+  end
+
+  def service_url(original_url)
+    ga_param = params[:_ga]
+    return original_url if ga_param.nil?
+
+    url = URI.parse(original_url)
+    new_query_ar = URI.decode_www_form(url.query || '') << ["_ga", ga_param]
+    url.query = URI.encode_www_form(new_query_ar)
+    url.to_s
   end
 
   def with_locale

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -21,7 +21,8 @@
 %>
 <%= form_tag({controller: 'content_items', action: 'service_sign_in_options'},
              method: "post",
-             data: data_attrs) do %>
+             data: data_attrs,
+             class: 'js-service-sign-in-form') do %>
   <% legend_text = render 'govuk_publishing_components/components/title', title: @content_item.title %>
   <%= render "govuk_publishing_components/components/fieldset", legend_text: legend_text do %>
     <div class="govuk-grid-row">

--- a/spec/javascripts/set-ga-client-id-on-form.spec.js
+++ b/spec/javascripts/set-ga-client-id-on-form.spec.js
@@ -1,0 +1,23 @@
+/* global describe beforeEach it expect */
+
+var $ = window.jQuery
+
+describe('SetGaClientIdOnForm', function () {
+
+  var GOVUK = window.GOVUK
+  var tracker = { clientId: 'clientId' }
+  tracker.get = function(arg) { return this[arg] }
+  window.ga = function(callback) { callback(tracker) }
+  var form
+
+  beforeEach(function () {
+    form = $(
+      '<form class="js-service-sign-in-form" action="/endpoint"></form>'
+    )
+    setter = new GOVUK.SetGaClientIdOnForm({ $form: form })
+  })
+
+  it('sets the _ga client id as a query param on the form action', function () {
+    expect(form.attr('action')).toBe('/endpoint?_ga=clientId')
+  })
+})


### PR DESCRIPTION
On pages such as https://www.gov.uk/log-in-file-self-assessment-tax-return/sign-in/prove-identity
we redirect users to services such as tax.service.gov.uk to complete their sign in.

This will pass the `_ga` cookie as the `_ga` param as part of cross-domain tracking, so that we can measure user journeys across domains.

This will only pass the _ga param to other .gov.uk services. Currently these are:
- www.tax.service.gov.uk
- www.signin.service.gov.uk
- www.ruralpayments.service.gov.uk

Pages to check: 

- https://government-frontend-pr-1483.herokuapp.com/log-in-file-self-assessment-tax-return/sign-in/prove-identity
- https://government-frontend-pr-1483.herokuapp.com/check-state-pension/sign-in/prove-identity
- https://government-frontend-pr-1483.herokuapp.com/update-company-car-details/sign-in/prove-identity
- https://government-frontend-pr-1483.herokuapp.com/personal-tax-account/sign-in/prove-identity
- https://government-frontend-pr-1483.herokuapp.com/update-company-car-details/sign-in/prove-identity

The urls we redirect to are defined in service_sign_on content item `details.choose_sign_in.options` ([example](https://www.gov.uk/api/content/check-state-pension/sign-in)). 

Further work is required on the signin.service.gov.uk to make use of the _ga param and ensure it is included in further redirects.

Trello: https://trello.com/c/ORdXWurC/101