### PR TITLE
Fix active_model require in webchat test

### DIFF
--- a/test/models/webchat_test.rb
+++ b/test/models/webchat_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-require "active_model"
+require "active_model/validations"
 
 class WebchatTest < ActiveSupport::TestCase
   webchat_config = {


### PR DESCRIPTION
Before:

```
bundle exec rails test test/models/webchat_test.rb:20
Started with run options --seed 46747

WebchatTest
  test_should_return_error_if_config_is_invalid                  ERROR (0.00s)
Minitest::UnexpectedError:         NameError: uninitialized constant ActiveModel::ValidationError
            test/models/webchat_test.rb:25:in `block in <class:WebchatTest>'

Finished in 0.00445s
1 tests, 0 assertions, 0 failures, 1 errors, 0 skips
```

After:

```
bundle exec rails test test/models/webchat_test.rb:20
Started with run options --seed 32937

WebchatTest
  test_should_return_error_if_config_is_invalid                   PASS (1.28s)

Finished in 1.28149s
1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
```

[The previous fix](https://github.com/alphagov/government-frontend/commit/277f49385154c028785fca9bda00901a578586ba) didn't seem to always work: https://ci.integration.publishing.service.gov.uk/job/government-frontend/job/master/1458/console