### PR TITLE
Update Govspeak usage

### DIFF
--- a/app/views/content_items/_attachments.html.erb
+++ b/app/views/content_items/_attachments.html.erb
@@ -5,9 +5,14 @@
         mobile_top_margin: true %>
 
     <% if legacy_pre_rendered_documents.present? %>
-      <%= render 'govuk_publishing_components/components/govspeak',
-                 content: legacy_pre_rendered_documents.html_safe,
-                 direction: page_text_direction %>
+      <%= render 'govuk_publishing_components/components/govspeak', {
+        direction: page_text_direction,
+      } do %>
+        <%= sanitize(legacy_pre_rendered_documents, {
+          attributes: %w(alt class data-module href id src),
+          tags: %w(a details div h2 img p section span summary),
+        }) %>
+      <% end %>
     <% else %>
       <% attachments.each do |attachment_id| %>
         <div class="attachment">
@@ -16,5 +21,6 @@
         </div>
       <% end %>
     <% end %>
+
   </section>
 <% end %>

--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -9,9 +9,11 @@
 
 <div class="govuk-grid-row responsive-bottom-margin">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/govspeak',
-               { direction: page_text_direction, disable_youtube_expansions: true } do %>
-      <%= raw @content_item.body %>
+    <%= render 'govuk_publishing_components/components/govspeak', {
+      direction: page_text_direction,
+      disable_youtube_expansions: true,
+    } do %>
+      <%= sanitize(@content_item.body) %>
     <% end %>
 
     <% if @content_item.last_updated && @content_item.schema_name == "help_page" %>

--- a/app/views/content_items/_document_collection_body.html.erb
+++ b/app/views/content_items/_document_collection_body.html.erb
@@ -4,10 +4,13 @@
 
 <% @content_item.groups.each_with_index do |group, group_index| %>
   <%= @content_item.group_heading(group) %>
+
   <% if group["body"].present? %>
-    <%= render 'govuk_publishing_components/components/govspeak',
-        content: raw(group["body"]),
-        direction: page_text_direction %>
+    <%= render 'govuk_publishing_components/components/govspeak', {
+        direction: page_text_direction,
+      } do %>
+      <%= sanitize(group["body"]) %>
+    <% end %>
   <% end %>
 
   <div data-module="track-click">

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -27,9 +27,11 @@
           credit: @content_item.image["credit"],
           caption: @content_item.image["caption"] if @content_item.image %>
 
