### PR TITLE
Fix the appearance of the dev landing page

### DIFF
--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -5,6 +5,7 @@
     government-frontend development page
   </title>
   <meta name="robots" content="noindex, nofollow">
+  <%= stylesheet_link_tag "application", integrity: false %>
 </head>
 <body>
   <div id="wrapper">


### PR DESCRIPTION
## What / why

The dev landing page was looking a bit broken. It's always looked a little unstyled, but with the recent change to the components gem it was looking worse (the search box was unstyled, footer layout was broken). This fixes that.

## Visual changes

Before:

<img width="912" alt="Screenshot 2020-03-19 at 16 30 10" src="https://user-images.githubusercontent.com/861310/77090502-25348f80-69ff-11ea-8a9d-0e1266a6cfc1.png">


After:

<img width="912" alt="Screenshot 2020-03-19 at 16 29 53" src="https://user-images.githubusercontent.com/861310/77090519-2cf43400-69ff-11ea-8156-3323ca899780.png">

