### PR TITLE
Remove unused pluralisation keys from locale files

### DIFF
--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -4,131 +4,94 @@ az:
   content_item:
     schema_name:
       announcement:
-        one: Elan
         other: Elanlar
       authored_article:
         other:
       case_study:
-        one: "Öyrənilib"
         other: "Öyrənilib"
       closed_consultation:
-        one: Bağlı məslətləşmə
         other: Bağlı məslətləşmələr
       consultation:
-        one: Məsləhət
         other: məsləhətləşmələr
       consultation_outcome:
-        one: məsləhətləşmənin nəticəsi
         other: məsləhətləşmənin nəticələri
       corporate_report:
-        one: birgə məruzə
         other: birgə məruzələr
       correspondence:
-        one: Yazışmalar
         other: Yazışmalar
       decision:
         other:
       detailed_guide:
-        one: "ətraflı məlumat"
         other: "ətraflı məlumat"
       document_collection:
-        one: növlər
         other:
       draft_text:
-        one: hazırlanmış mətn
         other: hazırlanmış mətn
       fatality_notice:
-        one: səhvlə bağlı qeyd
         other: səhvlə bağlı qeydlər
       foi_release:
-        one: Məlumat azadlığı ilə bağlı açıqlama
         other: Məlumat azadlığı ilə bağlı açıqlamalar
       form:
-        one: Forma
         other: Formalar
       government_response:
         other:
       guidance:
-        one: "İnstruksiya"
         other: "İnstruksiya"
       impact_assessment:
-        one: Dəyərləndirmə
         other: Dəyərləndirmə
       imported:
         other:
       independent_report:
-        one: Müstəqil məruzə
         other: Müstəqil məruzələr
       international_treaty:
         other:
       map:
-        one: Xəritə
         other: xəritələr
       national_statistics:
-        one: Statistika - milli statistika
         other: Statistika - milli statistika
       news_article:
-        one: məqalə
         other: məqalələr
       news_story:
-        one: Xəbərlər
         other: Xəbərlər
       notice:
         other:
       open_consultation:
-        one: açıq məsləhətləşmələr
         other: açıq məsləhətləşmələr
       oral_statement:
-        one: Parliamentə açıq bəyanat
         other: Parlamentə açıq bəyanatlar
       policy:
-        one: Siyasət
         other: Siyasət
       policy_paper:
-        one: Siyasi sənədlər
         other: Siyasi sənədlər
       press_release:
-        one: mətbuat üçün açıqlama
         other: mətbuat üçün açıqlama
       promotional:
-        one: Təşviqedici materiallar
         other: Təşviqedici materiallar
       publication:
-        one: Nəşrlər
         other: Nəşrlər
       regulation:
         other:
       research:
-        one: Tətqiqat və analiz
         other: Tətqiqat və analiz
       speaking_notes:
-        one: "Çıxış üçün  qeydləri"
         other: "Çıxış üçün  qeydləri"
       speech:
-        one: "çıxış"
         other: "Çıxışlar"
       statement_to_parliament:
-        one: Parlamentə bəyanat
         other: Parlamentə bəyanatlar
       statistical_data_set:
-        one: statistik məlumatlar bazası
         other: statistik məlumatlar bazaları
       official_statistics:
-        one: statistika
         other: statistika
       statutory_guidance:
         other:
       transcript:
-        one: Transkripsiya
         other: Transkripsiyalar
       transparency:
-        one: "Şəffaf məlumat"
         other: "Şəffaf məlumat"
       world_location_news_article:
-        one: məqalə
         other: məqalələr
       written_statement:
-        one: Parlamentə yazılı müraciət
         other: Parlamentə yazılı müraciət
     metadata:
       published: dərc olunub

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -7,7 +7,6 @@ az:
         one: Elan
         other: Elanlar
       authored_article:
-        one:
         other:
       case_study:
         one: "Öyrənilib"
@@ -28,7 +27,6 @@ az:
         one: Yazışmalar
         other: Yazışmalar
       decision:
-        one:
         other:
       detailed_guide:
         one: "ətraflı məlumat"
@@ -49,7 +47,6 @@ az:
         one: Forma
         other: Formalar
       government_response:
-        one:
         other:
       guidance:
         one: "İnstruksiya"
@@ -58,13 +55,11 @@ az:
         one: Dəyərləndirmə
         other: Dəyərləndirmə
       imported:
-        one:
         other:
       independent_report:
         one: Müstəqil məruzə
         other: Müstəqil məruzələr
       international_treaty:
-        one:
         other:
       map:
         one: Xəritə
@@ -79,7 +74,6 @@ az:
         one: Xəbərlər
         other: Xəbərlər
       notice:
-        one:
         other:
       open_consultation:
         one: açıq məsləhətləşmələr
@@ -103,7 +97,6 @@ az:
         one: Nəşrlər
         other: Nəşrlər
       regulation:
-        one:
         other:
       research:
         one: Tətqiqat və analiz
@@ -124,7 +117,6 @@ az:
         one: statistika
         other: statistika
       statutory_guidance:
-        one:
         other:
       transcript:
         one: Transkripsiya
@@ -147,7 +139,6 @@ az:
     related_guides:
   publication:
     documents:
-      one:
       other:
   corporate_information_page:
     corporate_information:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -30,7 +30,6 @@ fa:
         one: "مکاتبه"
         other: "مکاتبات"
       decision:
-        one:
         other:
       detailed_guide:
         one: "راهنمای تفصیلی"
@@ -66,7 +65,6 @@ fa:
         one: "گزارش مستقل"
         other: "گزارش های مستقل"
       international_treaty:
-        one:
         other:
       map:
         one: "نقشه"
@@ -81,7 +79,6 @@ fa:
         one: "خبر"
         other: "اخبار"
       notice:
-        one:
         other:
       open_consultation:
         one: "رایزنی باز"
@@ -105,7 +102,6 @@ fa:
         one: "نشریه"
         other: "نشریات"
       regulation:
-        one:
         other:
       research:
         one: "پژوهش و تحلیل"
@@ -126,7 +122,6 @@ fa:
         one: "آمار"
         other: "آمار"
       statutory_guidance:
