### PR TITLE
Format machine readable output

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -8,7 +8,7 @@
 
 <% unless @content_item.requesting_a_part? %>
 <script type="application/ld+json">
-  <%= raw MachineReadable::GuideFaqPageSchemaPresenter.new(@content_item, self).structured_data.to_json %>
+  <%= raw JSON.pretty_generate(MachineReadable::GuideFaqPageSchemaPresenter.new(@content_item, self).structured_data) %>
 </script>
 <% end %>
 


### PR DESCRIPTION
Continuing on from alphagov/govuk_publishing_components#1617 and https://github.com/alphagov/collections/pull/1840/commits/99718ffce5e9753be9eba16f63faf9cb9ab98d88

Human readable structured data is much easier to debug and reason about.
