### PR TITLE
Use compatibility flag for focus state colours and remove manual fixes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 // The main application stylesheet
 $govuk-compatibility-govuktemplate: true;
 $govuk-typography-use-rem: false;
+$govuk-use-legacy-palette: false;
 
 // Components from govuk_publishing_components gem
 @import 'govuk_publishing_components/all_components';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,5 @@
 // The main application stylesheet
-
+$govuk-compatibility-govuktemplate: true;
 $govuk-typography-use-rem: false;
 
 // Components from govuk_publishing_components gem
@@ -47,16 +47,4 @@ $govuk-typography-use-rem: false;
 @import 'views/help-page';
 @import "views/guide";
 
-// TODO: This style overrides one coming from govuk-template
-// which turns the focused text colour blue instead of the expected black
-// on all components with its global 'a:link:focus' declaration. This
-// code should be removed when govuk-template is no longer used.
 
-a[class^="gem-c-"],
-*[class^="gem-c-"] a
- {
-  &:focus {
-    color: $govuk-focus-text-colour !important;
-    text-decoration: none;
-  }
-}

--- a/app/assets/stylesheets/components/_back-to-top.scss
+++ b/app/assets/stylesheets/components/_back-to-top.scss
@@ -3,11 +3,6 @@
   margin-bottom: govuk-spacing(3);
   margin-left: govuk-spacing(3);
   margin-right: govuk-spacing(3);
-
-  &:focus {
-    @include govuk-template-link-focus-override;
-  }
-
 }
 
 .app-c-back-to-top__icon {

--- a/app/assets/stylesheets/components/_download-link.scss
+++ b/app/assets/stylesheets/components/_download-link.scss
@@ -4,10 +4,6 @@
   margin-top: govuk-spacing(3);
   margin-bottom: govuk-spacing(3);
 
-  &:focus {
-    @include govuk-template-link-focus-override;
-  }
-
   @include govuk-media-query($from: tablet) {
     margin-top: govuk-spacing(6);
   }

--- a/app/assets/stylesheets/components/_important-metadata.scss
+++ b/app/assets/stylesheets/components/_important-metadata.scss
@@ -31,10 +31,6 @@
 
   .app-link {
     color: govuk-colour("white");
-
-    &:focus {
-      @include govuk-template-link-focus-override;
-    }
   }
 
 }

--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -9,17 +9,6 @@
   .js-enabled & {
     display: inline-block;
   }
-
-  &:focus {
-    @include govuk-template-link-focus-override;
-  }
-
-}
-
-.app-c-published-dates__history-link {
-  &:focus {
-    @include govuk-template-link-focus-override;
-  }
 }
 
 .app-c-published-dates__change-history {

--- a/app/assets/stylesheets/components/_publisher-metadata.scss
+++ b/app/assets/stylesheets/components/_publisher-metadata.scss
@@ -4,11 +4,10 @@
   padding-top: govuk-spacing(3);
 }
 
-.app-c-publisher-metadata__other a {
-  font-weight: bold;
+.app-c-publisher-metadata__other {
 
-  &:focus {
-    @include govuk-template-link-focus-override;
+  .govuk-link {
+    font-weight: bold;
   }
 }
 

--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -24,10 +24,6 @@
     li {
       list-style: none;
       margin-bottom: 0.75em;
-
-      a:focus {
-        @include govuk-template-link-focus-override;
-      }
     }
   }
 

--- a/app/assets/stylesheets/mixins/_govuk-template-link-focus-override.scss
+++ b/app/assets/stylesheets/mixins/_govuk-template-link-focus-override.scss
@@ -1,9 +1,0 @@
-// TODO: Remove when appropriate
-// govuk_template overrides the styles set by
-// govuk-frontend 3.0.0. This mixin is intended as a temporary fix
-// to ensure focus styles are as expected in apps using govuk_template
-
-@mixin govuk-template-link-focus-override {
-  @include govuk-focused-text;
-  color: govuk-colour("black") !important;
-}

--- a/app/assets/stylesheets/mixins/_white-links.scss
+++ b/app/assets/stylesheets/mixins/_white-links.scss
@@ -7,7 +7,7 @@
   }
 
   a:focus {
-    @include govuk-template-link-focus-override;
+    @include govuk-focused-text;
   }
 
   a:active {

--- a/app/views/components/_download-link.html.erb
+++ b/app/views/components/_download-link.html.erb
@@ -2,7 +2,7 @@
   link_text ||= "Download File"
 %>
 
-<a class="app-c-download-link" href="<%= href %>">
+<a class="app-c-download-link govuk-link" href="<%= href %>">
   <svg class="app-c-download-link__icon"
         aria-hidden="true"
         viewBox="0 0 25 25"


### PR DESCRIPTION
https://trello.com/c/nhfpb4wh/139-revisit-government-frontend-in-light-of-knowing-about-the-govuk-compatibility-govuktemplate-flag

This switches to using the $govuk-compatibility-govuktemplate and removes other code that was implemented to get the correct focus states.

The only visual change should be an update to the focus state of buttons when they are both hovered/active and focused. 

Button example page: https://www.gov.uk/settled-status-eu-citizens-families/applying-for-settled-status
### Before
![Screenshot 2019-12-05 at 08 46 25](https://user-images.githubusercontent.com/31649453/70219156-3ac9c600-173c-11ea-9f40-ad337cc4d57f.png)
### After
![Screenshot 2019-12-05 at 08 45 47](https://user-images.githubusercontent.com/31649453/70219166-3f8e7a00-173c-11ea-8b52-bc8ac40eacce.png)

-----
Examples of pages affected by updates, where no visual change is expected:
 - Back to top link: https://www.gov.uk/guidance/pregnancy-advice-on-contact-with-animals-that-are-giving-birth
 - Download link: https://www.gov.uk/foreign-travel-advice/afghanistan (PDF link beneath image)
 - Published dates: https://www.gov.uk/government/consultations/environmental-permitting-standard-rules-consultation-no-21
 - Publisher metadata: https://www.gov.uk/government/consultations/environmental-permitting-standard-rules-consultation-no-21 (Environment Agency link)
 - Part navigation: https://www-origin.integration.publishing.service.gov.uk/change-address-driving-licence (contents list below main header)
 - White links: https://www.gov.uk/government/consultations/environmental-permitting-standard-rules-consultation-no-21 ("another website" link)