-        one:
         other:
       transcript:
         one: "رونوشت"

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -6,134 +6,94 @@ fa:
   content_item:
     schema_name:
       announcement:
-        one: "اعلامیه"
         other: "اعلامیه ها"
       authored_article:
-        one: "مقاله"
         other: "مقالات"
       case_study:
-        one: "مطالعه ی موردی"
         other: "مطالعه های موردی"
       closed_consultation:
-        one: "رایزنی بسته"
         other: "رایزنی های بسته"
       consultation:
-        one: "رایزنی"
         other: "رایزنی ها"
       consultation_outcome:
-        one: "نتیجه رایزنی"
         other: "نتایج رایزنی"
       corporate_report:
-        one: "گزارش سازمانی"
         other: "گزارش های سازمانی"
       correspondence:
-        one: "مکاتبه"
         other: "مکاتبات"
       decision:
         other:
       detailed_guide:
-        one: "راهنمای تفصیلی"
         other: "راهنمای تفصیلی"
       document_collection:
-        one: "ردیف"
         other:
       draft_text:
-        one: "متن پیش نویس"
         other: "متون پیش نویس"
       fatality_notice:
-        one: "اطلاعیه تلفات"
         other: "اطلاعیه تلفات"
       foi_release:
-        one: "انتشار آزاد اطلاعات"
         other: "انتشار آزاد اطلاعات"
       form:
-        one: "فرم"
         other: "فرم ها"
       government_response:
-        one: "جوابیه دولت"
         other: "جوابیه های دولت"
       guidance:
-        one: "راهنمایی"
         other: "راهنمایی"
       impact_assessment:
-        one: "ارزیابی تاثیرات"
         other: "ارزیابی های تاثیرات"
       imported:
-        one: "منتقل شده - در انتظار دسته بندی"
         other: "منتقل شده - در انتظار دسته بندی"
       independent_report:
-        one: "گزارش مستقل"
         other: "گزارش های مستقل"
       international_treaty:
         other:
       map:
-        one: "نقشه"
         other: "نقشه ها"
       national_statistics:
-        one: "آمار - آمار ملی"
         other: "آمار - آمار ملی"
       news_article:
-        one: "مقاله ی خبری"
         other: "مقالات خبری"
       news_story:
-        one: "خبر"
         other: "اخبار"
       notice:
         other:
       open_consultation:
-        one: "رایزنی باز"
         other: "رایزنی های باز"
       oral_statement:
-        one: "گزارش شفاهی به پارلمان"
         other: "گزارش های شفاهی به پارلمان"
       policy:
-        one: "سیاست"
         other: "سیاست ها"
       policy_paper:
-        one: "مقاله ی سیاسی"
         other: "مقاله های سیاسی"
       press_release:
-        one: "بیانیه"
         other: "بیانیه ها"
       promotional:
-        one: "مطالب تبلیغاتی"
         other: "مطالب تبلیغاتی"
       publication:
-        one: "نشریه"
         other: "نشریات"
       regulation:
         other:
       research:
-        one: "پژوهش و تحلیل"
         other: "پژوهش و تحلیل"
       speaking_notes:
-        one: "موضوعات سخنرانی"
         other: "موضوعات سخنرانی"
       speech:
-        one: "سخنرانی"
         other: "سخنرانی ها"
       statement_to_parliament:
-        one: "گزارش به پارلمان"
         other: "گزارش ها به پارلمان"
       statistical_data_set:
-        one: "بسته ی داده های آماری"
         other: "بسته های داده های آماری"
       official_statistics:
-        one: "آمار"
         other: "آمار"
       statutory_guidance:
         other:
       transcript:
-        one: "رونوشت"
         other: "رونوشت ها"
       transparency:
-        one: "داده های شفاف سازی"
         other: "داده های شفاف سازی"
       world_location_news_article:
-        one: "مقاله ی خبری"
         other: "مقالات خبری"
       written_statement:
-        one: "گزارش کتبی به پارلمان"
         other: "گزارش های کتبی به پارلمان"
     metadata:
       published: "منتشر شده"
@@ -144,7 +104,6 @@ fa:
     related_guides:
   publication:
     documents:
-      one: "مدرک"
       other: "مدارک"
   corporate_information_page:
     corporate_information: اطلاعات سازمانی

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -7,228 +7,138 @@ he:
     schema_name:
       announcement:
         one: "הודעה"
-        two:
-        many:
         other: "הודעות"
       authored_article:
         one: "מאמר מאושר"
-        two:
-        many:
         other: "מאמרים מאושרים"
       case_study:
         one: "מקרה בוחן"
-        two:
-        many:
         other: "מקרי בוחן"
       closed_consultation:
         one: "דיון סגור"
-        two:
-        many:
         other: "דיונים סגורים"
       consultation:
         one: "דיון"
-        two:
-        many:
         other: "דיונים"
       consultation_outcome:
         one: "תוצאות דיון"
-        two:
-        many:
         other: "תוצאות דיונים"
       corporate_report:
         one: דו"ח משותף
-        two:
-        many:
         other: דו"חות משותפים
       correspondence:
         one: "תכתובת"
-        two:
-        many:
         other: "תכתובות"
       decision:
         one:
-        two:
-        many:
         other:
       detailed_guide:
         one: "מדריך מפורט"
-        two:
-        many:
         other: "מדריך מפורט"
       document_collection:
         one: "סדרות"
-        two:
-        many:
         other:
       draft_text:
         one: "טיוטה"
-        two:
-        many:
         other: "טיוטות"
       fatality_notice:
         one: "הודעת פטירה"
-        two:
-        many:
         other: "הודעות פטירה"
       foi_release:
         one: "פרסום חופש מידע"
-        two:
-        many:
         other: "פרסומי חופש מידע"
       form:
         one: "טופס"
-        two:
-        many:
         other: "טפסים"
       government_response:
         one: "תגובה ממשלתית"
-        two:
-        many:
         other: "תגובות ממשלתיות"
       guidance:
         one: "הדרכה"
-        two:
-        many:
         other: "הדרכה"
       impact_assessment:
         one: "הערכת השפעה"
