### PR TITLE
Update back to top colour contrast

### DIFF
--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -21,7 +21,7 @@
 }
 
 .app-c-contents-list-with-body__link-wrapper.govuk-sticky-element--stuck-to-window {
-  background-color: govuk-colour("mid-grey", $legacy: "grey-3");
+  background-color: govuk-colour("light-grey", $legacy: "grey-3");
   bottom: -1px; // 'Fix' for anomalous 1px margin which sporadically appears below this element.
   left: 0;
   margin: 0;


### PR DESCRIPTION
## What
Update colour contrast for back-to-top bar as it currently doesn't meet WCAG AA

## Before
<img width="455" alt="Screenshot 2019-12-16 at 15 02 53" src="https://user-images.githubusercontent.com/29889908/70917629-984ff380-2015-11ea-9d23-152cb302c5fa.png">
<img width="717" alt="Screenshot 2019-12-16 at 15 03 29" src="https://user-images.githubusercontent.com/29889908/70917630-984ff380-2015-11ea-84a9-2acaadca08b0.png">

## After
<img width="489" alt="Screenshot 2019-12-16 at 15 03 59" src="https://user-images.githubusercontent.com/29889908/70917639-9c7c1100-2015-11ea-86f2-01a1b7ae293f.png">
<img width="723" alt="Screenshot 2019-12-16 at 15 04 13" src="https://user-images.githubusercontent.com/29889908/70917641-9d14a780-2015-11ea-8307-681a0530bdbd.png">

---

Example page:
https://government-frontend-pr-1589.herokuapp.com/guidance/track-a-dbs-application

Visual regression results:
https://government-frontend-pr-1589.surge.sh/gallery.html
