### PR TITLE
Change h3 to an h2 on 11 downing street

### DIFF
--- a/app/views/histories/11_downing_street.html.erb
+++ b/app/views/histories/11_downing_street.html.erb
@@ -58,7 +58,7 @@
 
   <div class="govuk-grid-column-two-thirds">
   <%= render "govuk_publishing_components/components/govspeak", {} do %>
-    <h3 id="roots-of-the-treasury">Roots of the Treasury</h3>
+    <h2 id="roots-of-the-treasury">Roots of the Treasury</h2>
     <p>Today’s Treasury dates from around the Norman Conquest. Even before 1066, the Anglo-Saxon Treasury collected taxes (including the danegeld, first levied as a tribute to the Vikings to persuade them &ndash; sometimes unsuccessfully &ndash; to stay away) and controlled expenditure.</p>
     <p>The first &lsquo;Treasurer&rsquo; was probably &lsquo;Henry the Treasurer&rsquo;, who owned land around Winchester, the site of most royal treasure of both the Anglo-Saxons and the Normans. Henry is referred to in the Domesday Book (a systematic tax assessment of the whole country undertaken by the Treasury) and is believed to have served William the Conqueror as his Treasurer.</p>
 


### PR DESCRIPTION
## What
Changes the first `h3` on the [history of 11 Downing Street page](https://www.gov.uk/government/history/11-downing-street) ("Roots of the Treasury") to a `h2`.

## Why
Currently this pages is semantically incorrect. Headings should follow a logical pattern stepping down one at a time based on sections in the content eg: h1, h2, h2, h2, h3, h2 etc. For screen reader users who explicitly rely on heading structure it could be confusing and create the idea that they've missed a section of text.

[Card](https://trello.com/c/bGJM4TXa/703-11-downing-street-page-has-confusing-heading-structure)

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-04-29 at 17 30 12](https://user-images.githubusercontent.com/64783893/116587561-7c9b7380-a912-11eb-958b-ada516f5c14a.png) | ![Screenshot 2021-04-29 at 17 30 24](https://user-images.githubusercontent.com/64783893/116587590-82915480-a912-11eb-82d8-b921d7250f42.png) |


