### PR TITLE
Ensure that FAQs are generated correctly

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -2,7 +2,7 @@
   <%= machine_readable_metadata(
     schema: :faq,
     canonical_url: @content_item.canonical_url,
-    body: @content_item.has_valid_part? ? @content_item.current_part_body : nil
+    body: @content_item.has_parts? ? @content_item.current_part_body : nil
   ) %>
 <% end %>
 

--- a/test/integration/answer_test.rb
+++ b/test/integration/answer_test.rb
@@ -26,5 +26,6 @@ class AnswerTest < ActionDispatch::IntegrationTest
     faq_schema = find_structured_data(page, "FAQPage")
 
     assert_equal faq_schema["headline"], @content_item['title']
+    assert_not_equal faq_schema["mainEntity"], []
   end
 end

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -82,6 +82,7 @@ class GuideTest < ActionDispatch::IntegrationTest
     faq_schema = find_structured_data(page, "FAQPage")
 
     assert_equal faq_schema["headline"], @content_item['title']
+    assert_not_equal faq_schema["mainEntity"], []
   end
 
   test "guide chapters show the faq schema" do
@@ -89,6 +90,7 @@ class GuideTest < ActionDispatch::IntegrationTest
     faq_schema = find_structured_data(page, "FAQPage")
 
     assert_equal faq_schema["headline"], @content_item['title']
+    assert_not_equal faq_schema["mainEntity"], []
   end
 
   def setup_and_visit_part_in_guide


### PR DESCRIPTION
The logic for guides was incorrect so the body of the default guide chapter wasn't being passed to the machine readable component.
