### PR TITLE
Set history banner title from government in the links hash

### DIFF
--- a/app/presenters/content_item/political.rb
+++ b/app/presenters/content_item/political.rb
@@ -5,7 +5,9 @@ module ContentItem
     end
 
     def publishing_government
-      content_item["details"]["government"]["title"]
+      content_item.dig(
+        "links", "government", 0, "title"
+      )
     end
 
   private

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -22,7 +22,7 @@ class PublicationPresenterTest < PresenterTestCase
   end
 
   test "presents the title of the publishing government" do
-    assert_equal schema_item["details"]["government"]["title"], presented_item.publishing_government
+    assert_equal schema_item["links"]["government"][0]["title"], presented_item.publishing_government
   end
 
   test "content can be historically political" do


### PR DESCRIPTION
Now that we properly represent governments in the links hash, we can use the title from there instead of the title of the government in the details hash.

[Trello](https://trello.com/c/WnCAxrlz/901-display-changed-government-name-in-history-mode-banner)