-      <%= render 'govuk_publishing_components/components/govspeak',
-          content: @content_item.body.html_safe,
-          direction: page_text_direction %>
+      <%= render 'govuk_publishing_components/components/govspeak', {
+        direction: page_text_direction,
+      } do %>
+        <%= sanitize(@content_item.body) %>
+      <% end %>
     </div>
 
     <%= render 'components/published-dates', {

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -25,7 +25,10 @@
         <% if @content_item.opening_date_midnight? %>on<% else %>at<% end %>
         <time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time>
       <% end %>
-      <%= render 'govuk_publishing_components/components/notice', title: "This consultation isn't open yet", description_text: content_item_unopened %>
+      <%= render 'govuk_publishing_components/components/notice', {
+        title: "This consultation isn't open yet",
+        description_text: content_item_unopened,
+      } %>
 
     <% elsif @content_item.pending_final_outcome? %>
       <% content_item_final_outcome = capture do %>
@@ -47,9 +50,11 @@
 
       <%= render 'govuk_publishing_components/components/heading', text: "Detail of outcome", mobile_top_margin: true %>
       <div class="consultation-outcome-detail">
-        <%= render 'govuk_publishing_components/components/govspeak',
-            content: @content_item.final_outcome_detail.html_safe,
-            direction: page_text_direction %>
+        <%= render 'govuk_publishing_components/components/govspeak', {
+          direction: page_text_direction,
+        } do %>
+          <%= sanitize(@content_item.final_outcome_detail) %>
+        <% end %>
       </div>
     <% end %>
 
@@ -59,18 +64,28 @@
         attachments: @content_item.public_feedback_attachments %>
 
     <% if @content_item.public_feedback_detail %>
-      <%= render 'govuk_publishing_components/components/heading', text: "Detail of feedback received", mobile_top_margin: true %>
+      <%= render 'govuk_publishing_components/components/heading', {
+        mobile_top_margin: true,
+        text: "Detail of feedback received",
+      } %>
       <div class="consultation-feedback">
-        <%= render 'govuk_publishing_components/components/govspeak',
-            content: @content_item.public_feedback_detail.html_safe,
-            direction: page_text_direction %>
+        <%= render 'govuk_publishing_components/components/govspeak', {
+          direction: page_text_direction,
+        } do %>
+          <%= sanitize(@content_item.public_feedback_detail) %>
+        <% end %>
       </div>
     <% end %>
 
     <% if @content_item.final_outcome? %>
       <section class="original-consultation">
         <header>
-          <%= render 'govuk_publishing_components/components/heading', text: "Original consultation", id: "original-consultation-title", heading_level: 2, mobile_top_margin: true %>
+          <%= render 'govuk_publishing_components/components/heading', {
+            heading_level: 2,
+            id: "original-consultation-title",
+            mobile_top_margin: true,
+            text: "Original consultation",
+          } %>
         </header>
     <% end %>
 
@@ -92,11 +107,18 @@
     <% consultation_desc = capture do %>
       <%= @content_item.description %>
       <% if @content_item.held_on_another_website? %>
-        <br/><br/>
-        <strong>This consultation <% if @content_item.closed? %>was<% else %>is being<% end %> held on <a href="<%= @content_item.held_on_another_website_url %>">another website</a>.</strong>
+        <p class="govuk-!-margin-top-2">
+          <strong>
+            This consultation <% if @content_item.closed? %>was<% else %>is being<% end %> held on <a href="<%= @content_item.held_on_another_website_url %>">another website</a>.
+          </strong>
+        </p>
       <% end %>
     <% end %>
-    <%= render 'components/banner', text: consultation_desc, title: 'Summary', aside: consultation_date %>
+    <%= render 'components/banner', {
+      aside: consultation_date,
+      text: consultation_desc,
+      title: 'Summary',
+    } %>
 
     <% if @content_item.final_outcome? %>
       </section>
@@ -104,8 +126,14 @@
 
 
     <div class="consultation-description">
-      <%= render 'govuk_publishing_components/components/heading', text: "Consultation description", mobile_top_margin: true %>
-      <%= render 'govuk_publishing_components/components/govspeak', @content_item.govspeak_body %>
+      <%= render 'govuk_publishing_components/components/heading', {
+        mobile_top_margin: true,
+        text: "Consultation description",
+      } %>
+
+      <%= render 'govuk_publishing_components/components/govspeak', {} do %>
+        <%= sanitize(@content_item.govspeak_body[:content]) %>
+      <% end %>
 
       <%= render "attachments",
           title: "Documents",
@@ -149,9 +177,11 @@
             <% end %>
           <% end %>
 
-        <%= render 'govuk_publishing_components/components/govspeak',
-          content: @ways_to_respond_body,
-          direction: page_text_direction %>
+        <%= render 'govuk_publishing_components/components/govspeak', {
+          direction: page_text_direction,
+        } do %>
+          <%= sanitize(@ways_to_respond_body) %>
+        <% end %>
       </div>
     <% end %>
 

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -47,7 +47,11 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
         <div class="responsive-bottom-margin">
-          <%= render 'govuk_publishing_components/components/govspeak', content: "#{@content_item.body}#{@additional_body}".html_safe %>
+          <%= render 'govuk_publishing_components/components/govspeak', {} do %>
+            <%= sanitize("#{@content_item.body}#{@additional_body}", {
+              attributes: %w(id href),
+            }) %>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -28,7 +28,10 @@
         margin_top: 0,
         margin_bottom: 6,
       } %>
