### PR TITLE
Support other domains in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,8 +45,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.hosts += [
-    "draft-government-frontend.dev.gov.uk",
-    "government-frontend.dev.gov.uk",
-  ]
+  config.hosts.clear
 end


### PR DESCRIPTION
Relates to: https://github.com/alphagov/govuk-docker/pull/478

This is required for testing authenticating-proxy(.dev.gov.uk).


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️