### PR TITLE
Add 'en' language attribute to the Brexit callout

### DIFF
--- a/app/views/components/_header-notice.html.erb
+++ b/app/views/components/_header-notice.html.erb
@@ -6,7 +6,7 @@
   featured_link ||= false
 %>
 <% if title && description %>
-  <section class="app-c-header-notice" aria-label="notice" role="region">
+  <section class="app-c-header-notice" aria-label="notice" role="region" lang="en">
     <div class="app-c-header-notice__header">
       <h2 class="app-c-header-notice__title"><%= title %></h2>
     </div>


### PR DESCRIPTION
This section is not currently translated, though it can and does appear on
[some non-English pages](https://www.gov.uk/government/publications/trade-with-the-uk-from-january-2021-prepare-your-eu-business/handel-mit-dem-vereinigten-konigreich-ab-1-januar-2021-fur-unternehmen-mit-sitz-in-der-eu).  Because of this, we should add the English language attribute to the section.

https://trello.com/c/uaDK0l8U/445-add-language-attribute-to-autogenerated-eu-transition-banner

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