-      <%= render 'govuk_publishing_components/components/govspeak', @content_item.govspeak_body %>
+
+      <%= render 'govuk_publishing_components/components/govspeak', {} do %>
+        <%= sanitize(@content_item.govspeak_body[:content]) %>
+      <% end %>
 
       <div class="responsive-bottom-margin">
         <%= render 'components/published-dates', {

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -27,9 +27,11 @@
           alt: @content_item.image["alt_text"],
           credit: @content_item.image["credit"],
           caption: @content_item.image["caption"] if @content_item.image %>
-      <%= render 'govuk_publishing_components/components/govspeak',
-          content: @content_item.body.html_safe,
-          direction: page_text_direction %>
+      <%= render 'govuk_publishing_components/components/govspeak', {
+        direction: page_text_direction,
+      } do %>
+        <%= sanitize(@content_item.body) %>
+      <% end %>
     </div>
 
     <%= render 'components/published-dates', {

--- a/app/views/content_items/gone.html.erb
+++ b/app/views/content_items/gone.html.erb
@@ -1,12 +1,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', title: 'The page you\'re looking for is no longer available' %>
+    <%= render "govuk_publishing_components/components/title", {
+      title: "The page you're looking for is no longer available",
+    } %>
 
     <p class="summary">
       The information on this page has been removed because it was published in error.
     </p>
 
-    <%= render 'govuk_publishing_components/components/govspeak', content: raw(@content_item.explanation) %>
+    <%= render "govuk_publishing_components/components/govspeak", {} do %>
+      <%= sanitize(@content_item.explanation) %>
+    <% end %>
 
     <% if @content_item.alternative_path.present? %>
       <p class="alternative">

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -37,10 +37,12 @@
         </h1>
       <% end %>
 
-      <%= render 'govuk_publishing_components/components/govspeak',
-          content: @content_item.current_part_body.html_safe,
-          direction: page_text_direction,
-          disable_youtube_expansions: true %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+        direction: page_text_direction,
+        disable_youtube_expansions: true
+      } do %>
+        <%= sanitize(@content_item.current_part_body) %>
+      <% end %>
 
       <% if @content_item.show_guide_navigation? %>
         <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -57,7 +57,9 @@
   </div>
 
   <div class="main-content-container<% unless @content_item.contents.any? %> offset-empty-contents-list<% end %>">
-    <%= render 'govuk_publishing_components/components/govspeak_html_publication', @content_item.govspeak_body %>
+    <%= render "govuk_publishing_components/components/govspeak_html_publication", {} do %>
+      <%= sanitize(@content_item.govspeak_body[:content]) %>
+    <% end %>
   </div>
 
   <div data-sticky-element class="govuk-sticky-element">

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -26,9 +26,11 @@
           alt: @content_item.image["alt_text"],
           credit: @content_item.image["credit"],
           caption: @content_item.image["caption"] if @content_item.image %>
-      <%= render 'govuk_publishing_components/components/govspeak',
-          content: @content_item.body.html_safe,
-          direction: page_text_direction %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+        direction: page_text_direction,
+      } do %>
+        <%= sanitize(@content_item.body) %>
+      <% end %>
     </div>
 
     <div class="dont-print responsive-bottom-margin">

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -36,13 +36,16 @@
 
 
       <section id="details">
-        <%= render 'govuk_publishing_components/components/heading',
+        <%= render "govuk_publishing_components/components/heading", {
           text: t("publication.details"),
-          mobile_top_margin: true %>
+          mobile_top_margin: true,
+        } %>
 
-        <%= render 'govuk_publishing_components/components/govspeak',
-                   content: @content_item.details.html_safe,
-                   direction: page_text_direction %>
+        <%= render "govuk_publishing_components/components/govspeak", {
+          direction: page_text_direction,
+        } do %>
+          <%= sanitize(@content_item.details) %>
+        <% end %>
       </section>
     </div>
 

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -27,7 +27,9 @@
   <%= render "govuk_publishing_components/components/fieldset", legend_text: legend_text do %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <%= render 'govuk_publishing_components/components/govspeak', content: raw(@content_item.description) %>
