### PR TITLE
Update the Wales link on travel advice call out

### DIFF
--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -26,7 +26,7 @@
       </div>
       <div class="travel-advice-notice__content">
         <p class="govuk-body">
-          <strong>From 5 November to 2 December 2020, travelling away from home, including internationally, is restricted from <a href="/guidance/new-national-restrictions-from-5-november">England</a> except in limited circumstances such as for work or for education.</strong> Different rules apply in <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/coronavirus-firebreak-frequently-asked-questions">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>. You must follow all the rules that apply to you.
+          <strong>From 5 November to 2 December 2020, travelling away from home, including internationally, is restricted from <a href="/guidance/new-national-restrictions-from-5-november">England</a> except in limited circumstances such as for work or for education.</strong> Different rules apply in <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/local-lockdown">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>. You must follow all the rules that apply to you.
         </p>
         <p class="govuk-body">
           <strong>The Foreign, Commonwealth &amp; Development Office (FCDO) provides guidance on COVID and non-COVID risks overseas. The FCDO currently advises against all but essential travel to many countries and territories on the basis of COVID risks.</strong> You should check the <a href="/foreign-travel-advice">travel advice</a> for your destination.


### PR DESCRIPTION
Trello: https://trello.com/c/iS4WvL1j

Updates the link to Wales restrictions on pages like https://www.gov.uk/foreign-travel-advice/cuba

We changed the link for wales information to:
https://gov.wales/coronavirus-firebreak-frequently-asked-questions

We should change it back to https://gov.wales/local-lockdown

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
