### PR TITLE
Restore original wording for travel advice emails

### DIFF
--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -57,7 +57,10 @@
         <%= render "govuk_publishing_components/components/contents_list", contents: @content_item.part_link_elements, underline_links: true %>
       </nav>
 
-      <%= render 'govuk_publishing_components/components/subscription_links', email_signup_link: @content_item.email_signup_link, feed_link: @content_item.feed_link %>
+      <%= render 'govuk_publishing_components/components/subscription_links',
+          email_signup_link: @content_item.email_signup_link,
+          email_signup_link_text: "Get email alerts",
+          feed_link: @content_item.feed_link %>
     </aside>
   </div>
 </div>

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -11,7 +11,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     assert page.has_css?("title", visible: false, text: @content_item["title"])
     assert_has_component_title(@content_item["details"]["country"]["name"])
 
-    assert page.has_css?("a[href=\"#{@content_item['details']['email_signup_link']}\"]", text: "Get emails")
+    assert page.has_css?("a[href=\"#{@content_item['details']['email_signup_link']}\"]", text: "Get email alerts")
     assert page.has_css?("a[href=\"#{@content_item['base_path']}.atom\"]", text: "Subscribe to feed")
 
     assert page.has_css?(".part-navigation li", count: @content_item["details"]["parts"].size + 1)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176908254

This has been requested by FCDO [1], and agreed with GOV.UK Notify,
who originally asked for the word "alert" to be removed so that it
did not conflict with the upcoming emergency alert pages on GOV.UK.
Note the original change was applied via the default text changing
in GOV.UK Publishing Components [2].

[1]: https://govuk.zendesk.com/agent/tickets/4417745
[2]: https://github.com/alphagov/govuk_publishing_components/commit/36953fd979db6c144ba0fd0245ed414066fc88b0


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️