### PR TITLE
Switch to meta block

### DIFF
--- a/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
+++ b/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
@@ -9,6 +9,7 @@
 
   .metadata-column {
     padding-left: 0;
+    padding-top: govuk-spacing(3);
   }
 
   .metadata-logo {

--- a/app/presenters/content_item/metadata.rb
+++ b/app/presenters/content_item/metadata.rb
@@ -21,12 +21,10 @@ module ContentItem
 
     def publisher_metadata
       {
-        published: published,
+        from: from,
+        first_published: published,
         last_updated: updated,
-        link_to_history: updated.present?,
-        other: {
-          from: from,
-        },
+        see_updates_link: true,
       }
     end
   end

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if @content_item.try(:logo) %>">
     <div class="govuk-grid-column-two-thirds metadata-column">
-      <%= render "components/publisher-metadata", @content_item.publisher_metadata %>
+      <%= render 'govuk_publishing_components/components/metadata', @content_item.publisher_metadata %>
     </div>
     <div class="govuk-grid-column-one-third">
       <% if @content_item.try(:logo) %>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -381,7 +381,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_select ".metadata-logo-wrapper", false
     assert_select ".app-c-figure", false
     assert_select ".gem-c-contextual-sidebar", false
-    assert_select ".app-c-published-dates", false
+    assert_select ".gem-c-metadata__definition", false
     assert_select ".gem-c-contextual-footer", false
   end
 

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -7,12 +7,10 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
 
-    assert_has_publisher_metadata(
-      published: "Published 4 November 2016",
-      last_updated: "Last updated 7 November 2016",
-      metadata: {
-        "From": { "Department for Education": "/government/organisations/department-for-education" },
-      },
+    assert_has_metadata(
+      published: "4 November 2016",
+      last_updated: "7 November 2016",
+      from: { "Department for Education": "/government/organisations/department-for-education" },
     )
 
     assert_footer_has_published_dates("Published 4 November 2016", "Last updated 7 November 2016")

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -11,14 +11,11 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
 
-    assert_has_publisher_metadata(
-      published: "Published 12 June 2014",
-      last_updated: "Last updated 18 February 2016",
-      history_link: true,
-      metadata: {
-        "From:": {
-          "HM Revenue & Customs": "/government/organisations/hm-revenue-customs",
-        },
+    assert_has_metadata(
+      published: "12 June 2014",
+      last_updated: "18 February 2016",
+      from: {
+        "HM Revenue & Customs": "/government/organisations/hm-revenue-customs",
       },
     )
   end

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -19,14 +19,10 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
 
   test "renders metadata and document footer" do
     setup_and_visit_content_item("document_collection")
-    assert_has_publisher_metadata(
-      published: "Published 29 February 2016",
-      metadata:
-      {
-        "From:":
-          {
-            "Driver and Vehicle Standards Agency": "/government/organisations/driver-and-vehicle-standards-agency",
-          },
+    assert_has_metadata(
+      published: "29 February 2016",
+      from: {
+        "Driver and Vehicle Standards Agency": "/government/organisations/driver-and-vehicle-standards-agency",
       },
     )
     assert_footer_has_published_dates("Published 29 February 2016")

--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -20,12 +20,11 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
 
     assert_not page.has_css?(".gem-c-notice")
 
-    assert_has_publisher_metadata(
-      published: "Published 27 February 1881",
-      last_updated: "Last updated 14 September 2016",
-      history_link: true,
-      metadata: {
-        "From": { "Ministry of Defence": "/government/organisations/ministry-of-defence" },
+    assert_has_metadata(
+      published: "27 February 1881",
+      last_updated: "14 September 2016",
+      from: {
+        "Ministry of Defence": "/government/organisations/ministry-of-defence",
       },
     )
 
@@ -60,8 +59,8 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
 
   test "fatality notice with minister" do
     setup_and_visit_content_item("fatality_notice_with_minister")
-    assert_has_publisher_metadata_other(
-      "From": {
+    assert_has_metadata(
+      from: {
         "Ministry of Defence": "/government/organisations/ministry-of-defence",
         "The Rt Hon Sir Eric Pickles MP": "/government/people/eric-pickles",
       },

--- a/test/integration/news_article_test.rb
+++ b/test/integration/news_article_test.rb
@@ -12,13 +12,11 @@ class NewsArticleTest < ActionDispatch::IntegrationTest
   test "renders first published and from in metadata and document footer" do
     setup_and_visit_content_item("news_article")
 
-    assert_has_publisher_metadata(
-      published: "Published 25 December 2016",
-      metadata: {
-        "From": {
-          "Prime Minister's Office, 10 Downing Street":
-            "/government/organisations/prime-ministers-office-10-downing-street",
-        },
+    assert_has_metadata(
+      published: "25 December 2016",
+      from: {
+        "Prime Minister's Office, 10 Downing Street":
+        "/government/organisations/prime-ministers-office-10-downing-street",
       },
     )
 

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -19,13 +19,11 @@ class PublicationTest < ActionDispatch::IntegrationTest
   test "renders metadata and document footer" do
     setup_and_visit_content_item("publication")
 
-    assert_has_publisher_metadata(
-      published: "Published 3 May 2016",
-      metadata: {
-        "From": {
-          "Environment Agency": "/government/organisations/environment-agency",
-          "The Rt Hon Sir Eric Pickles MP": "/government/people/eric-pickles",
-        },
+    assert_has_metadata(
+      published: "3 May 2016",
+      from: {
+        "Environment Agency": "/government/organisations/environment-agency",
+        "The Rt Hon Sir Eric Pickles MP": "/government/people/eric-pickles",
       },
     )
 

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -47,10 +47,10 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
   test "renders from in publisher metadata" do
     setup_and_visit_content_item("aaib-reports")
 
-    assert_has_publisher_metadata_other(
-      "From": {
+    assert_has_metadata(
+      from: {
         "Air Accidents Investigation Branch":
-          "/government/organisations/air-accidents-investigation-branch",
+        "/government/organisations/air-accidents-investigation-branch",
       },
     )
   end

--- a/test/integration/speech_test.rb
+++ b/test/integration/speech_test.rb
@@ -20,14 +20,12 @@ class SpeechTest < ActionDispatch::IntegrationTest
   test "renders metadata and document footer, including speaker" do
     setup_and_visit_content_item("speech")
 
-    assert_has_publisher_metadata(
-      published: "Published 8 March 2016",
-      metadata: {
-        "From": {
-          "Department of Energy & Climate Change and The Rt Hon Andrea Leadsom MP": nil,
-          "Department of Energy": "/government/organisations/department-of-energy-climate-change",
-          "The Rt Hon Andrea Leadsom MP": "/government/people/andrea-leadsom",
-        },
+    assert_has_metadata(
+      published: "8 March 2016",
+      from: {
+        "Department of Energy & Climate Change and The Rt Hon Andrea Leadsom MP": nil,
+        "Department of Energy": "/government/organisations/department-of-energy-climate-change",
+        "The Rt Hon Andrea Leadsom MP": "/government/people/andrea-leadsom",
       },
     )
 

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -11,11 +11,9 @@ class StatisticalDataSetTest < ActionDispatch::IntegrationTest
 
   test "renders metadata and document footer" do
     setup_and_visit_content_item("statistical_data_set")
-    assert_has_publisher_metadata(
-      published: "Published 13 December 2012",
-      metadata: {
-        "From:": { "Department for Transport": "/government/organisations/department-for-transport" },
-      },
+    assert_has_metadata(
+      published: "13 December 2012",
+      from: { "Department for Transport": "/government/organisations/department-for-transport" },
     )
     assert_footer_has_published_dates("Published 13 December 2012")
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -93,9 +93,9 @@ class ActionDispatch::IntegrationTest
   end
 
   def assert_has_publisher_metadata_other(metadata)
-    within(".app-c-publisher-metadata__other") do
+    within(".gem-c-metadata") do
       assert_has_metadata(
-        metadata, ".app-c-publisher-metadata__term", ".app-c-publisher-metadata__definition"
+        metadata, ".gem-c-metadata__term", ".gem-c-metadata__definition"
       )
     end
   end
@@ -120,7 +120,7 @@ class ActionDispatch::IntegrationTest
   end
 
   def assert_has_publisher_metadata(options)
-    within(".app-c-publisher-metadata") do
+    within(".gem-c-metadata") do
       assert_has_published_dates(options[:published], options[:last_updated], options[:history_link])
       assert_has_publisher_metadata_other(options[:metadata])
     end


### PR DESCRIPTION
## What?
Update local app Meta block to [gem component](https://components.publishing.service.gov.uk/component-guide/metadata)

## Why?

As part of on-going accessibility team work to align to gem based architecture to ensure future a11y improvements to components are cascaded to all apps

## Visuals
(Before > After)
 
<img width="1440" alt="Screenshot 2021-02-19 at 19 14 00" src="https://user-images.githubusercontent.com/71266765/108695174-e2751480-74f7-11eb-9fe1-a118889d5c82.png">

<img width="822" alt="Screenshot 2021-02-19 at 19 14 37" src="https://user-images.githubusercontent.com/71266765/108695165-df7a2400-74f7-11eb-95aa-01101bc3b304.png">

![image](https://user-images.githubusercontent.com/71266765/108695973-d3db2d00-74f8-11eb-90f6-dae254d8c789.png)

## Anything else?

[Ticket](https://trello.com/c/VSxcJHxI)
Testing Links:

https://www.gov.uk/government/news/statement-from-greg-clark-secretary-of-state-for-business-energy-and-industrial-strategy

https://www.gov.uk/government/publications/dwp-welsh-language-leaflets

https://www.gov.uk/government/news/christmas-2016-prime-ministers-message

Translations are out of scope of this particular card and have been [raised here](https://trello.com/c/mEGHKNGt/2371-5-investigate-and-fix-dates-not-being-translated):

![Screenshot 2021-02-19 at 10 52 16](https://user-images.githubusercontent.com/71266765/108695182-e4d76e80-74f7-11eb-9e13-408f6223a449.png)

![image](https://user-images.githubusercontent.com/71266765/108695662-75ae4a00-74f8-11eb-8ae6-bd9eb6d1c1c9.png)

