### PR TITLE
Remove unused i18n keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ end
 group :test do
   gem "capybara"
   gem "faker"
+  gem "i18n-coverage"
   gem "minitest-reporters"
   gem "mocha"
   gem "simplecov"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    i18n-coverage (0.2.0)
     image_size (2.1.0)
     io-like (0.3.1)
     jasmine (3.6.0)
@@ -432,6 +433,7 @@ DEPENDENCIES
   govuk_schemas
   govuk_test
   htmlentities
+  i18n-coverage
   jasmine
   jasmine_selenium_runner
   minitest-reporters

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -9,10 +9,10 @@
 <% if published || last_updated %>
 <div class="app-c-published-dates <%= history_class %>" <% if history.any? %>id="history" data-module="gem-toggle"<% end %> lang="en">
   <% if published %>
-    Published <%= published %>
+    <%= t('components.published_dates.published', date: published) %>
   <% end %>
   <% if last_updated %>
-    <% if published %><br /><% end %>Last updated <%= last_updated %>
+    <% if published %><br /><% end %><%= t('components.published_dates.last_updated', date: last_updated) %>
     <% if link_to_history && history.empty? %>
       &mdash; <a href="#history" class="app-c-published-dates__history-link govuk-link"><%= t('components.published_dates.see_all_updates', locale: :en) %></a>
     <% elsif history.any? %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -6,18 +6,8 @@ ar:
   components:
     share_links:
       share_this_page: "شارك هذه الصفحة"
-    related_navigation:
-      collections: "مجموعات"
-      external_links: "روابط خارجية"
-      policies: "سياسيات"
-      related_content: "محتوى ذو صلة"
-      topical_events: "أحداث ذات صلة بالموضوع"
-      topics: "المواضيع"
-      world_locations: "العالم"
     published_dates:
       published: "تاريخ النشر %{date}"
-    publisher_metadata:
-      from: "من"
   content_item:
     schema_name:
       announcement:
@@ -345,9 +335,6 @@ ar:
       published: "نشر"
       updated: "تحديث"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       zero:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -100,9 +100,6 @@ az:
       published: dərc olunub
       updated: yenilənib
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       other:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -237,9 +237,6 @@ be:
       published: "Апублікаваны"
       updated: "Адноўлена"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "Дакумент"

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -145,9 +145,6 @@ bg:
       published: "Публикувано"
       updated: "обновено"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "Документ"

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -146,9 +146,6 @@ bn:
       published:
       updated:
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -191,9 +191,6 @@ cs:
       published: Publikováno
       updated: Aktualizováno
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Dokument

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -334,10 +334,6 @@ cy:
       published: Cyhoeddwyd
       updated: Diweddarwyd
     contents: Cynnwys
-  detailed_guide:
-    related_mainstream_content: Gormod o fanylion?<br/>Edrychwch ar y canllawiau cyflym
-      hyn
-    related_guides: Arweiniad manwl perthnasol
   publication:
     details: Manylion
     documents:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -246,21 +246,8 @@ da:
       see_all_updates:
       show_all_updates:
     publisher_metadata:
-      collections:
-      from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -270,9 +257,6 @@ da:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   multi_page:
     next_page:
     previous_page:
@@ -282,9 +266,6 @@ da:
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -145,9 +145,6 @@ de:
       published: Veröffentlicht
       updated: Aktualisiert
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Dokument

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -147,9 +147,6 @@ dr:
       published: "نشر شده"
       updated: "به روز شده"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "سند"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -145,9 +145,6 @@ el:
       published: "Δημοσιευμένο"
       updated: "ανανεωμένο "
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "Έγγραφο"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,8 +33,6 @@ en:
   time:
     formats:
       short_ordinal: '%e %B %Y'
-  common:
-    last_updated: "Last updated"
   components:
     figure:
       image_credit: "Image credit: %{credit}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,30 +30,14 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  time:
-    formats:
-      short_ordinal: '%e %B %Y'
   components:
     figure:
       image_credit: "Image credit: %{credit}"
     share_links:
       share_this_page: "Share this page"
     publisher_metadata:
-      from: "From"
-      collections: "Collections"
       show_all: "show all"
       hide_all: "hide all"
-    related_navigation:
-      collections: "Collection"
-      external_links: "Elsewhere on the web"
-      policies: "Policy"
-      publishers: "Published by"
-      related_content: "Related content"
-      related_guides: "Detailed guidance"
-      statistical_data_sets: "Statistical data set"
-      topics: "Explore the topic"
-      topical_events: "Topical event"
-      world_locations: "World locations"
     published_dates:
       show_all_updates: "show all updates"
       hide_all_updates: "hide all updates"
@@ -357,9 +341,6 @@ en:
       published: Published
       updated: Updated
     contents: Contents
-  detailed_guide:
-    related_guides: "Related guides"
-    related_mainstream_content: Too much detail?<br/>See these quick guides
   publication:
     documents:
       one: Document

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -145,9 +145,6 @@ es-419:
       published: publicado
       updated: actualizado
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Documento

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -142,9 +142,6 @@ es:
       published: Publicado
       updated: Actualizado
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Documento

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -145,9 +145,6 @@ et:
       published: avaldatud
       updated: Täiendatud
     contents: Sisukord
