### PR TITLE
Remove translation keys that do not exist in the English version

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -14,11 +14,6 @@ ar:
       topical_events: "أحداث ذات صلة بالموضوع"
       topics: "المواضيع"
       world_locations: "العالم"
-    taxonomy_navigation:
-      collections: "مجموعات"
-      related_content: "محتوى ذو صلة"
-      topical_events: "أحداث ذات صلة بالموضوع"
-      world_locations: "العالم"
     published_dates:
       published: "تاريخ النشر %{date}"
     publisher_metadata:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -10,11 +10,6 @@ ru:
       topical_events: "Актуальные события"
       topics: "Темы"
       world_locations: "Страны, регионы, организации"
-    taxonomy_navigation:
-      collections: "Коллекции"
-      related_content: "На эту тему"
-      topical_events: "Актуальные события"
-      world_locations: "Страны, регионы, организации"
   content_item:
     schema_name:
       announcement:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -148,8 +148,6 @@ si:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "ලේඛණය"

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -148,8 +148,6 @@ so:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Dokumenti

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -240,8 +240,6 @@ sr:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Dokument

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -148,8 +148,6 @@ ta:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: " ஆவணம்"

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -148,8 +148,6 @@ tk:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -238,8 +238,6 @@ uk:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "Документ"

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -148,8 +148,6 @@ uz:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: Hujjat

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -148,8 +148,6 @@ zh-hk:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       one: "文件"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -105,8 +105,6 @@ zh:
   detailed_guide:
     related_mainstream_content:
     related_guides:
-  html_publication:
-    see_more:
   publication:
     documents:
       other: "文件"


### PR DESCRIPTION
Most of these are blank keys anyway. The exception is the `taxonomy_navigation` key which only exists in Arabic and Russian.

https://trello.com/c/qlDQFq2I/2428-3-remove-locale-keys-with-no-english-translation

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
