### PR TITLE
Hmrc webchat availability scenario update

### DIFF
--- a/app/assets/javascripts/webchat/library.js
+++ b/app/assets/javascripts/webchat/library.js
@@ -53,10 +53,9 @@
 
     function apiSuccess (result) {
 
-      result = {"inHOP":"true","status":"busy","availability":"false"}
-
       if(result.hasOwnProperty('inHOP')){
         var validState  = API_STATES.indexOf(result.status.toUpperCase()) != -1
+        console.log(validState)
         var state       = validState ? result.status : "ERROR"
         if (result.inHOP == "true"){
           if(result.availability == "true"){

--- a/app/assets/javascripts/webchat/library.js
+++ b/app/assets/javascripts/webchat/library.js
@@ -55,7 +55,6 @@
 
       if(result.hasOwnProperty('inHOP')){
         var validState  = API_STATES.indexOf(result.status.toUpperCase()) != -1
-        console.log(validState)
         var state       = validState ? result.status : "ERROR"
         if (result.inHOP == "true"){
           if(result.availability == "true"){

--- a/app/assets/javascripts/webchat/library.js
+++ b/app/assets/javascripts/webchat/library.js
@@ -53,6 +53,8 @@
 
     function apiSuccess (result) {
 
+      result = {"inHOP":"true","status":"busy","availability":"false"}
+
       if(result.hasOwnProperty('inHOP')){
         var validState  = API_STATES.indexOf(result.status.toUpperCase()) != -1
         var state       = validState ? result.status : "ERROR"
@@ -62,13 +64,17 @@
                     state="AVAILABLE"
                   }
                   if (result.status == "busy"){
-                      state="BUSY"
+                      state="AVAILABLE"
                   }
                   if (result.status == "offline"){
                       state="UNAVAILABLE"
                   }
             }else{
-              state="UNAVAILABLE"
+              if (result.status == "busy"){
+                  state="BUSY"
+              }else{
+                state="UNAVAILABLE"
+              }
             }
           }else{
             state = "UNAVAILABLE"

--- a/lib/webchat.yaml
+++ b/lib/webchat.yaml
@@ -1,40 +1,40 @@
 - base_path: /government/organisations/hm-revenue-customs/contact/child-benefit
   open_url: https://tax.service.gov.uk/ask-hmrc/webchat/child-benefit
-  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006859&siteID=10006719&businessUnitID=19001235
+  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006859&siteID=10006719&businessUnitID=19001235&q-thresh=1.2
   open_url_redirect: true
 - base_path: /government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees
   open_url: https://tax.service.gov.uk/ask-hmrc/webchat/income-tax-enquiries-for-individuals-pensioners-and-employees
-  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006852&siteID=10006719&businessUnitID=19001235
+  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006852&siteID=10006719&businessUnitID=19001235&q-thresh=1
   open_url_redirect: true
 - base_path: /government/organisations/hm-revenue-customs/contact/vat-online-services-helpdesk
   open_url: https://tax.service.gov.uk/ask-hmrc/webchat/vat-online-services-helpdesk
-  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006860&siteID=10006719&businessUnitID=19001235
+  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006860&siteID=10006719&businessUnitID=19001235&q-thresh=1.2
   open_url_redirect: true
 - base_path: /government/organisations/hm-revenue-customs/contact/national-insurance-numbers
   open_url: https://tax.service.gov.uk/ask-hmrc/webchat/national-insurance-numbers
-  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006855&siteID=10006719&businessUnitID=19001235
+  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006855&siteID=10006719&businessUnitID=19001235&q-thresh=1.2
   open_url_redirect: true
 - base_path: /government/organisations/hm-revenue-customs/contact/self-assessment
   open_url: https://tax.service.gov.uk/ask-hmrc/webchat/self-assessment
-  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006851&siteID=10006719&businessUnitID=19001235
+  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006851&siteID=10006719&businessUnitID=19001235&q-thresh=1.2
   open_url_redirect: true
 - base_path: /government/organisations/hm-revenue-customs/contact/tax-credits-enquiries
   open_url: https://tax.service.gov.uk/ask-hmrc/webchat/tax-credits-enquiries
-  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006858&siteID=10006719&businessUnitID=19001235
+  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006858&siteID=10006719&businessUnitID=19001235&q-thresh=1
   open_url_redirect: true
 - base_path: /government/organisations/hm-revenue-customs/contact/vat-enquiries
   open_url: https://tax.service.gov.uk/ask-hmrc/webchat/vat-enquiries
-  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006860&siteID=10006719&businessUnitID=19001235
+  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006860&siteID=10006719&businessUnitID=19001235&q-thresh=1.2
   open_url_redirect: true
 - base_path: /government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries
   open_url: https://tax.service.gov.uk/ask-hmrc/webchat/customs-international-trade-and-excise-enquiries
-  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006861&siteID=10006719&businessUnitID=19001235
+  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006861&siteID=10006719&businessUnitID=19001235&q-thresh=1.2
   open_url_redirect: true
 - base_path: /government/organisations/hm-revenue-customs/contact/employer-enquiries
   open_url: https://tax.service.gov.uk/ask-hmrc/webchat/employer-enquiries
-  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006854&siteID=10006719&businessUnitID=19001235
+  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006854&siteID=10006719&businessUnitID=19001235&q-thresh=1.2
   open_url_redirect: true
 - base_path: /government/organisations/hm-revenue-customs/contact/online-services-helpdesk
   open_url: https://tax.service.gov.uk/ask-hmrc/webchat/online-services-helpdesk
-  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006856&siteID=10006719&businessUnitID=19001235
+  availability_url: https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006856&siteID=10006719&businessUnitID=19001235&q-thresh=1.2
   open_url_redirect: true

--- a/test/presenters/contact_presenter_test.rb
+++ b/test/presenters/contact_presenter_test.rb
@@ -88,7 +88,7 @@ class ContactPresenterTest
       schema = schema_item("contact_with_webchat")
       presented = present_example(schema)
       assert_equal true, presented.show_webchat?
-      assert_equal presented.webchat.availability_url, "https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006852&siteID=10006719&businessUnitID=19001235"
+      assert_equal presented.webchat.availability_url, "https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006852&siteID=10006719&businessUnitID=19001235&q-thresh=1"
       assert_equal presented.webchat.open_url, "https://tax.service.gov.uk/ask-hmrc/webchat/income-tax-enquiries-for-individuals-pensioners-and-employees"
     end
   end


### PR DESCRIPTION
Updated display logic for messages in accordance with availability responses shown below.

Inside hours of operation, no agents logged in 
{"inHOP":"true","status":"offline","availability":"false"}  = UNAVAILABLE                 = Webchat is closed at the moment.

Outside hours of operation
{"inHOP":"false","status":"offline","availability":"false"} = UNAVAILABLE                 = Webchat is closed at the moment.

Inside hours of operation, agents logged in and chat ready immediately
{"inHOP":"true","status":"online","availability":"true"}   = AVAILABLE                      = Advisers are available to chat.

Inside hours of operation, agents logged in and there is a space in the queue
{"inHOP":"true","status":"busy","availability":"true"}      = AVAILABLE                      = Advisers are available to chat.

Inside hours of operation, agents logged in and there is no longer any spaces in the queue
{"inHOP":"true","status":"busy","availability":"false"}     = BUSY                                  = All webchat advisers are busy at the moment.

Added additional parameter to availability url to cater for Nuance queue Depths
---

Visual regression results:
https://government-frontend-pr-1630.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1630.herokuapp.com/component-guide
