### PR TITLE
Add eligibility criteria

### DIFF
--- a/config/machine_readable/voting-in-the-uk.yml
+++ b/config/machine_readable/voting-in-the-uk.yml
@@ -21,6 +21,8 @@ faqs:
         <li>18 years old in England, Wales and Northern Ireland</li>
         <li>16 years old in Scottish Parliament and local elections (and other elections when you’re 18)</li>
       </ul>
+      <h2 id="elections-you-can-vote-in">Elections you can vote in</h2>
+      <p><a href="/elections-in-the-uk">Different elections have different rules</a> on who can vote.</p>
 
   - question: Voting in person
     answer: >


### PR DESCRIPTION
We're extending the content covered in this schema to include a link to more comprehensive information about who can vote in the general election.

This is already in the [live content](https://www.gov.uk/voting-in-the-uk#elections-you-can-vote-in) but wasn't originally included in the schema for brevity.

