### PR TITLE
Update HMPO Webchat URL

### DIFF
--- a/lib/webchat.yaml
+++ b/lib/webchat.yaml
@@ -1,4 +1,4 @@
 - base_path: /government/organisations/hm-passport-office/contact/passport-advice-and-complaints
   open_url: https://hmpowebchat.klick2contact.com/v03/launcherV3.php?p=HMPO&d=717&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Chat&s=https://hmpowebchat.klick2contact.com/v03&u=&wo=&uh=&pid=2&iif=0
-  availability_url: https://hmpowebchat.klick2contact.com/v03/providers/HMPO2/api/availability.php
+  availability_url: https://hmpowebchat.klick2contact.com/v03/providers/HMPO/api/availability.php
   open_url_redirect: false


### PR DESCRIPTION
Trello: https://trello.com/c/mXx8NF3R

#WHAT

Update the YAML file for HMPO
https://github.com/alphagov/government-frontend/blob/master/lib/webchat.yaml

Change availability URL:
https://hmpowebchat.klick2contact.com/v03/providers/HMPO2/api/availability.php

to
https://hmpowebchat.klick2contact.com/v03/providers/HMPO/api/availability.php

#WHY
The above change should ensure the webchat page (which is live but not currently linked from anywhere) works correctly
www.gov.uk/government/organisations/hm-passport-office/contact/passport-advice-and-complaints

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
