### PR TITLE
Emergency travel warning

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,4 +48,14 @@ $govuk-use-legacy-palette: false;
 @import 'views/help-page';
 @import "views/guide";
 
+.travel-advice-notice {
+  background-color: govuk-colour("light-grey");
+  border: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(7);
+  padding: govuk-spacing(4) govuk-spacing(4) 0 govuk-spacing(9);
+  position: relative;
+}
 
+.travel-advice-notice__icon {
+  margin-left: govuk-spacing(3);
+}

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -1,10 +1,10 @@
 <% content_for :simple_header, true %>
 
 <% content_for :extra_head_content do %>
-  <%= auto_discovery_link_tag :atom, @content_item.feed_link,
+<%= auto_discovery_link_tag :atom, @content_item.feed_link,
     title: "Recent updates for #{@content_item.country_name}" %>
 
-  <%= machine_readable_metadata(
+<%= machine_readable_metadata(
     schema: :article,
     canonical_url: @content_item.canonical_url,
     title: @content_item.page_title,
@@ -13,52 +13,58 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
-    <aside class="part-navigation-container" role="complementary">
+    <div class="govuk-grid-column-two-thirds travel-advice__header">
+        <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
 
-      <nav role="navigation" class="govuk-grid-row part-navigation" aria-label="Travel advice pages" data-module="track-click">
-        <%  @content_item.parts_navigation.each_with_index do |part_group, i| %>
-          <ol
-            class="govuk-grid-column-one-half"
-            <% if i == 1 %>
-              start="<%=  @content_item.parts_navigation_second_list_start %>"
-            <% end %>
-          >
-            <% part_group.each do |part_nav_item| %>
-              <li>
-                <%= part_nav_item %>
-              </li>
-            <% end %>
-          </ol>
-        <% end %>
-      </nav>
+        <div class="travel-advice-notice">
+            <span class="govuk-warning-text__icon travel-advice-notice__icon" aria-hidden="true">!</span>
+            <h2 class="govuk-heading-m" aria-label="Important - this is a notice">
+                This is a notice
+            </h2>
+            <p class="govuk-body">Jelly-o wafer gummi bears bonbon carrot cake. Topping fruitcake lemon drops bonbon
+                dessert. Fruitcake danish cookie. Macaroon candy fruitcake fruitcake candy cheesecake. Cupcake soufflé
+                chupa chups toffee wafer cotton candy soufflé gingerbread marzipan.</p>
+        </div>
+
+        <aside class="part-navigation-container" role="complementary">
+
+            <nav role="navigation" class="govuk-grid-row part-navigation" aria-label="Travel advice pages" data-module="track-click">
+                <%  @content_item.parts_navigation.each_with_index do |part_group, i| %>
+                <ol class="govuk-grid-column-one-half" <% if i == 1 %> start="<%=  @content_item.parts_navigation_second_list_start %>" <% end %>>
+                    <% part_group.each do |part_nav_item| %>
+                    <li>
+                        <%= part_nav_item %>
+                    </li>
+                    <% end %>
+                </ol>
+                <% end %>
+            </nav>
 
 
-      <%= render 'govuk_publishing_components/components/subscription-links', email_signup_link: @content_item.email_signup_link, feed_link: @content_item.feed_link %>
-    </aside>
-  </div>
+            <%= render 'govuk_publishing_components/components/subscription-links', email_signup_link: @content_item.email_signup_link, feed_link: @content_item.feed_link %>
+        </aside>
+    </div>
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="part-title">
-      <%= @content_item.current_part_title %>
-    </h1>
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="part-title">
+            <%= @content_item.current_part_title %>
+        </h1>
 
-    <% if @content_item.is_summary? %>
-      <%= render 'shared/travel_advice_summary', content_item: @content_item %>
-    <% end %>
+        <% if @content_item.is_summary? %>
+        <%= render 'shared/travel_advice_summary', content_item: @content_item %>
+        <% end %>
 
-    <%= render 'govuk_publishing_components/components/govspeak',
+        <%= render 'govuk_publishing_components/components/govspeak',
         content: @content_item.current_part_body.html_safe,
         direction: page_text_direction %>
 
-    <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
+        <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
 
-    <%= render 'components/print-link', href: @content_item.print_link, link_text: t("multi_page.print_entire_guide") %>
-  </div>
-  <%= render 'shared/sidebar_navigation' %>
+        <%= render 'components/print-link', href: @content_item.print_link, link_text: t("multi_page.print_entire_guide") %>
+    </div>
+    <%= render 'shared/sidebar_navigation' %>
 </div>
 
 <%= render 'shared/footer_navigation' %>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -1,10 +1,9 @@
 <% content_for :simple_header, true %>
 
 <% content_for :extra_head_content do %>
-<%= auto_discovery_link_tag :atom, @content_item.feed_link,
-    title: "Recent updates for #{@content_item.country_name}" %>
+  <%= auto_discovery_link_tag :atom, @content_item.feed_link, title: "Recent updates for #{@content_item.country_name}" %>
 
-<%= machine_readable_metadata(
+  <%= machine_readable_metadata(
     schema: :article,
     canonical_url: @content_item.canonical_url,
     title: @content_item.page_title,
@@ -13,58 +12,56 @@
 <% end %>
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds travel-advice__header">
-        <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+  <div class="govuk-grid-column-two-thirds travel-advice__header">
+    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
 
-        <div class="travel-advice-notice">
-            <span class="govuk-warning-text__icon travel-advice-notice__icon" aria-hidden="true">!</span>
-            <h2 class="govuk-heading-m" aria-label="Important - this is a notice">
-                This is a notice
-            </h2>
-            <p class="govuk-body">Jelly-o wafer gummi bears bonbon carrot cake. Topping fruitcake lemon drops bonbon
-                dessert. Fruitcake danish cookie. Macaroon candy fruitcake fruitcake candy cheesecake. Cupcake soufflé
-                chupa chups toffee wafer cotton candy soufflé gingerbread marzipan.</p>
-        </div>
-
-        <aside class="part-navigation-container" role="complementary">
-
-            <nav role="navigation" class="govuk-grid-row part-navigation" aria-label="Travel advice pages" data-module="track-click">
-                <%  @content_item.parts_navigation.each_with_index do |part_group, i| %>
-                <ol class="govuk-grid-column-one-half" <% if i == 1 %> start="<%=  @content_item.parts_navigation_second_list_start %>" <% end %>>
-                    <% part_group.each do |part_nav_item| %>
-                    <li>
-                        <%= part_nav_item %>
-                    </li>
-                    <% end %>
-                </ol>
-                <% end %>
-            </nav>
-
-
-            <%= render 'govuk_publishing_components/components/subscription-links', email_signup_link: @content_item.email_signup_link, feed_link: @content_item.feed_link %>
-        </aside>
+    <div class="travel-advice-notice">
+      <span class="govuk-warning-text__icon travel-advice-notice__icon" aria-hidden="true">!</span>
+      <h2 class="govuk-heading-m" aria-label="Important - COVID-19 Exceptional Travel Advisory Notice">
+        COVID-19 Exceptional Travel Advisory Notice
+      </h2>
+      <p class="govuk-body">
+        As countries respond to the COVID-19 pandemic, including travel and border restrictions, <strong>the FCO advises British nationals against all but essential international travel</strong>. Any country or area may restrict travel without notice.
+      </p>
     </div>
+
+    <aside class="part-navigation-container" role="complementary">
+      <nav role="navigation" class="govuk-grid-row part-navigation" aria-label="Travel advice pages" data-module="track-click">
+        <%  @content_item.parts_navigation.each_with_index do |part_group, i| %>
+          <ol class="govuk-grid-column-one-half" <% if i == 1 %> start="<%=  @content_item.parts_navigation_second_list_start %>" <% end %>>
+            <% part_group.each do |part_nav_item| %>
+              <li>
+                <%= part_nav_item %>
+              </li>
+            <% end %>
+          </ol>
+        <% end %>
+      </nav>
+
+      <%= render 'govuk_publishing_components/components/subscription-links', email_signup_link: @content_item.email_signup_link, feed_link: @content_item.feed_link %>
+    </aside>
+  </div>
 </div>
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="part-title">
-            <%= @content_item.current_part_title %>
-        </h1>
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="part-title">
+      <%= @content_item.current_part_title %>
+    </h1>
 
-        <% if @content_item.is_summary? %>
-        <%= render 'shared/travel_advice_summary', content_item: @content_item %>
-        <% end %>
+    <% if @content_item.is_summary? %>
+      <%= render 'shared/travel_advice_summary', content_item: @content_item %>
+    <% end %>
 
-        <%= render 'govuk_publishing_components/components/govspeak',
-        content: @content_item.current_part_body.html_safe,
-        direction: page_text_direction %>
+    <%= render 'govuk_publishing_components/components/govspeak',
+      content: @content_item.current_part_body.html_safe,
+      direction: page_text_direction %>
 
-        <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
+    <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
 
-        <%= render 'components/print-link', href: @content_item.print_link, link_text: t("multi_page.print_entire_guide") %>
-    </div>
-    <%= render 'shared/sidebar_navigation' %>
+    <%= render 'components/print-link', href: @content_item.print_link, link_text: t("multi_page.print_entire_guide") %>
+  </div>
+  <%= render 'shared/sidebar_navigation' %>
 </div>
 
 <%= render 'shared/footer_navigation' %>


### PR DESCRIPTION
Add a warning about travel to travel advice pages. Awaiting final copy.

Bespoke component used - see also https://github.com/alphagov/frontend/pull/2282 for sibling pull request.

Design has been signed off by @stephenjoe1

Example URL: https://www.gov.uk/foreign-travel-advice/france

## Screenshots:

### Desktop before:

![image](https://user-images.githubusercontent.com/1732331/76786470-2d968b80-67af-11ea-8781-05e682967e7d.png)


### Desktop after:

![image](https://user-images.githubusercontent.com/1732331/76786207-b9f47e80-67ae-11ea-9a88-0735caae8d7b.png)


<table>
<tr>
<th>Mobile before</th>
<th>Mobile after</th>
</tr>

<tr><td valign="top">

![image](https://user-images.githubusercontent.com/1732331/76786321-f1fbc180-67ae-11ea-9091-32a92604c09f.png)


</td><td valign="top">

![image](https://user-images.githubusercontent.com/1732331/76786381-0d66cc80-67af-11ea-9cef-acec20c8e61b.png)


</td></tr></table>
