### PR TITLE
Add FAQ Page schema to detailed guides

### DIFF
--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -1,6 +1,6 @@
 <% content_for :extra_head_content do %>
   <%= machine_readable_metadata(
-    schema: :article
+    schema: :faq
   ) %>
 <% end %>
 

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -85,4 +85,12 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
 
     assert page.has_css?(".metadata-logo[alt='European structural investment funds']")
   end
+
+  test "renders FAQ structured data" do
+    setup_and_visit_content_item("detailed_guide")
+    faq_schema = find_structured_data(page, "FAQPage")
+
+    assert_equal faq_schema["name"], @content_item["title"]
+    assert_not_equal faq_schema["mainEntity"], []
+  end
 end


### PR DESCRIPTION
They are the same shape as answers, so we should be OK to reuse that template.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.

## Example 10 detailed guides

https://government-f-detailed-g-zfkvcd.herokuapp.com/guidance/get-a-discount-with-the-eat-out-to-help-out-scheme
https://government-f-detailed-g-zfkvcd.herokuapp.com/guidance/coronavirus-covid-19-travel-corridors
https://government-f-detailed-g-zfkvcd.herokuapp.com/guidance/north-west-of-england-local-restrictions-what-you-can-and-cannot-do
https://government-f-detailed-g-zfkvcd.herokuapp.com/guidance/coronavirus-covid-19-information-for-the-public
https://government-f-detailed-g-zfkvcd.herokuapp.com/guidance/coronavirus-covid-19-countries-and-territories-exempt-from-advice-against-all-but-essential-international-travel
https://government-f-detailed-g-zfkvcd.herokuapp.com/guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme
https://government-f-detailed-g-zfkvcd.herokuapp.com/guidance/travel-advice-novel-coronavirus
https://government-f-detailed-g-zfkvcd.herokuapp.com/guidance/fix-your-bike-voucher-scheme-apply-for-a-voucher
https://government-f-detailed-g-zfkvcd.herokuapp.com/guidance/claim-a-grant-through-the-self-employment-income-support-scheme
https://government-f-detailed-g-zfkvcd.herokuapp.com/guidance/coronavirus-covid-19-getting-tested

