### PR TITLE
Add healthcheck for memcached

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,10 @@ Rails.application.routes.draw do
 
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
-  get "healthcheck", to: proc { [200, {}, [""]] }
+  get "/healthcheck",
+      to: GovukHealthcheck.rack_response(
+        GovukHealthcheck::RailsCache,
+      )
 
   get "/government/uploads/*path" => "asset_manager_redirect#show", format: false
 


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

Previously this repo had a very basic healthcheck. This extends it
with a more thorough check of the infrastructure it needs to run:
Memcached [1] [2]. Since the caching can fail silently, there is
even more motivation for us to know about it.

[1]: https://github.com/alphagov/slimmer/blob/64482b28572a7d038827de214832317e75f0c1ae/lib/slimmer.rb#L13
[2]: https://github.com/alphagov/government-frontend/blob/0bd1bbad134b2ddb521e2372b45df0d08bc7b142/Gemfile#L5


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.