### PR TITLE
Add lang attribute to withdrawal notice

### DIFF
--- a/app/presenters/content_item/withdrawable.rb
+++ b/app/presenters/content_item/withdrawable.rb
@@ -14,6 +14,7 @@ module ContentItem
           title: withdrawal_notice_title,
           description_govspeak: withdrawal_notice["explanation"]&.html_safe,
           time: withdrawal_notice_time,
+          lang: I18n.locale.to_s == "en" ? false : "en",
         }
       end
     end


### PR DESCRIPTION
https://trello.com/c/k5JCHIoZ/382-add-language-attribute-to-withdrawn-banner

Withdrawal notices are always presented in English but sometimes
appear on a translated page. This passes en as a language value to
the notice component when that happens.

Example page: https://www.gov.uk/government/news/changes-to-uk-visa-application-process-in-germany.de

There are no visual changes. **The effects of this won't be seen until the notice component supports the lang attribute which will happen in a forthcoming release (see https://github.com/alphagov/govuk_publishing_components/pull/1686) but there are no ill effects from passing the extra parameter.**



:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
