### PR TITLE
Add translations for Bangla, Punjabi Gurmukhi and Punjabi Shahmukhi

### DIFF
--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -1,143 +1,144 @@
+---
 bn:
   language_names:
-    bn: "বাংলা"
+    bn: বাংলা
   content_item:
     schema_name:
       announcement:
-        one:
-        other:
+        one: ঘোষণা
+        other: ঘোষণাসমূহ
       authored_article:
-        one:
-        other:
+        one: রচনা নিবন্ধ
+        other: রচনা নিবন্ধসমূহ
       case_study:
-        one:
-        other:
+        one: কেস স্টাডি
+        other: কেস স্টাডিসমূহ
       closed_consultation:
-        one:
-        other:
+        one: সমাপ্ত শলাপরামর্শ
+        other: সমাপ্ত শলাপরামর্শসমূহ
       consultation:
-        one:
-        other:
+        one: শলাপরামর্শ
+        other: শলাপরামর্শসমূহ
       consultation_outcome:
-        one:
-        other:
+        one: শলাপরামর্শের ফলাফল
+        other: শলাপরামর্শের ফলাফলসমূহ
       corporate_report:
-        one:
-        other:
+        one: কর্পোরেট রিপোর্ট
+        other: কর্পোরেট রিপোর্টসমূহ
       correspondence:
-        one:
-        other:
+        one: চিঠিপত্র
+        other: চিঠিপত্রসমূহ
       decision:
-        one:
-        other:
+        one: সিদ্ধান্ত
+        other: সিদ্ধান্তসমূহ
       detailed_guide:
-        one:
-        other:
+        one: নির্দেশনা
+        other: নির্দেশনা
       document_collection:
-        one:
-        other:
+        one: সংগ্রহ
+        other: সংগ্রহসমূহ
       draft_text:
-        one:
-        other:
+        one: খসড়া পাঠ্য
+        other: খসড়া পাঠ্যসমূহ
       fatality_notice:
         one:
         other:
       foi_release:
-        one:
-        other:
+        one: এফওআই বিজ্ঞপ্তি
+        other: এফওআই বিজ্ঞপ্তিসমূহ
       form:
-        one:
-        other:
+        one: ফরম
+        other: ফরমসমূহ
       government_response:
-        one:
-        other:
+        one: সরকারী প্রতিক্রিয়া
+        other: সরকারী প্রতিক্রিয়াসমূহ
       guidance:
-        one:
-        other:
+        one: নির্দেশনা
+        other: নির্দেশনা
       impact_assessment:
-        one:
-        other:
+        one: প্রভাব মূল্যায়ন
+        other: প্রভাব মূল্যায়নসমূহ
       imported:
-        one:
-        other:
+        one: আমদানিকৃত- প্রত্যাশিত প্রকার
+        other: আমদানিকৃত- প্রত্যাশিত প্রকার
       independent_report:
-        one:
-        other:
+        one: স্বতন্ত্র রিপোর্ট
+        other: স্বতন্ত্র রিপোর্টসমূহ
       international_treaty:
-        one:
-        other:
+        one: আন্তর্জাতিক চুক্তি
+        other: আন্তর্জাতিক চুক্তিসমূহ
       map:
-        one:
-        other:
+        one: মানচিত্র
+        other: মানচিত্রসমূহ
       national_statistics:
-        one:
-        other:
+        one: জাতীয় পরিসংখ্যান
+        other: জাতীয় পরিসংখ্যান
       news_article:
-        one:
-        other:
+        one: সংবাদ প্রবন্ধ
+        other: সংবাদ প্রবন্ধসমূহ
       news_story:
-        one:
-        other:
+        one: সংবাদের কাহিনী
+        other: সংবাদের কাহিনীসমূহ
       notice:
-        one:
-        other:
+        one: প্রজ্ঞাপন
+        other: প্রজ্ঞাপনসমূহ
       open_consultation:
