### PR TITLE
Update content / design of Brexit notice

### DIFF
--- a/app/presenters/content_item/brexit_notice.rb
+++ b/app/presenters/content_item/brexit_notice.rb
@@ -23,15 +23,15 @@ module ContentItem
     end
 
     def brexit_notice_title
-      "Brexit transition: new rules for 2021"
+      "This guidance has been withdrawn"
     end
 
     def brexit_notice_description
-      "The UK has agreed a deal with the EU. This page tells you the new rules from 1 January 2021."
+      "The Brexit transition period has ended and new rules now apply. This page has been withdrawn because it’s out of date. "
     end
 
     def brexit_notice_link_intro
-      "For current information, read: "
+      "For current information about what you need to do, read: "
     end
 
     def brexit_landing_page_cta
@@ -42,12 +42,12 @@ module ContentItem
         "track-label": "Get your personalised list of actions",
       }
 
-      featured_link = view_context.link_to("get a personalised list of actions",
+      featured_link = view_context.link_to("other actions you need to take",
                                            "/transition",
                                            data: data_attributes,
                                            class: "govuk-link")
 
-      ("Use the Brexit checker to " + featured_link + " and sign up for email updates.").html_safe
+      ("You can also get a personalised list of the " + featured_link + ".").html_safe
     end
 
     def brexit_links

--- a/app/views/components/_brexit-notice.html.erb
+++ b/app/views/components/_brexit-notice.html.erb
@@ -19,9 +19,6 @@
       <% else %>
         <p class="app-c-brexit-notice__text govuk-body"><%= description %></p>
       <% end %>
-      <% if featured_link %>
-        <p class="app-c-brexit-notice__text govuk-body"><%= featured_link %></p>
-      <% end %>
       <% if links.any? %>
         <div class="app-c-brexit-notice__links">
           <% if links.count == 1 %>
@@ -39,8 +36,9 @@
           <% end %>
         </div>
       <% end %>
-
-
+      <% if featured_link %>
+        <p class="app-c-brexit-notice__text govuk-body"><%= featured_link %></p>
+      <% end %>
     </div>
   </section>
 <% end %>


### PR DESCRIPTION
https://trello.com/c/93GauglA/755-update-whitehall-guidance-call-out-box-8

## Before

<img width="1001" alt="Screenshot 2020-12-31 at 11 56 26" src="https://user-images.githubusercontent.com/9029009/103409710-ef146680-4b5f-11eb-9d0a-fbafdb4c21b6.png">

## After

<img width="1005" alt="Screenshot 2020-12-31 at 11 56 17" src="https://user-images.githubusercontent.com/9029009/103409721-f63b7480-4b5f-11eb-93f5-3f77f4bf9aec.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️