-        two:
-        many:
         other: "הערכת השפעות"
       imported:
         one: "יבוא- המתנה לסוג"
-        two:
-        many:
         other: "יבוא- המתנה לסוג"
       independent_report:
         one: דו"ח עצמאי
-        two:
-        many:
         other: דו"ות עצמאיים
       international_treaty:
         one:
-        two:
-        many:
         other:
       map:
         one: "מפה"
-        two:
-        many:
         other: "מפות"
       national_statistics:
         one: "סטטיסטיקות- סטטיסטיקה לאומית"
-        two:
-        many:
         other: "סטטיסטיקות- סטטסטיקה לאומית"
       news_article:
         one: "מאמר חדשות"
-        two:
-        many:
         other: "מאמרי חדשות"
       news_story:
         one: "חדשות"
-        two:
-        many:
         other: "חדשות"
       notice:
         one:
-        two:
-        many:
         other:
       open_consultation:
         one: "דיון פתוח"
-        two:
-        many:
         other: "דיון פתוח"
       oral_statement:
         one: "הצהרה בעל פה לפרלמנט"
-        two:
-        many:
         other: "הצהרות בעל פה לפרלמנט"
       policy:
         one: "מדיניות"
-        two:
-        many:
         other: "מדיניות"
       policy_paper:
         one: "נייר מדיניות"
-        two:
-        many:
         other: "ניירות מדיניות"
       press_release:
         one: "הודעה לעיתונות"
-        two:
-        many:
         other: "הודעות לעיתונות"
       promotional:
         one: "חומר פרסומי"
-        two:
-        many:
         other: "חומר פרסומי"
       publication:
         one: "פרסום"
-        two:
-        many:
         other: "פרסומים"
       regulation:
         one:
-        two:
-        many:
         other:
       research:
         one: "מחקר וניתוח"
-        two:
-        many:
         other: "מחקר וניתוח"
       speaking_notes:
         one: "נאומים"
-        two:
-        many:
         other: "נאומים"
       speech:
         one: "נאום"
-        two:
-        many:
         other: "נאומים"
       statement_to_parliament:
         one: "הצהרה לפרלמנט"
-        two:
-        many:
         other: "הצהרות לפרלמנט"
       statistical_data_set:
         one: "מידע סטטיסטי"
-        two:
-        many:
         other: "מידע סטטיסטי"
       official_statistics:
         one: "נתונים"
-        two:
-        many:
         other: "נתונים"
       statutory_guidance:
         one:
-        two:
-        many:
         other:
       transcript:
         one: "תמלול"
-        two:
-        many:
         other: "תמלולים"
       transparency:
         one: "שקיפות מידע"
-        two:
-        many:
         other: "שקיפות מידע"
       world_location_news_article:
         one: "מאמר חדשות"
-        two:
-        many:
         other: "מאמרי חדשות"
       written_statement:
         one: "הצהרה בכתב לפרלמנט"
-        two:
-        many:
         other: "הצהרות בכתב לפרלמנט"
     metadata:
       published: "פורסם"
@@ -240,8 +150,6 @@ he:
   publication:
     documents:
       one: "מסמך"
-      two:
-      many:
       other: "מסמכים"
   corporate_information_page:
     corporate_information: מידע מסחרי

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -28,7 +28,6 @@ id:
         one: Koresponden
         other: Koresponden-koresponden
       decision:
-        one:
         other:
       detailed_guide:
         one: Panduan lebih lanjut
@@ -64,7 +63,6 @@ id:
         one: Laporan independen
         other: Laporan-laporan independen
       international_treaty:
-        one:
         other:
       map:
         one: Peta
@@ -79,7 +77,6 @@ id:
         one: Berita
         other: Berita-berita
       notice:
-        one:
         other:
       open_consultation:
         one: Konsultasi terbuka
@@ -103,7 +100,6 @@ id:
         one: Publikasi
         other: Publikasi-publikasi
       regulation:
-        one:
         other:
       research:
         one: Riset dan analisis
@@ -124,7 +120,6 @@ id:
         one: Statistik
         other: Statistik-statistik
       statutory_guidance:
-        one:
         other:
       transcript:
         one: Transkrip

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -4,134 +4,94 @@ id:
   content_item:
     schema_name:
       announcement:
-        one: Pengumuman
         other: Pengumuman-pengumuman
       authored_article:
-        one: Artikel yang ditulis
         other: Artikel-artikel yang ditulis
       case_study:
-        one: Studi kasus
         other: Studi-studi kasus
       closed_consultation:
-        one: Konsultasi tertutup
         other: Konsultasi-konsultasi tertutup
       consultation:
-        one: Konsultasi
         other: Konsultasi-konsultasi
       consultation_outcome:
-        one: Hasil konsultasi
         other: Hasil-hasil konsultasi
       corporate_report:
-        one: Laporan korporat
         other: Laporan-laporan korporat
       correspondence:
-        one: Koresponden
         other: Koresponden-koresponden
       decision:
         other:
       detailed_guide:
-        one: Panduan lebih lanjut
         other: Panduan lebih lanjut
       document_collection:
-        one: Serial
         other:
       draft_text:
-        one: Rancangan teks
         other: Rancangan tulisan
       fatality_notice:
-        one: Pemberitahuan kematian
         other: Pemberitahuan-pemberitahuan kematian
       foi_release:
-        one: Rilis FOI
         other: Rilis FOI
       form:
-        one: Formulir
         other: Formulir-formulir
       government_response:
-        one: Respon Pemerintah
         other: Respon-respon Pemerintah
       guidance:
-        one: Panduan
         other: Panduan
       impact_assessment:
-        one: Penilaian dampak
         other: Penilaian-penilaian dampak
       imported:
-        one: Diimpor-menunggu tipe
         other: Diimpor-menunggu tipe
       independent_report:
-        one: Laporan independen
         other: Laporan-laporan independen
       international_treaty:
         other:
       map:
-        one: Peta
         other: Peta-peta
       national_statistics:
-        one: Statistik-statistik nasional
         other: Statistik-statistik nasional
       news_article:
-        one: Artikel berita
         other: Artikel-artikel berita
       news_story:
-        one: Berita
         other: Berita-berita
       notice:
         other:
       open_consultation:
-        one: Konsultasi terbuka
         other: Konsultasi-konsultasi terbuka
       oral_statement:
-        one: Pernyataan langsung kepada parlemen
         other: Pernyataan-pernyataan langsung kepada parlemen
       policy:
-        one: Kebijakan
         other: Kebijakan-kebijakan
       policy_paper:
-        one: Laporan kebijakan
         other: Laporan-laporan kebijakan
       press_release:
-        one: Rilis pers
         other: Rilis pers
       promotional:
-        one: Materi promosi
         other: Materi promosi
       publication:
-        one: Publikasi
         other: Publikasi-publikasi
       regulation:
         other:
       research:
-        one: Riset dan analisis
         other: Riset dan analisis
       speaking_notes:
-        one: Naskah Pembicara
         other: Naskah Pembicara
       speech:
-        one: Pidato
         other: Pidato-pidato
       statement_to_parliament:
-        one: Pernyatan kepada Parlemen
         other: Pernyataan-pernyaatan kepada Parlemen
       statistical_data_set:
-        one: Set data statistik
         other: Set data statistik
       official_statistics:
-        one: Statistik
         other: Statistik-statistik
       statutory_guidance:
         other:
       transcript:
-        one: Transkrip
         other: Transkrip-transkrip
       transparency:
-        one: Transparansi data
         other: Transparansi data
       world_location_news_article:
-        one: Artikel berita
         other: Artikel-artikel berita
       written_statement:
-        one: Pernyataan tertulis kepada parlemen
         other: Pernyataan-pernyatan tertulis kepada parlemen
     metadata:
       published: Diterbitkan
@@ -142,7 +102,6 @@ id:
     related_guides:
   publication:
     documents:
-      one: Dokumen
       other: Dokumen-dokumen
   corporate_information_page:
     corporate_information: Informasi korporat

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -28,7 +28,6 @@ ja:
         one: "通信文書"
         other: "通信文書"
       decision:
-        one:
         other:
       detailed_guide:
         one: "詳細説明"
@@ -64,7 +63,6 @@ ja:
         one: "第三者機関によるレポート"
         other: "第三者機関によるレポート"
       international_treaty:
-        one:
         other:
       map:
         one: "地図"
@@ -79,7 +77,6 @@ ja:
         one: "ニュース"
         other: "ニュース"
       notice:
-        one:
         other:
       open_consultation:
         one: "公開協議"
@@ -103,7 +100,6 @@ ja:
         one: "出版物"
         other: "出版物"
       regulation:
-        one:
         other:
       research:
         one: "調査と分析"
@@ -124,7 +120,6 @@ ja:
         one: "統計"
         other: "統計"
       statutory_guidance:
-        one:
         other:
       transcript:
         one: "スピーチ全文"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,134 +4,94 @@ ja:
   content_item:
     schema_name:
       announcement:
-        one: "ニュース"
         other: "ニュース"
       authored_article:
-        one: Authored article
         other: Authored articles
       case_study:
-        one: "ケーススタディ"
         other: "ケーススタディ"
       closed_consultation:
-        one: "非公開協議"
         other: "非公開協議"
       consultation:
-        one: "協議"
         other: "協議"
       consultation_outcome:
-        one: "協議結果"
         other: "協議結果"
       corporate_report:
-        one: "事業報告"
         other: "事業報告"
       correspondence:
-        one: "通信文書"
         other: "通信文書"
       decision:
         other:
       detailed_guide:
-        one: "詳細説明"
         other: "詳細説明"
       document_collection:
-        one: "シリーズ"
         other:
       draft_text:
-        one: "草稿"
         other: "草稿"
       fatality_notice:
-        one: "死亡告示"
         other: "死亡告示"
       foi_release:
-        one: "情報公開に関するニュース"
         other: "情報公開に関するニュース"
       form:
-        one: "フォーム"
         other: "フォーム"
       government_response:
-        one: "レスポンス"
         other: "レスポンス"
       guidance:
-        one: "ガイダンス"
         other: "ガイダンス"
       impact_assessment:
-        one: "影響評価"
         other: "影響評価"
       imported:
-        one: "確認中"
         other: "確認中"
       independent_report:
-        one: "第三者機関によるレポート"
         other: "第三者機関によるレポート"
       international_treaty:
         other:
       map:
-        one: "地図"
         other: "地図"
       national_statistics:
-        one: "国家統計"
         other: "国家統計"
       news_article:
-        one: "ニュース"
         other: "ニュース"
       news_story:
-        one: "ニュース"
         other: "ニュース"
       notice:
         other:
       open_consultation:
-        one: "公開協議"
         other: "公開協議"
       oral_statement:
-        one: "議会に対する口頭陳述"
         other: "議会に対する口頭陳述"
       policy:
-        one: "政策"
         other: "政策"
       policy_paper:
-        one: "政策文書"
         other: "政策文書"
       press_release:
-        one: "新聞発表"
         other: "新聞発表"
       promotional:
-        one: "宣伝資料"
         other: "宣伝資料"
       publication:
-        one: "出版物"
         other: "出版物"
       regulation:
         other:
       research:
-        one: "調査と分析"
         other: "調査と分析"
       speaking_notes:
-        one: "キーポイント"
         other: "キーポイント"
       speech:
-        one: "スピーチ"
         other: "スピーチ"
       statement_to_parliament:
-        one: "閣僚声明"
         other: "閣僚声明"
       statistical_data_set:
-        one: "統計データセット"
         other: "統計データセット"
       official_statistics:
-        one: "統計"
         other: "統計"
       statutory_guidance:
         other:
       transcript:
-        one: "スピーチ全文"
         other: "スピーチ全文"
       transparency:
-        one: "透明性データ"
         other: "透明性データ"
       world_location_news_article:
-        one: "ニュース"
         other: "ニュース"
       written_statement:
-        one: "閣僚声明文"
         other: "閣僚声明文"
     metadata:
       published: "掲載日"
@@ -142,7 +102,6 @@ ja:
     related_guides:
   publication:
     documents:
