### PR TITLE
Swap sanitize for raw when used in Govspeak component

### DIFF
--- a/app/views/content_items/_document_collection_body.html.erb
+++ b/app/views/content_items/_document_collection_body.html.erb
@@ -9,7 +9,7 @@
     <%= render 'govuk_publishing_components/components/govspeak', {
         direction: page_text_direction,
       } do %>
-      <%= sanitize(group["body"]) %>
+      <%= raw(group["body"]) %>
     <% end %>
   <% end %>
 

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -30,7 +30,7 @@
       <%= render 'govuk_publishing_components/components/govspeak', {
         direction: page_text_direction,
       } do %>
-        <%= sanitize(@content_item.body) %>
+        <%= raw(@content_item.body) %>
       <% end %>
     </div>
 

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -53,7 +53,7 @@
         <%= render 'govuk_publishing_components/components/govspeak', {
           direction: page_text_direction,
         } do %>
-          <%= sanitize(@content_item.final_outcome_detail) %>
+          <%= raw(@content_item.final_outcome_detail) %>
         <% end %>
       </div>
     <% end %>
@@ -72,7 +72,7 @@
         <%= render 'govuk_publishing_components/components/govspeak', {
           direction: page_text_direction,
         } do %>
-          <%= sanitize(@content_item.public_feedback_detail) %>
+          <%= raw(@content_item.public_feedback_detail) %>
         <% end %>
       </div>
     <% end %>
@@ -132,7 +132,7 @@
       } %>
 
       <%= render 'govuk_publishing_components/components/govspeak', {} do %>
-        <%= sanitize(@content_item.govspeak_body[:content]) %>
+        <%= raw(@content_item.govspeak_body[:content]) %>
       <% end %>
 
       <%= render "attachments",
@@ -180,7 +180,7 @@
         <%= render 'govuk_publishing_components/components/govspeak', {
           direction: page_text_direction,
         } do %>
-          <%= sanitize(@ways_to_respond_body) %>
+          <%= raw(@ways_to_respond_body) %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -48,9 +48,8 @@
       <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
         <div class="responsive-bottom-margin">
           <%= render 'govuk_publishing_components/components/govspeak', {} do %>
-            <%= sanitize("#{@content_item.body}#{@additional_body}", {
-              attributes: %w(id href),
-            }) %>
+            <%= raw(@content_item.body) %>
+            <%= raw(@additional_body) %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -30,7 +30,7 @@
       } %>
 
       <%= render 'govuk_publishing_components/components/govspeak', {} do %>
-        <%= sanitize(@content_item.govspeak_body[:content]) %>
+        <%= raw(@content_item.govspeak_body[:content]) %>
       <% end %>
 
       <div class="responsive-bottom-margin">

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -30,7 +30,7 @@
       <%= render 'govuk_publishing_components/components/govspeak', {
         direction: page_text_direction,
       } do %>
-        <%= sanitize(@content_item.body) %>
+        <%= raw(@content_item.body) %>
       <% end %>
     </div>
 

--- a/app/views/content_items/gone.html.erb
+++ b/app/views/content_items/gone.html.erb
@@ -9,7 +9,7 @@
     </p>
 
     <%= render "govuk_publishing_components/components/govspeak", {} do %>
-      <%= sanitize(@content_item.explanation) %>
+      <%= raw(@content_item.explanation) %>
     <% end %>
 
     <% if @content_item.alternative_path.present? %>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -41,7 +41,7 @@
         direction: page_text_direction,
         disable_youtube_expansions: true
       } do %>
-        <%= sanitize(@content_item.current_part_body) %>
+        <%= raw(@content_item.current_part_body) %>
       <% end %>
 
       <% if @content_item.show_guide_navigation? %>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -58,7 +58,7 @@
 
   <div class="main-content-container<% unless @content_item.contents.any? %> offset-empty-contents-list<% end %>">
     <%= render "govuk_publishing_components/components/govspeak_html_publication", {} do %>
-      <%= sanitize(@content_item.govspeak_body[:content]) %>
+      <%= raw(@content_item.govspeak_body[:content]) %>
     <% end %>
   </div>
 

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -29,7 +29,7 @@
       <%= render "govuk_publishing_components/components/govspeak", {
         direction: page_text_direction,
       } do %>
-        <%= sanitize(@content_item.body) %>
+        <%= raw(@content_item.body) %>
       <% end %>
     </div>
 

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -44,7 +44,7 @@
         <%= render "govuk_publishing_components/components/govspeak", {
           direction: page_text_direction,
         } do %>
