### PR TITLE
Fix flaky random publication tests

### DIFF
--- a/app/presenters/content_item/attachments.rb
+++ b/app/presenters/content_item/attachments.rb
@@ -1,7 +1,7 @@
 module ContentItem
   module Attachments
     def attachment_details(attachment_id)
-      content_item["details"]["attachments"].find do |attachment|
+      content_item.dig("details", "attachments")&.find do |attachment|
         attachment["id"] == attachment_id
       end
     end

--- a/app/views/content_items/_attachments.html.erb
+++ b/app/views/content_items/_attachments.html.erb
@@ -1,4 +1,6 @@
-<% if legacy_pre_rendered_documents.present? || attachments.any? %>
+<% attachments ||= [] %>
+<% attachment_details = attachments.filter_map { |id| @content_item&.attachment_details(id) } %>
+<% if legacy_pre_rendered_documents.present? || attachment_details.any? %>
   <section id="<%= title.parameterize %>">
     <%= render 'govuk_publishing_components/components/heading',
         text: title,
@@ -11,15 +13,14 @@
         <%= raw(legacy_pre_rendered_documents) %>
       <% end %>
     <% else %>
-      <% attachments.each do |attachment_id| %>
+      <% attachment_details.each do |details| %>
         <div class="attachment">
           <%= render 'govuk_publishing_components/components/attachment', {
             heading_level: 3,
-            attachment: @content_item.attachment_details(attachment_id)
+            attachment: details
           } %>
         </div>
       <% end %>
     <% end %>
-
   </section>
 <% end %>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -173,7 +173,7 @@ class ActionDispatch::IntegrationTest
 
   def setup_and_visit_random_content_item(document_type: nil)
     content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: schema_type) do |payload|
-      payload.merge("document_type" => document_type) unless document_type.nil?
+      payload.merge!("document_type" => document_type) unless document_type.nil?
       payload
     end
 


### PR DESCRIPTION
I was able to find three causes to a problem where unique schemas weren't being generated for the [random publication test](https://github.com/alphagov/government-frontend/blob/15c9c09d64767f73c145d9610494e675e246247d/test/integration/publication_test.rb#L4-L6).

1. Generating for an unexpected document type (fix in first commit)
2. Assumptions of attachment presence in code that don't match schema rules (fix in 2nd commit)
3. Invalid schemas being generated due to an array expecting unique items (fix in https://github.com/alphagov/govuk_schemas/pull/63) 

More info in the commits.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
