### PR TITLE
Roll out Dataset schema to more types

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -20,6 +20,10 @@ class PublicationPresenter < ContentItemPresenter
     document_type == "national_statistics"
   end
 
+  def dataset?
+    %(national_statistics official_statistics transparency).include? document_type
+  end
+
 private
 
   def documents_list

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -17,7 +17,7 @@ class PublicationPresenter < ContentItemPresenter
   end
 
   def national_statistics?
-    document_type === "national_statistics"
+    document_type == "national_statistics"
   end
 
 private

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -1,6 +1,6 @@
 <% content_for :extra_head_content do %>
   <%= machine_readable_metadata(
-    schema: :article
+    schema: (@content_item.dataset? ? :dataset : :article)
   ) %>
 <% end %>
 

--- a/test/contracts/govuk_content_schemas_test.rb
+++ b/test/contracts/govuk_content_schemas_test.rb
@@ -5,7 +5,7 @@ class GovukContentSchemasTest < ActionDispatch::IntegrationTest
 
   all_examples_for_supported_schemas.each do |content_item|
     test "can successfully render #{content_item['base_path']} schema example" do
-      content_store_has_item(content_item["base_path"], content_item)
+      stub_content_store_has_item(content_item["base_path"], content_item)
 
       get content_item["base_path"]
 

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -225,7 +225,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   test "sets the expiry as sent by content-store" do
     content_item = content_store_has_schema_example("coming_soon", "coming_soon")
-    content_store_has_item(content_item["base_path"], content_item, max_age: 20)
+    stub_content_store_has_item(content_item["base_path"], content_item, max_age: 20)
 
     get :show, params: { path: path_for(content_item) }
     assert_response :success
@@ -242,7 +242,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   test "honours cache-control private items" do
     content_item = content_store_has_schema_example("coming_soon", "coming_soon")
-    content_store_has_item(content_item["base_path"], content_item, private: true)
+    stub_content_store_has_item(content_item["base_path"], content_item, private: true)
 
     get :show, params: { path: path_for(content_item) }
     assert_response :success
@@ -282,7 +282,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     utf8_path    = "government/case-studies/caf\u00e9-culture"
     content_item["base_path"] = "/#{utf8_path}"
 
-    content_store_has_item(content_item["base_path"], content_item)
+    stub_content_store_has_item(content_item["base_path"], content_item)
 
     get :show, params: { path: utf8_path }
     assert_response :success
@@ -312,7 +312,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     content_item = content_store_has_schema_example("special_route", "special_route")
     content_item["base_path"] = "/government"
 
-    content_store_has_item("/#{path}", content_item)
+    stub_content_store_has_item("/#{path}", content_item)
 
     get :show, params: { path: path }
     assert_response :not_found
@@ -342,7 +342,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   test "returns a redirect when content item is a redirect" do
     content_item = content_store_has_schema_example("redirect", "redirect")
-    content_store_has_item("/406beacon", content_item)
+    stub_content_store_has_item("/406beacon", content_item)
 
     get :show, params: { path: "406beacon" }
     assert_redirected_to "https://www.test.gov.uk/maritime-safety-weather-and-navigation/register-406-mhz-beacons?query=answer#fragment"
@@ -350,7 +350,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   test "returns a prefixed redirect when content item is a prefix redirect" do
     content_item = content_store_has_schema_example("redirect", "redirect")
-    content_store_has_item("/406beacon/prefix/to-preserve", content_item)
+    stub_content_store_has_item("/406beacon/prefix/to-preserve", content_item)
 
     get :show, params: { path: "406beacon/prefix/to-preserve" }
     assert_redirected_to "https://www.test.gov.uk/new-406-beacons-destination/to-preserve"

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -335,7 +335,7 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
   test "returns 410 for content items that are gone" do
-    content_store_has_gone_item("/gone-item")
+    stub_content_store_has_gone_item("/gone-item")
     get :show, params: { path: "gone-item" }
     assert_response :gone
   end

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -291,7 +291,7 @@ class ContentItemsControllerTest < ActionController::TestCase
   test "returns 404 for invalid url" do
     path = "foreign-travel-advice/egypt]"
 