-        one:
-        other:
+        one: উন্মুক্ত শলাপরামর্শ
+        other: উন্মুক্ত শলাপরামর্শসমূহ
       oral_statement:
-        one:
-        other:
+        one: সংসদে মৌখিক বিবৃতি
+        other: সংসদে মৌখিক বিবৃতিসমূহ
       policy:
         one:
         other:
       policy_paper:
-        one:
-        other:
+        one: নীতিমালা সংক্রান্ত পত্র
+        other: নীতিমালা সংক্রান্ত পত্রসমূহ
       press_release:
-        one:
-        other:
+        one: সংবাদ বিজ্ঞপ্তি
+        other: সংবাদ বিজ্ঞপ্তিসমূহ
       promotional:
-        one:
-        other:
+        one: প্রচারমূলক উপাদান
+        other: প্রচারমূলক উপাদান
       publication:
-        one:
-        other:
+        one: প্রকাশনা
+        other: প্রকাশনাসমূহ
       regulation:
-        one:
-        other:
+        one: নিয়ম
+        other: নিয়মাবলী
       research:
-        one:
-        other:
+        one: গবেষণা ও বিশ্লেষণ
+        other: গবেষণা ও বিশ্লেষণ
       speaking_notes:
-        one:
-        other:
+        one: কথ্য নোটসমূহ
+        other: কথ্য নোটসমূহ
       speech:
-        one:
-        other:
+        one: ভাষণ
+        other: ভাষণসমূহ
       statement_to_parliament:
-        one:
-        other:
+        one: সংসদে বিবৃতি
+        other: সংসদে বিবৃতিসমূহ
       statistical_data_set:
-        one:
-        other:
+        one: পরিসংখ্যানমূলক ডেটা সেট
+        other: পরিসংখ্যানমূলক ডেটা সেটসমূহ
       official_statistics:
-        one:
-        other:
+        one: দাপ্তরিক পরিসংখ্যান
+        other: দাপ্তরিক পরিসংখ্যান
       statutory_guidance:
-        one:
-        other:
+        one: সংবিধিবদ্ধ নির্দেশনা
+        other: সংবিধিবদ্ধ নির্দেশনা
       transcript:
-        one:
-        other:
+        one: প্রতিলিপি
+        other: প্রতিলিপিসমূহ
       transparency:
-        one:
-        other:
+        one: স্বচ্ছতামূলক ডেটা
+        other: স্বচ্ছতামূলক ডেটা
       world_location_news_article:
         one:
         other:
       written_statement:
-        one:
-        other:
+        one: সংসদে লিখিত বিবৃতি
+        other: সংসদে লিখিত বিবৃতিসমূহ
     metadata:
       published:
       updated:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -1,3 +1,4 @@
+---
 pa-pk:
   i18n:
     direction: rtl
@@ -7,23 +8,23 @@ pa-pk:
         one:
         other:
       announcement:
-        one:
-        other:
+        one: اعلان
+        other: اعلانات
       asylum_support_decision:
         one:
         other:
       authored_article:
-        one:
-        other:
+        one: تصنیف شدہ مضمون
+        other: تصنیف شدہ مضامین
       business_finance_support_scheme:
         one:
         other:
       case_study:
-        one:
-        other:
+        one: کیس سٹڈی
+        other: کیس سٹڈیز
       closed_consultation:
-        one:
-        other:
+        one: بند مشورہ
+        other: بند مشورے
       cma_case:
         one:
         other:
@@ -31,38 +32,38 @@ pa-pk:
         one:
         other:
       consultation:
-        one:
-        other:
+        one: مشورہ
+        other: مشورے
       consultation_outcome:
-        one:
-        other:
+        one: مشورے دا نتیجہ
+        other: مشورے دے نتیجے
       corporate_information_page:
         one:
         other:
       corporate_report:
-        one:
-        other:
+        one: کاروباری روپوٹ
+        other: کاروباری روپوٹاں
       correspondence:
