### PR TITLE
Remove hidden "Share on" from share links text

### DIFF
--- a/app/presenters/content_item/shareable.rb
+++ b/app/presenters/content_item/shareable.rb
@@ -6,12 +6,12 @@ module ContentItem
       [
         {
           href: facebook_share_url,
-          text: '<span class="visually-hidden">Share on </span>Facebook'.html_safe,
+          text: "Facebook",
           icon: "facebook",
         },
         {
           href: twitter_share_url,
-          text: '<span class="visually-hidden">Share on </span>Twitter'.html_safe,
+          text: "Twitter",
           icon: "twitter",
         },
       ]

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -154,7 +154,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
 
   test "share urls" do
     setup_and_visit_content_item("open_consultation")
-    assert page.has_css?("a", text: "Share on Facebook")
-    assert page.has_css?("a", text: "Share on Twitter")
+    assert page.has_css?("a", text: "Facebook")
+    assert page.has_css?("a", text: "Twitter")
   end
 end


### PR DESCRIPTION
The [share links component](https://components.publishing.service.gov.uk/component-guide/share_links) has  "Share on" as visually hidden text by default.
This helps AT users make sense of the links (ie "Share on Facebook" makes more sense than just "Facebook").

It looks like `government-frontend` is also adding a hidden "Share on" as part of the share links text. This is causing an issue where hidden content is being repeated e.g. "Share on Share on Facebook". 

<img width="1131" alt="Screenshot 2020-11-17 at 17 56 27" src="https://user-images.githubusercontent.com/7116819/99428337-6a96bd00-28fe-11eb-8810-3527df4e097c.png">

https://trello.com/c/shAQ6AQu/460-social-media-links-repeat-hidden-content-bug

----------

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
