### PR TITLE
Fix branded links and organisation logo hover state text colour

### DIFF
--- a/app/assets/stylesheets/helpers/_organisation-links.scss
+++ b/app/assets/stylesheets/helpers/_organisation-links.scss
@@ -1,7 +1,13 @@
 @mixin organisation-links {
   @each $organisation in $all-organisation-brand-colours {
-    .#{nth($organisation, 1)}-brand-colour a {
-      color: nth($organisation, 3);
+    .#{nth($organisation, 1)}-brand-colour {
+      a {
+        color: nth($organisation, 3);
+
+        &:focus {
+          color: $govuk-focus-text-colour;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Why

Links on pages that used branding colours (for example, the [DCM and also S About page](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport/about)) didn't have the correct focus state text colour.

Rough and ready patch for #1487.

## What
This changes the text colour of the focus state of all of the links which use branded colours.

Before:
<img width="257" alt="Screen Shot 2019-09-16 at 14 05 49" src="https://user-images.githubusercontent.com/1732331/65140140-d3865a80-da05-11e9-9fa9-84d2fa24aefd.png">
<img width="328" alt="Screen Shot 2019-09-18 at 11 17 58" src="https://user-images.githubusercontent.com/1732331/65140218-fe70ae80-da05-11e9-8fc6-deb848ba77e8.png">
<img width="245" alt="Screen Shot 2019-09-18 at 11 17 43" src="https://user-images.githubusercontent.com/1732331/65140228-02043580-da06-11e9-9534-ad6d2902764f.png">


After:
<img width="194" alt="Screen Shot 2019-09-18 at 11 17 11" src="https://user-images.githubusercontent.com/1732331/65140168-e305a380-da05-11e9-9ccf-16c0bdcc5c3b.png">
<img width="387" alt="Screen Shot 2019-09-18 at 11 17 53" src="https://user-images.githubusercontent.com/1732331/65140240-07fa1680-da06-11e9-921e-55876eb957a7.png">
<img width="244" alt="Screen Shot 2019-09-18 at 11 17 49" src="https://user-images.githubusercontent.com/1732331/65140249-0cbeca80-da06-11e9-9732-6a40da8d6654.png">

---

Visual regression results:
https://government-frontend-pr-1491.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1491.herokuapp.com/component-guide