### PR TITLE
Use heading level 3 for attachments

### DIFF
--- a/app/views/content_items/_attachments.html.erb
+++ b/app/views/content_items/_attachments.html.erb
@@ -10,7 +10,7 @@
       } do %>
         <%= sanitize(legacy_pre_rendered_documents, {
           attributes: %w(alt class href id src data-module data-track-category data-track-action data-track-label data-track-options data-details-track-click),
-          tags: %w(a details div h3 img p section span summary),
+          tags: %w(a details div h2 h3 img p section span summary),
         }) %>
       <% end %>
     <% else %>

--- a/app/views/content_items/_attachments.html.erb
+++ b/app/views/content_items/_attachments.html.erb
@@ -16,8 +16,10 @@
     <% else %>
       <% attachments.each do |attachment_id| %>
         <div class="attachment">
-          <%= render 'govuk_publishing_components/components/attachment',
-              attachment: @content_item.attachment_details(attachment_id) %>
+          <%= render 'govuk_publishing_components/components/attachment', {
+            heading_level: 3,
+            attachment: @content_item.attachment_details(attachment_id)
+          } %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/content_items/_attachments.html.erb
+++ b/app/views/content_items/_attachments.html.erb
@@ -10,7 +10,7 @@
       } do %>
         <%= sanitize(legacy_pre_rendered_documents, {
           attributes: %w(alt class href id src data-module data-track-category data-track-action data-track-label data-track-options data-details-track-click),
-          tags: %w(a details div h2 img p section span summary),
+          tags: %w(a details div h3 img p section span summary),
         }) %>
       <% end %>
     <% else %>


### PR DESCRIPTION
Attachments are currently hard coded to use `h2` which isn't very flexible. The attachment component is often used as a child of a section of a page, in which case the heading level of the component should be adjusted to reflect the hierarchy of the content.

There is already a `h2`  in `app/views/content_items/_attachments.html.erb` –  it does not make sense that the attachments have the same heading level as their parent. This specifies that they use `h3` instead.


Related PRs:
- [adds the ability to override default heading level in attachment component](https://github.com/alphagov/govuk_publishing_components/pull/1781) 
- [changes the heading level of pre-rendered legacy attachments from Whitehall](https://github.com/alphagov/whitehall/pull/5885)



https://trello.com/c/KzyicaBh/491-publications-confusing-heading-structure 


-----


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
