### PR TITLE
Customise detailed guide pages for Brexit hubs

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -87,7 +87,6 @@ private
 
   def load_content_item
     content_item = Services.content_store.content_item(content_item_path)
-
     if Services.feature_toggler.use_recommended_related_links?(content_item["links"], request.headers)
       content_item["links"]["ordered_related_items"] = content_item["links"].fetch("suggested_ordered_related_items", [])
     end

--- a/app/presenters/content_item/brexit_hub_page.rb
+++ b/app/presenters/content_item/brexit_hub_page.rb
@@ -6,24 +6,21 @@ module ContentItem
     BREXIT_BUSINESS_PAGE_PATH = "/guidance/brexit-guidance-for-businesses".freeze
     BREXIT_CITIZEN_PAGE_PATH = "/guidance/brexit-guidance-for-individuals-and-families".freeze
 
-    def brexit_hub_page?
-      BREXIT_HUB_PAGE_CONTENT_IDS.include?(content_item.dig("content_id"))
+    def brexit_links
+      {
+        ContentItem::BrexitHubPage::BREXIT_BUSINESS_PAGE_CONTENT_ID => {
+          text: I18n.t("brexit.citizen_link"),
+          path: BREXIT_CITIZEN_PAGE_PATH,
+        },
+        ContentItem::BrexitHubPage::BREXIT_CITIZEN_PAGE_CONTENT_ID => {
+          text: I18n.t("brexit.business_link"),
+          path: BREXIT_BUSINESS_PAGE_PATH,
+        },
+      }
     end
 
-    def brexit_business_page?
-      BREXIT_BUSINESS_PAGE_CONTENT_ID == content_item.dig("content_id")
-    end
-
-    def brexit_citizen_page?
-      BREXIT_CITIZEN_PAGE_CONTENT_ID == content_item.dig("content_id")
-    end
-
-    def brexit_citizen_page
-      BREXIT_CITIZEN_PAGE_PATH
-    end
-
-    def brexit_business_page
-      BREXIT_BUSINESS_PAGE_PATH
+    def brexit_link
+      brexit_links[content_item.dig("content_id")]
     end
   end
 end

--- a/app/presenters/content_item/brexit_hub_page.rb
+++ b/app/presenters/content_item/brexit_hub_page.rb
@@ -1,0 +1,29 @@
+module ContentItem
+  module BrexitHubPage
+    BREXIT_BUSINESS_PAGE_CONTENT_ID = "91cd6143-69d5-4f27-99ff-a52fb0d51c78".freeze
+    BREXIT_CITIZEN_PAGE_CONTENT_ID = "6555e0bf-c270-4cf9-a0c5-d20b95fab7f1".freeze
+    BREXIT_HUB_PAGE_CONTENT_IDS = [BREXIT_BUSINESS_PAGE_CONTENT_ID, BREXIT_CITIZEN_PAGE_CONTENT_ID].freeze
+    BREXIT_BUSINESS_PAGE_PATH = "/guidance/brexit-guidance-for-businesses".freeze
+    BREXIT_CITIZEN_PAGE_PATH = "/guidance/brexit-guidance-for-individuals-and-families".freeze
+
+    def brexit_hub_page?
+      BREXIT_HUB_PAGE_CONTENT_IDS.include?(content_item.dig("content_id"))
+    end
+
+    def brexit_business_page?
+      BREXIT_BUSINESS_PAGE_CONTENT_ID == content_item.dig("content_id")
+    end
+
+    def brexit_citizen_page?
+      BREXIT_CITIZEN_PAGE_CONTENT_ID == content_item.dig("content_id")
+    end
+
+    def brexit_citizen_page
+      BREXIT_CITIZEN_PAGE_PATH
+    end
+
+    def brexit_business_page
+      BREXIT_BUSINESS_PAGE_PATH
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,5 +1,6 @@
 class ContentItemPresenter
   include ContentItem::Withdrawable
