### PR TITLE
Remove govuk_frontend_toolkit sass dependency

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,11 +3,6 @@
 $govuk-use-legacy-palette: true;
 $govuk-typography-use-rem: false;
 
-// govuk_frontend_toolkit dependencies
-@import "typography";
-@import "colours";
-@import "grid_layout";
-
 // Components from govuk_publishing_components gem
 @import 'govuk_publishing_components/all_components';
 

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -8,13 +8,13 @@
   padding: govuk-spacing(3);
   clear: both;
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(4) govuk-spacing(6);
   }
 }
 
 .app-c-banner--aside {
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(6);
   }
 }

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,6 +1,6 @@
 .app-c-banner {
   @include responsive-bottom-margin;
-  @include core-19;
+  @include govuk-font(19);
   @include white-links;
   direction: ltr;
   background: $govuk-blue;
@@ -20,16 +20,16 @@
 }
 
 .app-c-banner__text {
-  @include core-24;
+  @include govuk-font(24);
 }
 
 .app-c-banner__title {
-  @include bold-27;
+  @include govuk-font(27, $weight: bold);
   margin-bottom: govuk-spacing(2);
 }
 
 .app-c-banner__desc {
-  @include core-19;
+  @include govuk-font(19);
   // Ensure the text has a line-length of around 60 characters
   max-width: 30em;
   padding-top: govuk-spacing(2);

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -3,8 +3,8 @@
   @include govuk-font(19);
   @include white-links;
   direction: ltr;
-  background: $govuk-blue;
-  color: $white;
+  background: $govuk-brand-colour;
+  color: govuk-colour("white");
   padding: govuk-spacing(3);
   clear: both;
 

--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -21,7 +21,7 @@
 }
 
 .app-c-contents-list-with-body__link-wrapper.govuk-sticky-element--stuck-to-window {
-  background-color: $panel-colour;
+  background-color: govuk-colour("mid-grey", $legacy: "grey-3");
   bottom: -1px; // 'Fix' for anomalous 1px margin which sporadically appears below this element.
   left: 0;
   margin: 0;

--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -2,7 +2,7 @@
   margin: 0 auto;
   padding: 0;
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     max-width: 1024px;
   }
 
@@ -31,7 +31,7 @@
   width: 100%;
   z-index: 1;
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     padding-left: govuk-spacing(2);
   }
 
@@ -40,7 +40,7 @@
     padding: govuk-spacing(3);
     width: percentage(2 / 3);
 
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       padding: govuk-spacing(4);
     }
   }

--- a/app/assets/stylesheets/components/_download-link.scss
+++ b/app/assets/stylesheets/components/_download-link.scss
@@ -8,7 +8,7 @@
     @include govuk-focused-text;
   }
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     margin-top: govuk-spacing(6);
   }
 

--- a/app/assets/stylesheets/components/_download-link.scss
+++ b/app/assets/stylesheets/components/_download-link.scss
@@ -1,6 +1,6 @@
 .app-c-download-link {
   display: inline-block;
-  @include bold-19;
+  @include govuk-font(19, $weight: bold);
   margin-top: govuk-spacing(3);
   margin-bottom: govuk-spacing(3);
 

--- a/app/assets/stylesheets/components/_error-message.scss
+++ b/app/assets/stylesheets/components/_error-message.scss
@@ -2,12 +2,8 @@
 
 .app-c-error-message {
   display: block;
-
   margin-bottom: $app-spacing-scale-3;
-
   clear: both;
-
   color: $app-error-colour;
-
-  @include bold-19;
+  @include govuk-font(19, $weight: bold);
 }

--- a/app/assets/stylesheets/components/_error-message.scss
+++ b/app/assets/stylesheets/components/_error-message.scss
@@ -2,7 +2,7 @@
 
 .app-c-error-message {
   display: block;
-  margin-bottom: $app-spacing-scale-3;
+  margin-bottom: govuk-spacing(3);
   clear: both;
   color: $govuk-error-colour;
   @include govuk-font(19, $weight: bold);

--- a/app/assets/stylesheets/components/_error-message.scss
+++ b/app/assets/stylesheets/components/_error-message.scss
@@ -4,6 +4,6 @@
   display: block;
   margin-bottom: $app-spacing-scale-3;
   clear: both;
-  color: $app-error-colour;
+  color: $govuk-error-colour;
   @include govuk-font(19, $weight: bold);
 }

--- a/app/assets/stylesheets/components/_figure.scss
+++ b/app/assets/stylesheets/components/_figure.scss
@@ -2,7 +2,7 @@
   @extend %contain-floats;
   @include responsive-bottom-margin;
 
-  border-top: 1px solid $border-colour;
+  border-top: 1px solid $govuk-border-colour;
   padding-top: govuk-spacing(3);
 }
 

