### PR TITLE
Add travel advice updates for 17th May 2021

### DIFF
--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -25,22 +25,37 @@
         } %>
       </div>
       <div class="travel-advice-notice__content">
-        <p class="govuk-body">
-          <strong>
-            It is illegal to travel abroad from the UK for holidays.
-          </strong>
-          Follow current COVID-19 rules where you live: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/covid-19-alert-levels">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>.
-        </p>
-        <p class="govuk-body">
-          In England, you must have a <a href="/guidance/coronavirus-covid-19-declaration-form-for-international-travel">permitted reason to travel abroad</a> and complete the declaration form.
-        </p>
-        <p class="govuk-body">
-          Some countries have closed borders, and any country may further restrict travel or bring in new social distancing rules with little warning.
-          <a href="/guidance/travel-advice-novel-coronavirus">Check our advice</a> for each country you will visit or transit through.
-        </p>
-        <p class="govuk-body">
-          When you return, follow the rules to <a href="/uk-border-control">enter the UK from abroad</a> (except from Ireland).
-        </p>
+        <% if Time.zone.now < Date.parse("2021-05-17").beginning_of_day %>
+          <p class="govuk-body">
+            <strong>
+              It is illegal to travel abroad from the UK for holidays.
+            </strong>
+            Follow current COVID-19 rules where you live: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/covid-19-alert-levels">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>.
+          </p>
+          <p class="govuk-body">
+            In England, you must have a <a href="/guidance/coronavirus-covid-19-declaration-form-for-international-travel">permitted reason to travel abroad</a> and complete the declaration form.
+          </p>
+          <p class="govuk-body">
+            Some countries have closed borders, and any country may further restrict travel or bring in new social distancing rules with little warning.
+            <a href="/guidance/travel-advice-novel-coronavirus">Check our advice</a> for each country you will visit or transit through.
+          </p>
+          <p class="govuk-body">
+            When you return, follow the rules to <a href="/uk-border-control">enter the UK from abroad</a> (except from Ireland).
+          </p>
+        <% else %>
+          <p class="govuk-body">
+            Follow current COVID-19 rules where you live: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/covid-19-alert-levels">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>.
+          </p>
+          <p class="govuk-body">
+            To prevent new COVID variants from entering the UK, you should not travel to <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">amber or red list countries</a>.
+          </p>
+          <p class="govuk-body">
+            To understand the risks in a country follow <a href="/guidance/travel-advice-novel-coronavirus">FCDO Travel Advice</a>.
+          </p>
+          <p class="govuk-body">
+            When you return, follow the rules to <a href="/uk-border-control">enter the UK from abroad</a> (except from Ireland).
+          </p>
+        <% end %>
       </div>
     </div>
 


### PR DESCRIPTION
Trello: https://trello.com/c/nPAGEeOq

# What's changed?

Update travel advice callout box on `/foreign-travel-advice/<country-name>` to show the rule changes from Monday 17th May

# Expected changes

|Before|After|
|-------|-----|
|<img width="1648" alt="Screenshot 2021-05-14 at 16 25 00" src="https://user-images.githubusercontent.com/5793815/118293469-996aa600-b4d1-11eb-8e55-11d8a1fc95ad.png">|<img width="1648" alt="Screenshot 2021-05-14 at 16 25 45" src="https://user-images.githubusercontent.com/5793815/118293626-bdc68280-b4d1-11eb-8074-a0030bcc54ac.png">|





The new advice should start to be displayed from 00:00 on Monday 17th May.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
