### PR TITLE
Don't sort facets by type

### DIFF
--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -128,7 +128,7 @@ private
   end
 
   def facets_with_friendly_values
-    sorted_facets_with_values.map do |facet|
+    facets_with_values.map do |facet|
       facet_key = facet["key"]
       # Cast all values into an array
       values = [facet_values[facet_key]].flatten
@@ -146,14 +146,13 @@ private
     end
   end
 
-  def sorted_facets_with_values
+  def facets_with_values
     return [] unless facets && facet_values.any?
 
     facets
       .select { |f| facet_values[f["key"]] && facet_values[f["key"]].present? }
       .reject { |f| f["key"] == first_published_at_facet_key }
       .reject { |f| f["key"] == internal_notes_facet_key }
-      .sort_by { |f| f["type"] }
   end
 
   def friendly_facet_date(dates)

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -295,40 +295,6 @@ class SpecialistDocumentPresenterTest
       assert_equal "1 January 2010", presented_metadata["Facet name"]
     end
 
-    test "puts date facets together and before text facets" do
-      example = example_with_finder_facets(
-        [
-          {
-            "name" => "Facet name",
-            "key" => "facet-key",
-            "type" => "text",
-          },
-          {
-            "name" => "First date facet",
-            "key" => "first-date-facet",
-            "type" => "date",
-          },
-          {
-            "name" => "Second date facet",
-            "key" => "second-date-facet",
-            "type" => "date",
-          },
-          {
-            "name" => "More text",
-            "key" => "more-text",
-            "type" => "text",
-          },
-        ],
-        "facet-key" => "Text",
-        "first-date-facet" => "2010-01-01",
-        "second-date-facet" => "2010-02-03",
-        "more-text" => "More text",
-      )
-
-      expected_order = ["First date facet", "Second date facet", "Facet name", "More text"]
-      assert_equal expected_order, present_example(example).important_metadata.keys
-    end
-
     test "sends an error notification when there is no finder" do
       example = schema_item("aaib-reports")
       example["links"]["finder"] = []


### PR DESCRIPTION
This behaviour is slightly confusing because it re-orders the facets that are already in a defined order in Specialist Publisher. This means that content designers might be expecting the order in a certain way and then when it gets to the frontend the ordering is different.

A very clear example of this is if you had three facets, one `date`, one `text` and one `time`. In the finder the facets might be ordered such that you have the date, the time and then the text field.

However this code will re-order that so you end up with the date and time field separated by the text field in between them.

This change was added in 4f0f5a63b9127717bc738ac1375ef80f853979f5 but I would argue that a better solution is to avoid having this sort of logic in the frontend app and instead make it such that the publishing app decides the ordering of the fields. This means we can ensure that the fields in Specialist Publisher show up in the same order as on the frontend. We've recently been dealing with a department and there was some confusion over this because the order they were seeing in Specialist Publisher (which was the order they wanted) was not the order they saw when previewing their documents.

I've checked the other Specialist Finders and we won't negatively affect any of the existing ones, the dates will always be grouped together, but some of them may now appear at the bottom of the blue box instead of the top. But then again, this is now consistent with the ordering of the facets in the finder itself.

[Trello Card](https://trello.com/c/M4sHqWcA/2268-dont-re-order-metadata-of-specialist-documents)