### PR TITLE
Switch from static to govuk_publishing_components scripts

### DIFF
--- a/app/assets/javascripts/modules/sticky-element-container.js
+++ b/app/assets/javascripts/modules/sticky-element-container.js
@@ -46,7 +46,7 @@
         setInterval(checkScroll, _interval)
         checkResize()
         checkScroll()
-        $element.addClass('govuk-sticky-element--enabled')
+        $element.addClass('sticky-element--enabled')
       }
 
       function onResize () {
@@ -98,19 +98,19 @@
       }
 
       function stickToWindow () {
-        $element.addClass('govuk-sticky-element--stuck-to-window')
+        $element.addClass('sticky-element--stuck-to-window')
       }
 
       function stickToParent () {
-        $element.removeClass('govuk-sticky-element--stuck-to-window')
+        $element.removeClass('sticky-element--stuck-to-window')
       }
 
       function show () {
-        $element.removeClass('govuk-sticky-element--hidden')
+        $element.removeClass('sticky-element--hidden')
       }
 
       function hide () {
-        $element.addClass('govuk-sticky-element--hidden')
+        $element.addClass('sticky-element--hidden')
       }
     }
   }

--- a/app/assets/javascripts/modules/sticky-element-container.js
+++ b/app/assets/javascripts/modules/sticky-element-container.js
@@ -1,0 +1,117 @@
+/*
+  This module will cause a child in the target element to:
+  - hide when the top of the target element is visible;
+  - stick to the bottom of the window while the parent element is in view;
+  - stick to the bottom of the target when the user scrolls past the bottom.
+
+  Use 'data-module="sticky-element-container"' to instantiate, and add
+  `[data-sticky-element]` to the child you want to position.
+*/
+(function (Modules, root) {
+  'use strict'
+
+  var $ = root.$
+  var $window = $(root)
+
+  Modules.StickyElementContainer = function () {
+    var self = this
+
+    self._getWindowDimensions = function _getWindowDimensions () {
+      return {
+        height: $window.height(),
+        width: $window.width()
+      }
+    }
+
+    self._getWindowPositions = function _getWindowPositions () {
+      return {
+        scrollTop: $window.scrollTop()
+      }
+    }
+
+    self.start = function start ($el) {
+      var $element = $el.find('[data-sticky-element]')
+      var _hasResized = true
+      var _hasScrolled = true
+      var _interval = 50
+      var _windowVerticalPosition = 1
+      var _startPosition, _stopPosition
+
+      initialise()
+
+      function initialise () {
+        $window.resize(onResize)
+        $window.scroll(onScroll)
+        setInterval(checkResize, _interval)
+        setInterval(checkScroll, _interval)
+        checkResize()
+        checkScroll()
+        $element.addClass('govuk-sticky-element--enabled')
+      }
+
+      function onResize () {
+        _hasResized = true
+      }
+
+      function onScroll () {
+        _hasScrolled = true
+      }
+
+      function checkResize () {
+        if (_hasResized) {
+          _hasResized = false
+          _hasScrolled = true
+
+          var windowDimensions = self._getWindowDimensions()
+          _startPosition = $el.offset().top
+          _stopPosition = $el.offset().top + $el.height() - windowDimensions.height
+        }
+      }
+
+      function checkScroll () {
+        if (_hasScrolled) {
+          _hasScrolled = false
+
+          _windowVerticalPosition = self._getWindowPositions().scrollTop
+
+          updateVisibility()
+          updatePosition()
+        }
+      }
+
+      function updateVisibility () {
+        var isPastStart = _startPosition < _windowVerticalPosition
+        if (isPastStart) {
+          show()
+        } else {
+          hide()
+        }
+      }
+
+      function updatePosition () {
+        var isPastEnd = _stopPosition < _windowVerticalPosition
+        if (isPastEnd) {
+          stickToParent()
+        } else {
+          stickToWindow()
+        }
+      }
+
+      function stickToWindow () {
+        $element.addClass('govuk-sticky-element--stuck-to-window')
+      }
+
+      function stickToParent () {
+        $element.removeClass('govuk-sticky-element--stuck-to-window')
+      }
+
+      function show () {
+        $element.removeClass('govuk-sticky-element--hidden')
+      }
+
+      function hide () {
+        $element.addClass('govuk-sticky-element--hidden')
+      }
+    }
+  }
+})(window.GOVUK.Modules, window)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,9 +54,10 @@ $govuk-use-legacy-palette: false;
 @import 'helpers/organisation-logos';
 @import 'helpers/parts';
 @import 'helpers/add-title-margin';
