### PR TITLE
Update history.html.erb

### DIFF
--- a/app/views/histories/history.html.erb
+++ b/app/views/histories/history.html.erb
@@ -84,10 +84,10 @@
           <%= link_to "11 Downing Street", "/government/history/11-downing-street", class: "govuk-link" %>
         </li>
         <li>
-          <%= link_to "King Charles Street (FCO)", "/government/history/king-charles-street", class: "govuk-link" %>
+          <%= link_to "King Charles Street (FCDO)", "/government/history/king-charles-street", class: "govuk-link" %>
         </li>
         <li>
-          <%= link_to "Lancaster House (FCO)", "/government/history/lancaster-house", class: "govuk-link" %>
+          <%= link_to "Lancaster House (FCDO)", "/government/history/lancaster-house", class: "govuk-link" %>
         </li>
         <li>
           <%= link_to "Ministry of Defence, Whitehall", "/government/publications/history-of-the-ministry-of-defence", class: "govuk-link" %>
@@ -142,7 +142,7 @@
         margin_bottom: 3,
       } %>
 
-      <p class="govuk-body">Some government departments, including Number 10 and the Foreign and Commonwealth Office, write or commission articles and research to improve our knowledge of the history of the British government.</p>
+      <p class="govuk-body">Some government departments, including Number 10 and the Foreign, Commonwealth & Development Office, write or commission articles and research to improve our knowledge of the history of the British government.</p>
 
       <p class="govuk-body">Find out more on the <a href="http://history.blog.gov.uk" class="govuk-link">history of government blog</a>.</p>
     </div>


### PR DESCRIPTION
Changed:

2 acronyms and 1 name

REASON: FCO and DFID are merging to create FCDO

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
