### PR TITLE
Rename "Print ISBN" to "ISBN"

### DIFF
--- a/app/views/content_items/html_publication/_print_meta_data.html.erb
+++ b/app/views/content_items/html_publication/_print_meta_data.html.erb
@@ -16,6 +16,6 @@
 
 <% unless @content_item.isbn.blank? %>
     <p>
-      Print ISBN: <%= @content_item.isbn %>
+      ISBN: <%= @content_item.isbn %>
     </p>
 <% end %>

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -30,7 +30,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       assert page.find(".print-meta-data", visible: false)
 
       assert page.has_no_text?("© Crown copyright #{@content_item['details']['public_timestamp'].to_date.year}")
-      assert page.has_no_text?("Print ISBN: #{@content_item['details']['isbn']}")
+      assert page.has_no_text?("ISBN: #{@content_item['details']['isbn']}")
     end
   end
 
@@ -41,7 +41,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
       assert page.find(".print-meta-data", visible: true)
 
       assert page.has_text?("© Crown copyright #{@content_item['details']['public_timestamp'].to_date.year}")
-      assert page.has_text?("Print ISBN: #{@content_item['details']['isbn']}")
+      assert page.has_text?("ISBN: #{@content_item['details']['isbn']}")
     end
   end
 


### PR DESCRIPTION
Following https://github.com/alphagov/government-frontend/pull/1649 Web ISBN has been removed. This left us with "Print ISBN" which sounds a bit odd if there are no other ISBN's. This renames "Print ISBN" to make things a bit clearer.

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html
