### PR TITLE
allow tracking attributes to be rendered when sanitized

### DIFF
--- a/app/views/content_items/_attachments.html.erb
+++ b/app/views/content_items/_attachments.html.erb
@@ -9,7 +9,7 @@
         direction: page_text_direction,
       } do %>
         <%= sanitize(legacy_pre_rendered_documents, {
-          attributes: %w(alt class data-module href id src),
+          attributes: %w(alt class href id src data-module data-track-category data-track-action data-track-label data-track-options data-details-track-click),
           tags: %w(a details div h2 img p section span summary),
         }) %>
       <% end %>


### PR DESCRIPTION
# What

Allows tracking attributes to be rendered when sanitized

# Why

This will allow us to track detail summary component

https://trello.com/c/3U1QEEK1/584-add-event-tracking-to-track-how-many-times-request-accessible-format-is-clicked