### PR TITLE
Rename Top Actions in How To Vote schema

### DIFF
--- a/config/machine_readable/how-to-vote.yml
+++ b/config/machine_readable/how-to-vote.yml
@@ -5,7 +5,7 @@ preamble: >
   <p>There are elections and referendums in England, Scotland and Wales on 6 May 2021.</p>
 
 faqs:
-  - question: Top Actions
+  - question: Related content
     answer: >
       <a href="https://www.registertovote.service.gov.uk/register-to-vote/start?src=actions">Register to vote</a>
       <a href="/how-to-vote/postal-voting?src=actions">Apply for a postal vote</a>


### PR DESCRIPTION
This work is in preparation for the local elections on 6 May.

We can't use Top Actions because we don't render them visibly on the page. We've been advised to use "Related content" instead.

Related to: https://github.com/alphagov/frontend/pull/2665

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