-    content_store_does_not_have_item("/" + path)
+    stub_content_store_does_not_have_item("/" + path)
 
     get :show, params: { path: path }
     assert_response :not_found
@@ -300,7 +300,7 @@ class ContentItemsControllerTest < ActionController::TestCase
   test "returns 404 for item not in content store" do
     path = "government/case-studies/boost-chocolate-production"
 
-    content_store_does_not_have_item("/" + path)
+    stub_content_store_does_not_have_item("/" + path)
 
     get :show, params: { path: path }
     assert_response :not_found

--- a/test/controllers/service_sign_in_content_item_controller_test.rb
+++ b/test/controllers/service_sign_in_content_item_controller_test.rb
@@ -104,7 +104,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     content_item = govuk_content_schema_example("service_sign_in", "service_sign_in")
     link = "https://www.horse.service.gov.uk/account?horse=brown"
     content_item["details"]["choose_sign_in"]["options"][0]["url"] = link
-    content_store_has_item(content_item["base_path"], content_item)
+    stub_content_store_has_item(content_item["base_path"], content_item)
 
     path = "#{path_for(content_item)}/#{content_item['details']['choose_sign_in']['slug']}"
 

--- a/test/controllers/step_navigation_controller_test.rb
+++ b/test/controllers/step_navigation_controller_test.rb
@@ -9,7 +9,7 @@ class ContentItemsControllerTest < ActionController::TestCase
       content_item["base_path"] = "/pass-plus"
       path = content_item["base_path"][1..-1]
 
-      content_store_has_item(content_item["base_path"], content_item)
+      stub_content_store_has_item(content_item["base_path"], content_item)
 
       @controller.stubs(:page_in_scope?).returns(false)
 
@@ -24,7 +24,7 @@ class ContentItemsControllerTest < ActionController::TestCase
       content_item["base_path"] = "/not-part-of-a-step-by-step"
       path = content_item["base_path"][1..-1]
 
-      content_store_has_item(content_item["base_path"], content_item)
+      stub_content_store_has_item(content_item["base_path"], content_item)
 
       @controller.stubs(:page_in_scope?).returns(false)
 

--- a/test/integration/corporate_information_page_test.rb
+++ b/test/integration/corporate_information_page_test.rb
@@ -24,7 +24,7 @@ class CorporateInformationPageTest < ActionDispatch::IntegrationTest
       <h2>Item two</h2><p>Content about item two</p>
       </div>"
 
-    content_store_has_item(item["base_path"], item.to_json)
+    stub_content_store_has_item(item["base_path"], item.to_json)
     visit_with_cachebust(item["base_path"])
 
     assert_not page.has_css?(".gem-c-contents-list")
@@ -79,7 +79,7 @@ class CorporateInformationPageTest < ActionDispatch::IntegrationTest
       'explanation': "This is out of date",
       'withdrawn_at': "2014-08-09T11:39:05Z",
     }
-    content_store_has_item("/government/organisations/department-of-health/about", content_item.to_json)
+    stub_content_store_has_item("/government/organisations/department-of-health/about", content_item.to_json)
 
     visit_with_cachebust "/government/organisations/department-of-health/about"
 

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -11,7 +11,7 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
   test "document collection with no body and 2 collection groups where 1st group has long body" do
     content_item = get_content_example("document_collection")
     content_item["details"]["collection_groups"][0]["body"] = Faker::Lorem.characters(number: 416)
-    content_store_has_item(content_item["base_path"], content_item.to_json)
+    stub_content_store_has_item(content_item["base_path"], content_item.to_json)
     visit(content_item["base_path"])
 
     assert page.has_css?(".gem-c-contents-list")
@@ -53,7 +53,7 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
         "documents" => %w[a-content-id],
       },
     ]
-    content_store_has_item(item["base_path"], item.to_json)
+    stub_content_store_has_item(item["base_path"], item.to_json)
     visit_with_cachebust(item["base_path"])
 
     assert_not page.has_css?(".gem-c-contents-list")

--- a/test/integration/guide_print_test.rb
+++ b/test/integration/guide_print_test.rb
@@ -25,7 +25,7 @@ class GuidePrint < ActionDispatch::IntegrationTest
   def setup_and_visit_guide_print(name)
     example = get_content_example_by_schema_and_name("guide", name)
     @content_item = example.tap do |item|
