### PR TITLE
Add additional skip link on guide views

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -42,6 +42,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/title';
 @import 'govuk_publishing_components/components/translation-nav';
 @import 'govuk_publishing_components/components/warning-text';
+@import 'govuk_publishing_components/components/skip-link';
 
 // government-frontend mixins
 @import 'mixins/margins';

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -19,13 +19,17 @@
     <%= render 'govuk_publishing_components/components/title', { title: @content_item.content_title } %>
 
     <% if @content_item.show_guide_navigation? %>
+      <%= render "govuk_publishing_components/components/skip_link", {
+        text: "Skip to contents of guide",
+        href: "#guide-contents"
+      } %>
       <aside class="part-navigation-container" role="complementary">
         <%= render "govuk_publishing_components/components/contents_list", aria_label: 'Pages in this guide', contents: @content_item.part_link_elements, underline_links: true %>
       </aside>
     <% end %>
   </div>
 
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds" id="guide-contents">
     <% if @content_item.has_parts? %>
       <% if @content_item.show_guide_navigation? %>
         <h1 class="part-title">


### PR DESCRIPTION
## What
Adds an additional skip link above the guide contents that goes to the actual content of the guide.

## Why
This was identified as a WCAG fail (specifically WCAG SC 2.4.1) as for keyboard only users, it meant that they had the option to skip navigation in the govuk header but still have to tab through the navigation of the guide contents to get to the "actual" content of the guide. This solution of using an additional skip link is used on govuk search pages to skip past filters.

**Card:** https://trello.com/c/x3QKWP0z/340-cannot-bypass-repeated-navigation

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