+        <%= render 'govuk_publishing_components/components/govspeak', {} do %>
+          <%= sanitize(@content_item.description) %>
+        <% end %>
         <% if @error %>
           <%= render "components/error-message", text: t('service_sign_in.error.option') %>
         <% end %>

--- a/app/views/content_items/service_sign_in/_create_new_account.html.erb
+++ b/app/views/content_items/service_sign_in/_create_new_account.html.erb
@@ -1,6 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', title: @content_item.title %>
-    <%= render 'govuk_publishing_components/components/govspeak', content: @content_item.body.html_safe %>
+    <%= render 'govuk_publishing_components/components/govspeak', {} do %>
+      <% sanitize(@content_item.body) %>
+    <% end %>
   </div>
 </div>

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -34,15 +34,17 @@
       <% end %>
 
       <div class="responsive-bottom-margin">
-        <%= render 'govuk_publishing_components/components/govspeak', @content_item.govspeak_body %>
+        <%= render "govuk_publishing_components/components/govspeak", {} do %>
+          <%= sanitize(@content_item.govspeak_body[:content]) %>
+        <% end %>
+
         <% if @content_item.continuation_link %>
-          <%= render(
-              'govuk_publishing_components/components/button',
-              start: true,
-              href: @content_item.continuation_link,
-              text: "Find out more",
-              info_text: @content_item.will_continue_on
-          ) %>
+          <%= render "govuk_publishing_components/components/button", {
+            href: @content_item.continuation_link,
+            info_text: @content_item.will_continue_on,
+            start: true,
+            text: "Find out more",
+          } %>
         <% end %>
       </div>
 

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -30,9 +30,11 @@
           credit: @content_item.image["credit"],
           caption: @content_item.image["caption"] if @content_item.image %>
 
-      <%= render 'govuk_publishing_components/components/govspeak',
-          content: @content_item.body.html_safe,
-          direction: page_text_direction %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+          direction: page_text_direction,
+        } do %>
+          <%= sanitize(@content_item.body) %>
+        <% end %>
     </div>
 
     <%= render 'components/published-dates', {

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -26,9 +26,12 @@
 
     <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
     <div class="responsive-bottom-margin">
-      <%= render 'govuk_publishing_components/components/govspeak',
-                 content: @content_item.body.html_safe,
-                 direction: page_text_direction %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+        direction: page_text_direction,
+      } do %>
+        <% sanitize(@content_item.body) %>
+      <% end %>
+
     </div>
     <div class="responsive-bottom-margin">
       <%= render 'components/published-dates', {

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -21,9 +21,11 @@
         credit: @content_item.image["credit"],
         caption: @content_item.image["caption"] if @content_item.image %>
 
-    <%= render 'govuk_publishing_components/components/govspeak',
-      content: @content_item.body.html_safe,
-      direction: page_text_direction %>
+    <%= render "govuk_publishing_components/components/govspeak", {
+      direction: page_text_direction
+    } do %>
+      <%= sanitize(@content_item.body) %>
+    <% end %>
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -17,9 +17,11 @@
     <%= render "components/contents-list-with-body", {
       contents: @content_item.contents,
     } do %>
-      <%= render 'govuk_publishing_components/components/govspeak',
-          content: @content_item.body.html_safe,
-          direction: page_text_direction %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+        direction: page_text_direction,
+      } do %>
+        <%= sanitize(@content_item.body) %>
+      <% end %>
     <% end %>
   </div>
   <%= render 'shared/sidebar_navigation' %>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -54,9 +54,11 @@
       <%= render 'shared/travel_advice_summary', content_item: @content_item %>
     <% end %>
 
