### PR TITLE
Update 'FCO' in history page titles

### DIFF
--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -23,14 +23,14 @@ module PublishStaticPages
     },
     {
       content_id: "bd216990-c550-4d28-ac05-649329298601",
-      title: "History of King Charles Street (FCO)",
+      title: "History of King Charles Street (FCDO)",
       description: "The history of King Charles Street.",
       template: "histories/king_charles_street",
       base_path: "/government/history/king-charles-street",
     },
     {
       content_id: "60808448-769d-4915-981c-f34eb5f1b7bc",
-      title: "History of Lancaster House (FCO)",
+      title: "History of Lancaster House (FCDO)",
       description: "The history of Lancaster House.",
       template: "histories/lancaster_house",
       base_path: "/government/history/lancaster-house",


### PR DESCRIPTION
Replaced 'FCO' with 'FCDO' in Lancaster House and King Charles Street page titles.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