+  include ContentItem::BrexitHubPage
 
   attr_reader :content_item,
               :requested_path,

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -6,17 +6,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% title_and_context = @content_item.brexit_hub_page? ? { title: @content_item.title } : @content_item.title_and_context %>
+    <% title_and_context = @content_item.brexit_link ? { title: @content_item.title } : @content_item.title_and_context %>
     <%= render 'govuk_publishing_components/components/title', title_and_context %>
   </div>
   <%= render 'shared/translations' %>
   <div class="govuk-grid-column-two-thirds">
-    <% if @content_item.brexit_hub_page? %>
+    <% if @content_item.brexit_link %>
       <div class="govuk-body-l govuk-!-margin-bottom-7">
-        <% link_text = @content_item.brexit_citizen_page? ? "Brexit guidance for businesses" : "Brexit guidance for individuals and families" %>
-        <% link_path = @content_item.brexit_citizen_page? ? @content_item.brexit_business_page : @content_item.brexit_citizen_page %>
         <p class="govuk-body">
-          There's different <%= link_to link_text, link_path %>.
+          <%= I18n.t("brexit.heading_prefix") %> <%= link_to @content_item.brexit_link[:text], @content_item.brexit_link[:path] %>.
         </p>
       </div>
     <% else %>
@@ -25,7 +23,7 @@
   </div>
 </div>
 
-<%= render 'shared/publisher_metadata_with_logo' unless @content_item.brexit_hub_page? %>
+<%= render 'shared/publisher_metadata_with_logo' unless @content_item.brexit_link %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
@@ -37,7 +35,7 @@
       <%= render "govuk_publishing_components/components/print_link", {
         margin_top: 0,
         margin_bottom: 6,
-      } unless @content_item.brexit_hub_page? %>
+      } unless @content_item.brexit_link %>
 
       <%= render 'govuk_publishing_components/components/govspeak', {} do %>
         <%= raw(@content_item.govspeak_body[:content]) %>
@@ -48,13 +46,13 @@
             published: @content_item.published,
             last_updated: @content_item.updated,
             history: @content_item.history
-          } unless @content_item.brexit_hub_page? %>
+          } unless @content_item.brexit_link %>
       </div>
     <% end %>
     <%= render "govuk_publishing_components/components/print_link", {
         margin_top: 0,
         margin_bottom: 6,
-      } unless @content_item.brexit_hub_page? %>
+      } unless @content_item.brexit_link %>
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -6,15 +6,26 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <% title_and_context = @content_item.brexit_hub_page? ? { title: @content_item.title } : @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/title', title_and_context %>
   </div>
   <%= render 'shared/translations' %>
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
+    <% if @content_item.brexit_hub_page? %>
+      <div class="govuk-body-l govuk-!-margin-bottom-7">
+        <% link_text = @content_item.brexit_citizen_page? ? "Brexit guidance for businesses" : "Brexit guidance for individuals and families" %>
+        <% link_path = @content_item.brexit_citizen_page? ? @content_item.brexit_business_page : @content_item.brexit_citizen_page %>
+        <p class="govuk-body">
+          There's different <%= link_to link_text, link_path %>.
+        </p>
+      </div>
+    <% else %>
+      <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
+    <% end %>
   </div>
 </div>
 
-<%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'shared/publisher_metadata_with_logo' unless @content_item.brexit_hub_page? %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
@@ -26,7 +37,7 @@
       <%= render "govuk_publishing_components/components/print_link", {
         margin_top: 0,
         margin_bottom: 6,
-      } %>
+      } unless @content_item.brexit_hub_page? %>
 
       <%= render 'govuk_publishing_components/components/govspeak', {} do %>
         <%= raw(@content_item.govspeak_body[:content]) %>
@@ -37,13 +48,13 @@
             published: @content_item.published,
             last_updated: @content_item.updated,
             history: @content_item.history
-          } %>
+          } unless @content_item.brexit_hub_page? %>
       </div>
     <% end %>
     <%= render "govuk_publishing_components/components/print_link", {
         margin_top: 0,
         margin_bottom: 6,
-      } %>
+      } unless @content_item.brexit_hub_page? %>
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,6 +42,8 @@
     <% unless @do_not_show_breadcrumbs %>
       <% if @content_item.try(:back_link) %>
         <%= render 'govuk_publishing_components/components/back_link', href: @content_item.back_link %>
