### PR TITLE
Test alternative text for Transition navigation

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -92,11 +92,30 @@ private
       content_item["links"]["ordered_related_items"] = content_item["links"].fetch("suggested_ordered_related_items", [])
     end
 
+    if update_brexit_navigation?(content_item)
+      content_item["links"]["taxons"] = taxons_updated_for_brexit_test(content_item)
+    end
+
     @content_item = PresenterBuilder.new(
       content_item,
       content_item_path,
       view_context,
     ).presenter
+  end
+
+  def update_brexit_navigation?(content_item)
+    content_item["content_id"] == "7a616597-c921-47ba-bd50-7e73449e140b" # /visit-europe-1-january-2021
+  end
+
+  def taxons_updated_for_brexit_test(content_item)
+    content_item["links"]["taxons"].map do |taxon|
+      taxon["title"] = "The UK and EU transition: new rules for 2021" if brexit_taxon?(taxon)
+      taxon
+    end
+  end
+
+  def brexit_taxon?(taxon)
+    taxon["content_id"] == "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
   end
 
   def format_banner_links(links, type)

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -112,6 +112,35 @@ class GuideTest < ActionDispatch::IntegrationTest
     assert_nil faq_schema
   end
 
+  test "a specific guide has tweaked Brexit navigation" do
+    visit_europe_guide_id = "7a616597-c921-47ba-bd50-7e73449e140b"
+    setup_and_visit_a_guide_with_the_brexit_taxon(visit_europe_guide_id)
+
+    assert page.has_css?(".gem-c-step-nav-header__title", text: "The UK and EU transition: new rules for 2021")
+  end
+
+  test "a normal Brexit guide has normal Brexit navigation" do
+    setup_and_visit_a_guide_with_the_brexit_taxon
+
+    assert page.has_css?(".gem-c-step-nav-header__title", text: "Brexit things")
+  end
+
+  def setup_and_visit_a_guide_with_the_brexit_taxon(content_id = nil)
+    @content_item = get_content_example("guide").tap do |item|
+      item["content_id"] = content_id if content_id.present?
+      item["links"]["taxons"] = [brexit_taxon]
+      stub_content_store_has_item(item["base_path"], item.to_json)
+      visit_with_cachebust(item["base_path"])
+    end
+  end
+
+  def brexit_taxon
+    @brexit_taxon ||= GovukSchemas::Example.find("taxon", example_name: "taxon").tap do |taxon|
+      taxon["title"] = "Brexit things"
+      taxon["content_id"] = "d6c2de5d-ef90-45d1-82d4-5f2438369eea" # the real Brexit taxon ID
+    end
+  end
+
   def setup_and_visit_part_in_guide
     @content_item = get_content_example("guide").tap do |item|
       chapter_path = "#{item['base_path']}/key-stage-1-and-2"


### PR DESCRIPTION
We want to test whether changing the text on the banner navigation improves click through rate. We want to keep the test simple, so we've just chosen a [single, high traffic page](https://www.gov.uk/visit-europe-1-january-2021) as
victim.

The displayed navigation is determined in [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/blob/b4c917fb07db5d6c9ed24b1d27dc8a09387832b1/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb#L11), however we know how it works. If a certain taxonomy content_id is found in the taxon links of a content item, then a step by step banner (colloquially a "super breadcrumb") will be displayed using the title of the taxon.

If we intercept the content item before it is passed to the component, then we can tweak what is displayed.

https://trello.com/c/igPWXPvz/482-put-new-transition-taxon-live

## Examples

[This should show "The UK and EU transition: new rules for 2021"](http://government-f-transition-osrely.herokuapp.com/visit-europe-1-january-2021)
[This isn't tagged to Brexit so should just show its step by step header](http://government-f-transition-osrely.herokuapp.com/student-finance)
[This is tagged to Brexit, so should show "Transition period"](http://government-f-transition-osrely.herokuapp.com/guidance/pet-travel-to-europe-after-brexit)

## Before 
![Screenshot 2020-10-06 at 17 19 29](https://user-images.githubusercontent.com/773037/95229169-280a9c80-07f8-11eb-82fc-7fc343cf4b10.png)

## After 
![Screenshot 2020-10-06 at 17 19 04](https://user-images.githubusercontent.com/773037/95229170-28a33300-07f8-11eb-8209-3b8cbd7601ff.png)


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
