### PR TITLE
Add tracking for briefings page

### DIFF
--- a/app/assets/javascripts/modules/track-briefing.js
+++ b/app/assets/javascripts/modules/track-briefing.js
@@ -1,0 +1,34 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function TrackBriefing () {}
+
+  TrackBriefing.prototype.start = function($element) {
+    var scope = $element[0]
+
+    this.trackLinks(scope)
+  }
+
+  TrackBriefing.prototype.trackLinks = function(scope) {
+    var links = scope.getElementsByTagName('a')
+
+    for (var i = 0; i < links.length; i++) {
+      var link = links[i]
+      link.addEventListener('click', this.sendLinkClickEvent)
+    }
+  }
+
+  TrackBriefing.prototype.sendLinkClickEvent = function(event) {
+    GOVUK.analytics.trackEvent(
+      'Briefings page',
+      event.target.innerText,
+      {
+        transport: 'beacon',
+        label: event.target.getAttribute('href')
+      }
+    )
+  }
+
+  Modules.TrackBriefing = TrackBriefing
+})(window.GOVUK.Modules)

--- a/app/views/content_items/briefing.html.erb
+++ b/app/views/content_items/briefing.html.erb
@@ -7,7 +7,7 @@
   </div>
 </div>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" data-module="track-briefing">
   <div class="govuk-grid-column-two-thirds content-bottom-margin">
     <div class="responsive-bottom-margin">
       <%= render "govuk_publishing_components/components/govspeak", {

--- a/spec/javascripts/track-briefings.spec.js
+++ b/spec/javascripts/track-briefings.spec.js
@@ -1,0 +1,73 @@
+/* global describe beforeEach it spyOn expect */
+
+var $ = window.jQuery
+
+describe('Track Briefing', function () {
+
+  var GOVUK = window.GOVUK
+  var tracker
+  var element
+
+  GOVUK.analytics = GOVUK.analytics || {}
+  GOVUK.analytics.trackEvent = function () {}
+
+  describe('Single link', function () {
+    beforeEach(function () {
+      spyOn(GOVUK.analytics, 'trackEvent')
+  
+      element = document.createElement('div')
+      element.innerHTML = '<a href="/blah/blahhhh">Blahh</a>'
+  
+      tracker = new GOVUK.Modules.TrackBriefing()
+      tracker.start($(element))
+    })
+
+    afterEach(function () {
+      GOVUK.analytics.trackEvent.calls.reset()
+    })
+  
+    it('send ga event when link is clicked', function () {
+      element.querySelector('a').dispatchEvent(new Event('click'))
+  
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Briefings page', 'Blahh', { transport: 'beacon', label: "/blah/blahhhh" }
+      )
+    })
+  })
+
+  describe('Multiple links', function () {
+    beforeEach(function () {
+      spyOn(GOVUK.analytics, 'trackEvent')
+  
+      element = document.createElement('div')
+      element.innerHTML = '<a href="/blah/blahhhh">Blahh</a>'
+      element.innerHTML += '<a href="/blah/blahhhh2">Blahh2</a>'
+      element.innerHTML += '<a href="https://www.external-link.com">External link blahhh</a>'
+  
+      tracker = new GOVUK.Modules.TrackBriefing()
+      tracker.start($(element))
+    })
+
+    afterEach(function () {
+      GOVUK.analytics.trackEvent.calls.reset()
+    })
+  
+    it('send ga event when link is clicked', function () {
+      element
+        .querySelectorAll('a')
+        .forEach(function(link) {
+          link.dispatchEvent(new Event('click'))
+        })
+  
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Briefings page', 'Blahh', { transport: 'beacon', label: "/blah/blahhhh" }
+      )
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Briefings page', 'Blahh2', { transport: 'beacon', label: "/blah/blahhhh2" }
+      )
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Briefings page', 'External link blahhh', { transport: 'beacon', label: "https://www.external-link.com" }
+      )
+    })
+  })
+})


### PR DESCRIPTION
Add event tracking for links within the briefings page

This will help us understand which links users are interacting with.

https://trello.com/c/BHqdvxKg/688-set-up-analytics-for-briefing-video-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
