### PR TITLE
Set i18n.direction to rtl for languages DR, PA-UR, PS

### DIFF
--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -1,4 +1,6 @@
 dr:
+  i18n:
+    direction: rtl
   language_names:
     dr: "دری"
   content_item:

--- a/config/locales/pa-ur.yml
+++ b/config/locales/pa-ur.yml
@@ -1,4 +1,6 @@
 pa-ur:
+  i18n:
+    direction: rtl
   content_item:
     schema_name:
       aaib_report:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -1,4 +1,6 @@
 ps:
+  i18n:
+    direction: rtl
   language_names:
     ps: "پښتو"
   content_item:


### PR DESCRIPTION
Corresponding ticket: https://govuk.zendesk.com/agent/tickets/4398151.

These languages are right-to-left (RTL) in Whitehall, but not in this frontend app:
https://github.com/alphagov/whitehall/blob/bcda05ec43d87b3bec1541e644c1373bafa2a3e8/config/locales/ps.yml#L315-L316

This will ensure pages such as this one are rendered correctly:
https://www.gov.uk/guidance/coronavirus-covid-19-taxis-and-phvs.ps

How the page should look (with different language with correct cofig):
https://www.gov.uk/guidance/coronavirus-covid-19-taxis-and-phvs.ar

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