-@import "helpers/content-bottom-margin";
-@import "helpers/publisher-metadata-with-logo";
-@import "helpers/attachments";
+@import 'helpers/content-bottom-margin';
+@import 'helpers/publisher-metadata-with-logo';
+@import 'helpers/attachments';
+@import 'helpers/sticky-element-container';
 
 // Components from this application
 @import 'components/*';

--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -20,7 +20,7 @@
   }
 }
 
-.app-c-contents-list-with-body__link-wrapper.govuk-sticky-element--stuck-to-window {
+.app-c-contents-list-with-body__link-wrapper.sticky-element--stuck-to-window {
   background-color: govuk-colour("light-grey", $legacy: "grey-3");
   bottom: -1px; // 'Fix' for anomalous 1px margin which sporadically appears below this element.
   left: 0;

--- a/app/assets/stylesheets/helpers/_sticky-element-container.scss
+++ b/app/assets/stylesheets/helpers/_sticky-element-container.scss
@@ -1,0 +1,23 @@
+.js-enabled .govuk-sticky-element {
+  position: absolute;
+  bottom: 0;
+
+  &--stuck-to-window {
+    bottom: 0;
+    position: fixed;
+  }
+
+  &--enabled {
+    transition: opacity, .3s, ease;
+    opacity: 1;
+
+    @include govuk-media-query($until: tablet) {
+      position: static;
+    }
+  }
+
+  &--hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+}

--- a/app/assets/stylesheets/helpers/_sticky-element-container.scss
+++ b/app/assets/stylesheets/helpers/_sticky-element-container.scss
@@ -1,4 +1,4 @@
-.js-enabled .govuk-sticky-element {
+.js-enabled .sticky-element {
   position: absolute;
   bottom: 0;
 

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -54,14 +54,14 @@
     display: none;
   }
 
-  .govuk-sticky-element {
-    .govuk-sticky-element__print-link {
+  .sticky-element {
+    .sticky-element__print-link {
       margin-left: govuk-spacing(3);
     }
   }
 
   @include govuk-media-query($until: desktop) {
-    .govuk-sticky-element--enabled {
+    .sticky-element--enabled {
       position: static;
     }
   }

--- a/app/presenters/content_item/brexit_notice.rb
+++ b/app/presenters/content_item/brexit_notice.rb
@@ -36,7 +36,7 @@ module ContentItem
 
     def brexit_landing_page_cta
       data_attributes = {
-        "module": "track-click",
+        "module": "gem-track-click",
         "track-category": "no_deal_notice",
         "track-action": "/transition",
         "track-label": "Get your personalised list of actions",
@@ -56,7 +56,7 @@ module ContentItem
           title: link["title"],
           href: link["href"],
           data_attributes: {
-            "module": "track-click",
+            "module": "gem-track-click",
             "track-category": "no_deal_notice",
             "track-action": link["href"],
             "track-label": link["title"],

--- a/app/views/components/_important-metadata.html.erb
+++ b/app/views/components/_important-metadata.html.erb
@@ -10,7 +10,7 @@
     <% if title %>
       <h2 class="app-c-important-metadata__title"><%= sanitize title %></h2>
     <% end %>
-    <dl data-module="track-click">
+    <dl data-module="gem-track-click">
     <% items.each do |title, definition| %>
       <dt class="app-c-important-metadata__term"><%= sanitize title.to_s %>: </dt>
       <dd class="app-c-important-metadata__definition"><%= sanitize definition %></dd>

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -7,7 +7,7 @@
   history_class = "app-c-published-dates--history" if history.any?
 %>
 <% if published || last_updated %>
-<div class="app-c-published-dates <%= history_class %>" <% if history.any? %>id="history" data-module="toggle"<% end %> lang="en">
+<div class="app-c-published-dates <%= history_class %>" <% if history.any? %>id="history" data-module="gem-toggle"<% end %> lang="en">
   <% if published %>
     Published <%= published %>
   <% end %>

--- a/app/views/components/_publisher-metadata.html.erb
+++ b/app/views/components/_publisher-metadata.html.erb
@@ -11,7 +11,7 @@
     <%= render 'components/published-dates', published: published, last_updated: last_updated, link_to_history: link_to_history %>
     <% if other_has_values %>
       <div class="app-c-publisher-metadata__other">
-        <dl data-module="track-click">
+        <dl data-module="gem-track-click">
         <% other.each do |title, values| %>
           <%
             values ||= []

--- a/app/views/content_items/_document_collection_body.html.erb
+++ b/app/views/content_items/_document_collection_body.html.erb
@@ -13,7 +13,7 @@
     <% end %>
   <% end %>
 
-  <div data-module="track-click">
+  <div data-module="gem-track-click">
     <%= render 'govuk_publishing_components/components/document_list', items: @content_item.group_document_links(group, group_index) %>
   </div>
 <% end %>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -62,9 +62,9 @@
     <% end %>
   </div>
 
-  <div data-sticky-element class="govuk-sticky-element">
+  <div data-sticky-element class="sticky-element">
     <%= render 'components/back-to-top', href: "#contents" %>
-    <div class="govuk-sticky-element__print-link">
+    <div class="sticky-element__print-link">
       <%= render "govuk_publishing_components/components/print_link", {
           margin_top: 0,
           margin_bottom: 6,

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -53,7 +53,7 @@
     </div>
 
     <aside class="part-navigation-container" role="complementary">
-      <nav role="navigation" class="govuk-grid-row part-navigation" aria-label="Travel advice pages" data-module="track-click">
+      <nav role="navigation" class="govuk-grid-row part-navigation" aria-label="Travel advice pages" data-module="gem-track-click">
         <%= render "govuk_publishing_components/components/contents_list", contents: @content_item.part_link_elements, underline_links: true %>
       </nav>
 

--- a/spec/javascripts/modules/sticky-element-container.spec.js
+++ b/spec/javascripts/modules/sticky-element-container.spec.js
@@ -32,7 +32,7 @@ describe('A sticky-element-container module', function () {
       it('hides the element, when scrolled at the top', function () {
         instance.start($element)
 
-        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(true)
+        expect($footer.hasClass('sticky-element--hidden')).toBe(true)
       })
 
       it('shows the element, stuck to the window, when scrolled in the middle', function () {
@@ -43,8 +43,8 @@ describe('A sticky-element-container module', function () {
         }
         instance.start($element)
 
-        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false)
-        expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(true)
+        expect($footer.hasClass('sticky-element--hidden')).toBe(false)
+        expect($footer.hasClass('sticky-element--stuck-to-window')).toBe(true)
       })
 
       it('shows the element, stuck to the parent, when scrolled at the bottom', function () {
@@ -55,8 +55,8 @@ describe('A sticky-element-container module', function () {
         }
         instance.start($element)
 
-        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false)
-        expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(false)
+        expect($footer.hasClass('sticky-element--hidden')).toBe(false)
+        expect($footer.hasClass('sticky-element--stuck-to-window')).toBe(false)
       })
     })
   })

--- a/spec/javascripts/modules/sticky-element-container.spec.js
+++ b/spec/javascripts/modules/sticky-element-container.spec.js
@@ -1,0 +1,63 @@
+describe('A sticky-element-container module', function () {
+  'use strict'
+
+  var GOVUK = window.GOVUK
+  var $ = window.$
+  var instance
+
+  beforeEach(function () {
+    instance = new GOVUK.Modules.StickyElementContainer()
+  })
+
+  describe('in a large parent element', function () {
+    var $element = $(
+      '<div data-module="sticky-element-container" style="height: 9001px; margin-bottom: 1000px">' +
+        '<div data-sticky-element>' +
+          '<span>Content</span>' +
+        '</div>' +
+      '</div>'
+    )
+    var $footer = $element.find('[data-sticky-element]')
+
+    describe('on desktop', function () {
+      beforeEach(function () {
+        instance._getWindowDimensions = function () {
+          return {
+            height: 768,
+            width: 1024
+          }
+        }
+      })
+
+      it('hides the element, when scrolled at the top', function () {
+        instance.start($element)
+
+        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(true)
+      })
+
+      it('shows the element, stuck to the window, when scrolled in the middle', function () {
+        instance._getWindowPositions = function () {
+          return {
+            scrollTop: 5000
+          }
+        }
+        instance.start($element)
+
+        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false)
+        expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(true)
+      })
+
+      it('shows the element, stuck to the parent, when scrolled at the bottom', function () {
+        instance._getWindowPositions = function () {
+          return {
+            scrollTop: 9800
+          }
+        }
+        instance.start($element)
+
+        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false)
+        expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(false)
+      })
+    })
+  })
+})

--- a/test/components/important_metadata_test.rb
+++ b/test/components/important_metadata_test.rb
@@ -56,6 +56,6 @@ class ImportantMetadataTest < ComponentTestCase
 
   test "link tracking is enabled" do
     render_component(items: { "Case type": ["<a href='https://www.gov.uk/cma-cases?case_type%5B%5D=mergers'>Mergers</a>"] })
-    assert_select ".app-c-important-metadata dl[data-module='track-click']"
+    assert_select ".app-c-important-metadata dl[data-module='gem-track-click']"
   end
 end

--- a/test/components/published_dates_test.rb
+++ b/test/components/published_dates_test.rb
@@ -82,7 +82,7 @@ class PublishedDatesTest < ComponentTestCase
       last_updated: "15th July 2015",
       history: [display_time: "23 August 2013", note: "Updated with new data"],
     )
-    assert_select ".app-c-published-dates--history[data-module=\"toggle\"]"
+    assert_select ".app-c-published-dates--history[data-module=\"gem-toggle\"]"
     assert_select ".app-c-published-dates--history a[href=\"#full-history\"][data-controls=\"full-history\"]"
     assert_select ".app-c-published-dates--history a[href=\"#full-history\"][data-expanded=\"false\"]"
   end

--- a/test/components/publisher_metadata_test.rb
+++ b/test/components/publisher_metadata_test.rb
@@ -53,7 +53,7 @@ class PublisherMetadataTest < ComponentTestCase
 
   test "link tracking is enabled" do
     render_component(other: { from: ["<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"] })
-    assert_select ".app-c-publisher-metadata__other dl[data-module='track-click']"
+    assert_select ".app-c-publisher-metadata__other dl[data-module='gem-track-click']"
   end
 
   test "renders two collection links when two collections are given" do

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -99,7 +99,7 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
   test "includes tracking data on all collection documents" do
     setup_and_visit_content_item("document_collection")
     groups = page.all(".gem-c-document-list")
-    assert page.has_css?('[data-module="track-click"]'), count: groups.length
+    assert page.has_css?('[data-module="gem-track-click"]'), count: groups.length
 
     first_section_links = groups.first.all(".gem-c-document-list__item-title")
     first_link = first_section_links.first


### PR DESCRIPTION
### What

- Switch from using `trackClick` script to `gemTrackClick` script. They are virtually the same, the latter being [copied over from `static` to `govuk_publishing_components`](https://github.com/alphagov/govuk_publishing_components/pull/1751)
- Switch from using `toggle` script to `gemToggle` script
- Port `sticky-element-container` from `static` as this app is the only one using it ([PR prepared to remove it from `static`](https://github.com/alphagov/static/pull/2405) after this gets merged)

### Why

Part of [a bigger piece of work](https://github.com/alphagov/static/pull/2405) to reduce the size of assets served to users and keep our codebase to a minimum.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
