### PR TITLE
Add filter to prevent empty image tags from rendering in figures

### DIFF
--- a/app/views/components/_figure.html.erb
+++ b/app/views/components/_figure.html.erb
@@ -4,20 +4,19 @@
   credit ||= ''
 %>
 <figure class="app-c-figure" lang="en">
-    <% unless src.blank? %>
-      <img class="app-c-figure__image" src="<%= src %>" alt="<%= alt %>">
+  <% if src.present? %>
+    <img class="app-c-figure__image" src="<%= src %>" alt="<%= alt %>">
+  <% end %>
+  <figcaption class="app-c-figure__figcaption">
+    <% if caption.present? %>
+      <p class="app-c-figure__figcaption-text">
+        <%= caption %>
+      </p>
     <% end %>
-    <figcaption class="app-c-figure__figcaption">
-      <% unless caption.blank? %>
-        <p class="app-c-figure__figcaption-text">
-          <%= caption %>
+    <% if credit.present? %>
+        <p class="app-c-figure__figcaption-credit">
+          <%= I18n.t("components.figure.image_credit", credit: credit) %>
         </p>
-      <% end %>
-
-      <% if credit.present? %>
-          <p class="app-c-figure__figcaption-credit">
-            <%= I18n.t("components.figure.image_credit", credit: credit) %>
-          </p>
-      <% end %>
-    </figcaption>
+    <% end %>
+  </figcaption>
 </figure>

--- a/app/views/components/_figure.html.erb
+++ b/app/views/components/_figure.html.erb
@@ -4,7 +4,9 @@
   credit ||= ''
 %>
 <figure class="app-c-figure" lang="en">
-  <img class="app-c-figure__image" src="<%= src %>" alt="<%= alt %>">
+    <% unless src.blank? %>
+      <img class="app-c-figure__image" src="<%= src %>" alt="<%= alt %>">
+    <% end %>
     <figcaption class="app-c-figure__figcaption">
       <% unless caption.blank? %>
         <p class="app-c-figure__figcaption-text">

--- a/test/components/figure_test.rb
+++ b/test/components/figure_test.rb
@@ -11,6 +11,11 @@ class FigureTest < ComponentTestCase
     end
   end
 
+  test "fails to render an image when no source is given" do
+    render_component(src: "", alt: "")
+    assert_select "img", false, "Should not have drawn img tag with no src"
+  end
+
   test "renders a figure correctly" do
     render_component(src: "/image", alt: "image alt text")
     assert_select ".app-c-figure__image[src=\"/image\"]"


### PR DESCRIPTION
Previously if the image source was missing the tag would still render.
This was fine in many browsers but caused a big empty space in IE.
This pull request should fix that issue.

Zendesk: https://govuk.zendesk.com/agent/tickets/4391436

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
