### PR TITLE
Replace sanitize with raw for legacy document list

### DIFF
--- a/app/views/content_items/_attachments.html.erb
+++ b/app/views/content_items/_attachments.html.erb
@@ -8,10 +8,7 @@
       <%= render 'govuk_publishing_components/components/govspeak', {
         direction: page_text_direction,
       } do %>
-        <%= sanitize(legacy_pre_rendered_documents, {
-          attributes: %w(alt class href id src data-module data-track-category data-track-action data-track-label data-track-options data-details-track-click aria-hidden),
-          tags: %w(a details div h2 h3 img p section span summary),
-        }) %>
+        <%= raw(legacy_pre_rendered_documents) %>
       <% end %>
     <% else %>
       <% attachments.each do |attachment_id| %>


### PR DESCRIPTION
## What
Replace `sanitize` with `raw` for the legacy pre-rendered documents list.

## Why
`sanitize` was stripping out the `tabindex` attribute from the legacy document list markup provided by Whitehall. `sanitize` requires an allowlist of attributes, but a more future-proof option is to use `raw` since this is markup from a trusted source.

## Visual differences

The document icon was focusable with an invisible focus state - so a user could tab there but there was no visual indication that the document icon was focused. This removes that link from the tab index, so it's no longer reachable by tabbing through the page. This means that the tab focus jumps from the document title to the next document title without detouring.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
