### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ ADD . $APP_HOME
 
 RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
 
-HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck || exit 1
+HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck/ready || exit 1
 
 CMD foreman run web

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,6 @@ Rails.application.routes.draw do
 
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
-  get "/healthcheck",
-      to: GovukHealthcheck.rack_response(
-        GovukHealthcheck::RailsCache,
-      )
-
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::RailsCache,


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
