### PR TITLE
Replace bespoke nav with contents list component

### DIFF
--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -14,16 +14,10 @@
   }
 
   .part-navigation {
-    margin-bottom: 0;
-    @include govuk-font(19);
+    margin-left: 0;
 
-    @include govuk-media-query($from: tablet) {
-      @include govuk-font(16);
-    }
-
-    li {
-      list-style: none;
-      margin-bottom: 0.75em;
+    @include govuk-media-query($until: tablet) {
+      margin-left: govuk-spacing(1);
     }
   }
 

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -36,15 +36,7 @@
 
     <aside class="part-navigation-container" role="complementary">
       <nav role="navigation" class="govuk-grid-row part-navigation" aria-label="Travel advice pages" data-module="track-click">
-        <%  @content_item.parts_navigation.each_with_index do |part_group, i| %>
-          <ol class="govuk-grid-column-one-half" <% if i == 1 %> start="<%=  @content_item.parts_navigation_second_list_start %>" <% end %>>
-            <% part_group.each do |part_nav_item| %>
-              <li>
-                <%= part_nav_item %>
-              </li>
-            <% end %>
-          </ol>
-        <% end %>
+        <%= render "govuk_publishing_components/components/contents_list", contents: @content_item.part_link_elements, underline_links: true %>
       </nav>
 
       <%= render 'govuk_publishing_components/components/subscription-links', email_signup_link: @content_item.email_signup_link, feed_link: @content_item.feed_link %>

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -14,7 +14,6 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     assert page.has_css?("a[href=\"#{@content_item['details']['email_signup_link']}\"]", text: "Get email alerts")
     assert page.has_css?("a[href=\"#{@content_item['base_path']}.atom\"]", text: "Subscribe to feed")
 
-    assert page.has_css?(".part-navigation ol", count: 2)
     assert page.has_css?(".part-navigation li", count: @content_item["details"]["parts"].size + 1)
     assert page.has_css?(".part-navigation li", text: "Summary")
     assert_not page.has_css?(".part-navigation li a", text: "Summary")


### PR DESCRIPTION
This removes the bespoke 2 column layout for parts navigation and replaces it with the contents-list component. This brings in a header of "Contents" and makes the navigation more consistent with the rest of the site which is good for accessibility. 
https://trello.com/c/LbVmpaK6/441-inconsistent-naming-of-table-of-contents
Sample page: https://www.gov.uk/foreign-travel-advice/switzerland

### Before
![Screenshot 2020-10-14 at 15 03 41](https://user-images.githubusercontent.com/31649453/96000185-8c4be280-0e2e-11eb-93a0-9f97e936a1f8.png)

### After
![Screenshot 2020-10-14 at 15 03 31](https://user-images.githubusercontent.com/31649453/96000212-9372f080-0e2e-11eb-9f1b-d0cb1bfb0a68.png)
