### PR TITLE
Fix to search input

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,6 +35,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/radio';
 @import 'govuk_publishing_components/components/related-navigation';
 @import 'govuk_publishing_components/components/share-links';
+@import 'govuk_publishing_components/components/search';
 @import 'govuk_publishing_components/components/step-by-step-nav';
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/step-by-step-nav-related';


### PR DESCRIPTION
## What?

Fix to resolve visual issue on `government-frontend` app within search as it doesn't import the scss from the gem.

## Why?

There was an issue highlighted with search [on this page ](https://www.gov.uk/guidance/access-the-public-register-for-environmental-information)which was related to a [search PR](https://github.com/alphagov/govuk_publishing_components/pull/1793)

## Visuals

Before
![Screenshot 2020-12-22 at 18 00 57](https://user-images.githubusercontent.com/71266765/102919097-2445f800-4480-11eb-8ef9-28c24adc9edf.png)

After
![Screenshot 2020-12-22 at 18 01 15](https://user-images.githubusercontent.com/71266765/102919094-227c3480-4480-11eb-9480-04c498ccc3a9.png)

Before
![Screenshot 2020-12-22 at 18 00 04](https://user-images.githubusercontent.com/71266765/102919084-1c865380-4480-11eb-85f3-051b353406cd.png)

After
![Screenshot 2020-12-22 at 18 00 19](https://user-images.githubusercontent.com/71266765/102919344-9585ab00-4480-11eb-96f8-126afe4b18a7.png)

## Anything else?

URL test links
https://www.gov.uk/guidance/access-the-public-register-for-environmental-information
https://www.gov.uk/guidance/alcohol-licensing

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
