### PR TITLE
[DO NOT MERGE] Move webchat section to be above the email section

### DIFF
--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -16,11 +16,6 @@
   <div class="govuk-grid-column-two-thirds">
 
     <% body = capture do %>
-      <% if @content_item.show_webchat? %>
-        <h2 id="webchat-title">Webchat</h2>
-        <%= render 'shared/webchat' %>
-      <% end %>
-
       <% if @content_item.online_form_links.any? %>
         <h2 id="online-forms-title">Online</h2>
         <% @content_item.online_form_links.each do |link| %>
@@ -30,6 +25,11 @@
           <%= link[:description] %>
         <% end %>
         <%= @content_item.online_form_body %>
+      <% end %>
+
+      <% if @content_item.show_webchat? %>
+        <h2 id="webchat-title">Webchat</h2>
+        <%= render 'shared/webchat' %>
       <% end %>
 
       <% if @content_item.email.any? %>


### PR DESCRIPTION
There was some confusion in the last change (5b00d3e40ec26778a918be73aeb58f99f82c585f) and it looks like they would prefer the webchat section to appear above the email section (rather than above the phone section).

[Trello Card](https://trello.com/c/L5LSGY8T/1879-move-webchat-section-on-hmrc-contact-pages)