--- a/app/assets/stylesheets/components/_figure.scss
+++ b/app/assets/stylesheets/components/_figure.scss
@@ -1,5 +1,5 @@
 .app-c-figure {
-  @extend %contain-floats;
+  @include govuk-clearfix;
   @include responsive-bottom-margin;
 
   border-top: 1px solid $govuk-border-colour;

--- a/app/assets/stylesheets/components/_figure.scss
+++ b/app/assets/stylesheets/components/_figure.scss
@@ -17,11 +17,11 @@
 }
 
 .app-c-figure__figcaption {
-  @include core-16;
+  @include govuk-font(16);
 
 
   @include govuk-media-query($from: tablet) {
-    @include core-14;
+    @include govuk-font(14);
 
     display: block;
     vertical-align: top;

--- a/app/assets/stylesheets/components/_figure.scss
+++ b/app/assets/stylesheets/components/_figure.scss
@@ -10,7 +10,7 @@
   display: block;
   width: 100%;
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     float: left;
     width: 50%;
   }
@@ -20,7 +20,7 @@
   @include core-16;
 
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     @include core-14;
 
     display: block;
@@ -32,7 +32,7 @@
     width: 50%;
   }
 
-  @include media(mobile) {
+  @include govuk-media-query($until: tablet) {
     margin-top: govuk-spacing(2);
   }
 }
@@ -40,7 +40,7 @@
 .app-c-figure__figcaption-text {
   margin-bottom: 0;
 
-  @include media(desktop, tablet) {
+  @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(2);
   }
 }

--- a/app/assets/stylesheets/components/_important-metadata.scss
+++ b/app/assets/stylesheets/components/_important-metadata.scss
@@ -3,7 +3,7 @@
   color: govuk-colour("white");
   padding: govuk-spacing(3);
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     overflow: auto;
     padding: govuk-spacing(4) govuk-spacing(6);
   }

