### PR TITLE
Add break word to contact class

### DIFF
--- a/app/assets/stylesheets/views/_contact.scss
+++ b/app/assets/stylesheets/views/_contact.scss
@@ -1,4 +1,5 @@
 .contact {
+  word-wrap: break-word;
   @include add-title-margin;
 
   // FIXME: Overrides specific govspeak heading styles while h3s & h4s look similar


### PR DESCRIPTION
## What
Adds a `word-wrap` css class to `.contact`

## Why
bandaid fix for issues with the contacts block on [this page](http://government-frontend.dev.gov.uk/government/publications/attendance-allowance-claim-form).

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-04-21 at 16 18 06](https://user-images.githubusercontent.com/64783893/115578462-36fcfc00-a2bd-11eb-9d6c-7deb087b3657.png) | ![Screenshot 2021-04-21 at 16 18 12](https://user-images.githubusercontent.com/64783893/115578478-3cf2dd00-a2bd-11eb-9d64-ea018485bcc6.png) |

### Note
This is a very quick fix and does not solve the root problem that whitehall is using a single partial to render similar information for 2 different use cases ([the other use case](https://www.gov.uk/world/organisations/british-embassy-kabul)). Notably, the instance seen here is using a heading above the contacts section which has been agreed as bad for accessibility. This should be investigated and amended ASAP.