### PR TITLE
Use a placeholder image from asset-manager

### DIFF
--- a/app/presenters/content_item/news_image.rb
+++ b/app/presenters/content_item/news_image.rb
@@ -12,7 +12,8 @@ module ContentItem
     end
 
     def placeholder_image
-      { "url" => "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg" }
+      # this image has been uploaded to asset-manager
+      { "url" => "https://assets.publishing.service.gov.uk/media/5e59279b86650c53b2cefbfe/placeholder.jpg" }
     end
   end
 end

--- a/test/presenters/content_item/news_image_test.rb
+++ b/test/presenters/content_item/news_image_test.rb
@@ -34,7 +34,7 @@ class ContentItemNewsImageTest < ActiveSupport::TestCase
 
   test "presents a placeholder image if document has no image or default news image" do
     item = DummyContentItem.new
-    placeholder_image = { "url" => "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg" }
+    placeholder_image = { "url" => "https://assets.publishing.service.gov.uk/media/5e59279b86650c53b2cefbfe/placeholder.jpg" }
 
     assert_equal placeholder_image, item.image
   end


### PR DESCRIPTION
In the past this linked to an image served by Whitehall, but because of the way Rails generates hashes for assets, we can't guarantee that this URL will always exist. This hasn't been a problem in the past because we've been able to put an unhashed version of the image on the Whitehall machines, but since moving to AWS the machines can be recreated at any moment and won't have the file.

To solve this problem I've uploaded the file to Asset Manager and we can link to that instead. Ideally, we wouldn't depend on a file in a different application, but this solves the problem for now.

This is similar to https://github.com/alphagov/collections/pull/1522.

[Trello Card](https://trello.com/c/2hsW6TBA/1766-5-investigateplaceholderjpg-being-missing-from-whitehallbackend-machines-now-its-in-aws)