### PR TITLE
Enable 'standard' publication types to be rendered

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -284,6 +284,12 @@ ar:
         few:
         many:
         other: "كلمات"
+      standard:
+        one:
+        two:
+        few:
+        many:
+        other:
       statement_to_parliament:
         zero:
         one: "تصريح للبرلمان"

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -77,6 +77,9 @@ az:
         other: "Çıxış üçün  qeydləri"
       speech:
         other: "Çıxışlar"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         other: Parlamentə bəyanatlar
       statistical_data_set:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -188,6 +188,11 @@ be:
         few:
         many:
         other: "Выступы"
+      standard:
+        one:
+        few:
+        many:
+        other:
       statement_to_parliament:
         one: "Заява ў парламенце"
         few:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -114,6 +114,9 @@ bg:
       speech:
         one: "Реч"
         other: "Речи"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "Изявление в парламента"
         other: "Изявления в парламента"

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -115,6 +115,9 @@ bn:
       speech:
         one: ভাষণ
         other: ভাষণসমূহ
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: সংসদে বিবৃতি
         other: সংসদে বিবৃতিসমূহ

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -151,6 +151,10 @@ cs:
         one: Proslov
         few:
         other: Proslovy
+      standard:
+        few:
+        one:
+        other:
       statement_to_parliament:
         one: Prohlášení v parlamentu
         few:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -267,6 +267,13 @@ cy:
         few:
         many:
         other: Areithiau
+      standard:
+        zero:
+        one: Safon
+        two:
+        few:
+        many:
+        other: Safonau
       statement_to_parliament:
         zero:
         one: Datganiad i'r senedd

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -186,6 +186,9 @@ da:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -114,6 +114,9 @@ de:
       speech:
         one: Rede
         other: Reden
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Erklärung vor dem Parlament
         other: Erklärungen vor dem Parlament

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -116,6 +116,9 @@ dr:
       speech:
         one: "سخنرانی"
         other: "سخنرانی ها"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "بیانیه به پارلمان"
         other: "بیانیه ها به پارلمان"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -114,6 +114,9 @@ el:
       speech:
         one: "Ομιλία"
         other: "Ομιλίες"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "Δήλωση στη Βουλή"
         other: "Δηλώσεις στη Βουλή "

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -310,6 +310,9 @@ en:
       speech:
         one: Speech
         other: Speeches
+      standard:
+        one: Standard
+        other: Standards
       statement_to_parliament:
         one: Statement to Parliament
         other: Statements to Parliament

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -114,6 +114,9 @@ es-419:
       speech:
         one: Discurso
         other: Discursos
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Declaración al Parlamento
         other: Declaraciones al Parlamento

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -114,6 +114,9 @@ et:
       speech:
         one: 'Kõne  '
         other: Kõned
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Avaldus parlamendis
         other: Avaldused parlamendis

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -79,6 +79,9 @@ fa:
         other: "موضوعات سخنرانی"
       speech:
         other: "سخنرانی ها"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         other: "گزارش ها به پارلمان"
       statistical_data_set:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -186,6 +186,9 @@ fi:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -114,6 +114,9 @@ fr:
       speech:
         one: Discours
         other: Discours
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Déclaration au Parlement
         other: Déclarations au Parlement

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -308,6 +308,11 @@ gd:
         two:
         few:
         other:
+      standard:
+        one:
+        two:
+        few:
+        other:
       statement_to_parliament:
         one:
         two:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -184,6 +184,9 @@ gu:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -116,6 +116,9 @@ he:
       speech:
         one: "נאום"
         other: "נאומים"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "הצהרה לפרלמנט"
         other: "הצהרות לפרלמנט"

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -114,6 +114,9 @@ hi:
       speech:
         one: "भाषण"
         other: "भाषण"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "संसद में बयान"
         other: "संसद में बयान"

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -308,6 +308,11 @@ hr:
         few:
         many:
         other:
+      standard:
+        one:
+        few:
+        many:
+        other:
       statement_to_parliament:
         one:
         few:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -114,6 +114,9 @@ hu:
       speech:
         one: Beszéd
         other: Beszédek
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Parlamenti nyilatkozat
         other: Parlamenti nyilatkozatok

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -114,6 +114,9 @@ hy:
       speech:
         one: "Ելույթ"
         other: "Ելույթներ"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "Դիմում խորհրդարան"
         other: "Դիմումներ խորհրդարան"

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -77,6 +77,9 @@ id:
         other: Naskah Pembicara
       speech:
         other: Pidato-pidato
+      standard:
+        one:
+        other:
       statement_to_parliament:
         other: Pernyataan-pernyaatan kepada Parlemen
       statistical_data_set:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -186,6 +186,9 @@ is:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -114,6 +114,9 @@ it:
       speech:
         one: Discorso
         other: Discorsi
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Dichiarazione in parlamento
         other: Dichiarazioni in parlamento

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -77,6 +77,9 @@ ja:
         other: "キーポイント"
       speech:
         other: "スピーチ"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         other: "閣僚声明"
       statistical_data_set:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -77,6 +77,9 @@ ka:
         other:
       speech:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         other:
       statistical_data_set:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -184,6 +184,9 @@ kk:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -77,6 +77,9 @@ ko:
         other: "요점사항"
       speech:
         other: "연설문"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         other: "의회로 성명"
       statistical_data_set:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -151,6 +151,10 @@ lt:
         one: Kalba
         few:
         other: Kalbos
+      standard:
+        one:
+        few:
+        other:
       statement_to_parliament:
         one: Kreipimasis į parlamentą
         few:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -114,6 +114,9 @@ lv:
       speech:
         one: Runa
         other: Runas
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Ziņojums parlamentam
         other: Ziņojumi parlamentam

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -77,6 +77,9 @@ ms:
         other:
       speech:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         other:
       statistical_data_set:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -308,6 +308,11 @@ mt:
         few:
         many:
         other:
