### PR TITLE
Use individual component sass

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,7 +4,41 @@ $govuk-typography-use-rem: false;
 $govuk-use-legacy-palette: false;
 
 // Components from govuk_publishing_components gem
-@import 'govuk_publishing_components/all_components';
+@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/component_support';
+@import 'govuk_publishing_components/components/attachment';
+@import 'govuk_publishing_components/components/back-link';
+@import 'govuk_publishing_components/components/breadcrumbs';
+@import 'govuk_publishing_components/components/button';
+@import 'govuk_publishing_components/components/contents-list';
+@import 'govuk_publishing_components/components/contextual-sidebar';
+@import 'govuk_publishing_components/components/details';
+@import 'govuk_publishing_components/components/document-list';
+@import 'govuk_publishing_components/components/error-message';
+@import 'govuk_publishing_components/components/error-summary';
+@import 'govuk_publishing_components/components/feedback';
+@import 'govuk_publishing_components/components/fieldset';
+@import 'govuk_publishing_components/components/govspeak';
+@import 'govuk_publishing_components/components/govspeak-html-publication';
+@import 'govuk_publishing_components/components/heading';
+@import 'govuk_publishing_components/components/hint';
+@import 'govuk_publishing_components/components/input';
+@import 'govuk_publishing_components/components/inverse-header';
+@import 'govuk_publishing_components/components/label';
+@import 'govuk_publishing_components/components/lead-paragraph';
+@import 'govuk_publishing_components/components/metadata';
+@import 'govuk_publishing_components/components/notice';
+@import 'govuk_publishing_components/components/organisation-logo';
+@import 'govuk_publishing_components/components/previous-and-next-navigation';
+@import 'govuk_publishing_components/components/radio';
+@import 'govuk_publishing_components/components/related-navigation';
+@import 'govuk_publishing_components/components/share-links';
+@import 'govuk_publishing_components/components/step-by-step-nav';
+@import 'govuk_publishing_components/components/step-by-step-nav-header';
+@import 'govuk_publishing_components/components/step-by-step-nav-related';
+@import 'govuk_publishing_components/components/subscription-links';
+@import 'govuk_publishing_components/components/title';
+@import 'govuk_publishing_components/components/translation-nav';
 
 // government-frontend mixins
 @import 'mixins/margins';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,6 +39,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/subscription-links';
 @import 'govuk_publishing_components/components/title';
 @import 'govuk_publishing_components/components/translation-nav';
+@import 'govuk_publishing_components/components/warning-text';
 
 // government-frontend mixins
 @import 'mixins/margins';
@@ -87,8 +88,16 @@ $govuk-use-legacy-palette: false;
   background-color: govuk-colour("light-grey");
   border: 1px solid $govuk-border-colour;
   margin-bottom: govuk-spacing(7);
-  padding: govuk-spacing(4) govuk-spacing(4) 0 govuk-spacing(9);
   position: relative;
+}
+
+.travel-advice-notice__header {
+  padding: govuk-spacing(4) govuk-spacing(4) 0 govuk-spacing(3);
+}
+
+.travel-advice-notice__content {
+  margin-top: - govuk-spacing(3);
+  padding: 0 govuk-spacing(4) 0 govuk-spacing(9);
 }
 
 .travel-advice-notice__icon {

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,2 +1,17 @@
-@import 'govuk_publishing_components/all_components_print';
+@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/components/print/attachment';
+@import 'govuk_publishing_components/components/print/back-link';
+@import 'govuk_publishing_components/components/print/button';
+@import 'govuk_publishing_components/components/print/contents-list';
+@import 'govuk_publishing_components/components/print/feedback';
+@import 'govuk_publishing_components/components/print/govspeak';
+@import 'govuk_publishing_components/components/print/govspeak-html-publication';
+@import 'govuk_publishing_components/components/print/metadata';
+@import 'govuk_publishing_components/components/print/share-links';
+@import 'govuk_publishing_components/components/print/step-by-step-nav';
+@import 'govuk_publishing_components/components/print/step-by-step-nav-header';
+@import 'govuk_publishing_components/components/print/subscription-links';
+@import 'govuk_publishing_components/components/print/title';
+@import 'govuk_publishing_components/components/print/translation-nav';
+
 @import 'print/html-publication';

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -16,13 +16,19 @@
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
 
     <div class="travel-advice-notice">
-      <span class="govuk-warning-text__icon travel-advice-notice__icon" aria-hidden="true">!</span>
-      <h2 class="govuk-heading-m" aria-label="Important - COVID-19 Exceptional Travel Advisory Notice">
-        COVID-19 Exceptional Travel Advisory Notice
-      </h2>
-      <p class="govuk-body">
-        As countries respond to the COVID-19 pandemic, including travel and border restrictions, <strong>the FCO advises British nationals against all but essential international travel</strong>. Any country or area may restrict travel without notice. If you live in the UK and are currently travelling abroad, <strong>you are strongly advised to return now</strong>, where and while there are still commercial routes available. Many airlines are suspending flights and many airports are closing, preventing flights from leaving.
-      </p>
+      <div class="travel-advice-notice__header">
+        <%= render "govuk_publishing_components/components/warning_text", {
+          text: "COVID-19 Exceptional Travel Advisory Notice",
+          text_assistive: "Important",
+          large_font: true,
+          heading_level: 2
+        } %>
+      </div>
+      <div class="travel-advice-notice__content">
+        <p class="govuk-body">
+          As countries respond to the COVID-19 pandemic, including travel and border restrictions, <strong>the FCO advises British nationals against all but essential international travel</strong>. Any country or area may restrict travel without notice. If you live in the UK and are currently travelling abroad, <strong>you are strongly advised to return now</strong>, where and while there are still commercial routes available. Many airlines are suspending flights and many airports are closing, preventing flights from leaving.
+        </p>
+      </div>
     </div>
 
     <aside class="part-navigation-container" role="complementary">


### PR DESCRIPTION
Update government-frontend to import the sass for only the components it is using, instead of all components, as [documented here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-sass-for-individual-components).

## Filesize comparison

Before:

<img width="472" alt="Screenshot 2020-04-01 at 08 56 03" src="https://user-images.githubusercontent.com/861310/78113298-6eb9ad00-73f7-11ea-9796-5d9909b5a771.png">

Total **851 KB**

After:

<img width="469" alt="Screenshot 2020-04-01 at 15 45 10" src="https://user-images.githubusercontent.com/861310/78150933-e3104280-742f-11ea-87f8-0698c8189e15.png">

Total **628 KB**

## Additional changes

Also update all travel pages (such as [foreign travel advice to the USA](http://localhost:3090/foreign-travel-advice/usa/entry-requirements)) to use the warning text component. This was previously not possible because the component did not allow for a heading but has been updated to allow this.

This is being done as part of this PR because this page used styles from the component but not the component itself - so I noticed it had broken when I made the Sass change (because the warning text component is not used anywhere, it was not part of the 'suggested sass' output. It now is).

<img width="751" alt="Screenshot 2020-04-06 at 14 47 02" src="https://user-images.githubusercontent.com/861310/78565360-b5534100-7815-11ea-9ac5-b7084dff5c2a.png">


Trello card: https://trello.com/c/GWttlBxs/228-upgrade-applications-to-use-individual-component-sass