### PR TITLE
Make entire repository pass Rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
 


### PR DESCRIPTION
This is depended on by https://github.com/alphagov/govuk-jenkinslib/pull/66.