### PR TITLE
Ensure asset-manager redirects are cached

### DIFF
--- a/app/controllers/asset_manager_redirect_controller.rb
+++ b/app/controllers/asset_manager_redirect_controller.rb
@@ -5,6 +5,7 @@ class AssetManagerRedirectController < ApplicationController
       asset_url = Plek.new.external_url_for("draft-assets")
     end
 
+    expires_in 1.day, public: true
     redirect_to host: URI.parse(asset_url).host, status: :moved_permanently
   end
 end

--- a/test/controllers/asset_manager_redirect_controller_test.rb
+++ b/test/controllers/asset_manager_redirect_controller_test.rb
@@ -6,6 +6,13 @@ class AssetManagerRedirectControllerTest < ActionController::TestCase
     Plek.any_instance.stubs(:external_url_for).returns("http://draft-asset-host.com")
   end
 
+  test "sets the cache-control max-age to 1 day" do
+    request.host = "some-host.com"
+    get :show, params: { path: "asset.txt" }
+
+    assert_equal @response.headers["Cache-Control"], "max-age=86400, public"
+  end
+
   test "redirects asset requests made via public host to the public asset host" do
     request.host = "some-host.com"
     get :show, params: { path: "asset.txt" }


### PR DESCRIPTION
At the moment these redirects aren't cached which means that they won't be cached by Fastly and will always hit our origin. This PR should prevent this from happening and instead they'll be cached by Fastly for 1 day.

We should think about moving this code out of government-frontend and into Nginx, but that's a bigger change so this PR should help for now.

[Trello Card](https://trello.com/c/CN2bhhZi/1998-make-asset-redirections-cacheable)