### PR TITLE
Remove web_isbn and print_meta_data_contact_address

### DIFF
--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -7,14 +7,6 @@ class HtmlPublicationPresenter < ContentItemPresenter
     content_item["details"]["isbn"]
   end
 
-  def web_isbn
-    content_item["details"]["web_isbn"]
-  end
-
-  def print_meta_data_contact_address
-    content_item["details"]["print_meta_data_contact_address"]
-  end
-
   def copyright_year
     content_item["details"]["public_timestamp"].to_date.year if public_timestamp.present?
   end

--- a/app/views/content_items/html_publication/_print_meta_data.html.erb
+++ b/app/views/content_items/html_publication/_print_meta_data.html.erb
@@ -13,21 +13,9 @@
 <p>
   This publication is available at <%= @content_item.full_path(request) %>
 </p>
-<% unless @content_item.print_meta_data_contact_address.blank? %>
-    <p>
-      Any enquiries regarding this publication should be sent to us at:<br/>
-    </p>
-    <%= simple_format(@content_item.print_meta_data_contact_address) %>
-<% end %>
 
 <% unless @content_item.isbn.blank? %>
     <p>
       Print ISBN: <%= @content_item.isbn %>
-    </p>
-<% end %>
-
-<% unless @content_item.web_isbn.blank? %>
-    <p>
-      Web ISBN: <%= @content_item.web_isbn %>
     </p>
 <% end %>

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -30,10 +30,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       assert page.find(".print-meta-data", visible: false)
 
       assert page.has_no_text?("© Crown copyright #{@content_item['details']['public_timestamp'].to_date.year}")
-      assert page.has_no_text?("Any enquiries regarding this publication should be sent to us at:")
-      assert page.has_no_text?((@content_item["details"]["print_meta_data_contact_address"]).to_s)
       assert page.has_no_text?("Print ISBN: #{@content_item['details']['isbn']}")
-      assert page.has_no_text?("Web ISBN: #{@content_item['details']['web_isbn']}")
     end
   end
 
@@ -44,8 +41,6 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       assert page.find(".print-meta-data", visible: true)
 
       assert page.has_text?("© Crown copyright #{@content_item['details']['public_timestamp'].to_date.year}")
-      assert page.has_text?("Any enquiries regarding this publication should be sent to us at:")
-      assert page.has_text?(:all, @content_item["details"]["print_meta_data_contact_address"].squish)
       assert page.has_text?("Print ISBN: #{@content_item['details']['isbn']}")
     end
   end

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -19,8 +19,6 @@ class HtmlPublicationPresenterTest < PresenterTestCase
 
   test "presents the meta data info of a content item" do
     assert_equal schema_item("print_with_meta_data")["details"]["isbn"], presented_item("print_with_meta_data").isbn
-    assert_equal schema_item("print_with_meta_data")["details"]["web_isbn"], presented_item("print_with_meta_data").web_isbn
-    assert_equal schema_item("print_with_meta_data")["details"]["print_meta_data_contact_address"], presented_item("print_with_meta_data").print_meta_data_contact_address
   end
 
   test "presents the last change date" do


### PR DESCRIPTION
Trello - https://trello.com/c/w5dsqKuc/1381-remove-redundant-fields-for-whitehall-attachments-org-contact-and-web-isbn

These file types are redundant and should be removed. They are no longer being sent to the publishing api by whitehall

These fields are also being removed from govuk content schemas and whitehall
whitehall - https://github.com/alphagov/whitehall/pull/5333
content schemas - https://github.com/alphagov/govuk-content-schemas/pull/958

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html
