### PR TITLE
Correct spelling of Nederlands

### DIFF
--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,6 +1,6 @@
 nl:
   language_names:
-    nl: Nederlandse
+    nl: Nederlands
   content_item:
     schema_name:
       aaib_report:


### PR DESCRIPTION
Our translation for Dutch is incorrect