### PR TITLE
Fix corporate information pages error

### DIFF
--- a/app/presenters/content_item/corporate_information_groups.rb
+++ b/app/presenters/content_item/corporate_information_groups.rb
@@ -61,15 +61,14 @@ module ContentItem
     end
 
     def normalised_group_links(group)
-      group["contents"].map do |group_item|
-        normalised_group_item_link(group_item)
-      end
+      group["contents"].map { |group_item| normalised_group_item_link(group_item) }.compact
     end
 
     def normalised_group_item_link(group_item)
       if group_item.is_a?(String)
         group_item_link = corporate_information_page_links.find { |l| l["content_id"] == group_item }
-        view_context.link_to(group_item_link["title"], group_item_link["base_path"])
+        # it's possible for corporation_information_groups in details and links hashes to be out of sync.
+        view_context.link_to(group_item_link["title"], group_item_link["base_path"]) if group_item_link
       else
         view_context.link_to(group_item["title"], group_item["path"] || group_item["url"])
       end


### PR DESCRIPTION
Some [corporate information pages](https://www.gov.uk/government/organisations/migration-advisory-committee/about) are erroring because the list of IDs in corporate information groups in the  details hash doesn't match the list of linked corporate information pages in the links hash.

Even if they do eventually resolve, these two lists will occasionally be out of sync when they're updated because of the way our publishing system works. We should defend against this so it doesn't error.

Resolves this [sentry error](https://sentry.io/organizations/govuk/issues/1813208304/?environment=production&project=202226&query=is%3Aunresolved&statsPeriod=14d)

Compare:
- [before](http://government-frontend.herokuapp.com/government/organisations/migration-advisory-committee/about)
- [after](http://government-f-fix-corp-i-nqpdno.herokuapp.com/government/organisations/migration-advisory-committee/about)


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
