### PR TITLE
Update the date of the election on FAQPage schema

### DIFF
--- a/config/machine_readable/voting-in-the-uk.yml
+++ b/config/machine_readable/voting-in-the-uk.yml
@@ -32,7 +32,7 @@ faqs:
 
   - question: When you can vote
     answer: >
-      <p>Polling stations are open from 7am to 10pm on the day of the election (‘polling day’).</p>
+      <p>Polling stations will be open from 7am to 10pm on 12 December (‘polling day’).</p>
 
   - question: ID you need to bring
     answer: >
@@ -59,12 +59,11 @@ faqs:
       </ul>
       <h2 id="how-to-apply-for-a-proxy-vote">How to apply for a proxy vote</h2>
       <p><a href="/government/collections/proxy-voting-application-forms">Apply for a proxy vote</a> using a paper form. You need to send it to your local Electoral Registration Office.</p>
-      <p>Usually, you need to apply for a proxy vote at least 6 working days before election day if you want to vote in England, Scotland or Wales.</p>
-      <p>There’s a different form to <a rel="external" href="http://www.eoni.org.uk/Vote/Voting-by-post-or-proxy">apply to vote by proxy in Northern Ireland</a>. Apply at least 14 working days before election day.</p>
+      <p>You need to apply by 5pm on 4 December to vote by proxy in the General Election in England, Scotland or Wales.</p>
+      <p>There’s a different form to <a rel="external" href="http://www.eoni.org.uk/Vote/Voting-by-post-or-proxy">apply to vote by proxy in Northern Ireland</a>. Apply by 5pm on 21 November.</p>
 
   - question: Voting from abroad
     answer: >
-      <p>If you’re abroad on election day you need to make arrangements in advance. Apply to vote by proxy if the election is less than 2 weeks away and you have not made the arrangements yet.</p>
       <p>How you vote when you’re abroad depends on:</p>
       <ul>
         <li>whether you’ll be abroad temporarily or living abroad</li>
@@ -73,12 +72,13 @@ faqs:
       <h2 id="if-youll-be-abroad-temporarily">If you’ll be abroad temporarily</h2>
       <p>You can vote by post or proxy if you’ll be abroad temporarily on election day, for example on holiday or a work trip.</p>
       <h3 id="voting-in-england-scotland-or-wales">Voting in England, Scotland or Wales</h3>
-      <p>You can arrange:</p>
+      <p>After you’ve <a href=\"/register-to-vote\">registered to vote</a>, you can apply:</p>
       <ul>
         <li>to <a href="/voting-in-the-uk/postal-voting">vote by post</a></li>
         <li>for someone else to vote for you (<a href="/voting-in-the-uk/voting-by-proxy">vote by proxy</a>)</li>
       </ul>
-      <p>Your postal ballot will be sent to the address you’ve chosen no earlier than 16 days before the election. You need to return your ballot before 10pm on polling day.</p>
+      <p>If you want to vote by proxy in the General Election, apply by 5pm on 4 December.</p>
+      <p>If you want to vote by post, apply by 5pm on 26 November to get your postal voting pack. Your postal vote must then arrive at your Electoral Office in the UK by 10pm on 12 December.</p>
       <h3 id="voting-in-northern-ireland">Voting in Northern Ireland</h3>
       <p>There’s a different process to <a rel="external" href="http://www.eoni.org.uk/Vote/Voting-by-post-or-proxy">apply to vote by post or proxy if you live in Northern Ireland</a> and will be abroad temporarily on election day.</p>
       <p>If you vote by post you must return your ballot before going abroad (you cannot post it from outside the UK).</p>


### PR DESCRIPTION
This is in sync with the live version of https://www.gov.uk/voting-in-the-uk

There's a diff of the content here: https://publisher.publishing.service.gov.uk/editions/5db306a6ed915d0abee89539/diff

Not all sections of the content item are included (which is why we have the schema config in a yaml file right now).