-      one: "お知らせ"
       other: "お知らせ"
   corporate_information_page:
     corporate_information: 各種情報

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -4,139 +4,94 @@ ka:
   content_item:
     schema_name:
       announcement:
-        one:
         other:
       authored_article:
-        one:
         other:
       case_study:
-        one:
         other:
       closed_consultation:
-        one:
         other:
       consultation:
-        one:
         other:
       consultation_outcome:
-        one:
         other:
       corporate_report:
-        one:
         other:
       correspondence:
-        one:
         other:
       decision:
-        one:
         other:
       detailed_guide:
-        one:
         other:
       document_collection:
-        one:
         other:
       draft_text:
-        one:
         other:
       fatality_notice:
-        one:
         other:
       foi_release:
-        one:
         other:
       form:
-        one:
         other:
       government_response:
-        one:
         other:
       guidance:
-        one:
         other:
       impact_assessment:
-        one:
         other:
       imported:
-        one:
         other:
       independent_report:
-        one:
         other:
       international_treaty:
-        one:
         other:
       map:
-        one:
         other:
       national_statistics:
-        one:
         other:
       news_article:
-        one:
         other:
       news_story:
-        one:
         other:
       notice:
-        one:
         other:
       open_consultation:
-        one:
         other:
       oral_statement:
-        one:
         other:
       policy:
-        one:
         other:
       policy_paper:
-        one:
         other:
       press_release:
-        one:
         other:
       promotional:
-        one:
         other:
       publication:
-        one:
         other:
       regulation:
-        one:
         other:
       research:
-        one:
         other:
       speaking_notes:
-        one:
         other:
       speech:
-        one:
         other:
       statement_to_parliament:
-        one:
         other:
       statistical_data_set:
-        one:
         other:
       official_statistics:
-        one:
         other:
       statutory_guidance:
-        one:
         other:
       transcript:
-        one:
         other:
       transparency:
-        one:
         other:
       world_location_news_article:
-        one:
         other:
       written_statement:
-        one:
         other:
     metadata:
       published:
@@ -147,7 +102,6 @@ ka:
     related_guides:
   publication:
     documents:
-      one:
       other:
   corporate_information_page:
     corporate_information:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -28,7 +28,6 @@ ko:
         one: "서신"
         other: "서신"
       decision:
-        one:
         other:
       detailed_guide:
         one: "상세 안내"
@@ -64,7 +63,6 @@ ko:
         one: "독립 레포트"
         other: "독립 레포트"
       international_treaty:
-        one:
         other:
       map:
         one: "지도"
@@ -79,7 +77,6 @@ ko:
         one: "뉴스 스토리"
         other: "뉴스 스토리"
       notice:
-        one:
         other:
       open_consultation:
         one: "오픈 컨설테이션"
@@ -103,7 +100,6 @@ ko:
         one: "간행물"
         other: "간행물"
       regulation:
-        one:
         other:
       research:
         one: "리써치 및 분석"
@@ -124,7 +120,6 @@ ko:
         one: "통계"
         other: "통계"
       statutory_guidance:
-        one:
         other:
       transcript:
         one: "트랜스크립트"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -4,134 +4,94 @@ ko:
   content_item:
     schema_name:
       announcement:
-        one: "공지"
         other: "공지"
       authored_article:
-        one: "기사"
         other: "기사"
       case_study:
-        one: "케이스 스터디"
         other: "케이스 스터디"
       closed_consultation:
-        one: "비공개 협의"
         other: "비공개 협의"
       consultation:
-        one: "협의"
         other: "협의"
       consultation_outcome:
-        one: "협의 결과"
         other: "협의 결과"
       corporate_report:
-        one: "기업 레포트"
         other: "기업 레포트"
       correspondence:
-        one: "서신"
         other: "서신"
       decision:
         other:
       detailed_guide:
-        one: "상세 안내"
         other: "상세 안내"
       document_collection:
-        one: "시리즈"
         other:
       draft_text:
-        one: "드래프트 택스트"
         other: "드래프트 택스트"
       fatality_notice:
-        one: "사상자 공지"
         other: "사상자 공지"
       foi_release:
-        one: FOI 보도자료
         other: FOI 보도자료
       form:
-        one: "문서"
         other: "문서"
       government_response:
-        one: "정부 대책"
         other: "정부 대책"
       guidance:
-        one: "안내"
         other: "안내"
       impact_assessment:
-        one: "임팩트 평가"
         other: "임팩트 평가"
       imported:
-        one: "수입 - 대기"
         other: "수입 - 대기"
       independent_report:
-        one: "독립 레포트"
         other: "독립 레포트"
       international_treaty:
         other:
       map:
-        one: "지도"
         other: "지도"
       national_statistics:
-        one: "통계 - 국가 통계"
         other: "통계 - 국가 통계"
       news_article:
-        one: "뉴스"
         other: "뉴스"
       news_story:
-        one: "뉴스 스토리"
         other: "뉴스 스토리"
       notice:
         other:
       open_consultation:
-        one: "오픈 컨설테이션"
         other: "오픈 컨설테이션"
       oral_statement:
-        one: "의회로 구두 성명"
         other: "의회로 구두 성명"
       policy:
-        one: "정책"
         other: "정책"
       policy_paper:
-        one: "정책 논문"
         other: "정책 논문"
       press_release:
-        one: "보도자료"
         other: "보도자료"
       promotional:
-        one: "홍보물"
         other: "홍보물"
       publication:
-        one: "간행물"
         other: "간행물"
       regulation:
         other:
       research:
-        one: "리써치 및 분석"
         other: "리써치 및 분석"
       speaking_notes:
-        one: "요점사항"
         other: "요점사항"
       speech:
-        one: "연설문"
         other: "연설문"
       statement_to_parliament:
-        one: "의회로 성명"
         other: "의회로 성명"
       statistical_data_set:
-        one: "통계 데이터 세트"
         other: "통계 데이터 세트"
       official_statistics:
-        one: "통계"
         other: "통계"
       statutory_guidance:
         other:
       transcript:
-        one: "트랜스크립트"
         other: "트랜스크립트"
       transparency:
