### PR TITLE
Use individual component JS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,14 @@
+//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/details
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/feedback
+//= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/print-link
+//= require govuk_publishing_components/components/radio
+//= require govuk_publishing_components/components/step-by-step-nav
+
 //= require_tree ./modules
-//= require govuk_publishing_components/all_components
 //= require set-ga-client-id-on-form
 
 jQuery(function ($) {


### PR DESCRIPTION
Update government-frontend to import the Javascript for only the components it is using, instead of all components, as [documented here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-sass-for-individual-components) and [here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-javascript-for-individual-components).

## Filesize comparison

Before:

<img width="435" alt="Screenshot 2020-07-03 at 08 59 09" src="https://user-images.githubusercontent.com/861310/86446358-c07e1600-bd0b-11ea-8524-de4748c5b68f.png">

JS: **473 KB** 

After:

<img width="434" alt="Screenshot 2020-07-03 at 08 59 30" src="https://user-images.githubusercontent.com/861310/86446381-c8d65100-bd0b-11ea-9544-a655a7d279ea.png">

JS: **265 KB** 


Trello card: https://trello.com/c/GWttlBxs/228-upgrade-applications-to-use-individual-component-sass

