### PR TITLE
Switch to using the government from links, rather than the details

### DIFF
--- a/app/presenters/content_item/political.rb
+++ b/app/presenters/content_item/political.rb
@@ -15,7 +15,14 @@ module ContentItem
     end
 
     def historical?
-      content_item["details"].include?("government") && !content_item["details"]["government"]["current"]
+      government_current = content_item.dig(
+        "links", "government", 0, "details", "current"
+      )
+
+      # Treat no government as not historical
+      return false if government_current.nil?
+
+      !government_current
     end
   end
 end


### PR DESCRIPTION
Currently, Whitehall includes the details of the associated government
for some content in the details. Now Whitehall also links the content
to a content item representing the government.

Using the linking approach is preferable going forward, as that means
the Publishing API can take care of updating the content store when a
government changes (becoming historical), rather than Whitehall having
to publish new editions.

This change to Government Frontend can be deployed once all the
relevant content has been linked to the correct government, something
which is being done in bulk from Whitehall.