### PR TITLE
[DO NOT MERGE] Add AB Test for Weighted Suggested Related Links

### DIFF
--- a/app/controllers/concerns/weighted_links_ab_testable.rb
+++ b/app/controllers/concerns/weighted_links_ab_testable.rb
@@ -1,0 +1,25 @@
+module WeightedLinksAbTestable
+  CUSTOM_DIMENSION = 123 # TODO: Get this value from PAs
+  ALLOWED_VARIANTS = %w[A B Z].freeze
+
+  def weighted_links_test
+    @weighted_links_test ||= GovukAbTesting::AbTest.new(
+      "WeightedLinksAbTestable",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+    )
+  end
+
+  def weighted_links_variant
+    weighted_links_test.requested_variant(request.headers)
+  end
+
+  def set_weighted_links_response
+    weighted_links_variant.configure_response(response) if weighted_links_testable?
+  end
+
+  def weighted_links_testable?
+    WeightedLinksPage.find_page_with_base_path(request.path)
+  end
+end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -9,6 +9,12 @@ class ContentItemsController < ApplicationController
   rescue_from PresenterBuilder::SpecialRouteReturned, with: :error_notfound
   rescue_from PresenterBuilder::GovernmentReturned, with: :error_notfound
 
+  include WeightedLinksAbTestable
+
+  before_action :set_weighted_links_response
+
+  helper_method :weighted_links_variant, :weighted_links_testable?
+
   attr_accessor :content_item, :taxonomy_navigation
 
   def show
@@ -91,7 +97,11 @@ private
     if show_suggested_links?(content_item_data)
       suggested_links_builder ||= SuggestedLinksBuilder.new(content_item_data)
 
