### PR TITLE
Add support for briefing

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -117,7 +117,13 @@ private
   end
 
   def content_item_template
+    return "briefing" if is_briefing?
+
     @content_item.schema_name
+  end
+
+  def is_briefing?
+    @content_item.content_id == "3d66e959-72d2-417d-89c1-00cd72eea30f"
   end
 
   def render_template

--- a/app/views/content_items/briefing.html.erb
+++ b/app/views/content_items/briefing.html.erb
@@ -1,0 +1,28 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'govuk_publishing_components/components/title', title: @content_item.title %>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds content-bottom-margin">
+    <div class="responsive-bottom-margin">
+      <%= render "govuk_publishing_components/components/govspeak", {
+        direction: page_text_direction,
+      } do %>
+        <%= raw(@content_item.body) %>
+      <% end %>
+    </div>
+
+    <div class="dont-print responsive-bottom-margin">
+      <%= render 'govuk_publishing_components/components/share_links',
+        links: @content_item.share_links,
+        track_as_sharing: true,
+        title: t('components.share_links.share_this_page')
+      %>
+    </div>
+  </div>
+</div>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -366,6 +366,25 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_equal response.headers["Access-Control-Allow-Origin"], "*"
   end
 
+  test "renders briefing view correctly" do
+    content_item = content_store_has_schema_example("news_article", "news_article")
+    content_item["content_id"] = "3d66e959-72d2-417d-89c1-00cd72eea30f"
+    stub_content_store_has_item(content_item["base_path"], content_item)
+
+    get :show, params: { path: path_for(content_item) }
+    assert_response :success
+    assert_select ".gem-c-title", content_item["title"]
+    assert_select ".gem-c-lead-paragraph", content_item["description"]
+    assert_select ".gem-c-govspeak"
+    assert_select ".gem-c-share-links"
+    assert_select ".gem-c-title .gem-c-title__context", false
+    assert_select ".metadata-logo-wrapper", false
+    assert_select ".app-c-figure", false
+    assert_select ".gem-c-contextual-sidebar", false
+    assert_select ".app-c-published-dates", false
+    assert_select ".gem-c-contextual-footer", false
+  end
+
   def path_for(content_item, locale = nil)
     base_path = content_item["base_path"].sub(/^\//, "")
     base_path.gsub!(/\.#{locale}$/, "") if locale


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Add support for briefing

Creates a new schema type style for briefings

https://trello.com/c/MGERWyD9/682-add-page-template-for-video-briefing-to-government-frontend