### PR TITLE
[DO NOT MERGE] Noindex withdrawn content for crawlers

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,10 @@
     <% end %>
   </title>
 
+  <% if @content_item.withdrawn? %>
+    <meta name="robots" content="noindex">
+  <% end %>
+
   <% if ENV['HEROKU_APP_NAME'].present? %>
     <meta name="robots" content="noindex, nofollow">
   <% end %>

--- a/test/integration/meta_tags_test.rb
+++ b/test/integration/meta_tags_test.rb
@@ -14,6 +14,7 @@ class MetaTagsTest < ActionDispatch::IntegrationTest
     visit_with_cachebust "/some-page"
 
     assert page.has_css?("meta[property='og:title'][content='Zhe title']", visible: false)
+    assert page.has_no_css?("meta[name='robots'][content='noindex']", visible: false)
   end
 
   test "correct meta tags are displayed for pages without images" do
@@ -48,5 +49,13 @@ class MetaTagsTest < ActionDispatch::IntegrationTest
     assert page.has_css?("meta[name='twitter:card'][content='summary_large_image']", visible: false)
     assert page.has_css?("meta[name='twitter:image'][content='https://example.org/image.jpg']", visible: false)
     assert page.has_css?("meta[property='og:image'][content='https://example.org/image.jpg']", visible: false)
+  end
+
+  test "correct meta tags are displayed for withdrawn pages" do
+    withdrawn_case_study = GovukSchemas::Example.find("case_study", example_name: "archived")
+    stub_content_store_has_item("/withdrawn", withdrawn_case_study.to_json)
+    visit_with_cachebust "/withdrawn"
+
+    assert page.has_css?("meta[name='robots'][content='noindex']", visible: false)
   end
 end


### PR DESCRIPTION
** This has been paused until we sort out the proposition/comms **

We publish a sitemap with down-weighting for withdrawn content, however this does not seem to affect the ranking of external search results as much as we might hope.

By no-indexing here, we hope to surface current information more readily in places like google.

Should users wish to find withdrawn content, then it'll be findable via site search or navigation.

https://trello.com/c/YcXJ8OFD/258-noindex-withdrawn-content