+      <% elsif @content_item.brexit_hub_page? %>
+        <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: [ { url: "/", title: "Home" } , { url: "/transition", title: "Brexit" } ] %>
       <% else %>
         <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.content_item.parsed_content %>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
     <% unless @do_not_show_breadcrumbs %>
       <% if @content_item.try(:back_link) %>
         <%= render 'govuk_publishing_components/components/back_link', href: @content_item.back_link %>
-      <% elsif @content_item.brexit_hub_page? %>
+      <% elsif @content_item.brexit_link %>
         <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: [ { url: "/", title: "Home" } , { url: "/transition", title: "Brexit" } ] %>
       <% else %>
         <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.content_item.parsed_content %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -281,6 +281,10 @@ en:
       written_statement:
         one: Written statement to Parliament
         other: Written statements to Parliament
+  brexit:
+    heading_prefix: There’s different
+    business_link: Brexit guidance for businesses
+    citizen_link: Brexit guidance for individuals and families
   corporate_information_page:
     about_our_services_html: Find out %{link}.
     corporate_information: Corporate information

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -90,4 +90,26 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     assert_equal faq_schema["name"], @content_item["title"]
     assert_not_equal faq_schema["mainEntity"], []
   end
+
+  test "renders brexit child taxon pages in special ways" do
+    setup_and_visit_brexit_child_taxon("business")
+
+    # hides the print links
+    assert_not page.has_css?(".gem-c-print-link")
+    assert_not page.has_content?("Print this page")
+
+    # hides published by metadata
+    assert_not page.has_css?(".gem-c-metadata")
+
+    # renders description field as a custom link
+    assert_not page.has_text?(@content_item["description"])
+    link_text = "Brexit guidance for individuals and families"
+    assert page.has_link?(link_text, href: ContentItem::BrexitHubPage::BREXIT_CITIZEN_PAGE_PATH)
+
+    setup_and_visit_brexit_child_taxon("citizen")
+
+    assert_not page.has_text?(@content_item["description"])
+    link_text = "Brexit guidance for businesses"
+    assert page.has_link?(link_text, href: ContentItem::BrexitHubPage::BREXIT_BUSINESS_PAGE_PATH)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -176,6 +176,22 @@ class ActionDispatch::IntegrationTest
     end
   end
 
+  def setup_and_visit_brexit_child_taxon(type = nil)
+    @content_item = get_content_example("detailed_guide").tap do |item|
+      item["content_id"] = type == "business" ? brexit_business_id : brexit_citizen_id
+      stub_content_store_has_item(item["base_path"], item.to_json)
+      visit_with_cachebust((item["base_path"]).to_s)
+    end
+  end
+
+  def brexit_citizen_id
+    ContentItem::BrexitHubPage::BREXIT_CITIZEN_PAGE_CONTENT_ID
+  end
+
+  def brexit_business_id
+    ContentItem::BrexitHubPage::BREXIT_BUSINESS_PAGE_CONTENT_ID
+  end
+
   def setup_and_visit_random_content_item(document_type: nil)
     content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: schema_type) do |payload|
       payload.merge!("document_type" => document_type) unless document_type.nil?


### PR DESCRIPTION
## What

We are using the detailed guide doc type to publish the brexit child taxon pages, but we need to customise a few things. 

See [commit](https://github.com/alphagov/government-frontend/pull/2097/commits/fa11d218fd8a1e152be8b2dc219a8d72191adeec) message for more details.

The review apps for this pr are pointed at integration where the detailed guides have been published.

- [Business page](https://government-f-brexit-hub-pxjxwy.herokuapp.com/guidance/brexit-guidance-for-businesses)
- [Citizens page](https://government-f-brexit-hub-pxjxwy.herokuapp.com/guidance/brexit-guidance-for-individuals-and-families)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
https://trello.com/c/7bevQJP4/1497-investigate-options-to-hide-display-components-on-a-detailed-guide-page
https://trello.com/c/TaSxtjir/1540-build-custom-templates-for-brexit-child-taxon-pages