### PR TITLE
Fix focus states for 'applies to' links

### DIFF
--- a/app/assets/stylesheets/components/_important-metadata.scss
+++ b/app/assets/stylesheets/components/_important-metadata.scss
@@ -31,6 +31,9 @@
 
   .app-link {
     color: govuk-colour("white");
-  }
 
+    &:focus {
+      color: $govuk-text-colour;
+    }
+  }
 }


### PR DESCRIPTION
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.

## What/why

Fixes the focus state for links in the important metadata component, on pages like https://www.gov.uk/guidance/coronavirus-covid-19-travel-corridors

Before:

<img width="627" alt="Screenshot 2020-08-14 at 14 11 47" src="https://user-images.githubusercontent.com/861310/90253318-dddcee80-de38-11ea-830d-0cb499f53b4f.png">

After:

<img width="609" alt="Screenshot 2020-08-14 at 14 11 58" src="https://user-images.githubusercontent.com/861310/90253336-e503fc80-de38-11ea-975b-1a7755c3eab8.png">

This occurred on visited links when focussed.
