### PR TITLE
Add script names to Punjabi locale variations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,8 +101,8 @@ en:
     mt: Maltese
     nl: Dutch
     "no": Norwegian
-    pa: Punjabi
-    pa-pk: Punjabi (Pakistan)
+    pa: Punjabi Gurmukhi
+    pa-pk: Punjabi Shahmukhi
     pl: Polish
     ps: Pashto
     pt: Portuguese


### PR DESCRIPTION
We have support for two variations of Punjabi. This PR updates the language names for these two locales for clearer differentiation.

[trello](https://trello.com/c/devOCero/2369-3-change-punjabi-pakistan-language-tag)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