-  detailed_guide:
-    related_mainstream_content: 'Liiga detailne?<br/>Vt. neid kokkuvõtlikke juhendeid? '
-    related_guides: Seotud detailne juhend
   publication:
     documents:
       one: Dokument

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -102,9 +102,6 @@ fa:
       published: "منتشر شده"
       updated: "به روز رسانی شده"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       other: "مدارک"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -246,21 +246,8 @@ fi:
       see_all_updates:
       show_all_updates:
     publisher_metadata:
-      collections:
-      from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -270,9 +257,6 @@ fi:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   multi_page:
     next_page:
     previous_page:
@@ -282,9 +266,6 @@ fi:
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -145,9 +145,6 @@ fr:
       published: publié
       updated: mise à jour
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Document

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -396,21 +396,8 @@ gd:
       see_all_updates:
       show_all_updates:
     publisher_metadata:
-      collections:
-      from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -420,9 +407,6 @@ gd:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   multi_page:
     next_page:
     previous_page:
@@ -432,9 +416,6 @@ gd:
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -244,21 +244,8 @@ gu:
       see_all_updates:
       show_all_updates:
     publisher_metadata:
-      collections:
-      from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -268,9 +255,6 @@ gu:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   language_names:
     gu: ગુજરાતી
   multi_page:
@@ -282,9 +266,6 @@ gu:
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -147,9 +147,6 @@ he:
       published: "פורסם"
       updated: "מעודכן"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "מסמך"

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -145,9 +145,6 @@ hi:
       published: "प्रकाशित"
       updated: "अद्यतन"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "दस्तावेज़"

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -396,21 +396,8 @@ hr:
       see_all_updates:
       show_all_updates:
     publisher_metadata:
-      collections:
-      from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -420,9 +407,6 @@ hr:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   multi_page:
     next_page:
     previous_page:
@@ -432,9 +416,6 @@ hr:
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -145,9 +145,6 @@ hu:
       published: közzététel dátuma
       updated: 'Utolsó frissítés:'
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Dokumentum

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -145,9 +145,6 @@ hy:
       published: "հրապարակված"
       updated: "Թարմացված"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "Փաստաթուղթ"

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -100,9 +100,6 @@ id:
       published: Diterbitkan
       updated: Terkini
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       other: Dokumen-dokumen

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -246,21 +246,8 @@ is:
       see_all_updates:
       show_all_updates:
     publisher_metadata:
-      collections:
-      from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -270,9 +257,6 @@ is:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   multi_page:
     next_page:
     previous_page:
@@ -282,9 +266,6 @@ is:
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -145,9 +145,6 @@ it:
       published: pubblicato
       updated: aggiornato
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Documento

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -100,9 +100,6 @@ ja:
       published: "掲載日"
       updated: "更新"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       other: "お知らせ"

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -100,9 +100,6 @@ ka:
       published:
       updated:
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       other:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -244,21 +244,8 @@ kk:
       see_all_updates:
       show_all_updates:
     publisher_metadata:
-      collections:
-      from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -268,9 +255,6 @@ kk:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   language_names:
     kk: Qazaq
   multi_page:
@@ -282,9 +266,6 @@ kk:
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -100,9 +100,6 @@ ko:
       published: "발행"
       updated: "업데이트"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       other: "문서"

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -191,9 +191,6 @@ lt:
       published: publikuota
       updated: atnaujinta
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Dokumentas

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -145,9 +145,6 @@ lv:
       published: publicēts
       updated: atjaunināts
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Dokuments

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -100,9 +100,6 @@ ms:
       published:
       updated:
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       other:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -396,21 +396,8 @@ mt:
       see_all_updates:
       show_all_updates:
     publisher_metadata:
-      collections:
-      from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -420,9 +407,6 @@ mt:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   multi_page:
     next_page:
     previous_page:
@@ -432,9 +416,6 @@ mt:
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -250,17 +250,6 @@ nl:
       from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -270,9 +259,6 @@ nl:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   multi_page:
     next_page:
     previous_page:
@@ -282,9 +268,6 @@ nl:
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -246,21 +246,8 @@
       see_all_updates:
       show_all_updates:
     publisher_metadata:
-      collections:
-      from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -270,9 +257,6 @@
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   multi_page:
     next_page:
     previous_page:
@@ -282,9 +266,6 @@
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -247,21 +247,8 @@ pa-pk:
       see_all_updates:
       show_all_updates:
     publisher_metadata:
-      collections:
-      from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -271,9 +258,6 @@ pa-pk:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   language_names:
     pa-pk: پن٘جابی
   multi_page:
@@ -285,9 +269,6 @@ pa-pk:
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -245,21 +245,8 @@ pa:
       see_all_updates:
       show_all_updates:
     publisher_metadata:
-      collections:
-      from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -269,9 +256,6 @@ pa:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   language_names:
     pa: ਪੰਜਾਬੀ
   multi_page:
