### PR TITLE
Remove crossorigin and SRI from our static assets (CSS/JS)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,13 +13,13 @@
     <meta name="robots" content="noindex, nofollow">
   <% end %>
 
-  <%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %>
+  <%= stylesheet_link_tag "application", integrity: false %>
   <% if Rails.env.test? && params[:medium] == 'print' %>
-    <%= stylesheet_link_tag "print.css", :media => "screen", integrity: true, crossorigin: 'anonymous' %>
+    <%= stylesheet_link_tag "print.css", :media => "screen", integrity: false %>
   <% else %>
-    <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: 'anonymous' %>
+    <%= stylesheet_link_tag "print.css", :media => "print", integrity: false %>
   <% end %>
-  <%= javascript_include_tag "application", integrity: true, crossorigin: 'anonymous' %>
+  <%= javascript_include_tag "application", integrity: false %>
   <%= csrf_meta_tags %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item.content_item %>
 

--- a/app/views/shared/_webchat.html.erb
+++ b/app/views/shared/_webchat.html.erb
@@ -26,4 +26,4 @@
   </span>
 </p>
 <% # This is inline in the source however slimmer will optimize this. %>
-<%= javascript_include_tag "webchat", integrity: true, crossorigin: 'anonymous' %>
+<%= javascript_include_tag "webchat", integrity: false %>


### PR DESCRIPTION
Change to remove SRI on the JavaScript / CSS and remove the `crossorigin` attribute.

This change is part of [RFC-115](https://github.com/alphagov/govuk-rfcs/pull/115).

Changes have been tested on integration, [seen here](https://github.com/alphagov/static/pull/1993#issuecomment-580287175)