--- a/app/assets/stylesheets/components/_important-metadata.scss
+++ b/app/assets/stylesheets/components/_important-metadata.scss
@@ -1,5 +1,5 @@
 .app-c-important-metadata {
-  background: $govuk-blue;
+  background: $govuk-brand-colour;
   color: govuk-colour("white");
   padding: govuk-spacing(3);
 

--- a/app/assets/stylesheets/components/_print-link.scss
+++ b/app/assets/stylesheets/components/_print-link.scss
@@ -7,7 +7,7 @@
     padding: 0.5em 0.5em 0.5em 38px;
     margin-left: -10px;
 
-    @include device-pixel-ratio() {
+    @include govuk-device-pixel-ratio($ratio: 2) {
       background-image: image-url("icon-print-2x.png");
       background-size: 16px 18px;
     }

--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -38,5 +38,5 @@
 
 .app-c-published-dates--history {
   padding-top: govuk-spacing(2);
-  border-top: 1px solid $border-colour;
+  border-top: 1px solid $govuk-border-colour;
 }

--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -33,7 +33,7 @@
 
 .app-c-published-dates__change-date {
   display: block;
-  @include bold-16;
+  @include govuk-font(16, $weight: bold);
 }
 
 .app-c-published-dates--history {

--- a/app/assets/stylesheets/components/helpers/_variables.scss
+++ b/app/assets/stylesheets/components/helpers/_variables.scss
@@ -20,5 +20,3 @@ $app-border-width-form-element: 2px;
 
 // Focus
 $app-focus-width: 3px;
-
-$app-error-colour: $red;

--- a/app/assets/stylesheets/components/helpers/_variables.scss
+++ b/app/assets/stylesheets/components/helpers/_variables.scss
@@ -1,15 +1,3 @@
-// Forked from GOV.UK Frontend, namespace changed to ensure no conflicts.
-
-$app-spacing-scale-0: 0;
-$app-spacing-scale-1: 5px;
-$app-spacing-scale-2: 10px;
-$app-spacing-scale-3: 15px;
-$app-spacing-scale-4: 20px;
-$app-spacing-scale-5: 30px;
-$app-spacing-scale-6: 40px;
-$app-spacing-scale-7: 50px;
-$app-spacing-scale-8: 60px;
-
 $app-text-colour: $govuk-text-colour;
 $app-secondary-text-colour: govuk-colour("dark-grey", $legacy: "grey-1");
 

--- a/app/assets/stylesheets/components/helpers/_variables.scss
+++ b/app/assets/stylesheets/components/helpers/_variables.scss
@@ -10,8 +10,8 @@ $app-spacing-scale-6: 40px;
 $app-spacing-scale-7: 50px;
 $app-spacing-scale-8: 60px;
 
-$app-text-colour: $text-colour;
-$app-secondary-text-colour: $grey-1;
+$app-text-colour: $govuk-text-colour;
+$app-secondary-text-colour: govuk-colour("dark-grey", $legacy: "grey-1");
 
 // Border widths
 $app-border-width-mobile: 4px;

--- a/app/assets/stylesheets/helpers/_content-bottom-margin.scss
+++ b/app/assets/stylesheets/helpers/_content-bottom-margin.scss
@@ -1,7 +1,7 @@
 .content-bottom-margin {
   margin-bottom: govuk-spacing(4);
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     @include responsive-bottom-margin;
   }
 }

--- a/app/assets/stylesheets/helpers/_organisation-links.scss
+++ b/app/assets/stylesheets/helpers/_organisation-links.scss
@@ -1,8 +1,12 @@
+@import "govuk/settings/colours-palette";
+@import "govuk/settings/colours-organisations";
+@import "govuk/helpers/colour";
+
 @mixin organisation-links {
-  @each $organisation in $all-organisation-brand-colours {
-    .#{nth($organisation, 1)}-brand-colour {
+  @each $organisation in map-keys($govuk-colours-organisations) {
+    .#{$organisation}-brand-colour {
       a {
-        color: nth($organisation, 3);
+        color: govuk-organisation-colour($organisation);
 
         &:focus {
           color: $govuk-focus-text-colour;

--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -4,7 +4,7 @@
     margin-bottom: govuk-spacing(6);
     padding-bottom: govuk-spacing(3);
 
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       margin-top: 0;
       margin-bottom: 0;
       padding-bottom: govuk-spacing(3);
@@ -17,7 +17,7 @@
     margin-bottom: 0;
     @include core-19;
 
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       @include core-16;
     }
 
@@ -36,7 +36,7 @@
     margin-bottom: govuk-spacing(3);
     margin-top: govuk-spacing(3);
 
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       margin-bottom: govuk-spacing(4);
       margin-top: govuk-spacing(4);
     }

--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -15,10 +15,10 @@
 
   .part-navigation {
     margin-bottom: 0;
-    @include core-19;
+    @include govuk-font(19);
 
     @include govuk-media-query($from: tablet) {
-      @include core-16;
+      @include govuk-font(16);
     }
 
     li {
@@ -32,7 +32,7 @@
   }
 
   .part-title {
-    @include bold-27;
+    @include govuk-font(27, $weight: bold);
     margin-bottom: govuk-spacing(3);
     margin-top: govuk-spacing(3);
 

--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -10,7 +10,7 @@
       padding-bottom: govuk-spacing(3);
     }
 
-    border-bottom: 1px solid $grey-2;
+    border-bottom: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
   }
 
   .part-navigation {

--- a/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
+++ b/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
@@ -17,7 +17,7 @@
     padding-bottom: govuk-spacing(3);
     padding-top: govuk-spacing(3);
 
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       float: right;
     }
   }

--- a/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
+++ b/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
@@ -3,7 +3,7 @@
 // formats so they may ultimately become component styles.
 .metadata-logo-wrapper {
   @include govuk-clearfix;
-  border-top: 1px solid $border-colour;
+  border-top: 1px solid $govuk-border-colour;
   margin-left: govuk-spacing(3);
   margin-right: govuk-spacing(3);
 

--- a/app/assets/stylesheets/mixins/_margins.scss
+++ b/app/assets/stylesheets/mixins/_margins.scss
@@ -1,7 +1,7 @@
 @mixin responsive-bottom-margin {
   margin-bottom: govuk-spacing(3);
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(8);
   }
 }
@@ -9,7 +9,7 @@
 @mixin responsive-top-margin {
   margin-top: govuk-spacing(3);
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     margin-top: govuk-spacing(8);
   }
 }

--- a/app/assets/stylesheets/mixins/_white-links.scss
+++ b/app/assets/stylesheets/mixins/_white-links.scss
@@ -2,11 +2,11 @@
   a,
   a:visited,
   a:hover {
-    color: $white;
+    color: govuk-colour("white");
     text-decoration: underline;
   }
 
   a:active {
-    color: $link-active-colour;
+    color: $govuk-link-active-colour;
   }
 }

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,5 +1,2 @@
-// govuk_frontend_toolkit imports
-@import 'typography';
-
 @import 'govuk_publishing_components/all_components_print';
 @import 'print/html-publication';

--- a/app/assets/stylesheets/views/_coming-soon.scss
+++ b/app/assets/stylesheets/views/_coming-soon.scss
@@ -1,6 +1,6 @@
 .coming-soon {
   .summary {
-    @include core-24;
+    @include govuk-font(24);
     margin-bottom: govuk-spacing(3);
   }
 }

--- a/app/assets/stylesheets/views/_consultation.scss
+++ b/app/assets/stylesheets/views/_consultation.scss
@@ -8,7 +8,7 @@
   .original-consultation {
     border-top: 1px solid $border-colour;
 
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       padding-top: govuk-spacing(6);
     }
   }

--- a/app/assets/stylesheets/views/_consultation.scss
+++ b/app/assets/stylesheets/views/_consultation.scss
@@ -6,7 +6,7 @@
   }
 
   .original-consultation {
-    border-top: 1px solid $border-colour;
+    border-top: 1px solid $govuk-border-colour;
 
     @include govuk-media-query($from: tablet) {
       padding-top: govuk-spacing(6);

--- a/app/assets/stylesheets/views/_consultation.scss
+++ b/app/assets/stylesheets/views/_consultation.scss
@@ -2,7 +2,7 @@
   @include sidebar-with-body;
 
   .consultation-date {
-    @include bold-19;
+    @include govuk-font(19, $weight: bold);
   }
 
   .original-consultation {

--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -15,7 +15,7 @@
   .logo-image {
     max-width: 70%;
 
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       margin-top: 45px;
       max-width: 100%;
     }

--- a/app/assets/stylesheets/views/_document-collection.scss
+++ b/app/assets/stylesheets/views/_document-collection.scss
@@ -3,7 +3,7 @@
   @include sidebar-with-body;
 
   .group-title {
-    @include bold-27;
+    @include govuk-font(27, $weight: bold);
     margin-top: govuk-spacing(6);
     margin-bottom: govuk-spacing(3);
 

--- a/app/assets/stylesheets/views/_document-collection.scss
+++ b/app/assets/stylesheets/views/_document-collection.scss
@@ -7,7 +7,7 @@
     margin-top: govuk-spacing(6);
     margin-bottom: govuk-spacing(3);
 
-    @include media(desktop) {
+    @include govuk-media-query($from: desktop) {
       margin-top: govuk-spacing(8);
       margin-bottom: govuk-spacing(4);
     }

--- a/app/assets/stylesheets/views/_guide.scss
+++ b/app/assets/stylesheets/views/_guide.scss
@@ -18,7 +18,7 @@
   // https://github.com/alphagov/static/blob/f44470edc4e4159ea37481985c641034741623ac/app/assets/stylesheets/helpers/_text.scss#L38
   .govuk-govspeak {
     h2 {
-      @include bold-24;
+      @include govuk-font(24, $weight: bold);
     }
   }
 }

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -46,7 +46,7 @@
     padding: 0 15px;
     box-sizing: border-box;
 
-    @include media(desktop) {
+    @include govuk-media-query($from: desktop) {
       width: 75%;
       float: right;
     }
@@ -64,7 +64,7 @@
     display: none;
   }
 
-  @include media(false, $desktop-breakpoint) {
+  @include govuk-media-query($until: desktop) {
     .govuk-sticky-element--enabled {
       position: static;
     }

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -25,7 +25,7 @@
   }
 
   .publication-header__last-changed {
-    @include core-19;
+    @include govuk-font(19);
     margin-top: govuk-spacing(3);
   }
 

--- a/app/assets/stylesheets/views/_unpublishing.scss
+++ b/app/assets/stylesheets/views/_unpublishing.scss
@@ -4,7 +4,7 @@
 
   .summary,
   .alternative {
-    @include core-19;
+    @include govuk-font(19);
     margin-bottom: govuk-spacing(3);
   }
 }


### PR DESCRIPTION
Remove toolkit sass dependency. Should be no visual changes.

(some) Pages to check:

- https://government-frontend-pr-1529.herokuapp.com
- https://government-frontend-pr-1529.herokuapp.com/government/organisations/attorney-generals-office/about
- https://government-frontend-pr-1529.herokuapp.com/government/case-studies/get-britain-building-carlisle-park
- https://government-frontend-pr-1529.herokuapp.com/government/publications/car-show-me-tell-me-vehicle-safety-questions/car-show-me-tell-me-vehicle-safety-questions
- https://government-frontend-pr-1529.herokuapp.com/log-in-file-self-assessment-tax-return

---

Component guide for this PR:
https://government-frontend-pr-1529.herokuapp.com/component-guide
