### PR TITLE
Update travel advice callout boxes

### DIFF
--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -32,7 +32,7 @@
           Check the <a href="/guidance/national-lockdown-stay-at-home">rules in England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/covid-19-alert-levels">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>.
         </p>
         <p class="govuk-body">
-          Do not travel unless you have a legally permitted reason to do so. In England, from 8 March you must <a href="/guidance/coronavirus-covid-19-declaration-form-for-international-travel">complete a declaration form for international travel</a> (except for travel to Ireland).
+          Do not travel unless you have a legally permitted reason to do so. In England, you must <a href="/guidance/coronavirus-covid-19-declaration-form-for-international-travel">complete a declaration form for international travel</a> (except for travel to Ireland).
         </p>
         <p class="govuk-body">
           <a href="/guidance/travel-advice-novel-coronavirus">Check our advice</a> for all the countries you will visit or transit through. Some countries have closed borders, and any country may further restrict travel or bring in new rules with little warning.


### PR DESCRIPTION
This removes `from 8 March` from the copy in the callout boxes.

### Before

![Screenshot 2021-03-08 at 09 18 11](https://user-images.githubusercontent.com/44037625/110303577-72d05080-7ff2-11eb-864a-d66cc993f625.png)

### After

![Screenshot 2021-03-08 at 09 20 14](https://user-images.githubusercontent.com/44037625/110303541-6946e880-7ff2-11eb-871f-a778763ed09a.png)

[Trello](https://trello.com/c/SGZS4z43/224-travel-advice-call-out-box-update-8-march)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