-      content_item_data["links"]["ordered_related_items"] = suggested_links_builder.suggested_related_links
+      content_item_data["links"]["ordered_related_items"] = if weighted_links_variant.variant?("B")
+                                                              suggested_links_builder.weighted_related_links
+                                                            else
+                                                              suggested_links_builder.suggested_related_links
+                                                            end
     end
 
     @content_item = PresenterBuilder.new(

--- a/app/lib/suggested_links_builder.rb
+++ b/app/lib/suggested_links_builder.rb
@@ -1,0 +1,13 @@
+class SuggestedLinksBuilder
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def suggested_related_links
+    @content_item["links"].fetch("suggested_ordered_related_items", [])
+  end
+
+private
+
+  attr_reader :content_item
+end

--- a/app/lib/suggested_links_builder.rb
+++ b/app/lib/suggested_links_builder.rb
@@ -7,6 +7,16 @@ class SuggestedLinksBuilder
     @content_item["links"].fetch("suggested_ordered_related_items", [])
   end
 
+  def weighted_related_links
+    weighted_page = WeightedLinksPage.find_page_with_base_path(@content_item["base_path"])
+
+    if weighted_page
+      weighted_page.related_links.map do |link|
+        Services.content_store.content_item(link)
+      end
+    end
+  end
+
 private
 
   attr_reader :content_item

--- a/app/lib/weighted_links_page.rb
+++ b/app/lib/weighted_links_page.rb
@@ -1,0 +1,29 @@
+class WeightedLinksPage
+  include ActiveModel::Validations
+
+  CONFIG_PATH = Rails.root.join("app/lib/weighted_links_pages.yaml")
+
+  attr_accessor :page_base_path, :related_links
+
+  validates_presence_of :page_base_path, :related_links
+  validate { errors.add(:related_links, "is not an array") unless related_links.is_a? Array }
+
+  def initialize(attrs)
+    attrs.each { |key, value| instance_variable_set("@#{key}", value) }
+    validate!
+  end
+
+  def self.find_page_with_base_path(base_path)
+    load_all.find do |page|
+      page.page_base_path == base_path
+    end
+  end
+
+  def self.load(params)
+    new(params)
+  end
+
+  def self.load_all
+    @load_all ||= YAML.load_file(CONFIG_PATH)["weighted_links_pages"].map { |page| load(page) }
+  end
+end

--- a/app/lib/weighted_links_pages.yaml
+++ b/app/lib/weighted_links_pages.yaml
@@ -1,0 +1,9 @@
+weighted_links_pages:
+  - page_base_path: "/government/case-studies/using-rewards-encouraging-good-behaviour"
+    related_links:
+      - "/coronavirus"
+      - "/guidance/rapid-lateral-flow-testing-for-households-and-bubbles-of-school-pupils-and-staff"
+  - page_base_path: "/guidance/making-a-support-bubble-with-another-household"
+    related_links:
+      - "/coronavirus"
+      - "/get-coronavirus-test"

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -2,6 +2,7 @@
   <%= machine_readable_metadata(
     schema: :article
   ) %>
+  <%= weighted_links_variant.analytics_meta_tag.html_safe if weighted_links_testable? %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -2,6 +2,7 @@
   <%= machine_readable_metadata(
     schema: :faq
   ) %>
+  <%= weighted_links_variant.analytics_meta_tag.html_safe if weighted_links_testable? %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -385,6 +385,55 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_select ".gem-c-contextual-footer", false
   end
 
+  test "shows the B variant suggested related link" do
+    content_item = content_store_has_example_item("/government/case-studies/using-rewards-encouraging-good-behaviour", schema: "case_study")
+    content_item["links"]["suggested_ordered_related_items"] =
+      [
+        {
+          "content_id": "774cee22-d896-44c1-a611-e3109cce8eae",
+          "title": "Coronavirus (COVID-19): guidance and support",
+          "locale": "en",
+          "api_path": "/api/content/coronavirus",
+          "base_path": "/coronavirus",
+          "document_type": "coronavirus_landing_page",
+          "public_updated_at": "2020-12-23T15:27:18Z",
+          "schema_name": "coronavirus_landing_page",
+          "withdrawn": false,
+          "description": "Find information on coronavirus, including guidance, support, announcements and statistics.",
+          "links": {},
+          "api_url": "https://www.gov.uk/api/content/coronavirus",
+          "web_url": "https://www.gov.uk/coronavirus",
+        },
+        {
+          "content_id": "b32fd0f5-b2fa-45c5-8fe8-8715a0f6574b",
+          "title": "Making a support bubble with another household",
+          "locale": "en",
+          "api_path": "/api/content/guidance/making-a-support-bubble-with-another-household",
+          "base_path": "/guidance/making-a-support-bubble-with-another-household",
+          "document_type": "detailed_guide",
+          "public_updated_at": "2021-01-15T16:40:21Z",
+          "schema_name": "detailed_guide",
+          "withdrawn": false,
+          "links": {},
+          "api_url": "https://www.gov.uk/api/content/guidance/making-a-support-bubble-with-another-household",
+          "web_url": "https://www.gov.uk/guidance/making-a-support-bubble-with-another-household",
+        },
+      ]
+
+    with_variant WeightedLinksAbTestable: "B" do
+      get :show, params: { path: path_for(content_item) }
+
+      assert_response :success
+      assert_select "h2.gem-c-related-navigation__main-heading"
+    end
+  end
+
+  test "headers are not modified when pages are not in AB test" do
+    content_item = content_store_has_schema_example("case_study", "case_study")
+    get :show, params: { path: path_for(content_item) }
+    assert_response_not_modified_for_ab_test(WeightedLinksAbTestable)
+  end
+
   def path_for(content_item, locale = nil)
     base_path = content_item["base_path"].sub(/^\//, "")
     base_path.gsub!(/\.#{locale}$/, "") if locale

--- a/test/models/weighted_links_page_test.rb
+++ b/test/models/weighted_links_page_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class WeightedLinksPageTest < ActiveSupport::TestCase
+  test "is invalid without any attributes" do
+    attrs = {}
+
+    assert_raise do
+      WeightedLinksPage.new(attrs)
+    end
+  end
+
+  test "is invalid without any related links" do
+    attrs = {
+      "page_base_path" => "/coronavirus",
+    }
+
+    assert_raise do
+      WeightedLinksPage.new(attrs)
+    end
+  end
+
+  test "has errors if related links are not an array" do
+    attrs = {
+      "page_base_path" => "/coronavirus",
+      "related_links" => "not an array",
+    }
+
+    assert_raise do
+      page = WeightedLinksPage.new(attrs)
+      assert_not_empty page.errors.messages
+    end
+  end
+
+  test "valid" do
+    attrs = {
+      "page_base_path" => "/coronavirus",
+      "related_links" => %w[stuff in here],
+    }
+    page = WeightedLinksPage.new(attrs)
+
+    assert page.valid?
+    assert_empty page.errors.messages
+  end
+
+  test "load" do
+    attrs = {
+      "page_base_path" => "/coronavirus",
+      "related_links" => %w[/stay-at-home /wear-a-mask /wash-your-hands],
+    }
+    page = WeightedLinksPage.load(attrs)
+
+    assert_equal "/coronavirus", page.page_base_path
+    assert page.related_links.is_a?(Array)
+
+    %w[/stay-at-home /wear-a-mask /wash-your-hands].each do |related_link|
+      assert page.related_links.include?(related_link)
+    end
+  end
+
+  test "find_page_with_base_path" do
+    attrs = {
+      "page_base_path" => "/brexit",
+      "related_links" => %w[/travelling-abroad /customs /citizenship],
+    }
+    page = WeightedLinksPage.load(attrs)
+
+    WeightedLinksPage.expects(:find_page_with_base_path).with("/brexit").returns(page)
+    assert_equal page, WeightedLinksPage.find_page_with_base_path("/brexit")
+  end
+end

--- a/test/support/govuk_content_schema_examples.rb
+++ b/test/support/govuk_content_schema_examples.rb
@@ -25,6 +25,16 @@ module GovukContentSchemaExamples
     document
   end
 
+  def content_store_has_example_item(base_path, schema:, example: nil)
+    content_item = GovukSchemas::Example.find(schema, example_name: example || schema)
+
+    content_item["links"] ||= {}
+    content_item["base_path"] = base_path
+
+    stub_content_store_has_item(base_path, content_item)
+    content_item
+  end
+
   def govuk_content_schema_example(schema_name, example_name)
     GovukSchemas::Example.find(schema_name, example_name: example_name)
   end


### PR DESCRIPTION
Adds in an AB Test for Related Links onto Case Studies and Detailed Guides. The pages that are to have the new links are hard-coded from a pre-generated list from the [related-links-recommender](https://github.com/alphagov/govuk-related-links-recommender/pull/83) for this test.

Trello card https://trello.com/c/wRj0CsIV/864-build-in-ab-feature-for-weighted-related-links

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