@@ -283,9 +267,6 @@ pa:
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -237,9 +237,6 @@ pl:
       published: opublikowano
       updated: Zaktualizowany
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Dokument

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -147,9 +147,6 @@ ps:
       published: "خپور شوی"
       updated: "تازه شوي"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "سند"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -145,9 +145,6 @@ pt:
       published: publicado
       updated: Atualizado
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Documento

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -191,9 +191,6 @@ ro:
       published: Data publicării
       updated: Actualizat
     contents: Conținut
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Document

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,15 +1,6 @@
 ru:
   language_names:
     ru: "Русский"
-  components:
-    related_navigation:
-      collections: "Коллекции"
-      external_links: "Внешние ссылки"
-      policies: "Политика"
-      related_content: "На эту тему"
-      topical_events: "Актуальные события"
-      topics: "Темы"
-      world_locations: "Страны, регионы, организации"
   content_item:
     schema_name:
       announcement:
@@ -244,9 +235,6 @@ ru:
       published: "Опубликовано"
       updated: "обновлено"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "Документ"

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -145,9 +145,6 @@ si:
       published: "පල කරන ලදී"
       updated: "යාවත්කාලීන කල"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "ලේඛණය"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -191,9 +191,6 @@ sk:
       published:
       updated:
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -396,21 +396,8 @@ sl:
       see_all_updates:
       show_all_updates:
     publisher_metadata:
-      collections:
-      from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -420,9 +407,6 @@ sl:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   multi_page:
     next_page:
     previous_page:
@@ -432,9 +416,6 @@ sl:
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -145,9 +145,6 @@ so:
       published: La-daabacay/nashriyey
       updated: Wax lagu kordhiyey
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Dokumenti

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -145,9 +145,6 @@ sq:
       published: publikuar
       updated: rifreskuar
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Dokument

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -237,9 +237,6 @@ sr:
       published: objavljeno
       updated: ažurirano
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Dokument

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -246,21 +246,8 @@ sv:
       see_all_updates:
       show_all_updates:
     publisher_metadata:
-      collections:
-      from:
       hide_all:
       show_all:
-    related_navigation:
-      collections:
-      external_links:
-      policies:
-      publishers:
-      related_content:
-      related_guides:
-      statistical_data_sets:
-      topical_events:
-      topics:
-      world_locations:
     share_links:
       share_this_page:
   corporate_information_page:
@@ -270,9 +257,6 @@ sv:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
-  detailed_guide:
-    related_guides:
-    related_mainstream_content:
   multi_page:
     next_page:
     previous_page:
@@ -282,9 +266,6 @@ sv:
     error:
       option:
       title:
-  time:
-    formats:
-      short_ordinal:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -145,9 +145,6 @@ sw:
       published:
       updated:
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -145,9 +145,6 @@ ta:
       published: "பிரசுரிக்கப்பட்டது"
       updated: "இற்றைப்படுத்தப்பட்டது"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: " ஆவணம்"

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -100,9 +100,6 @@ th:
       published: "ตีพิมพ์"
       updated: "ปรับปรุง"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       other: "เอกสารต่างๆ"

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -145,9 +145,6 @@ tk:
       published:
       updated:
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -145,9 +145,6 @@ tr:
       published: Yayında
       updated: Güncellendi
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Belge

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -235,9 +235,6 @@ uk:
       published: "опубліковано"
       updated: "оновлено"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "Документ"

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -147,9 +147,6 @@ ur:
     contents:
   language_names:
     ur: "اردو"
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "دستاویز"

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -145,9 +145,6 @@ uz:
       published: nashr qilindi
       updated: yangilandi
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: Hujjat

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -100,9 +100,6 @@ vi:
       published: "Đã xuất bản"
       updated: Cập nhật
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       other: Tài liệu

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -145,9 +145,6 @@ zh-hk:
       published: "已發布"
       updated: "已更新"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "文件"

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -145,9 +145,6 @@ zh-tw:
       published: "發行"
       updated: "更新"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       one: "文件"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -102,9 +102,6 @@ zh:
       published: "已发布"
       updated: "已更新"
     contents:
-  detailed_guide:
-    related_mainstream_content:
-    related_guides:
   publication:
     documents:
       other: "文件"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,10 @@ ENV["GOVUK_ASSET_ROOT"] = "http://static.test.gov.uk"
 require "simplecov"
 SimpleCov.start
 
+require "i18n/coverage/printers/file_printer"
+I18n::Coverage.config.printer = I18n::Coverage::Printers::FilePrinter
+I18n::Coverage.start
+
 require File.expand_path("../config/environment", __dir__)
 require "rails/test_help"
 require "capybara/rails"


### PR DESCRIPTION
This PR adds the [i18n-coverage gem](https://github.com/hiptest/i18n-coverage) to monitor untested i18n keys. I've then removed used the coverage reports to identify and remove unused keys. See commits for details.

Trello: https://trello.com/c/Z3Pitrfg/2454-identify-and-remove-unused-keys-in-locale-files-5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
