### PR TITLE
Support redirecting to asset preview URLs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 
   get "healthcheck", to: proc { [200, {}, [""]] }
 
-  get "/government/uploads/*path" => "asset_manager_redirect#show", format: true
+  get "/government/uploads/*path" => "asset_manager_redirect#show", format: false
 
   get "*path/:variant" => "content_items#show",
       constraints: {

--- a/test/controllers/asset_manager_redirect_controller_test.rb
+++ b/test/controllers/asset_manager_redirect_controller_test.rb
@@ -8,15 +8,22 @@ class AssetManagerRedirectControllerTest < ActionController::TestCase
 
   test "redirects asset requests made via public host to the public asset host" do
     request.host = "some-host.com"
-    get :show, params: { path: "asset", format: "txt" }
+    get :show, params: { path: "asset.txt" }
 
     assert_redirected_to "http://asset-host.com/government/uploads/asset.txt"
   end
 
   test "redirects asset requests made via draft host to the draft asset host" do
     request.host = "draft-some-host.com"
-    get :show, params: { path: "asset", format: "txt" }
+    get :show, params: { path: "asset.txt" }
 
     assert_redirected_to "http://draft-asset-host.com/government/uploads/asset.txt"
+  end
+
+  test "redirects asset preview requests made via public host to the public asset host" do
+    request.host = "some-host.com"
+    get :show, params: { path: "asset.csv/preview" }
+
+    assert_redirected_to "http://asset-host.com/government/uploads/asset.csv/preview"
   end
 end


### PR DESCRIPTION
Currently the route for assets assumes that it ends with a file extension (for example `.pdf`). In the case of the preview URLs (which end with `/preview`) it thinks the format of the page is `.pdf/preview`. This gets URL encoded into `.pdf%2Fpreview` by Rails and so the redirect doesn't work.

Rather than handling the file extension special, this PR changes it to accept any path containing any number of file extensions or slashes in no particular format.