### PR TITLE
Fix "uninitialized constant ActiveModel::ValidationError" in test

### DIFF
--- a/test/models/webchat_test.rb
+++ b/test/models/webchat_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "active_model"
 
 class WebchatTest < ActiveSupport::TestCase
   webchat_config = {


### PR DESCRIPTION
See failure in https://ci.integration.publishing.service.gov.uk/job/government-frontend/job/deployed-to-production/506/console