### PR TITLE
Use Plek#asset_root over Plek#public_asset_host

### DIFF
--- a/app/controllers/asset_manager_redirect_controller.rb
+++ b/app/controllers/asset_manager_redirect_controller.rb
@@ -1,6 +1,6 @@
 class AssetManagerRedirectController < ApplicationController
   def show
-    asset_url = Plek.new.public_asset_host
+    asset_url = Plek.new.asset_root
     if request.host.start_with?("draft-")
       asset_url = Plek.new.external_url_for("draft-assets")
     end

--- a/test/controllers/asset_manager_redirect_controller_test.rb
+++ b/test/controllers/asset_manager_redirect_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class AssetManagerRedirectControllerTest < ActionController::TestCase
   setup do
-    Plek.any_instance.stubs(:public_asset_host).returns("http://asset-host.com")
+    Plek.any_instance.stubs(:asset_root).returns("http://asset-host.com")
     Plek.any_instance.stubs(:external_url_for).returns("http://draft-asset-host.com")
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

I'm removing this as part of a plan to remove Plek#public_asset_host and
the associated GOVUK_ASSET_HOST env var. The reason to remove these is
because they are the same #asset_root and GOVUK_ASSET_ROOT, which pushes
developers to consider which one to use when they both have the same
effect.

Government frontend appears to be the only app other than Whitehall that
has used this method, which I assume is because the code it is used in
was ported from Whitehall.

---

Visual regression results:
https://government-frontend-pr-[THIS PR NUMBER].surge.sh/gallery.html
