### PR TITLE
Switch asset hostname

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get install -y build-essential nodejs && apt-get clean
 RUN gem install foreman
 
 ENV GOVUK_APP_NAME government-frontend
-ENV GOVUK_ASSET_ROOT http://assets-origin.dev.gov.uk
 ENV PORT 3090
 ENV RAILS_ENV development
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -103,6 +103,10 @@ module GovernmentFrontend
     # Path within public/ where assets are compiled to
     config.assets.prefix = "/assets/government-frontend"
 
+    # allow overriding the asset host with an enironment variable, useful for
+    # when router is proxying to this app but asset proxying isn't set up.
+    config.asset_host = ENV["ASSET_HOST"]
+
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -101,7 +101,7 @@ module GovernmentFrontend
     config.action_dispatch.rack_cache = nil
 
     # Path within public/ where assets are compiled to
-    config.assets.prefix = "/government-frontend"
+    config.assets.prefix = "/assets/government-frontend"
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,8 +51,4 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-
-  if ENV["GOVUK_ASSET_ROOT"].present?
-    config.asset_host = ENV["GOVUK_ASSET_ROOT"]
-  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,10 +1,4 @@
 Rails.application.configure do
-  # Set GOVUK_ASSET_ROOT for heroku - for review apps we have the hostname set
-  # at the time of the app being built so can't be set up in the app.json
-  if !ENV.include?("GOVUK_ASSET_ROOT") && ENV["HEROKU_APP_NAME"]
-    ENV["GOVUK_ASSET_ROOT"] = "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
-  end
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,10 +33,6 @@ Rails.application.configure do
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = Plek.current.asset_root
-  config.slimmer.asset_host = Plek.current.find("static")
-
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This is marked as a draft until the following PR's are merged (and in puppets case, deployed):

- [x] https://github.com/alphagov/govuk-puppet/pull/10360
- [x] https://github.com/alphagov/publishing-e2e-tests/pull/383
- [x] https://github.com/alphagov/govuk-docker/pull/351

This removes the configuration in this app that specifies that this app should use the `assets.publishing.service.gov.uk` hostname for serving assets with the expectation that these assets will instead be served off the `www` hostname. This is to implement [RFC 115](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-115-enabling-http2-on-govuk.md). Because of this the path to assets will be changed to be prefixed with `/assets` so all GOV.UK assets are hosted in the same path.

The asset host can still be configured in this app by a `ASSET_HOST` environment variable, this will be used in govuk-docker and publishing-e2e-tests to avoid needing additional nginx configuration.

