### PR TITLE
Show no deal notice with no links

### DIFF
--- a/app/assets/stylesheets/components/_header-notice.scss
+++ b/app/assets/stylesheets/components/_header-notice.scss
@@ -18,6 +18,14 @@
   padding: govuk-spacing(4);
 }
 
+.app-c-header-notice__description {
+  margin-bottom: 0;
+}
+
+.app-c-header-notice__links {
+  margin-top: govuk-spacing(2);
+}
+
 .app-c-header-notice__list {
   margin-bottom: 0;
 }

--- a/app/assets/stylesheets/components/_header-notice.scss
+++ b/app/assets/stylesheets/components/_header-notice.scss
@@ -18,20 +18,21 @@
   padding: govuk-spacing(4);
 }
 
-.app-c-header-notice__description {
-  margin-bottom: 0;
+.app-c-header-notice__text {
+  margin-bottom: govuk-spacing(2);
 }
 
 .app-c-header-notice__links {
-  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(2);
 }
 
 .app-c-header-notice__list {
+  margin-top: -5px;
   margin-bottom: 0;
 }
 
 .app-c-header-notice__link-intro {
-  margin-bottom: govuk-spacing(1);
+  margin-bottom: govuk-spacing(2);
 }
 
 .app-c-header-notice__link {

--- a/app/presenters/content_item/no_deal_notice.rb
+++ b/app/presenters/content_item/no_deal_notice.rb
@@ -15,6 +15,7 @@ module ContentItem
           description: no_deal_notice_description,
           link_intro: no_deal_notice_link_intro,
           links: no_deal_links,
+          featured_link: no_deal_landing_page_cta,
         }
       end
     end
@@ -30,11 +31,25 @@ module ContentItem
     end
 
     def no_deal_notice_description
-      "This page tells you what you will need to do from January 2021. <a class='govuk-link' href='/email-signup?topic=%2Ftransition'>Sign up for email alerts</a> to find out when it is updated.".html_safe
+      "This page tells you what you'll need to do from 1 January 2021. It'll be updated if anything changes. "
     end
 
     def no_deal_notice_link_intro
       "For current information, read: "
+    end
+
+    def no_deal_landing_page_cta
+      data_attributes = {
+        "module": "track-click",
+        "track-category": "no_deal_notice",
+        "track-action": "/transition",
+        "track-label": "the transition period",
+      }
+
+      featured_link = link_to("the transition period", "/transition", data: data_attributes, class: "govuk-link")
+      featured_link_intro = no_deal_notice_links.any? ? "You can also read about" : "You can read about"
+
+      (featured_link_intro + " " + featured_link + ".").html_safe
     end
 
     def no_deal_links

--- a/app/presenters/content_item/no_deal_notice.rb
+++ b/app/presenters/content_item/no_deal_notice.rb
@@ -5,7 +5,7 @@ module ContentItem
     include ActionView::Context
 
     def has_no_deal_notice?
-      no_deal_notice.present?
+      content_item.dig("details").has_key?("brexit_no_deal_notice")
     end
 
     def no_deal_notice_component
@@ -21,7 +21,7 @@ module ContentItem
 
   private
 
-    def no_deal_notice
+    def no_deal_notice_links
       content_item.dig("details", "brexit_no_deal_notice")
     end
 
@@ -38,7 +38,7 @@ module ContentItem
     end
 
     def no_deal_links
-      no_deal_notice.map do |link|
+      no_deal_notice_links.map do |link|
         {
           title: link["title"],
           href: link["href"],

--- a/app/views/components/_header-notice.html.erb
+++ b/app/views/components/_header-notice.html.erb
@@ -3,6 +3,7 @@
   description ||= false
   link_intro ||= false
   links ||= []
+  featured_link ||= false
 %>
 <% if title && description %>
   <section class="app-c-header-notice" aria-label="notice" role="region">
@@ -11,7 +12,7 @@
     </div>
 
     <div class="app-c-header-notice__content">
-      <p class="app-c-header-notice__description govuk-body"><%= description %></p>
+      <p class="app-c-header-notice__text govuk-body"><%= description %></p>
       <% if links.any? %>
         <div class="app-c-header-notice__links">
           <% if links.count == 1 %>
@@ -28,6 +29,10 @@
             </ul>
           <% end %>
         </div>
+      <% end %>
+
+      <% if featured_link %>
+        <p class="app-c-header-notice__text govuk-body"><%= featured_link %></p>
       <% end %>
     </div>
   </section>

--- a/app/views/components/_header-notice.html.erb
+++ b/app/views/components/_header-notice.html.erb
@@ -11,19 +11,23 @@
     </div>
 
     <div class="app-c-header-notice__content">
-      <p class="govuk-body"><%= description %></p>
-      <% if links.count == 1 %>
-        <p class="govuk-body">
-          <% if link_intro %><%= link_intro %><% end %>
-          <%= link_to(links[0][:title], links[0][:href], data: links[0][:data_attributes], class: "app-c-header-notice__link") %>
-        </p>
-      <% else %>
-        <% if link_intro %><p class="govuk-body app-c-header-notice__link-intro"><%= link_intro %></p><% end %>
-        <ul class="app-c-header-notice__list govuk-list">
-          <% links.each do |link| %>
-            <li><%= link_to(link[:title], link[:href], data: link[:data_attributes], class: "app-c-header-notice__link") %></li>
+      <p class="app-c-header-notice__description govuk-body"><%= description %></p>
+      <% if links.any? %>
+        <div class="app-c-header-notice__links">
+          <% if links.count == 1 %>
+            <p class="govuk-body app-c-header-notice__link-intro">
+              <% if link_intro %><%= link_intro %><% end %>
+              <%= link_to(links[0][:title], links[0][:href], data: links[0][:data_attributes], class: "app-c-header-notice__link") %>
+            </p>
+          <% else %>
+            <% if link_intro %><p class="govuk-body app-c-header-notice__link-intro"><%= link_intro %></p><% end %>
+            <ul class="app-c-header-notice__list govuk-list">
+              <% links.each do |link| %>
+                <li><%= link_to(link[:title], link[:href], data: link[:data_attributes], class: "app-c-header-notice__link") %></li>
+              <% end %>
+            </ul>
           <% end %>
-        </ul>
+        </div>
       <% end %>
     </div>
   </section>

--- a/app/views/components/docs/header-notice.yml
+++ b/app/views/components/docs/header-notice.yml
@@ -21,4 +21,11 @@ examples:
           href: "/this-is-a-link"
         - title: "This is a second link"
           href: "/this-is-a-link"
+  without_links:
+    description: The link intro does not render if there are no links, even if it has been provided
+    data:
+      title: "This is an important notice"
+      description: "Here is a message about this notice"
+      link_intro: "Look at these links: "
+
 

--- a/app/views/components/docs/header-notice.yml
+++ b/app/views/components/docs/header-notice.yml
@@ -7,6 +7,7 @@ examples:
     data:
       title: "This is an important notice"
       description: "Here is a message about this notice"
+      featured_link: "You can also read about <a class='govuk-link' href='/transition'>the transition period</a>"
       link_intro: "Look at these links: "
       links:
         - title: "This is a link"
@@ -15,6 +16,7 @@ examples:
     data:
       title: "This is an important notice"
       description: "Here is a message about this notice"
+      featured_link: "You can also read about <a class='govuk-link' href='/transition'>the transition period</a>"
       link_intro: "Look at these links: "
       links:
         - title: "This is a link"
@@ -27,5 +29,6 @@ examples:
       title: "This is an important notice"
       description: "Here is a message about this notice"
       link_intro: "Look at these links: "
+      featured_link: "You can also read about <a class='govuk-link' href='/transition'>the transition period</a>"
 
 

--- a/test/components/header_notice_test.rb
+++ b/test/components/header_notice_test.rb
@@ -30,10 +30,11 @@ class HeaderNoticeTest < ComponentTestCase
   end
 
   test "renders a header notice with no link" do
-    render_component(title: "This is an important notice", description: "This is a description", links: [])
+    render_component(title: "This is an important notice", description: "This is a description", link_intro: "This should not be shown", links: [])
 
     assert_select ".app-c-header-notice__title", text: "This is an important notice"
     assert_select ".app-c-header-notice__content p", text: "This is a description"
+    assert_select ".app-c-header-notice__link-intro", false, "A link intro shouldn't be shown when no links are provided"
   end
 
   test "renders a header notice with one link" do

--- a/test/components/header_notice_test.rb
+++ b/test/components/header_notice_test.rb
@@ -29,6 +29,13 @@ class HeaderNoticeTest < ComponentTestCase
     assert_select "section[aria-label=notice]"
   end
 
+  test "renders a header notice with no link" do
+    render_component(title: "This is an important notice", description: "This is a description", links: [])
+
+    assert_select ".app-c-header-notice__title", text: "This is an important notice"
+    assert_select ".app-c-header-notice__content p", text: "This is a description"
+  end
+
   test "renders a header notice with one link" do
     render_component(title: "This is an important notice", description: "This is a description", links: [{ title: "test", href: "/test" }])
 


### PR DESCRIPTION
Trello: https://trello.com/c/fBavxD33/426-no-deal-notice-should-display-if-no-links-provided

When the publisher in Whitehall ticks the checkbox for the notice to be displayed with no links, the `brexit_no_deal_notice` is present, with a value of `[]`.

We were expecting to see the notice in this case. However, the code was assuming we should only show the notice if links were present.
