### PR TITLE
Update voting eligibility to match live content

### DIFF
--- a/config/machine_readable/voting-in-the-uk.yml
+++ b/config/machine_readable/voting-in-the-uk.yml
@@ -16,13 +16,15 @@ faqs:
 
   - question: Eligibility to vote
     answer: >
-      <p>You can vote when you’re:</p>
+      <p><a href="/elections-in-the-uk?src=schema">Different elections have different rules</a> on who can vote.</p>
+      <p>To vote in the General Election on 12 December you must:</p>
       <ul>
-        <li>18 years old in England, Wales and Northern Ireland</li>
-        <li>16 years old in Scottish Parliament and local elections (and other elections when you’re 18)</li>
+        <li>be <a href="/register-to-vote?src=schema">registered to vote</a></li>
+        <li>be 18 or over on the day of the election (‘polling day’)</li>
+        <li>be a British, Irish or <a rel="external" href="https://www.yourvotematters.co.uk/can-i-vote/who-can-register-to-vote?src=schema">qualifying Commonwealth</a> citizen</li>
+        <li>be resident at an address in the UK (or a British citizen living abroad who has been registered to vote in the UK in the last 15 years)</li>
+        <li>not be legally excluded from voting</li>
       </ul>
-      <h2 id="elections-you-can-vote-in">Elections you can vote in</h2>
-      <p><a href="/elections-in-the-uk">Different elections have different rules</a> on who can vote.</p>
 
   - question: Voting in person
     answer: >


### PR DESCRIPTION
The diff of this is [markdown in publisher](https://publisher.publishing.service.gov.uk/editions/5dd7c2dfe5274a0aca896563/diff) which might be easier to use to check the changes.

The content is now live though, and so the html should match that in the [Eligibility to vote section](https://www.gov.uk/voting-in-the-uk?sdfsd#eligibility-to-vote)

I've added the `src=schema` query string to the links to help us monitor traffic driven from the schema.org json.
