### PR TITLE
Bump govuk_publishing_components

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (21.8.0)
+    govuk_publishing_components (21.8.1)
       gds-api-adapters
       govuk_app_config
       kramdown


### PR DESCRIPTION
I think dependabot is being really slow/ignoring this version of govuk_publishing_components.

This change adds the [`data-nosnippet` attribute](https://developers.google.com/search/reference/robots_meta_tag#data-nosnippet-attr) to the cookie banner

[Changelog](https://github.com/alphagov/govuk_publishing_components/blob/master/CHANGELOG.md#2181)

