### PR TITLE
Handle old-style /goverment/uploads routes

### DIFF
--- a/app/controllers/asset_manager_redirect_controller.rb
+++ b/app/controllers/asset_manager_redirect_controller.rb
@@ -1,0 +1,10 @@
+class AssetManagerRedirectController < ApplicationController
+  def show
+    asset_url = Plek.new.public_asset_host
+    if request.host.start_with?("draft-")
+      asset_url = Plek.new.external_url_for("draft-assets")
+    end
+
+    redirect_to host: URI.parse(asset_url).host, status: :moved_permanently
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
 
   get "healthcheck", to: proc { [200, {}, [""]] }
 
+  get "/government/uploads/*path" => "asset_manager_redirect#show", format: true
+
   get "*path/:variant" => "content_items#show",
       constraints: {
         variant: /print/,

--- a/test/controllers/asset_manager_redirect_controller_test.rb
+++ b/test/controllers/asset_manager_redirect_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class AssetManagerRedirectControllerTest < ActionController::TestCase
+  setup do
+    Plek.any_instance.stubs(:public_asset_host).returns("http://asset-host.com")
+    Plek.any_instance.stubs(:external_url_for).returns("http://draft-asset-host.com")
+  end
+
+  test "redirects asset requests made via public host to the public asset host" do
+    request.host = "some-host.com"
+    get :show, params: { path: "asset", format: "txt" }
+
+    assert_redirected_to "http://asset-host.com/government/uploads/asset.txt"
+  end
+
+  test "redirects asset requests made via draft host to the draft asset host" do
+    request.host = "draft-some-host.com"
+    get :show, params: { path: "asset", format: "txt" }
+
+    assert_redirected_to "http://draft-asset-host.com/government/uploads/asset.txt"
+  end
+end


### PR DESCRIPTION
This is [currently handled by Whitehall](https://github.com/alphagov/whitehall/blob/master/test/functional/asset_manager_redirect_controller_test.rb) but we're trying to move away from Whitehall being a frontend application. The next best place for this bit of code seems to be Government Frontend.

The code itself is used to handle assets which are still being requested on their own URL before we migrated all assets over to Asset Manager.

Once this is merged and deployed, I will set up a route in Special Route Publisher which sends requests prefixed with `/government/uploads` to Government Frontend.

[Trello Card](https://trello.com/c/Ubk3IEYg/1450-investigate-redirecting-whitehall-assets-higher-in-the-stack)