### PR TITLE
Add basic auth to government frontend review app

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,7 +25,14 @@
     },
     "HEROKU_APP_NAME": {
       "required": true
-    }
+    },
+    "BASIC_AUTH_USERNAME": {
+      "required": true
+    },
+    "BASIC_AUTH_PASSWORD": {
+      "required": true
+    },
+    "REQUIRE_BASIC_AUTH": "true"
   },
   "image": "heroku/ruby",
   "buildpacks": [

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,14 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery except: :service_sign_in_options
 
+
+  if ENV["BASIC_AUTH_USERNAME"]
+    http_basic_authenticate_with(
+      name: ENV.fetch("BASIC_AUTH_USERNAME"),
+      password: ENV.fetch("BASIC_AUTH_PASSWORD")
+    )
+  end
+
 private
 
   def content_item_path


### PR DESCRIPTION
This has been lifted from [Collections](https://github.com/alphagov/collections/blob/master/app/controllers/application_controller.rb#L11-L16)

The env variables have been added to government-frontend.herokuapp.com already.

This is to prevent users from accidentally landing on a page in the review
app and believing that it's GOV.UK.

---

Example page for this PR:
https://government-frontend-pr-1484.herokuapp.com/universal-credit
