### PR TITLE
Allow aria-hidden attribute so icons are hidden from screenreaders

### DIFF
--- a/app/views/content_items/_attachments.html.erb
+++ b/app/views/content_items/_attachments.html.erb
@@ -9,7 +9,7 @@
         direction: page_text_direction,
       } do %>
         <%= sanitize(legacy_pre_rendered_documents, {
-          attributes: %w(alt class href id src data-module data-track-category data-track-action data-track-label data-track-options data-details-track-click),
+          attributes: %w(alt class href id src data-module data-track-category data-track-action data-track-label data-track-options data-details-track-click aria-hidden),
           tags: %w(a details div h2 h3 img p section span summary),
         }) %>
       <% end %>


### PR DESCRIPTION
A user on basecamp recently reported confusing navigation around attachments where they were hearing numbers as part of the link. This turned out to be due to Jaws reading out the filename of the attachments as the aria-hidden attribute is being sanitized out of the duplicate thumbnail link. This adds aria-hidden to the allow list to prevent that.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/government-frontend), after merging.
