### PR TITLE
Add Webchat to `hm-passport-office-webchat page`

### DIFF
--- a/lib/webchat.yaml
+++ b/lib/webchat.yaml
@@ -6,3 +6,7 @@
   open_url: https://hmpowebchat.klick2contact.com/v03/launcherV3.php?p=HMPO&d=717&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Chat&s=https://hmpowebchat.klick2contact.com/v03&u=&wo=&uh=&pid=2&iif=0
   availability_url: https://hmpowebchat.klick2contact.com/v03/providers/HMPO/api/availability.php
   open_url_redirect: false
+- base_path: /government/organisations/hm-passport-office/contact/hm-passport-office-webchat
+  open_url: https://hmpowebchat.klick2contact.com/v03/launcherV3.php?p=HMPO&d=717&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Chat&s=https://hmpowebchat.klick2contact.com/v03&u=&wo=&uh=&pid=2&iif=0
+  availability_url: https://hmpowebchat.klick2contact.com/v03/providers/HMPO/api/availability.php
+  open_url_redirect: false


### PR DESCRIPTION
Trello: https://trello.com/c/qawZD9QE

# What?

Update the YAML file for HMPO - add webchat to a new page
https://github.com/alphagov/government-frontend/blob/master/lib/webchat.yaml

Adds this page as a base_path:
https://www.gov.uk/government/organisations/hm-passport-office/contact/hm-passport-office-webchat

With the same values for open_url, availability_url and
open_url_redirect

# Why?

The above change will add a webchat page which will be linked to from
https://www.gov.uk/passport-advice-line.

This retitles and will replace the existing page as they were getting a
number of people thinking it was an HMRC page.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