-        one: "투명성 데이타"
         other: "투명성 데이타"
       world_location_news_article:
-        one: "뉴스"
         other: "뉴스"
       written_statement:
-        one: "의회로 서면 성명"
         other: "의회로 서면 성명"
     metadata:
       published: "발행"
@@ -142,7 +102,6 @@ ko:
     related_guides:
   publication:
     documents:
-      one: "문서"
       other: "문서"
   corporate_information_page:
     corporate_information: 대사관 정보

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -4,139 +4,94 @@ ms:
   content_item:
     schema_name:
       announcement:
-        one:
         other:
       authored_article:
-        one:
         other:
       case_study:
-        one:
         other:
       closed_consultation:
-        one:
         other:
       consultation:
-        one:
         other:
       consultation_outcome:
-        one:
         other:
       corporate_report:
-        one:
         other:
       correspondence:
-        one:
         other:
       decision:
-        one:
         other:
       detailed_guide:
-        one:
         other:
       document_collection:
-        one:
         other:
       draft_text:
-        one:
         other:
       fatality_notice:
-        one:
         other:
       foi_release:
-        one:
         other:
       form:
-        one:
         other:
       government_response:
-        one:
         other:
       guidance:
-        one:
         other:
       impact_assessment:
-        one:
         other:
       imported:
-        one:
         other:
       independent_report:
-        one:
         other:
       international_treaty:
-        one:
         other:
       map:
-        one:
         other:
       national_statistics:
-        one:
         other:
       news_article:
-        one:
         other:
       news_story:
-        one:
         other:
       notice:
-        one:
         other:
       open_consultation:
-        one:
         other:
       oral_statement:
-        one:
         other:
       policy:
-        one:
         other:
       policy_paper:
-        one:
         other:
       press_release:
-        one:
         other:
       promotional:
-        one:
         other:
       publication:
-        one:
         other:
       regulation:
-        one:
         other:
       research:
-        one:
         other:
       speaking_notes:
-        one:
         other:
       speech:
-        one:
         other:
       statement_to_parliament:
-        one:
         other:
       statistical_data_set:
-        one:
         other:
       official_statistics:
-        one:
         other:
       statutory_guidance:
-        one:
         other:
       transcript:
-        one:
         other:
       transparency:
-        one:
         other:
       world_location_news_article:
-        one:
         other:
       written_statement:
-        one:
         other:
     metadata:
       published:
@@ -147,7 +102,6 @@ ms:
     related_guides:
   publication:
     documents:
-      one:
       other:
   corporate_information_page:
     corporate_information:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -28,7 +28,6 @@ th:
         one: "จดหมาย"
         other: "จดหมาย"
       decision:
-        one:
         other:
       detailed_guide:
         one: "คู่มือโดยละเอียด"
@@ -64,7 +63,6 @@ th:
         one: "รายงานอิสระ"
         other: "รายงานอิสระ"
       international_treaty:
-        one:
         other:
       map:
         one: "แผนที่"
@@ -79,7 +77,6 @@ th:
         one: "ข่าว"
         other: "ข่าว"
       notice:
-        one:
         other:
       open_consultation:
         one: "การให้คำปรึกษาเปิด"
@@ -103,7 +100,6 @@ th:
         one: "สิ่งพิมพ์"
         other: "สิ่งพิมพ์"
       regulation:
-        one:
         other:
       research:
         one: "บทวิจัยและบทวิเคราะห์"
@@ -124,7 +120,6 @@ th:
         one: "สถิติ"
         other: "สถิติ"
       statutory_guidance:
-        one:
         other:
       transcript:
         one: "สำเนา"

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -4,134 +4,94 @@ th:
   content_item:
     schema_name:
       announcement:
-        one: "ข่าวสาร"
         other: "ข่าวสาร"
       authored_article:
-        one: "บทความที่เขียน"
         other: "บทความที่เขียน"
       case_study:
-        one: "กรณีศึกษา"
         other: "กรณีศึกษา"
       closed_consultation:
-        one: "การศึกษาแบบปิด"
         other: "การศึกษาแบบปิด"
       consultation:
-        one: "การปรึกษา"
         other: "การปรึกษา"
       consultation_outcome:
-        one: "ผลการปรึกษา"
         other: "ผลการปรึกษา"
       corporate_report:
-        one: "รายงานบริษัท"
         other: "รายงานบริษัท"
       correspondence:
-        one: "จดหมาย"
         other: "จดหมาย"
       decision:
         other:
       detailed_guide:
-        one: "คู่มือโดยละเอียด"
         other: "คู่มือโดยละเอียด"
       document_collection:
-        one: "ตอน"
         other:
       draft_text:
-        one: "ร่างข้อความ"
         other: "ร่างข้อความ"
       fatality_notice:
-        one: "การแจ้งมรณะกรรม"
         other: "การแจ้งมรณะกรรม"
       foi_release:
-        one: "ข้อมูลที่เปิดเผยได้"
         other: "ข้อมูลที่เปิดเผยได้"
       form:
-        one: "แบบฟอร์ม"
         other: "แบบฟอร์ม"
       government_response:
-        one: "การตอบสนองของรัฐบาล"
         other: "การตอบสนองของรัฐบาล"
       guidance:
-        one: "คู่มือ"
         other: "คู่มือ"
       impact_assessment:
-        one: "การประเมินผลกระทบ"
         other: "การประเมินผลกระทบ"
       imported:
-        one: "ประเภทรอนำเข้า"
         other: "ประเภทรอนำเข้า"
       independent_report:
-        one: "รายงานอิสระ"
         other: "รายงานอิสระ"
       international_treaty:
         other:
       map:
-        one: "แผนที่"
         other: "แผนที่"
       national_statistics:
-        one: "สถิติ-สถิติแห่งชาน"
         other: "สถิติ-สถิติแห่งชาติ"
       news_article:
-        one: "บทความข่าว"
         other: "บทความข่าว"
       news_story:
-        one: "ข่าว"
         other: "ข่าว"
       notice:
         other:
       open_consultation:
-        one: "การให้คำปรึกษาเปิด"
         other: "การให้คำปรึกษาเปิด"
       oral_statement:
-        one: "แถลงการณ์ด้วยวาจาต่อรัฐสภา"
         other: "แถลงการณ์ด้วยวาจาต่อรัฐสภา"
       policy:
-        one: "นโยบาย"
         other: "นโยบาย"
       policy_paper:
-        one: "เอกสารนโยบาย"
         other: "เอกสารนโยบาย"
       press_release:
-        one: "ข่าวประชาสัมพันธ์"
         other: "ข่าวประชาสัมพันธ์"
       promotional:
-        one: "เอกสารเพี่อการประชาสัมพันธ์"
         other: "เอกสารเพือการประชาสัมพันธ์"
       publication:
-        one: "สิ่งพิมพ์"
         other: "สิ่งพิมพ์"
       regulation:
         other:
       research:
-        one: "บทวิจัยและบทวิเคราะห์"
         other: "บทวิจัยและบทวิเคราะห์"
       speaking_notes:
-        one: "ประเด็นการพูด"
         other: "ประเด็นการพูด"
       speech:
-        one: "สุนทรพจน์"
         other: "สุนทรพจน์"
       statement_to_parliament:
-        one: "แถลงการณ์ต่อรัฐสภา"
         other: "แถลงการณ์ต่อรัฐสภา"
       statistical_data_set:
-        one: "ชุดข้อมูลสถิติ"
         other: "ชุดข้อมูลสถิติ"
       official_statistics:
-        one: "สถิติ"
         other: "สถิติ"
       statutory_guidance:
         other:
       transcript:
-        one: "สำเนา"
         other: "สำเนา"
       transparency:
-        one: "ข้อมูลโปร่งใส"
         other: "ข้อมูลโปร่งใส"
       world_location_news_article:
-        one: "บทความข่าว"
         other: "บทความข่าว"
       written_statement:
-        one: "แถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา "
         other: "แถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา "
     metadata:
       published: "ตีพิมพ์"
@@ -142,7 +102,6 @@ th:
     related_guides:
   publication:
     documents:
-      one: "เอกสาร"
       other: "เอกสารต่างๆ"
   corporate_information_page:
     corporate_information: ข้อมูลบริษัท

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -4,134 +4,94 @@ vi:
   content_item:
     schema_name:
       announcement:
-        one: Thông báo
         other: Các thông báo
       authored_article:
-        one: bài viết do tác giả
         other: Các bài viết do tác giả
       case_study:
-        one: Trường hợp cụ thể
         other: Các Trường hợp cụ thể
       closed_consultation:
-        one: Kết thúc tham vấn
         other: Kết thúc các cuộc tham vấn
       consultation:
-        one: Tham vấn
         other: Các cuộc tham vấn
       consultation_outcome:
-        one: Kết quả tham vấn
         other: Các Kết quả tham vấn
       corporate_report:
-        one: báo cáo tổng hợp
         other: Các báo cáo tổng hợp
       correspondence:
-        one: Liên hệ
         other: Liên hệ
       decision:
         other:
       detailed_guide:
-        one: Hướng dẫn chi tiết
         other: Hướng dẫn chi tiết
       document_collection:
-        one: Chuỗi
         other:
       draft_text:
-        one: Nội dung dự thảo
         other: Các nội dung dự thảo
       fatality_notice:
-        one: Tin buồn
         other: Tin buồn
       foi_release:
-        one: Thông cáo FOI
         other: Thông cáo FOI
       form:
-        one: Mẫu đơn
         other: Các mẫu đơn
       government_response:
-        one: Phản ứng của Chính phủ
         other: các phản hồi của Chính phủ
       guidance:
-        one: hướng dẫn
         other: hướng dẫn
       impact_assessment:
-        one: "Đánh giá tác động"
         other: "Đánh giá tác động"
       imported:
-        one: Loại tài liệu đính kèm
         other: Loại tài liệu đính kèm
       independent_report:
-        one: Báo cáo độc lập
         other: Các báo cáo độc lập
       international_treaty:
         other:
       map:
-        one: Bản đồ
         other: Các bản đồ
       national_statistics:
-        one: Thống kê - Thống kê quốc gia
         other: Thống kê - Thống kê quốc gia
       news_article:
-        one: Tin tức
         other: Tin tức
       news_story:
-        one: Câu chuyện tin tức
         other: Câu chuyện tin tức
       notice:
         other:
       open_consultation:
-        one: Tham vấn mở rộng
         other: Tham vấn mở rộng
       oral_statement:
-        one: Tuyên bố bằng lời nói tới quốc hội
         other: Tuyên bố bằng lời nói tới quốc hội
       policy:
-        one: Chính sách
         other: Các chính sách
       policy_paper:
-        one: Tài liệu chính sách
         other: Tài liệu chính sách
       press_release:
-        one: Thông cáo báo chí
         other: Thông cáo báo chí
       promotional:
-        one: Tài liệu truyền thông
         other: Tài liệu truyền thông
       publication:
-        one: Tài liệu truyền thông
         other: Tài liệu truyền thông
       regulation:
         other:
       research:
-        one: Nghiên cứu và phân tích
         other: Nghiên cứu và phân tích
       speaking_notes:
-        one: Bài phát biểu
         other: Bài phát biểu
       speech:
-        one: Bài phát biểu
         other: Các bài phát biểu
       statement_to_parliament:
-        one: Tuyên bố tới Quốc hội
         other: Tuyên bố tới Quốc hội
       statistical_data_set:
-        one: Bộ dữ liệu thống kê
         other: Bộ dữ liệu thống kê
       official_statistics:
-        one: Thống kê
         other: Thống kê
       statutory_guidance:
         other:
       transcript:
-        one: Kịch bản
         other: Kịch bản
       transparency:
-        one: Dữ liệu kịch bản
         other: Dữ liệu kịch bản
       world_location_news_article:
-        one: Tin tức
         other: Tin tức
       written_statement:
-        one: Tuyên bố bằng văn bản tới quốc hội
         other: Các Tuyên bố bằng văn bản tới quốc hội
     metadata:
       published: "Đã xuất bản"
@@ -142,7 +102,6 @@ vi:
     related_guides:
   publication:
     documents:
