### PR TITLE
Remove .rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,0 @@
---color
---require spec_helper


### PR DESCRIPTION
This project dropped rspec for minitest all the way back in 2014 (798ee918)
so no longer needs this file.

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html
