### PR TITLE
HUH-74: Fix margin for on the Verify hint

### DIFF
--- a/app/assets/stylesheets/views/_choose_sign_in.scss
+++ b/app/assets/stylesheets/views/_choose_sign_in.scss
@@ -2,7 +2,7 @@
   border: 5px solid $govuk-border-colour;
   padding: govuk-spacing(3);
   box-sizing: border-box;
-  margin: - govuk-spacing(6) 0 govuk-spacing(6);
+  margin: 0 0 govuk-spacing(6);
 
   .verify-hint-logos {
     margin-bottom: govuk-spacing(3);


### PR DESCRIPTION
There's some inconsistency in the browsers (talking about you Safari!). Firefox and Chrome works fine.
By setting to a zero value instead of negative it makes it better.

---

Visual regression results:
https://government-frontend-pr-1588.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1588.herokuapp.com/component-guide