-          <%= sanitize(@content_item.details) %>
+          <%= raw(@content_item.details) %>
         <% end %>
       </section>
     </div>

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -28,7 +28,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= render 'govuk_publishing_components/components/govspeak', {} do %>
-          <%= sanitize(@content_item.description) %>
+          <%= raw(@content_item.description) %>
         <% end %>
         <% if @error %>
           <%= render "components/error-message", text: t('service_sign_in.error.option') %>

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -35,7 +35,7 @@
 
       <div class="responsive-bottom-margin">
         <%= render "govuk_publishing_components/components/govspeak", {} do %>
-          <%= sanitize(@content_item.govspeak_body[:content]) %>
+          <%= raw(@content_item.govspeak_body[:content]) %>
         <% end %>
 
         <% if @content_item.continuation_link %>

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -33,7 +33,7 @@
       <%= render "govuk_publishing_components/components/govspeak", {
           direction: page_text_direction,
         } do %>
-          <%= sanitize(@content_item.body) %>
+          <%= raw(@content_item.body) %>
         <% end %>
     </div>
 

--- a/app/views/content_items/take_part.html.erb
+++ b/app/views/content_items/take_part.html.erb
@@ -24,7 +24,7 @@
     <%= render "govuk_publishing_components/components/govspeak", {
       direction: page_text_direction
     } do %>
-      <%= sanitize(@content_item.body) %>
+      <%= raw(@content_item.body) %>
     <% end %>
   </div>
   <%= render 'shared/sidebar_navigation' %>

--- a/app/views/content_items/topical_event_about_page.html.erb
+++ b/app/views/content_items/topical_event_about_page.html.erb
@@ -20,7 +20,7 @@
       <%= render "govuk_publishing_components/components/govspeak", {
         direction: page_text_direction,
       } do %>
-        <%= sanitize(@content_item.body) %>
+        <%= raw(@content_item.body) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -57,7 +57,7 @@
     <%= render 'govuk_publishing_components/components/govspeak', {
       direction: page_text_direction,
     } do %>
-      <%= sanitize(@content_item.current_part_body) %>
+      <%= raw(@content_item.current_part_body) %>
     <% end %>
 
     <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>

--- a/app/views/content_items/unpublishing.html.erb
+++ b/app/views/content_items/unpublishing.html.erb
@@ -7,7 +7,7 @@
     </p>
 
     <%= render "govuk_publishing_components/components/govspeak", {} do %>
-      <%= sanitize(@content_item.explanation) %>
+      <%= raw(@content_item.explanation) %>
     <% end %>
 
     <% if @content_item.alternative_url.present? %>

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -31,12 +31,8 @@
       <%= render 'govuk_publishing_components/components/govspeak', {
         direction: page_text_direction,
       } do %>
-        <%= sanitize(@content_item.body, {
-          attributes: %w(id class href),
-        }) %>
-        <%= sanitize(@additional_body, {
-          attributes: %w(id class href),
-        }) %>
+        <%= raw(@content_item.body) %>
+        <%= raw(@additional_body) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/content_items/world_location_news_article.html.erb
+++ b/app/views/content_items/world_location_news_article.html.erb
@@ -30,7 +30,7 @@
       <%= render 'govuk_publishing_components/components/govspeak', {
         direction: page_text_direction,
       } do %>
-        <%= sanitize(@content_item.body) %>
+        <%= raw(@content_item.body) %>
       <% end %>
     </div>
 

--- a/app/views/shared/_travel_advice_summary.html.erb
+++ b/app/views/shared/_travel_advice_summary.html.erb
@@ -3,7 +3,7 @@
     direction: page_text_direction,
   } do %>
     <div class="help-notice">
-      <%= sanitize(content_item.alert_status) %>
+      <%= raw(content_item.alert_status) %>
     </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
## What 

Replaces the `sanitize` method with the `raw` method when using in the Govspeak component.

## Why

The `sanitize` method is stripping out too much and breaking things - swapping it for `raw` (which stringifies and uses the `html_safe` method) fixes this. This will need a more secure fix in the future.

## Visual differences

Tables before:

![image](https://user-images.githubusercontent.com/1732331/97888155-b7856b80-1d22-11eb-90fd-8f863713a8d6.png)

Tables after:

![image](https://user-images.githubusercontent.com/1732331/97888123-ab011300-1d22-11eb-8e0e-80b56257d2d9.png)

---

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
