### PR TITLE
Hides print button if content longer than 10 items on HTML

### DIFF
--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -43,10 +43,13 @@
   <% if @content_item.contents.any? %>
     <div class="govuk-grid-column-one-quarter-from-desktop contents-list-container">
       <%= render 'govuk_publishing_components/components/contents_list', contents: @content_item.contents, format_numbers: true %>
-      <%= render "govuk_publishing_components/components/print_link", {
-        margin_top: 0,
-        margin_bottom: 6,
-      } %>
+
+      <% if @content_item.contents.size < 10 %>
+        <%= render "govuk_publishing_components/components/print_link", {
+          margin_top: 0,
+          margin_bottom: 6,
+        } %>
+      <% end %>
     </div>
   <% end %>
 


### PR DESCRIPTION
This change hides the print button under the content if the content items exceed 10 or more.

This fixes the following issue:
https://github.com/alphagov/government-frontend/issues/1907

It means that there is only one print button showing at one time.

## Before

![before](https://user-images.githubusercontent.com/788096/98545922-19e3ec00-228e-11eb-8848-4c0a9c5dd7fa.gif)

## After

![Mar-23-2021 12-38-26](https://user-images.githubusercontent.com/4599889/112147931-2a5d8900-8bd5-11eb-8823-64e67e5c04a7.gif)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
