### PR TITLE
Don't notify Sentry when specialist document is missing finder

### DIFF
--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -103,17 +103,8 @@ private
     values.length == 1 ? values.first : values
   end
 
-  # Finder is a required link that must have 1 item
   def finder
-    parent_finder = content_item.dig("links", "finder", 0)
-    if parent_finder.nil?
-      GovukError.notify(
-        "Finder not found",
-        extra: { error_message: "Finder not found in #{base_path} content item" },
-      )
-    end
-
-    parent_finder
+    content_item.dig("links", "finder", 0)
   end
 
   def facets

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -295,18 +295,6 @@ class SpecialistDocumentPresenterTest
       assert_equal "1 January 2010", presented_metadata["Facet name"]
     end
 
-    test "sends an error notification when there is no finder" do
-      example = schema_item("aaib-reports")
-      example["links"]["finder"] = []
-
-      GovukError.expects(:notify).with(
-        "Finder not found",
-        extra: { error_message: "Finder not found in /aaib-reports/aaib-investigation-to-rotorsport-uk-calidus-g-pcpc content item" },
-      )
-
-      present_example(example).important_metadata
-    end
-
     test "omits first_published_at facet values from `other` section of component parameters to avoid duplicates" do
       facets = [
         {


### PR DESCRIPTION
Fixes https://sentry.io/organizations/govuk/issues/1870942805/events/latest/?project=202226

This code was initially added in 9f39d8856f8d8a998e8b2c26f61c334eb9a3af69,
around 4 years ago, seemingly just being cautious. There's no
evidence it has highlighted any useful problems for us, and
recently the check has become problematic as departments often
publish documents first before making the finder live.

The link would be there in Publishing API, but Publishing API
wouldn't know how to expand it yet as the finder itself isn't
live, so nothing matches its `content_id`.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
