### PR TITLE
Upgrade to ruby 2.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-ruby File.read(".ruby-version").strip
-
 gem "rails", "6.0.3.3"
 
 gem "dalli"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
-    brakeman (4.8.2)
+    brakeman (4.9.1)
     builder (3.2.4)
     capybara (3.33.0)
       addressable
@@ -137,7 +137,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    image_size (2.0.2)
+    image_size (2.1.0)
     io-like (0.3.1)
     jasmine (3.6.0)
       jasmine-core (~> 3.6.0)
@@ -197,8 +197,8 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (4.0.5)
-    puma (4.3.5)
+    public_suffix (4.0.6)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -266,8 +266,8 @@ GEM
       rubocop-ast (>= 0.1.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.2.0)
-      parser (>= 2.7.0.1)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
     rubocop-govuk (3.17.0)
       rubocop (= 0.87.1)
       rubocop-rails (= 2.6.0)
@@ -399,9 +399,6 @@ DEPENDENCIES
   webdrivers
   webmock
   wraith
-
-RUBY VERSION
-   ruby 2.6.6
 
 BUNDLED WITH
    1.17.3

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,6 @@ private
                                  .compact
                                  .join(".")
 
-    "/" + URI.encode(path_and_optional_locale) # rubocop:disable Lint/UriEscapeUnescape
+    "/" + URI.encode_www_form_component(path_and_optional_locale).gsub("%2F", "/")
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,9 +4,9 @@ module ApplicationHelper
   end
 
   def t_locale_fallback(key, options = {})
-    options["locale"] = I18n.locale
+    options[:locale] = I18n.locale
     options[:fallback] = nil
-    translation = I18n.t(key, options)
+    translation = I18n.t(key, **options)
 
     if translation.nil? || translation.include?("translation missing")
       I18n.default_locale


### PR DESCRIPTION
These are the changes required to upgrade to ruby 2.7

There's a script that can be run to change the ruby version across all apps, so I've made the necessary changes for 2.7.1 but left the version as 2.6.6. However, the tests don't pass under ruby 2.6.6.


---

Visual regression results:
https://government-frontend-pr-1828.surge.sh/gallery.html


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.