### PR TITLE
Update back-to-top SVG arrow attributes

### DIFF
--- a/app/views/components/_back-to-top.html.erb
+++ b/app/views/components/_back-to-top.html.erb
@@ -3,7 +3,7 @@
 %>
 <a class="govuk-link app-c-back-to-top dont-print"
     href="<%= href %>">
-    <svg class="app-c-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+    <svg class="app-c-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17" aria-hidden="true" focusable="false">
       <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"/>
     </svg>
     <%= text %>


### PR DESCRIPTION
It was recommended on GOVUK Accounts team's DAC report that `focusable="false"` and `aria-hidden="true"` are added to the "up arrow" SVG on our [Privacy notice and Accessibility statement page](https://www.gov.uk/government/publications/govuk-accounts-trial-full-privacy-notice-and-accessibility-statement/govuk-accounts-trial-full-privacy-notice#content):
<img width="581" alt="Screenshot 2021-03-12 at 16 43 25" src="https://user-images.githubusercontent.com/7116819/110970880-18b4ef80-8352-11eb-8ede-219ee5706ed7.png">

SVGs are in tab sequence in IE, which means that focus disappears as it sequences over them. Adding `focusable="false"` ensures the SVG is not in tab sequence, while `aria-hidden="true"` ensures that it is hidden from screen readers.


https://trello.com/c/lNkwruEi/647-fix-accessibility-issues-raised-by-dac 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
