### PR TITLE
Header notice spacing tweaks

### DIFF
--- a/app/assets/stylesheets/components/_header-notice.scss
+++ b/app/assets/stylesheets/components/_header-notice.scss
@@ -14,7 +14,9 @@
 }
 
 .app-c-header-notice__content {
-  border: $govuk-border-width solid govuk-colour("black");
+  border-left: $govuk-border-width solid govuk-colour("black");
+  border-right: $govuk-border-width solid govuk-colour("black");
+  border-bottom: $govuk-border-width solid govuk-colour("black");
   padding: govuk-spacing(4);
 }
 
@@ -38,4 +40,8 @@
 .app-c-header-notice__link {
   @extend %govuk-link;
   font-weight: bold;
+}
+
+.app-c-header-notice__content .app-c-header-notice__text:last-child {
+  margin-bottom: 0;
 }


### PR DESCRIPTION
## What
- Adjust padding on black header to take border into account
- Remove bottom margin on last paragraph inside the notice

## Before
<img width="914" alt="Screenshot 2020-03-11 at 11 50 48" src="https://user-images.githubusercontent.com/29889908/76414233-d055a100-638e-11ea-9fe8-6de42e9a7e80.png">
<img width="317" alt="Screenshot 2020-03-11 at 11 50 40" src="https://user-images.githubusercontent.com/29889908/76414214-c92e9300-638e-11ea-81bf-b0a264e5b81d.png">


## After
<img width="916" alt="Screenshot 2020-03-11 at 11 54 45" src="https://user-images.githubusercontent.com/29889908/76414404-275b7600-638f-11ea-9640-245122e44aa4.png">
<img width="319" alt="Screenshot 2020-03-11 at 11 55 00" src="https://user-images.githubusercontent.com/29889908/76414405-27f40c80-638f-11ea-80b5-4414725e7a96.png">