-        one:
-        other:
+        one: خط و کتابت
+        other: خط و کتابت
       countryside_stewardship_grant:
         one:
         other:
       decision:
-        one:
-        other:
+        one: فیصلہ
+        other: فیصلے
       detailed_guide:
-        one:
-        other:
+        one: گائڈنس
+        other: گائڈنس
       dfid_research_output:
         one:
         other:
       document_collection:
-        one:
-        other:
+        one: مجموعہ
+        other: مجموعے
       draft_text:
-        one:
-        other:
+        one: متن دا مسودہ
+        other: متن دے مسودے
       drug_safety_update:
         one:
         other:
@@ -79,38 +80,38 @@ pa-pk:
         one:
         other:
       foi_release:
-        one:
-        other:
+        one: FOI اجراء
+        other: FOI اجراء
       form:
-        one:
-        other:
+        one: فارم
+        other: فارم
       government_response:
-        one:
-        other:
+        one: سرکاری جواب
+        other: سرکاری جواب
       guidance:
-        one:
-        other:
+        one: گائڈنس
+        other: گائڈنس
       impact_assessment:
-        one:
-        other:
+        one: اثر دا اندازہ
+        other: اثر دے اندازے
       imported:
-        one:
-        other:
+        one: درآمد شدہ- منتظر قسم
+        other: درآمد شدہ- منتظر قسم
       independent_report:
-        one:
-        other:
+        one: آزاد رپورٹ
+        other: آزاد رپورٹاں
       international_development_fund:
         one:
         other:
       international_treaty:
-        one:
-        other:
+        one: بین الاقوامی معاہدہ
+        other: بین الاقوامی معاہدے
       maib_report:
         one:
         other:
       map:
-        one:
-        other:
+        one: نقشہ
+        other: نقشے
       medical_safety_alert:
         one:
         other:
@@ -118,59 +119,59 @@ pa-pk:
         one:
         other:
       national_statistics:
-        one:
-        other:
+        one: قومی شماریات
+        other: قومی شماریات
       national_statistics_announcement:
         one:
         other:
       news_article:
-        one:
-        other:
+        one: خبر دا مضمون
+        other: خبر دے مضمون
       news_story:
-        one:
-        other:
+        one: خبر دی کہانی
+        other: خبر دی کہانیاں
       notice:
-        one:
-        other:
+        one: نوٹس
+        other: نوٹس
       official:
         one:
         other:
       official_statistics:
-        one:
-        other:
+        one: دفتری شماریات
+        other: دفتری شماریات
       official_statistics_announcement:
         one:
         other:
       open_consultation:
-        one:
-        other:
+        one: آزاد مشورہ
+        other: آزاد مشورے
       oral_statement:
-        one:
-        other:
+        one: پارلیمنٹ نوں زبانی بیان
+        other: پارلیمنٹ نوں زبانی بیانات
       policy:
         one:
         other:
       policy_paper:
-        one:
-        other:
+        one: پالیسی دا کاغذ
+        other: پالیسی دے کاغذات
       press_release:
-        one:
-        other:
+        one: پریس ریلیز
+        other: پریس ریلیزاں
       promotional:
-        one:
-        other:
+        one: تشہیری مواد
+        other: تشہیری مواد
       publication:
-        one:
-        other:
+        one: اشاعت
+        other: اشاعتاں
       raib_report:
         one:
         other:
       regulation:
-        one:
-        other:
+        one: ضابطہ
+        other: ضابطے
       research:
-        one:
-        other:
+        one: تحقیق و تجزیہ
+        other: تحقیق و تجزیہ
       residential_property_tribunal_decision:
         one:
         other:
@@ -181,23 +182,23 @@ pa-pk:
         one:
         other:
       speaking_notes:
-        one:
-        other:
+        one: بولن دے نوٹس
+        other: بولن دے نوٹس
       speech:
