### PR TITLE
Fix component references

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -8,6 +8,7 @@
 @import 'govuk_publishing_components/components/print/govspeak-html-publication';
 @import 'govuk_publishing_components/components/print/metadata';
 @import 'govuk_publishing_components/components/print/share-links';
+@import 'govuk_publishing_components/components/print/skip-link';
 @import 'govuk_publishing_components/components/print/step-by-step-nav';
 @import 'govuk_publishing_components/components/print/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/print/subscription-links';

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -48,7 +48,7 @@
         <%= render "govuk_publishing_components/components/contents_list", contents: @content_item.part_link_elements, underline_links: true %>
       </nav>
 
-      <%= render 'govuk_publishing_components/components/subscription-links', email_signup_link: @content_item.email_signup_link, feed_link: @content_item.feed_link %>
+      <%= render 'govuk_publishing_components/components/subscription_links', email_signup_link: @content_item.email_signup_link, feed_link: @content_item.feed_link %>
     </aside>
   </div>
 </div>

--- a/app/views/shared/_translations.html.erb
+++ b/app/views/shared/_translations.html.erb
@@ -1,6 +1,6 @@
 <% if @content_item.available_translations.length > 1 %>
   <div class="govuk-grid-column-one-third">
-    <%= render 'govuk_publishing_components/components/translation-nav',
+    <%= render 'govuk_publishing_components/components/translation_nav',
         translations: @content_item.available_translations %>
   </div>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Update component references following this change to correct component file names: https://github.com/alphagov/govuk_publishing_components/pull/1848

Also taking the opportunity to add missing print styles for the `skip link` component.