### PR TITLE
Add print link to detailed guides

### DIFF
--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -56,6 +56,12 @@
     display: none;
   }
 
+  .govuk-sticky-element {
+    .govuk-sticky-element__print-link {
+      margin-left: govuk-spacing(3);
+    }
+  }
+
   @include govuk-media-query($until: desktop) {
     .govuk-sticky-element--enabled {
       position: static;

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -24,6 +24,10 @@
     <%= render 'components/important-metadata', items: @content_item.important_metadata %>
 
     <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
+      <%= render "govuk_publishing_components/components/print_link", {
+        margin_top: 0,
+        margin_bottom: 6,
+      } %>
       <%= render 'govuk_publishing_components/components/govspeak', @content_item.govspeak_body %>
 
       <div class="responsive-bottom-margin">
@@ -34,6 +38,10 @@
           } %>
       </div>
     <% end %>
+    <%= render "govuk_publishing_components/components/print_link", {
+        margin_top: 0,
+        margin_bottom: 6,
+      } %>
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -43,6 +43,10 @@
   <% if @content_item.contents.any? %>
     <div class="govuk-grid-column-one-quarter-from-desktop contents-list-container">
       <%= render 'govuk_publishing_components/components/contents_list', contents: @content_item.contents, format_numbers: true %>
+      <%= render "govuk_publishing_components/components/print_link", {
+        margin_top: 0,
+        margin_bottom: 6,
+      } %>
     </div>
   <% end %>
 
@@ -58,5 +62,11 @@
 
   <div data-sticky-element class="govuk-sticky-element">
     <%= render 'components/back-to-top', href: "#contents" %>
+    <div class="govuk-sticky-element__print-link">
+      <%= render "govuk_publishing_components/components/print_link", {
+          margin_top: 0,
+          margin_bottom: 6,
+        } %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
# What
Adds print link to detailed guides
    
# Why
User research found that users were not clear on how to print pages.
    
https://trello.com/c/zSFv4dxR/497-add-the-print-button-to-c19-pages-that-dont-have-it

# Demo
- Detailed guide: https://government-f-add-print--e2mbxk.herokuapp.com/guidance/coronavirus-covid-19-information-for-the-public
- HTML publications: https://government-f-add-print--e2mbxk.herokuapp.com/government/publications/wuhan-novel-coronavirus-infection-prevention-and-control/updates-to-the-infection-prevention-and-control-guidance-for-covid-19

# Before

## Top
![Screenshot 2020-10-27 at 15 26 07](https://user-images.githubusercontent.com/4599889/97323583-dc806700-1868-11eb-9967-787b024ead7c.png)

## Bottom
![Screenshot 2020-10-27 at 15 26 21](https://user-images.githubusercontent.com/4599889/97323608-e2764800-1868-11eb-8bfe-d6508f27d1f1.png)


# After

## Top

![Screenshot 2020-10-27 at 15 26 13](https://user-images.githubusercontent.com/4599889/97323629-e73afc00-1868-11eb-8ca3-a2fdb4b8843a.png)

## Bottom
![Screenshot 2020-10-27 at 15 26 26](https://user-images.githubusercontent.com/4599889/97323632-e73afc00-1868-11eb-82b6-badb426b75b9.png)



--- 
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
