### PR TITLE
Remove redundant RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,12 +6,3 @@ inherit_gem:
 inherit_mode:
   merge:
     - Exclude
-
-Metrics/BlockLength:
-  Exclude:
-    - "test/**/*_test.rb"
-
-Rails/OutputSafety:
-  Enabled: false
-Rails/HelperInstanceVariable:
-  Enabled: false

--- a/app/helpers/machine_readable_metadata_helper.rb
+++ b/app/helpers/machine_readable_metadata_helper.rb
@@ -1,6 +1,6 @@
 module MachineReadableMetadataHelper
   def machine_readable_metadata(args)
-    locals = { content_item: @content_item.content_item }.merge(args)
+    locals = { content_item: @content_item.content_item }.merge(args) # rubocop:disable Rails/HelperInstanceVariable
     render("govuk_publishing_components/components/machine_readable_metadata", locals)
   end
 end

--- a/app/helpers/webchat_availability_helper.rb
+++ b/app/helpers/webchat_availability_helper.rb
@@ -11,7 +11,7 @@ module WebchatAvailabilityHelper
 
   def webchat_unavailable?(now = Time.zone.now)
     show_unavailability = now >= UNAVAILABILITY_START && now < UNAVAILABILITY_END
-    show_unavailability && HMRC_WEBCHAT_CONTACT_PATHS.include?(@content_item.base_path)
+    show_unavailability && HMRC_WEBCHAT_CONTACT_PATHS.include?(@content_item.base_path) # rubocop:disable Rails/HelperInstanceVariable
   end
 
   def unavailability_message


### PR DESCRIPTION
https://github.com/alphagov/rubocop-govuk/issues/73

We should avoid disable Cops for the entire repo on the basis of a
couple of issues, which can be fixed or ignored in-place.


---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html