-      content_store_has_item(item["base_path"], item.to_json)
+      stub_content_store_has_item(item["base_path"], item.to_json)
       visit "#{item['base_path']}/print"
     end
   end

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -115,7 +115,7 @@ class GuideTest < ActionDispatch::IntegrationTest
   def setup_and_visit_part_in_guide
     @content_item = get_content_example("guide").tap do |item|
       chapter_path = "#{item['base_path']}/key-stage-1-and-2"
-      content_store_has_item(chapter_path, item.to_json)
+      stub_content_store_has_item(chapter_path, item.to_json)
       visit_with_cachebust(chapter_path)
     end
   end

--- a/test/integration/help_page_test.rb
+++ b/test/integration/help_page_test.rb
@@ -12,7 +12,7 @@ class HelpPageTest < ActionDispatch::IntegrationTest
   test "sets noindex meta tag for '/help/cookie-details'" do
     @content_item = get_content_example("help_page").tap do |item|
       item["base_path"] = "/help/cookie-details"
-      content_store_has_item(item["base_path"], item.to_json)
+      stub_content_store_has_item(item["base_path"], item.to_json)
       visit_with_cachebust(item["base_path"])
     end
 

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -86,7 +86,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       'withdrawn_at': "2014-08-09T11:39:05Z",
     }
 
-    content_store_has_item("/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration", content_item.to_json)
+    stub_content_store_has_item("/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration", content_item.to_json)
     visit_with_cachebust "/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration"
 
     assert page.has_css?(".gem-c-notice__title", text: "This policy paper was withdrawn on 9 August 2014")
@@ -101,7 +101,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       'withdrawn_at': "2014-08-09T11:39:05Z",
     }
 
-    content_store_has_item("/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration", content_item.to_json)
+    stub_content_store_has_item("/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration", content_item.to_json)
     visit_with_cachebust "/government/publications/canada-united-kingdom-joint-declaration/canada-united-kingdom-joint-declaration"
 
     assert page.has_css?(".gem-c-notice__title", text: "This publication was withdrawn on 9 August 2014")

--- a/test/integration/meta_tags_test.rb
+++ b/test/integration/meta_tags_test.rb
@@ -9,7 +9,7 @@ class MetaTagsTest < ActionDispatch::IntegrationTest
       )
     end
 
-    content_store_has_item("/some-page", case_study.to_json)
+    stub_content_store_has_item("/some-page", case_study.to_json)
 
     visit_with_cachebust "/some-page"
 
@@ -22,7 +22,7 @@ class MetaTagsTest < ActionDispatch::IntegrationTest
       random
     end
 
-    content_store_has_item("/some-page", case_study.to_json)
+    stub_content_store_has_item("/some-page", case_study.to_json)
 
     visit_with_cachebust "/some-page"
 
@@ -41,7 +41,7 @@ class MetaTagsTest < ActionDispatch::IntegrationTest
       random
     end
 
-    content_store_has_item("/some-page", case_study.to_json)
+    stub_content_store_has_item("/some-page", case_study.to_json)
 
     visit_with_cachebust "/some-page"
 

--- a/test/integration/phase_label_test.rb
+++ b/test/integration/phase_label_test.rb
@@ -5,7 +5,7 @@ class PhaseLabelTest < ActionDispatch::IntegrationTest
     case_study = GovukSchemas::Example.find("case_study", example_name: "case_study")
     case_study["phase"] = "alpha"
 
-    content_store_has_item("/government/case-studies/get-britain-building-carlisle-park", case_study.to_json)
+    stub_content_store_has_item("/government/case-studies/get-britain-building-carlisle-park", case_study.to_json)
 
     visit_with_cachebust "/government/case-studies/get-britain-building-carlisle-park"
 
@@ -15,7 +15,7 @@ class PhaseLabelTest < ActionDispatch::IntegrationTest
   test "No phase label is displayed for a Content item without a phase field" do
     content_item = GovukSchemas::Example.find("case_study", example_name: "case_study")
     content_item.delete("phase")
