### PR TITLE
Swap sanitize for raw when used in Govspeak component

### DIFF
--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -13,7 +13,7 @@
       direction: page_text_direction,
       disable_youtube_expansions: true,
     } do %>
-      <%= sanitize(@content_item.body) %>
+      <%= raw(@content_item.body) %>
     <% end %>
 
     <% if @content_item.last_updated && @content_item.schema_name == "help_page" %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -30,7 +30,7 @@
       } %>
 
       <%= render 'govuk_publishing_components/components/govspeak', {} do %>
-        <%= sanitize(@content_item.govspeak_body[:content]) %>
+        <%= raw(@content_item.govspeak_body[:content]) %>
       <% end %>
 
       <div class="responsive-bottom-margin">


### PR DESCRIPTION
## What
Replaces `sanitise` with `raw` in detailed guide template.

## Why 

The `sanitize` method was stripping out tables for reasons. But using `sanitize`s allow list meant listing most of the HTML elements, and introducing a risk of further breakages if a element is accidently left out of the allow list - so using `raw` was the least worst compromise between fixing this now, fixing this in the future, and security.

## Visual differences

Before:

![image](https://user-images.githubusercontent.com/1732331/97883328-a174ac80-1d1c-11eb-9a3f-0923ab0df680.png)

After:

![image](https://user-images.githubusercontent.com/1732331/97883436-c832e300-1d1c-11eb-92e8-b5c0bf653d42.png)


---

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
