### PR TITLE
Update brexit callout box content

### DIFF
--- a/app/presenters/content_item/no_deal_notice.rb
+++ b/app/presenters/content_item/no_deal_notice.rb
@@ -27,8 +27,7 @@ module ContentItem
     end
 
     def no_deal_notice_description
-      ["The UK has left the EU. This page tells you the new rules from 1 January 2021.",
-       "It will be updated if there’s new information about the UK’s deal with the EU that affects what you need to do."]
+      "The UK has agreed a deal with the EU. This page tells you the new rules from 1 January 2021."
     end
 
     def no_deal_notice_link_intro
@@ -43,10 +42,12 @@ module ContentItem
         "track-label": "Get your personalised list of actions",
       }
 
-      featured_link = view_context.link_to("Get your personalised list of actions", "/transition", data: data_attributes, class: "govuk-link")
-      featured_link_text = " and subscribe to email updates to find out when things change."
+      featured_link = view_context.link_to("get a personalised list of actions",
+                                           "/transition",
+                                           data: data_attributes,
+                                           class: "govuk-link")
 
-      (featured_link + featured_link_text).html_safe
+      ("Use the Brexit checker to " + featured_link + " and sign up for email updates.").html_safe
     end
 
     def no_deal_links


### PR DESCRIPTION
https://trello.com/c/kUqdYsCD/746-update-the-wording-of-the-whitehall-brexit-callout-box

This is a short-term change to encourage users to act on what they
see, in advance of the planned content update on the 31st.

## Before

<img width="992" alt="Screenshot 2020-12-29 at 14 59 58" src="https://user-images.githubusercontent.com/9029009/103292851-953c6100-49e6-11eb-9cf3-4fd48422c0ab.png">

## After

<img width="996" alt="Screenshot 2020-12-29 at 14 58 35" src="https://user-images.githubusercontent.com/9029009/103292857-98cfe800-49e6-11eb-943f-d33f884eacad.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️