### PR TITLE
No longer render text as <strong> importance

### DIFF
--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -27,8 +27,9 @@
       <div class="travel-advice-notice__content">
         <p class="govuk-body">
           <strong>
-            Under current UK COVID-19 restrictions, you must stay at home. You must not leave home or travel, including abroad, unless you have a legally permitted reason to do so. Check the rules that apply to you in <a href="/guidance/national-lockdown-stay-at-home">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/covid-19-alert-levels">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>.
+            Under current UK COVID-19 restrictions, you must stay at home. You must not leave home or travel, including abroad, unless you have a legally permitted reason to do so.
           </strong>
+          Check the rules that apply to you in <a href="/guidance/national-lockdown-stay-at-home">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/covid-19-alert-levels">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>.
         </p>
         <p class="govuk-body">
           If you are legally permitted to travel, <a href="/guidance/travel-advice-novel-coronavirus">check our advice</a> for the country you are visiting. Other countries have closed borders, and may further restrict movement or bring in new rules including testing requirements with little warning. Before you return to the UK you must <a href="/provide-journey-contact-details-before-travel-uk">provide your journey and contact details</a>. Also check if you need to <a href="/uk-border-control">self isolate</a>.


### PR DESCRIPTION
The last line should not be `<strong>`, so this has been amended.

## Before

![government-frontend-before](https://user-images.githubusercontent.com/5963488/104206151-1f44ea80-5427-11eb-8fc1-ced96c0032ff.png)

## After

![gov-frontend-after](https://user-images.githubusercontent.com/5963488/104206175-24099e80-5427-11eb-9965-177c4d3041c8.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
