### PR TITLE
Add deadlines for how-to-vote

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)

--- a/config/machine_readable/how-to-vote.yml
+++ b/config/machine_readable/how-to-vote.yml
@@ -63,6 +63,13 @@ faqs:
         <li>permanently</li>
       </ul>
       <p>Arrange to <a href="/how-to-vote/voting-by-proxy?src=schema">vote by proxy</a> if there are under 2 weeks until election day and you have not made arrangements.</p>
+      <p>If you’re in Northern Ireland, you’ll need to apply <a rel="external" href="http://www.eoni.org.uk/Vote/Voting-by-post-or-proxy">using a paper application form</a>.</p>
+      <h3 id="postal-vote-deadlines-for-6-may-elections">Postal vote deadlines for 6 May elections</h3>
+      <p>If you want to vote by post on 6 May 2021, your application form must arrive at your local Electoral Registration Office by:</p>
+      <ul>
+        <li>20 April at 5pm if you’re registered to vote in England or Wales</li>
+        <li>6 April at 5pm if you’re registered to vote in Scotland</li>
+      </ul>
 
   - question: Voting by proxy
     answer: >
@@ -76,6 +83,8 @@ faqs:
       <h2 id="how-to-apply-for-a-proxy-vote">How to apply for a proxy vote</h2>
       <p><a href="/government/collections/proxy-voting-application-forms?src=schema">Apply for a proxy vote</a> using a paper form. You need to send it to your local <a href="/contact-electoral-registration-office?src=schema">Electoral Registration Office</a>.</p>
       <p>Usually, you need to apply for a proxy vote at least 6 working days before election day if you want to vote in England, Scotland or Wales.</p>
+      <p>There’s a different form to <a rel="external" href="http://www.eoni.org.uk/Vote/Voting-by-post-or-proxy">apply to vote by proxy in Northern Ireland</a>. Apply at least 14 working days before election day.</p>
+      <p>If you want to vote by proxy on 6 May 2021, your application form must arrive at your local Electoral Registration Office by 27 April at 5pm.</p>
 
   - question: Voting from abroad
     answer: >


### PR DESCRIPTION
We know the actual deadline dates now, so we can add them to the schema.

Should match the content in https://www.gov.uk/how-to-vote#postal-vote-deadlines-for-6-may-elections (and the proxy section)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
