### PR TITLE
Add different placeholder image for world news

### DIFF
--- a/app/presenters/content_item/news_image.rb
+++ b/app/presenters/content_item/news_image.rb
@@ -13,7 +13,11 @@ module ContentItem
 
     def placeholder_image
       # this image has been uploaded to asset-manager
-      { "url" => "https://assets.publishing.service.gov.uk/media/5e59279b86650c53b2cefbfe/placeholder.jpg" }
+      if content_item.dig("document_type") == "world_news_story"
+        { "url" => "https://assets.publishing.service.gov.uk/media/5e985599d3bf7f3fc943bbd8/UK_government_logo.jpg" }
+      else
+        { "url" => "https://assets.publishing.service.gov.uk/media/5e59279b86650c53b2cefbfe/placeholder.jpg" }
+      end
     end
   end
 end

--- a/test/presenters/content_item/news_image_test.rb
+++ b/test/presenters/content_item/news_image_test.rb
@@ -38,4 +38,12 @@ class ContentItemNewsImageTest < ActiveSupport::TestCase
 
     assert_equal placeholder_image, item.image
   end
+
+  test "presents a placeholder image if world location news has no image or default news image" do
+    item = DummyContentItem.new
+    item.content_item["document_type"] = "world_news_story"
+    placeholder_image = { "url" => "https://assets.publishing.service.gov.uk/media/5e985599d3bf7f3fc943bbd8/UK_government_logo.jpg" }
+
+    assert_equal placeholder_image, item.image
+  end
 end


### PR DESCRIPTION
Adds a new placeholder image for world news stories.

https://govuk.zendesk.com/agent/tickets/3992513
