### PR TITLE
Add new webchat base_path for HMPO

### DIFF
--- a/lib/webchat.yaml
+++ b/lib/webchat.yaml
@@ -2,3 +2,7 @@
   open_url: https://hmpowebchat.klick2contact.com/v03/launcherV3.php?p=HMPO&d=717&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Chat&s=https://hmpowebchat.klick2contact.com/v03&u=&wo=&uh=&pid=2&iif=0
   availability_url: https://hmpowebchat.klick2contact.com/v03/providers/HMPO/api/availability.php
   open_url_redirect: false
+- base_path: /government/organisations/hm-passport-office/contact/webchat
+  open_url: https://hmpowebchat.klick2contact.com/v03/launcherV3.php?p=HMPO&d=717&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Chat&s=https://hmpowebchat.klick2contact.com/v03&u=&wo=&uh=&pid=2&iif=0
+  availability_url: https://hmpowebchat.klick2contact.com/v03/providers/HMPO/api/availability.php
+  open_url_redirect: false


### PR DESCRIPTION
Trello: https://trello.com/c/VmJdgRXL

Add this page as a base_path:
https://www.gov.uk/government/organisations/hm-passport-office/contact/webchat

With the same values for open_url, availability_url and open_url_redirect as the existing page.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
