### PR TITLE
Don't attempt to render pages for Governments

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -7,6 +7,7 @@ class ContentItemsController < ApplicationController
   rescue_from ActionController::UnknownFormat, with: :error_406
   rescue_from PresenterBuilder::RedirectRouteReturned, with: :error_redirect
   rescue_from PresenterBuilder::SpecialRouteReturned, with: :error_notfound
+  rescue_from PresenterBuilder::GovernmentReturned, with: :error_notfound
 
   attr_accessor :content_item, :taxonomy_navigation
 

--- a/app/services/presenter_builder.rb
+++ b/app/services/presenter_builder.rb
@@ -9,6 +9,7 @@ class PresenterBuilder
   def presenter
     raise SpecialRouteReturned if special_route?
     raise RedirectRouteReturned, content_item if redirect_route?
+    raise GovernmentReturned if government_content_item?
 
     presenter_name.constantize.new(content_item, content_item_path)
   end
@@ -21,6 +22,10 @@ private
 
   def redirect_route?
     content_item && content_item["schema_name"] == "redirect"
+  end
+
+  def government_content_item?
+    content_item && content_item["document_type"] == "government"
   end
 
   def presenter_name
@@ -57,4 +62,5 @@ private
     end
   end
   class SpecialRouteReturned < StandardError; end
+  class GovernmentReturned < StandardError; end
 end


### PR DESCRIPTION
This content is new to the Publishing API, and while I believe
Government Frontend is the appropriate place for it to be rendered, I
want to put of that decision, and the decisions around how to render
it until after the intended changes to history mode have been made, as
that's what I'm focusing on.