### PR TITLE
Add message to alpha/beta banner

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -12,6 +12,7 @@ class ContentItemPresenter
               :schema_name,
               :locale,
               :phase,
+              :phase_message,
               :part_slug,
               :document_type,
               :step_by_steps,
@@ -29,6 +30,7 @@ class ContentItemPresenter
     @schema_name = content_item["schema_name"]
     @locale = content_item["locale"] || "en"
     @phase = content_item["phase"]
+    @phase_message = content_item.dig("details", "phase_message", "content")
     @document_type = content_item["document_type"]
     @taxons = content_item["links"]["taxons"] if content_item["links"]
     @step_by_steps = content_item["links"]["part_of_step_navs"] if content_item["links"]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,9 @@
 
   <div id="wrapper" class="<%= wrapper_class %>">
     <% if @content_item.show_phase_banner? %>
-      <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase %>
+      <%= render 'govuk_publishing_components/components/phase_banner',
+        phase: @content_item.phase,
+        message: sanitize(@content_item.phase_message) %>
     <% end %>
 
     <% if @content_item.try(:back_link) %>

--- a/test/integration/phase_label_test.rb
+++ b/test/integration/phase_label_test.rb
@@ -21,4 +21,16 @@ class PhaseLabelTest < ActionDispatch::IntegrationTest
 
     assert_not page.has_text?("alpha")
   end
+
+  test "Phase message is displayed for a content item that has one" do
+    content_item = GovukSchemas::Example.find("case_study", example_name: "case_study")
+    content_item["phase"] = "alpha"
+    content_item["details"]["phase_message"] = { "content" => "phase message" }
+
+    stub_content_store_has_item("/government/case-studies/get-britain-building-carlisle-park", content_item.to_json)
+
+    visit_with_cachebust "/government/case-studies/get-britain-building-carlisle-park"
+
+    assert page.has_text?("phase message")
+  end
 end


### PR DESCRIPTION
https://trello.com/c/ZITqImYk/109-change-publisher-app-to-allow-publisher-to-show-which-phase-the-product-is-in

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html
