### PR TITLE
Update Brexit notice

### DIFF
--- a/app/presenters/content_item/no_deal_notice.rb
+++ b/app/presenters/content_item/no_deal_notice.rb
@@ -23,11 +23,12 @@ module ContentItem
     end
 
     def no_deal_notice_title
-      "The UK has left the EU and the transition period after Brexit comes to an end this year."
+      "New rules for January 2021"
     end
 
     def no_deal_notice_description
-      "This page tells you what you'll need to do from 1 January 2021. It will be updated if anything changes."
+      ["The UK has left the EU, and the transition period after Brexit comes to an end this year.",
+       "This page tells you what you'll need to do from 1 January 2021. It will be updated if anything changes."]
     end
 
     def no_deal_notice_link_intro

--- a/app/views/components/_header-notice.html.erb
+++ b/app/views/components/_header-notice.html.erb
@@ -12,7 +12,13 @@
     </div>
 
     <div class="app-c-header-notice__content">
-      <p class="app-c-header-notice__text govuk-body"><%= description %></p>
+      <% if description.is_a? Array %>
+        <% description.map do |line| %>
+          <p class="app-c-header-notice__text govuk-body"><%= line %></p>
+        <% end %>
+      <% else %>
+        <p class="app-c-header-notice__text govuk-body"><%= description %></p>
+      <% end %>
       <% if links.any? %>
         <div class="app-c-header-notice__links">
           <% if links.count == 1 %>

--- a/test/components/header_notice_test.rb
+++ b/test/components/header_notice_test.rb
@@ -24,6 +24,14 @@ class HeaderNoticeTest < ComponentTestCase
     assert_select ".app-c-header-notice__content p", text: "This is some important information about the content."
   end
 
+  test "renders a header notice with text correctly with a multi-line description" do
+    render_component(title: "This is an important notice", description: ["This is some important information about the content.", "It runs on to two lines."])
+
+    assert_select ".app-c-header-notice__title", text: "This is an important notice"
+    assert_select ".app-c-header-notice__content p", text: "This is some important information about the content."
+    assert_select ".app-c-header-notice__content p", text: "It runs on to two lines."
+  end
+
   test "renders a header notice with an aria label" do
     render_component(title: "This is an important notice", description: "This is some important information about the content.")
     assert_select "section[aria-label=notice]"


### PR DESCRIPTION
We wanted to be able to display multiple lines of text.

[Content update](https://docs.google.com/document/d/1jfwDr-G4NP0HKDfNKA5FG2POGjeH1JVK7qGrA4Fj7FE/edit#)

[Trello card](https://trello.com/c/ijTzb33b/347-tweak-the-brexit-banner-on-whitehall-pages)

Example page: https://www.gov.uk/government/publications/eu-lawyers-in-the-uk-from-1-january-2021
