### PR TITLE
Allow new lines to show in change notes

### DIFF
--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -36,6 +36,10 @@
   @include bold-16;
 }
 
+.app-c-published-dates__change-note {
+  white-space: pre-line;
+}
+
 .app-c-published-dates--history {
   padding-top: govuk-spacing(2);
   border-top: 1px solid $border-colour;

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -26,7 +26,7 @@
           <% history.each do |change| %>
             <li class="app-c-published-dates__change-item">
               <time class="app-c-published-dates__change-date timestamp" datetime="<%= change[:timestamp] %>"><%= change[:display_time] %></time>
-              <p class="app-c-published-dates__change-note"><%= change[:note] %></p>
+              <p class="app-c-published-dates__change-note"><%= change[:note].strip %></p>
             </li>
           <% end %>
         </ol>

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -26,7 +26,7 @@
           <% history.each do |change| %>
             <li class="app-c-published-dates__change-item">
               <time class="app-c-published-dates__change-date timestamp" datetime="<%= change[:timestamp] %>"><%= change[:display_time] %></time>
-              <%= change[:note] %>
+              <p class="app-c-published-dates__change-note"><%= change[:note] %></p>
             </li>
           <% end %>
         </ol>

--- a/test/components/published_dates_test.rb
+++ b/test/components/published_dates_test.rb
@@ -35,6 +35,16 @@ class PublishedDatesTest < ComponentTestCase
     assert_select ".app-c-published-dates--history .app-c-published-dates__change-date", text: "23 August 2013"
   end
 
+  test "strips leading and trailing whitespace from note text" do
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"],
+    )
+    assert_select ".app-c-published-dates__change-history#full-history"
+    assert_select ".app-c-published-dates--history .app-c-published-dates__change-note", text: /^\S/
+  end
+
   test "only adds history id when passed page history" do
     render_component(published: "1st November 2000")
     assert_select "#history", false, "should only render history id if passed history item"


### PR DESCRIPTION
Change notes are currently rendered all on one line, which can be hard to read.

This preserves line breaks in the change notes, ensuring any leading or trainlig blank lines are removed.

Before
<img width="632" alt="Screenshot 2020-01-15 at 12 22 58" src="https://user-images.githubusercontent.com/13475227/72433746-e893b000-3791-11ea-9b15-eae71e7c3bd8.png">

After
<img width="404" alt="Screenshot 2020-01-15 at 12 19 34" src="https://user-images.githubusercontent.com/13475227/72433497-51c6f380-3791-11ea-83c7-403f87064430.png">



[Trello](https://trello.com/c/rdNti5Hh/1670-5-investigate-allowing-line-breaks-in-change-notes)