### PR TITLE
304 Fix FAQ Schemas for html publications

### DIFF
--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -1,6 +1,6 @@
 <% content_for :extra_head_content do %>
   <%= machine_readable_metadata(
-    schema: :faq
+    schema: :html_publication
   ) %>
 <% end %>
 


### PR DESCRIPTION
Updates html publication content items to use the new _html_publication_ schema [recently added to govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/pull/1543)   
