### PR TITLE
Remove heroku link from PR template

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE
+++ b/docs/PULL_REQUEST_TEMPLATE
@@ -2,6 +2,3 @@
 
 Visual regression results:
 https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html
-
-Component guide for this PR:
-https://government-frontend-pr-[THIS PR NUMBER].herokuapp.com/component-guide


### PR DESCRIPTION
## What
Remove the heroku link in PR templates

## Why
We are using the new heroku review apps, which don't have fixed URLs based on PR number.
