### PR TITLE
Fix error when running a single test

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ ENV["GOVUK_ASSET_ROOT"] = "http://static.test.gov.uk"
 require "simplecov"
 SimpleCov.start
 
+require "i18n/coverage"
 require "i18n/coverage/printers/file_printer"
 I18n::Coverage.config.printer = I18n::Coverage::Printers::FilePrinter
 I18n::Coverage.start


### PR DESCRIPTION
The require statement for the printer doesn't replace the general one for
the module. It's actually unclear how this worked without it, but I don't
think that's worth investigating.

Error, for reference:

```
 /govuk/government-frontend/test/test_helper.rb:10:in `<top (required)>':
undefined method `config' for I18n::Coverage:Module (NoMethodError)
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️