-    <%= render 'govuk_publishing_components/components/govspeak',
-      content: @content_item.current_part_body.html_safe,
-      direction: page_text_direction %>
+    <%= render 'govuk_publishing_components/components/govspeak', {
+      direction: page_text_direction,
+    } do %>
+      <%= sanitize(@content_item.current_part_body) %>
+    <% end %>
 
     <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
 

--- a/app/views/content_items/unpublishing.html.erb
+++ b/app/views/content_items/unpublishing.html.erb
@@ -6,7 +6,9 @@
       The information on this page has been removed because it was published in error.
     </p>
 
-    <%= render 'govuk_publishing_components/components/govspeak', content: raw(@content_item.explanation) %>
+    <%= render "govuk_publishing_components/components/govspeak", {} do %>
+      <%= sanitize(@content_item.explanation) %>
+    <% end %>
 
     <% if @content_item.alternative_url.present? %>
       <p class="alternative">

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -28,9 +28,16 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
     <%= render 'components/contents-list-with-body', contents: @content_item.contents do %>
-      <%= render 'govuk_publishing_components/components/govspeak',
-            content: "#{@content_item.body} #{@additional_body}".html_safe,
-            direction: page_text_direction %>
+      <%= render 'govuk_publishing_components/components/govspeak', {
+        direction: page_text_direction,
+      } do %>
+        <%= sanitize(@content_item.body, {
+          attributes: %w(id class href),
+        }) %>
+        <%= sanitize(@additional_body, {
+          attributes: %w(id class href),
+        }) %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -27,9 +27,11 @@
           credit: @content_item.image["credit"],
           caption: @content_item.image["caption"] if @content_item.image %>
 
-      <%= render 'govuk_publishing_components/components/govspeak',
-        content: @content_item.body.html_safe,
-        direction: page_text_direction %>
+      <%= render 'govuk_publishing_components/components/govspeak', {
+        direction: page_text_direction,
+      } do %>
+        <%= sanitize(@content_item.body) %>
+      <% end %>
     </div>
 
     <div class="dont-print responsive-bottom-margin">

--- a/app/views/shared/_travel_advice_summary.html.erb
+++ b/app/views/shared/_travel_advice_summary.html.erb
@@ -1,12 +1,11 @@
 <% if content_item.alert_status.present? %>
-  <% alert_body = capture do %>
+  <%= render 'govuk_publishing_components/components/govspeak', {
+    direction: page_text_direction,
+  } do %>
     <div class="help-notice">
-      <%= content_item.alert_status %>
+      <%= sanitize(content_item.alert_status) %>
     </div>
   <% end %>
-  <%= render 'govuk_publishing_components/components/govspeak',
-      content: alert_body,
-      direction: page_text_direction %>
 <% end %>
 
 <%= render 'govuk_publishing_components/components/metadata', content_item.metadata %>


### PR DESCRIPTION
## What

This updates the way Govspeak wraps content.

Templates updated:

* world location news article - [live](https://gov.uk/government/news/changes-to-secure-english-language-test-providers-for-uk-visas) - [dev](http://government-frontend.dev.gov.uk/government/news/changes-to-secure-english-language-test-providers-for-uk-visas)
* working group - [live](https://gov.uk/government/groups/abstraction-reform) - [dev](http://government-frontend.dev.gov.uk/government/groups/abstraction-reform)
* unpublishing - [live](https://www.gov.uk/government/publications/foi-03274-cost-of-advertising-on-social-media) - [dev](http://government-frontend.dev.gov.uk/publications/foi-03274-cost-of-advertising-on-social-media)
* gone - seems to be the same as unpublishing?
* travel advice - [live](https://gov.uk/foreign-travel-advice/nepal) - [dev](http://government-frontend.dev.gov.uk/foreign-travel-advice/nepal)
* topical event about - [live](https://gov.uk/government/topical-events/2014-overseas-territories-joint-ministerial-council/about) - [dev](http://government-frontend.dev.gov.uk/government/topical-events/2014-overseas-territories-joint-ministerial-council/about)
* take part - [live](https://gov.uk/government/get-involved/take-part/become-a-councillor) - [dev](http://government-frontend.dev.gov.uk/government/get-involved/take-part/become-a-councillor)
* statistical data set - [live](https://gov.uk/government/statistical-data-sets/unclaimed-estates-list) - [dev](http://government-frontend.dev.gov.uk/government/statistical-data-sets/unclaimed-estates-list)
* speech - [live](https://gov.uk/government/speeches/government-at-your-service-ben-gummer-speech) - [dev](http://government-frontend.dev.gov.uk/government/speeches/government-at-your-service-ben-gummer-speech)
* specialist document - [live](https://gov.uk/business-finance-support/access-to-finance-advice-north-west-england) - [dev](http://government-frontend.dev.gov.uk/business-finance-support/access-to-finance-advice-north-west-england)
* publication - [live](https://gov.uk/government/publications/budget-2016-documents) - [dev](http://government-frontend.dev.gov.uk/government/publications/budget-2016-documents)
* news article - [live](https://gov.uk/government/news/the-personal-independence-payment-amendment-regulations-2017-statement-by-paul-gray) - [dev](http://government-frontend.dev.gov.uk/government/news/the-personal-independence-payment-amendment-regulations-2017-statement-by-paul-gray)
* HTML publications - [live](https://gov.uk/government/publications/budget-2016-documents/budget-2016) - [dev](http://government-frontend.dev.gov.uk/government/publications/budget-2016-documents/budget-2016)
* guide - [live](https://gov.uk/guidance/waste-exemption-nwfd-2-temporary-storage-at-the-place-of-production--2) - [dev](http://government-frontend.dev.gov.uk/guidance/waste-exemption-nwfd-2-temporary-storage-at-the-place-of-production--2)
* fatality notice - [live](https://gov.uk/government/fatalities/corporal-lee-churcher-dies-in-iraq) - [dev](http://government-frontend.dev.gov.uk/government/fatalities/corporal-lee-churcher-dies-in-iraq)
* detailed guide - [live](https://gov.uk/guidance/waste-exemption-nwfd-2-temporary-storage-at-the-place-of-production--2) - [dev](http://government-frontend.dev.gov.uk/guidance/waste-exemption-nwfd-2-temporary-storage-at-the-place-of-production--2)
* corporate info page - [live](https://gov.uk/government/organisations/government-digital-service/about) - [dev](http://government-frontend.dev.gov.uk/government/organisations/government-digital-service/about)
* consultation - [live](https://gov.uk/government/consultations/soft-drinks-industry-levy) - [dev](http://government-frontend.dev.gov.uk/government/consultations/soft-drinks-industry-levy)
* case study - [live](https://gov.uk/government/case-studies/2013-elections-in-swaziland) - [dev](http://government-frontend.dev.gov.uk/government/case-studies/2013-elections-in-swaziland)
* news article - [live](https://gov.uk) - [dev](http://government-frontend.dev.gov.uk)
* HTML publications - [live](https://gov.uk) - [dev](http://government-frontend.dev.gov.uk)
* guide - [live](https://gov.uk) - [dev](http://government-frontend.dev.gov.uk)
* fatality notice - [live](https://gov.uk) - [dev](http://government-frontend.dev.gov.uk)
* detailed guide - [live](https://gov.uk) - [dev](http://government-frontend.dev.gov.uk)
* corporate info page - [live](https://gov.uk) - [dev](http://government-frontend.dev.gov.uk)
* consultation - [live](https://gov.uk) - [dev](http://government-frontend.dev.gov.uk)
* case study - [live](https://gov.uk) - [dev](http://government-frontend.dev.gov.uk)

## Why

The previous method of adding content to Govspeak - using the `content` attribute - is being deprecated in favour of using `do` blocks with sanitized markup. See https://github.com/alphagov/govuk_publishing_components/pull/1632 for more details.

## Visual changes

None.

---

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
