### PR TITLE
Remove redundant Jenkinsfile config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,10 +6,5 @@ REPOSITORY = 'government-frontend'
 
 node {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-government-frontend")
-  govuk.buildProject(
-    beforeTest: { sh("yarn install") },
-    sassLint: false,
-    publishingE2ETests: true,
-    brakeman: true,
-  )
+  govuk.buildProject(publishingE2ETests: true)
 }


### PR DESCRIPTION
Yarn install now happens automatically, sassLint is no longer a supported option and brakeman runs implicitly.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