-    content_store_has_item("/government/case-studies/get-britain-building-carlisle-park", content_item.to_json)
+    stub_content_store_has_item("/government/case-studies/get-britain-building-carlisle-park", content_item.to_json)
 
     visit_with_cachebust "/government/case-studies/get-britain-building-carlisle-park"
 

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -29,6 +29,8 @@ class PublicationTest < ActionDispatch::IntegrationTest
       },
     )
 
+    assert_has_structured_data(page, "Article")
+
     assert_footer_has_published_dates("Published 3 May 2016")
   end
 
@@ -61,6 +63,11 @@ class PublicationTest < ActionDispatch::IntegrationTest
   test "national statistics publication shows a logo" do
     setup_and_visit_content_item("statistics_publication")
     assert page.has_css?('img[alt="National Statistics"]')
+  end
+
+  test "national statistics publication has correct structured data" do
+    setup_and_visit_content_item("statistics_publication")
+    assert_has_structured_data(page, "Dataset")
   end
 
   test "renders 'Applies to' block in important metadata when there are excluded nations" do

--- a/test/integration/service_sign_in/choose_sign_in_test.rb
+++ b/test/integration/service_sign_in/choose_sign_in_test.rb
@@ -112,7 +112,7 @@ module ServiceSignIn
     def setup_and_visit_choose_sign_in_page(example_name, example_path)
       content_item = get_content_example(example_name)
       content_path = content_item["base_path"] + example_path
-      content_store_has_item(content_path, content_item.to_json)
+      stub_content_store_has_item(content_path, content_item.to_json)
       visit(content_path)
     end
 

--- a/test/integration/service_sign_in/create_new_account_test.rb
+++ b/test/integration/service_sign_in/create_new_account_test.rb
@@ -37,7 +37,7 @@ module ServiceSignIn
     def setup_and_visit_create_new_account_page
       content_item = get_content_example("service_sign_in")
       path = content_item["base_path"] + "/create-new-account"
-      content_store_has_item(path, content_item.to_json)
+      stub_content_store_has_item(path, content_item.to_json)
       visit(path)
     end
 

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -62,7 +62,7 @@ class StatisticalDataSetTest < ActionDispatch::IntegrationTest
       <h2>Item two</h2><p>Content about item two</p>
       </div>"
 
-    content_store_has_item(item["base_path"], item.to_json)
+    stub_content_store_has_item(item["base_path"], item.to_json)
     visit_with_cachebust(item["base_path"])
 
     assert_not page.has_css?(".gem-c-contents-list")

--- a/test/integration/topical_event_about_page_test.rb
+++ b/test/integration/topical_event_about_page_test.rb
@@ -26,7 +26,7 @@ class TopicalEventAboutPageTest < ActionDispatch::IntegrationTest
     @content_item = get_content_example("topical_event_about_page")
     @content_item["details"]["body"] = body_with_two_contents_list_items
 
-    content_store_has_item(@content_item["base_path"], @content_item.to_json)
+    stub_content_store_has_item(@content_item["base_path"], @content_item.to_json)
 
     visit_with_cachebust @content_item["base_path"]
     assert_not page.has_css?(".gem-c-contents-list")
@@ -36,7 +36,7 @@ class TopicalEventAboutPageTest < ActionDispatch::IntegrationTest
     @content_item = get_content_example("topical_event_about_page")
     @content_item["details"]["body"] = long_first_item_body
 
-    content_store_has_item(@content_item["base_path"], @content_item.to_json)
+    stub_content_store_has_item(@content_item["base_path"], @content_item.to_json)
 
     visit_with_cachebust @content_item["base_path"]
     assert page.has_css?(".gem-c-contents-list")

--- a/test/integration/travel_advice_atom_feed_test.rb
+++ b/test/integration/travel_advice_atom_feed_test.rb
@@ -45,7 +45,7 @@ class TravelAdviceAtomFeed < ActionDispatch::IntegrationTest
       path: "#{@content_item['base_path']}.atom",
     )
 
-    content_store_has_item(@content_item["base_path"], @content_item.to_json)
+    stub_content_store_has_item(@content_item["base_path"], @content_item.to_json)
 
     @feed = RSS::Parser.parse(uri.read)
   end