-      one: Tài liệu
       other: Tài liệu
   corporate_information_page:
     corporate_information: Thông tin về phòng tổng hợp

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -28,7 +28,6 @@ vi:
         one: Liên hệ
         other: Liên hệ
       decision:
-        one:
         other:
       detailed_guide:
         one: Hướng dẫn chi tiết
@@ -64,7 +63,6 @@ vi:
         one: Báo cáo độc lập
         other: Các báo cáo độc lập
       international_treaty:
-        one:
         other:
       map:
         one: Bản đồ
@@ -79,7 +77,6 @@ vi:
         one: Câu chuyện tin tức
         other: Câu chuyện tin tức
       notice:
-        one:
         other:
       open_consultation:
         one: Tham vấn mở rộng
@@ -103,7 +100,6 @@ vi:
         one: Tài liệu truyền thông
         other: Tài liệu truyền thông
       regulation:
-        one:
         other:
       research:
         one: Nghiên cứu và phân tích
@@ -124,7 +120,6 @@ vi:
         one: Thống kê
         other: Thống kê
       statutory_guidance:
-        one:
         other:
       transcript:
         one: Kịch bản

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -30,7 +30,6 @@ zh:
         one: "交流"
         other: "交流"
       decision:
-        one:
         other:
       detailed_guide:
         one: "详细指导"
@@ -66,7 +65,6 @@ zh:
         one: "独立报告"
         other: "独立报告"
       international_treaty:
-        one:
         other:
       map:
         one: "地图"
@@ -81,7 +79,6 @@ zh:
         one: "新闻报道"
         other: "新闻报道"
       notice:
-        one:
         other:
       open_consultation:
         one: "公开咨询"
@@ -105,7 +102,6 @@ zh:
         one: "发布的报告"
         other: "发布的报告"
       regulation:
-        one:
         other:
       research:
         one: "研究及分析"
@@ -126,7 +122,6 @@ zh:
         one: "统计数据"
         other: "统计数据"
       statutory_guidance:
-        one:
         other:
       transcript:
         one: "副本"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -6,134 +6,94 @@ zh:
   content_item:
     schema_name:
       announcement:
-        one: "公告"
         other: "公告"
       authored_article:
-        one: "撰写的文章"
         other: "撰写的文章"
       case_study:
-        one: "实例研究"
         other: "实例研究"
       closed_consultation:
-        one: "已办结的咨询"
         other: "已办结的咨询"
       consultation:
-        one: "咨询"
         other: "咨询"
       consultation_outcome:
-        one: "咨询结果"
         other: "咨询结果"
       corporate_report:
-        one: "政府报告"
         other: "政府报告"
       correspondence:
-        one: "交流"
         other: "交流"
       decision:
         other:
       detailed_guide:
-        one: "详细指导"
         other: "详细指导"
       document_collection:
-        one: "系列"
         other:
       draft_text:
-        one: "草拟稿件"
         other: "草拟稿件"
       fatality_notice:
-        one: "死亡通告"
         other: "死亡通告"
       foi_release:
-        one: "资讯自由(FOI)信息发布"
         other: "资讯自由(FOI)信息发布"
       form:
-        one: "表格"
         other: "表格"
       government_response:
-        one: "政府反应"
         other: "政府反应"
       guidance:
-        one: "指导"
         other: "指导"
       impact_assessment:
-        one: "影响评估"
         other: "影响评估"
       imported:
-        one: "导入 - 正在等待的类型"
         other: "导入 - 正在等待的类型"
       independent_report:
-        one: "独立报告"
         other: "独立报告"
       international_treaty:
         other:
       map:
-        one: "地图"
         other: "地图"
       national_statistics:
-        one: "统计数据 - 国家数据"
         other: "统计数据 - 国家数据"
       news_article:
-        one: "新闻文章"
         other: "新闻文章"
       news_story:
-        one: "新闻报道"
         other: "新闻报道"
       notice:
         other:
       open_consultation:
-        one: "公开咨询"
         other: "公开咨询"
       oral_statement:
-        one: "对议会的口头声明"
         other: "对议会的口头声明"
       policy:
-        one: "政策"
         other: "政策"
       policy_paper:
-        one: "政策文件"
         other: "政策文件"
       press_release:
-        one: "新闻稿"
         other: "新闻稿"
       promotional:
-        one: "宣传材料"
         other: "宣传材料"
       publication:
-        one: "发布的报告"
         other: "发布的报告"
       regulation:
         other:
       research:
-        one: "研究及分析"
         other: "研究及分析"
       speaking_notes:
-        one: "演讲稿"
         other: "演讲稿"
       speech:
-        one: "演讲"
         other: "演讲"
       statement_to_parliament:
-        one: "对议会的声明"
         other: "对议会的声明"
       statistical_data_set:
-        one: "统计数据集"
         other: "统计数据集"
       official_statistics:
-        one: "统计数据"
         other: "统计数据"
       statutory_guidance:
         other:
       transcript:
-        one: "副本"
         other: "副本"
       transparency:
-        one: "透明化数据"
         other: "透明化数据"
       world_location_news_article:
-        one: "新闻文章"
         other: "新闻文章"
       written_statement:
-        one: "对议会的书面声明"
         other: "对议会的书面声明"
     metadata:
       published: "已发布"
@@ -146,7 +106,6 @@ zh:
     see_more:
   publication:
     documents:
-      one: "文件"
       other: "文件"
   corporate_information_page:
     corporate_information: 政府信息


### PR DESCRIPTION
In https://github.com/alphagov/government-frontend/pull/2045, we updated the plural rules for each language that we support that is not included [in the ruby-i18n gem](https://github.com/ruby-i18n/i18n/blob/master/test/test_data/locales/plurals.rb).

This removes the keys that are no longer required in each language from their locale files.

Trello card: https://trello.com/c/lkVB57ri

I have not made any changes to `zh-hk` and `zh-tw` as there are problems with the translations, which will be addressed in https://trello.com/c/mbFPEn9h.  Also not made any changes to `tr` as I believe the i18n rules for this could be wrong, so will write a card to look into this.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