-        one:
-        other:
+        one: تقریر
+        other: تقریراں
       statement_to_parliament:
-        one:
-        other:
+        one: پارلیمنٹ نوں بیان
+        other: پارلیمنٹ نوں بیانات
       statistical_data_set:
-        one:
-        other:
+        one: شماریاتی ڈیٹا سیٹ
+        other: شماریاتی ڈیٹا سیٹ
       statistics_announcement:
         one:
         other:
       statutory_guidance:
-        one:
-        other:
+        one: قانونی رہنمائی
+        other: قانونی رہنمائی
       take_part:
         one:
         other:
@@ -205,11 +206,11 @@ pa-pk:
         one:
         other:
       transcript:
-        one:
-        other:
+        one: نقل
+        other: نقلاں
       transparency:
-        one:
-        other:
+        one: شفافیت دا مواد
+        other: شفافیت دا مواد
       utaac_decision:
         one:
         other:
@@ -220,8 +221,8 @@ pa-pk:
         one:
         other:
       written_statement:
-        one:
-        other:
+        one: پارلیمنٹ نوں لکھیا ہویا بیان
+        other: پارلیمنٹ نوں لکھے ہوئے بیان
     contents:
     metadata:
       published:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -1,3 +1,4 @@
+---
 pa:
   content_item:
     schema_name:
@@ -5,23 +6,23 @@ pa:
         one:
         other:
       announcement:
-        one:
-        other:
+        one: ਘੋਸ਼ਣਾ
+        other: ਘੋਸ਼ਣਾਵਾਂ
       asylum_support_decision:
         one:
         other:
       authored_article:
-        one:
-        other:
+        one: ਲੇਖਕ ਦਾ ਲੇਖ
+        other: ਲੇਖਕ ਦੇ ਲੇਖ
       business_finance_support_scheme:
         one:
         other:
       case_study:
-        one:
-        other:
+        one: ਕੇਸ ਅਧਿਐਨ
+        other: ਕੇਸ ਅਧਿਐਨ
       closed_consultation:
-        one:
-        other:
+        one: ਬੰਦ ਸਲਾਹ-ਮਸ਼ਵਰਾ
+        other: ਬੰਦ ਸਲਾਹ-ਮਸ਼ਵਰੇ
       cma_case:
         one:
         other:
@@ -29,38 +30,38 @@ pa:
         one:
         other:
       consultation:
-        one:
-        other:
+        one: ਸਲਾਹ-ਮਸ਼ਵਰਾ
+        other: ਸਲਾਹ-ਮਸ਼ਵਰੇ
       consultation_outcome:
-        one:
-        other:
+        one: ਸਲਾਹ-ਮਸ਼ਵਰੇ ਦਾ ਨਤੀਜਾ
+        other: ਸਲਾਹ-ਮਸ਼ਵਰੇ ਦੇ ਨਤੀਜੇ
       corporate_information_page:
         one:
         other:
       corporate_report:
-        one:
-        other:
+        one: ਕਾਰਪੋਰੇਟ ਰਿਪੋਰਟ
+        other: ਕਾਰਪੋਰੇਟ ਰਿਪੋਰਟਾਂ
       correspondence:
-        one:
-        other:
+        one: ਪੱਤਰ-ਵਿਹਾਰ
+        other: ਪੱਤਰ-ਵਿਹਾਰ
       countryside_stewardship_grant:
         one:
         other:
       decision:
-        one:
-        other:
+        one: ਫੈਸਲਾ
+        other: ਫੈਸਲੇ
       detailed_guide:
-        one:
-        other:
+        one: ਸੇਧ
+        other: ਸੇਧ
       dfid_research_output:
         one:
         other:
       document_collection:
-        one:
-        other:
+        one: ਸੰਗ੍ਰਹਿ
+        other: ਸੰਗ੍ਰਹਿ
       draft_text:
