### PR TITLE
Hmrc webchat update to JSON availability reqest

### DIFF
--- a/app/assets/javascripts/webchat/library.js
+++ b/app/assets/javascripts/webchat/library.js
@@ -24,7 +24,6 @@
     var webchatStateClass   = 'js-webchat-advisers-'
     var intervalID          = null
     var lastRecordedState   = null
-    var response_datatype    = $el.attr('data-redirect')
 
     function init () {
       if (!availabilityUrl || !openUrl) throw 'urls for webchat not defined'
@@ -35,7 +34,7 @@
 
     function handleOpenChat (evt) {
       evt.preventDefault()
-      this.dataset.redirect =="true" ? window.location.href = openUrl : global.open(openUrl, 'newwin', 'width=366,height=516')
+      this.dataset.redirect == "true" ? window.location.href = openUrl : global.open(openUrl, 'newwin', 'width=366,height=516')
       trackEvent('opened')
     }
 
@@ -43,7 +42,6 @@
       var ajaxConfig = {
         url: availabilityUrl,
         type: 'GET',
-        dataType: response_datatype,
         timeout: AJAX_TIMEOUT,
         success: apiSuccess,
         error: apiError

--- a/app/models/webchat.rb
+++ b/app/models/webchat.rb
@@ -5,14 +5,13 @@ class Webchat
 
   validates_presence_of :base_path, :open_url, :availability_url
 
-  attr_reader :base_path, :open_url, :availability_url, :open_url_redirect, :availability_payload_format
+  attr_reader :base_path, :open_url, :availability_url, :open_url_redirect
 
   def initialize(attrs)
     @base_path = attrs["base_path"] if attrs["base_path"].present?
     @open_url = attrs["open_url"] if attrs["open_url"].present?
     @availability_url = attrs["availability_url"] if attrs["availability_url"].present?
     @open_url_redirect = attrs.fetch("open_url_redirect", nil)
-    @availability_payload_format = attrs.fetch("availability_payload_format", nil)
     validate!
   end
 

--- a/app/views/shared/_webchat.html.erb
+++ b/app/views/shared/_webchat.html.erb
@@ -4,7 +4,7 @@
   <span class="js-webchat"
     data-availability-url="<%= @content_item.webchat.availability_url %>"
     data-open-url="<%= @content_item.webchat.open_url %>"
-    data-redirect="<%=  @content_item.webchat.availability_payload_format.present? ? @content_item.webchat.availability_payload_format : 'jsonp' %>"
+    data-redirect="<%=  @content_item.webchat.open_url_redirect.present? ? 'true': 'false' %>"
   >
     <% if webchat_unavailable? %>
       <%= unavailability_message %>

--- a/spec/javascripts/webchat.spec.js
+++ b/spec/javascripts/webchat.spec.js
@@ -10,7 +10,7 @@ describe('Webchat', function () {
   GOVUK.analytics.trackEvent = function () {}
   var CHILD_BENEFIT_API_URL = 'https://hmrc-uk.digital.nuance.com/tagserver/launch/agentAvailability?agentGroupID=10006859&siteID=10006719&businessUnitID=19001235'
 
-  var INSERTION_HOOK = '<div class="js-webchat" data-availability-url="' + CHILD_BENEFIT_API_URL + '" data-open-url="' + CHILD_BENEFIT_API_URL + '" data-redirect="jsonp">' +
+  var INSERTION_HOOK = '<div class="js-webchat" data-availability-url="' + CHILD_BENEFIT_API_URL + '" data-open-url="' + CHILD_BENEFIT_API_URL + '" data-redirect="true">' +
     '<div class="js-webchat-advisers-error">Error</div>' +
     '<div class="js-webchat-advisers-unavailable hidden">Unavailable</div>' +
     '<div class="js-webchat-advisers-busy hidden">Busy</div>' +
@@ -68,7 +68,7 @@ describe('Webchat', function () {
       mount()
       expect(
         $.ajax
-      ).toHaveBeenCalledWith({ url: CHILD_BENEFIT_API_URL, type: 'GET', dataType: "jsonp" ,timeout: jasmine.any(Number), success: jasmine.any(Function), error: jasmine.any(Function) })
+      ).toHaveBeenCalledWith({ url: CHILD_BENEFIT_API_URL, type: 'GET' ,timeout: jasmine.any(Number), success: jasmine.any(Function), error: jasmine.any(Function) })
     })
 
     it('should inform user whether advisors are available', function () {


### PR DESCRIPTION
Updated the default availability request to be in JSON as opposed to JSONP. 

Need to check on integration as this environment has been "whitelisted" to allow requests to the Nuance server.

Note: Local Dev environments using port numbers have not been included 

---

Visual regression results:
https://government-frontend-pr-1642.surge.sh/gallery.html

Component guide for this PR:
https://government-frontend-pr-1642.herokuapp.com/component-guide