+      standard:
+        one:
+        few:
+        many:
+        other:
       statement_to_parliament:
         one:
         few:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -186,6 +186,9 @@ nl:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -186,6 +186,9 @@
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -187,6 +187,9 @@ pa-pk:
       speech:
         one: تقریر
         other: تقریراں
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: پارلیمنٹ نوں بیان
         other: پارلیمنٹ نوں بیانات

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -185,6 +185,9 @@ pa:
       speech:
         one: ਬੋਲਣਾ
         other: ਭਾਸ਼ਣ
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: ਸੰਸਦ ਨੂੰ ਬਿਆਨ
         other: ਸੰਸਦ ਨੂੰ ਬਿਆਨ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -188,6 +188,11 @@ pl:
         few:
         many:
         other: Przemówienia
+      standard:
+        one:
+        few:
+        many:
+        other:
       statement_to_parliament:
         one: Wystapienie przed parlamentem
         few:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -116,6 +116,9 @@ ps:
       speech:
         one: "وینا"
         other: "ویناوې"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "پارلمان ته اعلامیه"
         other: "پارلمان ته اعلامیې"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -114,6 +114,9 @@ pt:
       speech:
         one: Discurso
         other: Discursos
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Declaração ao Parlamento
         other: Declarações ao Parlamento

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -151,6 +151,10 @@ ro:
         one: Discurs
         few:
         other: Discursuri
+      standard:
+        one:
+        few:
+        other:
       statement_to_parliament:
         one: Declarație în Parlament
         few:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -202,6 +202,9 @@ ru:
         few:
         many:
         other: "Тексты выступлений"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "Заявление парламенту"
         few:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -114,6 +114,9 @@ si:
       speech:
         one: "කථාව"
         other: "කථා"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "පාර්ලිමේන්තුවට කල ප්‍රකාශය"
         other: "පාර්ලිමේන්තුවට කල ප්‍රකාශ"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -151,6 +151,10 @@ sk:
         one:
         few:
         other:
+      standard:
+        one:
+        few:
+        other:
       statement_to_parliament:
         one:
         few:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -308,6 +308,11 @@ sl:
         two:
         few:
         other:
+      standard:
+        one:
+        two:
+        few:
+        other:
       statement_to_parliament:
         one:
         two:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -114,6 +114,9 @@ so:
       speech:
         one: Hadal
         other: Hadallo
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Hadal loo jeediyo baarlamaanka
         other: hadallo loo jeediyo baarlamaanka

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -114,6 +114,9 @@ sq:
       speech:
         one: Fjalim
         other: Fjalime
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Deklarate per Parliamentin
         other: Deklarata per Parlamentin

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -188,6 +188,11 @@ sr:
         few:
         many:
         other: Govori
+      standard:
+        one:
+        few:
+        many:
+        other:
       statement_to_parliament:
         one: obraćanje Parlamentu
         few:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -186,6 +186,9 @@ sv:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -114,6 +114,9 @@ sw:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -114,6 +114,9 @@ ta:
       speech:
         one: "உரை"
         other: "உரைகள்"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "பாராளுமன்றத்துக்கான அறிக்கை"
         other: "பாராளுமன்றத்துக்கான அறிக்கைகள்"

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -77,6 +77,9 @@ th:
         other: "ประเด็นการพูด"
       speech:
         other: "สุนทรพจน์"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         other: "แถลงการณ์ต่อรัฐสภา"
       statistical_data_set:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -114,6 +114,9 @@ tk:
       speech:
         one:
         other:
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one:
         other:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -114,6 +114,9 @@ tr:
       speech:
         one: Konuşma
         other: Konuşmalar
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Parlamento'ya yapılan açıklama
         other: Parlamento'ya yapılan açıklamalar

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -188,6 +188,9 @@ uk:
         few:
         many:
         other: "Промови"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "Заява у парламенті"
         few:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -114,6 +114,9 @@ ur:
       speech:
         one: "تقریر"
         other: "تقاریر"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "پارلیمنٹ میں بیان"
         other: "پارلیمنٹ میں بیانات"

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -114,6 +114,9 @@ uz:
       speech:
         one: Nutq
         other: Nutqlar
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: Parlament uchun hisobot
         other: Parlament uchun hisobotlar

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -77,6 +77,9 @@ vi:
         other: Bài phát biểu
       speech:
         other: Các bài phát biểu
+      standard:
+        one:
+        other:
       statement_to_parliament:
         other: Tuyên bố tới Quốc hội
       statistical_data_set:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -114,6 +114,9 @@ zh-hk:
       speech:
         one: "演講"
         other: "其他演講"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "提交國會的聲明"
         other: "提交國會的其他聲明"

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -114,6 +114,9 @@ zh-tw:
       speech:
         one: "演講"
         other: "其他演講"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         one: "議會聲明"
         other: "議會聲明"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -79,6 +79,9 @@ zh:
         other: "演讲稿"
       speech:
         other: "演讲"
+      standard:
+        one:
+        other:
       statement_to_parliament:
         other: "对议会的声明"
       statistical_data_set:


### PR DESCRIPTION
Adds locales needed to render the new 'standard' document type.

I've added the foreign translation placeholders as they are used unlike the the ones located in [Whitehall](https://github.com/alphagov/whitehall/pull/5969). We'll need to decide if we want a translation for all locales, some or just for English.

Dependent on:

- [x] Foreign locale translations being agreed upon and implemented (decision is for no translations to be created initially) 

Trello:
https://trello.com/c/ugeapNY0/2318-5-create-new-standard-document-sub-type-in-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