-        one:
-        other:
+        one: ਡ੍ਰਾਫਟ ਟੈਕਸਟ
+        other: ਡ੍ਰਾਫਟ ਟੈਕਸਟ
       drug_safety_update:
         one:
         other:
@@ -77,38 +78,38 @@ pa:
         one:
         other:
       foi_release:
-        one:
-        other:
+        one: FOI ਰਿਲੀਜ਼
+        other: FOI ਰਿਲੀਜ਼
       form:
-        one:
-        other:
+        one: ਫਾਰਮ
+        other: ਫਾਰਮ
       government_response:
-        one:
-        other:
+        one: ਸਰਕਾਰ ਦਾ ਜਵਾਬ
+        other: ਸਰਕਾਰ ਦੇ ਜਵਾਬ
       guidance:
-        one:
-        other:
+        one: ਸੇਧ
+        other: ਸੇਧ
       impact_assessment:
-        one:
-        other:
+        one: ਪ੍ਰਭਾਵ ਦਾ ਮੁਲਾਂਕਣ
+        other: ਪ੍ਰਭਾਵ ਦੇ ਮੁਲਾਂਕਣ
       imported:
-        one:
-        other:
+        one: ਆਯਾਤ ਕੀਤਾ - ਕਿਸਮ ਦੀ ਉਡੀਕ ਹੋ ਰਹੀ
+        other: ਆਯਾਤ ਕੀਤਾ - ਕਿਸਮ ਦੀ ਉਡੀਕ ਹੋ ਰਹੀ
       independent_report:
-        one:
-        other:
+        one: ਸੁਤੰਤਰ ਰਿਪੋਰਟ
+        other: ਸੁਤੰਤਰ ਰਿਪੋਰਟਾਂ
       international_development_fund:
         one:
         other:
       international_treaty:
-        one:
-        other:
+        one: ਅੰਤਰਰਾਸ਼ਟਰੀ ਸੰਧੀ
+        other: ਅੰਤਰਰਾਸ਼ਟਰੀ ਸੰਧੀਆਂ
       maib_report:
         one:
         other:
       map:
-        one:
-        other:
+        one: ਨਕਸ਼ਾ
+        other: ਨਕਸ਼ੇ
       medical_safety_alert:
         one:
         other:
@@ -116,59 +117,59 @@ pa:
         one:
         other:
       national_statistics:
-        one:
-        other:
+        one: ਰਾਸ਼ਟਰੀ ਅੰਕੜੇ
+        other: ਰਾਸ਼ਟਰੀ ਅੰਕੜੇ
       national_statistics_announcement:
         one:
         other:
       news_article:
-        one:
-        other:
+        one: ਖ਼ਬਰਾਂ ਦਾ ਲੇਖ
+        other: ਖ਼ਬਰਾਂ ਦੇ ਲੇਖ
       news_story:
-        one:
-        other:
+        one: ਖ਼ਬਰਾਂ ਦੀ ਕਹਾਣੀ
+        other: ਖ਼ਬਰਾਂ ਦੀਆਂ ਕਹਾਣੀਆਂ
       notice:
-        one:
-        other:
+        one: ਨੋਟਿਸ
+        other: ਨੋਟਿਸ
       official:
         one:
         other:
       official_statistics:
-        one:
-        other:
+        one: ਅਧਿਕਾਰਤ ਅੰਕੜੇ
+        other: ਅਧਿਕਾਰਤ ਅੰਕੜੇ
       official_statistics_announcement:
         one:
         other:
       open_consultation:
-        one:
-        other:
+        one: ਖੁੱਲ੍ਹਾ ਸਲਾਹ-ਮਸ਼ਵਰਾ
+        other: ਖੁੱਲ੍ਹੇ ਸਲਾਹ-ਮਸ਼ਵਰੇ
       oral_statement:
