### PR TITLE
Add Dataset structured data

### DIFF
--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -1,6 +1,6 @@
 <% content_for :extra_head_content do %>
   <%= machine_readable_metadata(
-    schema: :article
+    schema: :dataset
   ) %>
 <% end %>
 


### PR DESCRIPTION
Use the Dataset schema.org schema for statistical dataset pages.

Related to https://github.com/alphagov/govuk_publishing_components/pull/1247

https://trello.com/c/0W3LfcGl/1232-implement-schemaorg-dataset-schema-on-published-statistics-document-types

---

Visual regression results:
https://government-frontend-pr-1609.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1609.herokuapp.com/component-guide
