### PR TITLE
Update /voting-in-the-uk schema

### DIFF
--- a/config/machine_readable/voting-in-the-uk.yml
+++ b/config/machine_readable/voting-in-the-uk.yml
@@ -77,8 +77,9 @@ faqs:
         <li>to <a href="/voting-in-the-uk/postal-voting">vote by post</a></li>
         <li>for someone else to vote for you (<a href="/voting-in-the-uk/voting-by-proxy">vote by proxy</a>)</li>
       </ul>
-      <p>If you want to vote by proxy in the General Election, apply by 5pm on 4 December.</p>
+      <p>If you want to vote by proxy in the General Election on 12 December, apply by 5pm on 4 December.</p>
       <p>If you want to vote by post, apply by 5pm on 26 November to get your postal voting pack. Your postal vote must then arrive at your Electoral Office in the UK by 10pm on 12 December.</p>
       <h3 id="voting-in-northern-ireland">Voting in Northern Ireland</h3>
       <p>There’s a different process to <a rel="external" href="http://www.eoni.org.uk/Vote/Voting-by-post-or-proxy">apply to vote by post or proxy if you live in Northern Ireland</a> and will be abroad temporarily on election day.</p>
-      <p>If you vote by post you must return your ballot before going abroad (you cannot post it from outside the UK).</p>
+      <p>If you will not have time to receive and return your postal ballot in Northern Ireland before going abroad you’ll need to vote by proxy. You cannot apply to have your postal vote sent outside the UK.</p>
+      <p>The deadline for applying for a postal or proxy vote in Northern Ireland is 5pm on 21 November.</p>


### PR DESCRIPTION
The content was updated on Friday so we need to update this to keep it in step.  There is [a diff of the content changes](https://publisher.publishing.service.gov.uk/editions/5dbc325c40f0b670153e4e18/diff) in Publisher.

The relevant page in the preview app is https://government-frontend-pr-1537.herokuapp.com/voting-in-the-uk

Only certain sections of the page are included in the schema, because there's a limit to the amount of content that can be included in the FAQ schema. (That's also the reason for using a separate yml config file for this rather than generating it dynamically from the content item).

The [initial version of the page](https://docs.google.com/document/d/14g7FK-v_Y5iqWcB9y5WqTUWU6JuY_eaSGAqxXSMb0Ek/edit#heading=h.9w2yx5uysegs) (with the relevant FAQ sections highlighted) is available to review if necessary). This provides a decent indication of which sections are in scope for the schema, but is now out of date.

There are a couple of existing [tests to ensure that this works OK](https://github.com/alphagov/government-frontend/blob/master/test/integration/guide_test.rb#L116-L136).

Speak to me or Sam Dub for further details if required.
