### PR TITLE
Add margin top to organisation logos

### DIFF
--- a/app/assets/stylesheets/helpers/_organisation-logos.scss
+++ b/app/assets/stylesheets/helpers/_organisation-logos.scss
@@ -4,6 +4,7 @@
   flex-wrap: wrap;
   justify-content: flex-start;
   list-style-type: none;
+  margin-top: govuk-spacing(2);
 }
 
 .organisation-logos__logo {


### PR DESCRIPTION
- this prevents the contextual breadcrumb component, when showing the step nav header component, from colliding with it
- the step nav component has no margin bottom, but the other components that can be displayed in the contextual breadcrumb do, so this change should not impact variations on this layout as the newly added top margin will overlap any bottom margin from the breadcrumb

Happens on pages like: https://www.gov.uk/government/publications/coronavirus-covid-19-guidance-on-phased-return-of-sport-and-recreation/elite-sport-return-to-domestic-competition-guidance

Before:

<img width="972" alt="Screenshot 2020-06-02 at 15 53 40" src="https://user-images.githubusercontent.com/861310/83535248-b1782e00-a4e9-11ea-98a4-8646dd5f2d24.png">

After:

<img width="978" alt="Screenshot 2020-06-02 at 15 53 47" src="https://user-images.githubusercontent.com/861310/83535271-b76e0f00-a4e9-11ea-879e-5de32c0cdc03.png">