--- a/test/integration/travel_advice_print_test.rb
+++ b/test/integration/travel_advice_print_test.rb
@@ -33,7 +33,7 @@ class TravelAdvicePrint < ActionDispatch::IntegrationTest
   def setup_and_visit_travel_advice_print(name)
     example = get_content_example_by_schema_and_name("travel_advice", name)
     @content_item = example.tap do |item|
-      content_store_has_item(item["base_path"], item.to_json)
+      stub_content_store_has_item(item["base_path"], item.to_json)
       visit "#{item['base_path']}/print"
     end
   end

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -67,7 +67,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
 
   def setup_and_visit_travel_advice_part(name, part)
     @content_item = get_content_example(name).tap do |item|
-      content_store_has_item("#{item['base_path']}/#{part}", item.to_json)
+      stub_content_store_has_item("#{item['base_path']}/#{part}", item.to_json)
       visit "#{item['base_path']}/#{part}"
     end
   end

--- a/test/integration/working_group_test.rb
+++ b/test/integration/working_group_test.rb
@@ -36,7 +36,7 @@ class WorkingGroupTest < ActionDispatch::IntegrationTest
   test "with a body that has no h2s" do
     item = get_content_example("short")
     item["details"]["body"] = "<div class='govspeak'><p>Some content<p></div>"
-    content_store_has_item(item["base_path"], item.to_json)
+    stub_content_store_has_item(item["base_path"], item.to_json)
     visit(item["base_path"])
 
     assert page.has_text?("Some content")
@@ -49,7 +49,7 @@ class WorkingGroupTest < ActionDispatch::IntegrationTest
       <h2>Item two</h2><p>Content about item two</p>
       </div>"
 
-    content_store_has_item(item["base_path"], item.to_json)
+    stub_content_store_has_item(item["base_path"], item.to_json)
     visit_with_cachebust(item["base_path"])
 
     assert_not page.has_css?(".gem-c-contents-list")

--- a/test/support/govuk_content_schema_examples.rb
+++ b/test/support/govuk_content_schema_examples.rb
@@ -21,7 +21,7 @@ module GovukContentSchemaExamples
 
   def content_store_has_schema_example(schema_name, example_name)
     document = govuk_content_schema_example(schema_name, example_name)
-    content_store_has_item(document["base_path"], document)
+    stub_content_store_has_item(document["base_path"], document)
     document
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -183,6 +183,10 @@ class ActionDispatch::IntegrationTest
     visit(uri)
   end
 
+  def assert_has_structured_data(page, schema_name)
+    assert find_structured_data(page, schema_name).present?
+  end
+
   def find_structured_data(page, schema_name)
     schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
     schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -134,7 +134,7 @@ class ActionDispatch::IntegrationTest
 
   def setup_and_visit_content_item(name, parameter_string = "")
     @content_item = get_content_example(name).tap do |item|
-      content_store_has_item(item["base_path"], item.to_json)
+      stub_content_store_has_item(item["base_path"], item.to_json)
       visit_with_cachebust("#{item['base_path']}#{parameter_string}")
     end
   end
@@ -142,7 +142,7 @@ class ActionDispatch::IntegrationTest
   def setup_and_visit_content_item_with_taxons(name, taxons)
     @content_item = get_content_example(name).tap do |item|
       item["links"]["taxons"] = taxons
-      content_store_has_item(item["base_path"], item.to_json)
+      stub_content_store_has_item(item["base_path"], item.to_json)
       visit_with_cachebust(item["base_path"])
     end
   end


### PR DESCRIPTION
We want to use the correct schema.org type as much as possible.  National statistics, Official statistics and Transparency types contain things of interest to people searching for open data.

I've fixed a bunch of gds-api-adapter deprecation warnings as part of this PR, so reviewing by commit might be advised.

 I also discovered a `===` comparison which I'm not sure is intended, so I've flipped it back to `==`.

Example pages: 

- https://government-f-stats-2-675loifr4.herokuapp.com/government/statistics/residues-of-veterinary-medicines-in-food-2019 (official stats)
- https://government-f-stats-2-675loifr4.herokuapp.com/government/statistics/local-authority-capital-expenditure-and-receipts-in-england-2018-to-2019-individual-local-authority-data (national stats)
- https://government-f-stats-2-675loifr4.herokuapp.com/government/publications/charity-commission-spend-over-25000-2019-to-2020 (transparency)