-        one:
-        other:
+        one: ਸੰਸਦ ਨੂੰ ਮੌਖਿਕ ਬਿਆਨ
+        other: ਸੰਸਦ ਨੂੰ ਮੌਖਿਕ ਬਿਆਨ
       policy:
         one:
         other:
       policy_paper:
-        one:
-        other:
+        one: ਨੀਤੀ ਪੱਤਰ
+        other: ਨੀਤੀ ਪੱਤਰ
       press_release:
-        one:
-        other:
+        one: ਪ੍ਰੈਸ ਰਿਲੀਜ਼
+        other: ਪ੍ਰੈਸ ਰਿਲੀਜ਼
       promotional:
-        one:
-        other:
+        one: ਪ੍ਰਚਾਰ ਸਮੱਗਰੀ
+        other: ਪ੍ਰਚਾਰ ਸਮੱਗਰੀ
       publication:
-        one:
-        other:
+        one: ਪ੍ਰਕਾਸ਼ਨ
+        other: ਪ੍ਰਕਾਸ਼ਨ
       raib_report:
         one:
         other:
       regulation:
-        one:
-        other:
+        one: ਨਿਯਮ
+        other: ਨਿਯਮ
       research:
-        one:
-        other:
+        one: ਖੋਜ ਅਤੇ ਵਿਸ਼ਲੇਸ਼ਣ
+        other: ਖੋਜ ਅਤੇ ਵਿਸ਼ਲੇਸ਼ਣ
       residential_property_tribunal_decision:
         one:
         other:
@@ -179,23 +180,23 @@ pa:
         one:
         other:
       speaking_notes:
-        one:
-        other:
+        one: ਬੋਲਣ ਲਈ ਨੋਟ
+        other: ਬੋਲਣ ਲਈ ਨੋਟ
       speech:
-        one:
-        other:
+        one: ਬੋਲਣਾ
+        other: ਭਾਸ਼ਣ
       statement_to_parliament:
-        one:
-        other:
+        one: ਸੰਸਦ ਨੂੰ ਬਿਆਨ
+        other: ਸੰਸਦ ਨੂੰ ਬਿਆਨ
       statistical_data_set:
-        one:
-        other:
+        one: ਅੰਕੜਾ ਡੇਟਾ ਸਮੂਹ
+        other: ਅੰਕੜਾ ਡੇਟਾ ਸਮੂਹ
       statistics_announcement:
         one:
         other:
       statutory_guidance:
-        one:
-        other:
+        one: ਵਿਧਾਨਿਕ ਸੇਧ
+        other: ਵਿਧਾਨਿਕ ਸੇਧ
       take_part:
         one:
         other:
@@ -203,11 +204,11 @@ pa:
         one:
         other:
       transcript:
-        one:
-        other:
+        one: ਪ੍ਰਤਿਲਿਪੀ
+        other: ਪ੍ਰਤਿਲਿਪੀਆਂ
       transparency:
-        one:
-        other:
+        one: ਪਾਰਦਰਸ਼ਤਾ ਡਾਟਾ
+        other: ਪਾਰਦਰਸ਼ਤਾ ਡਾਟਾ
       utaac_decision:
         one:
         other:
@@ -218,8 +219,8 @@ pa:
         one:
         other:
       written_statement:
-        one:
-        other:
+        one: ਸੰਸਦ ਨੂੰ ਲਿਖਤੀ ਬਿਆਨ
+        other: ਸੰਸਦ ਨੂੰ ਲਿਖਤੀ ਬਿਆਨ
     contents:
     metadata:
       published:


### PR DESCRIPTION
Adds the provided translated strings for the following languages:

* Bangla (`bn`)
* Punjabi Gurmukhi (`pa`)
* Punjabi Shahmukhi (`pa-PK`)

Follows on from https://github.com/alphagov/whitehall/pull/6023.

This was done with the `locales_export_import` gem to avoid large amounts of copy and pasting.

Trello card: https://trello.com/c/bJZCbzaI

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
