### PR TITLE
Fix step nav appearing over contents

### DIFF
--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -29,7 +29,7 @@
   padding-left: 0;
   position: fixed;
   width: 100%;
-  z-index: 1;
+  z-index: 10;
 
   @include govuk-media-query($from: tablet) {
     padding-left: govuk-spacing(2);


### PR DESCRIPTION
- fixes issue https://github.com/alphagov/government-frontend/issues/1921
- 'contents' sticky element z-index was lower than z-index for some of the elements of the step by step navigation in the right hand column

Before: 

<img width="755" alt="Screenshot 2021-01-14 at 10 10 45" src="https://user-images.githubusercontent.com/861310/104576978-d7a1a700-5650-11eb-853d-de7c0c3a8a79.png">

After:

<img width="766" alt="Screenshot 2021-01-14 at 10 11 07" src="https://user-images.githubusercontent.com/861310/104577000-dd978800-5650-11eb-8a7a-f4b887898a0b.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
