### PR TITLE
Remove ordered list markup for organisation logos

### DIFF
--- a/app/assets/stylesheets/helpers/_organisation-logos.scss
+++ b/app/assets/stylesheets/helpers/_organisation-logos.scss
@@ -9,11 +9,7 @@
 
 .organisation-logos__logo {
   padding-bottom: govuk-spacing(3);
+  margin-right: govuk-spacing(3);
   flex-basis: 25%;
   min-width: 130px;
-}
-
-.organisation-logo__inner {
-  max-width: 215px;
-  padding-right: govuk-spacing(3);
 }

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -10,17 +10,15 @@
 
 <% if @content_item.organisations %>
   <div class="publication-external">
-    <ol class="organisation-logos">
+    <ul class="organisation-logos">
       <% @content_item.organisations.each do |organisation| %>
-      <% logo_attributes = @content_item.organisation_logo(organisation) %>
-      <% next unless logo_attributes %>
+        <% logo_attributes = @content_item.organisation_logo(organisation) %>
+        <% next unless logo_attributes %>
         <li class="organisation-logos__logo">
-          <div class="organisation-logo__inner">
-            <%= render 'govuk_publishing_components/components/organisation_logo', logo_attributes %>
-          </div>
+          <%= render 'govuk_publishing_components/components/organisation_logo', logo_attributes %>
         </li>
       <% end %>
-    </ol>
+    </ul>
   </div>
 <% end %>
 

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -69,7 +69,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   end
 
   def assert_has_component_organisation_logo_with_brand(brand, index = 1)
-    within("li.organisation-logos__logo:nth-of-type(#{index})") do
+    within(".organisation-logos__logo:nth-of-type(#{index})") do
       assert page.has_css?(".gem-c-organisation-logo.brand--#{brand}")
     end
   end


### PR DESCRIPTION
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.

## What
Move logos at the top of organisation pages out of the ordered list element.

## Why
These logos should not be in an ordered list as there's nothing to denote them as ordered. This could've been changed into an unordered list but this itself isn't ideal as they aren't really intended as a list. [Example of a page with multiple logos](https://www.gov.uk/government/publications/face-coverings-when-to-wear-one-and-how-to-make-your-own/face-coverings-when-to-wear-one-and-how-to-make-your-own).

No visual changes.

**Card:** https://trello.com/c/zeNDQ9hA/374-ordered-list-used-when-list-is-not-ordered