### PR TITLE
Remove hardcoded strings from controllers, presenters and views

### DIFF
--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -12,13 +12,13 @@ class FatalityNoticePresenter < ContentItemPresenter
   end
 
   def image
-    { "url" => view_context.image_url("ministry-of-defence-crest.png"), "alt_text" => "Ministry of Defence crest" }
+    { "url" => view_context.image_url("ministry-of-defence-crest.png"), "alt_text" => I18n.t("fatality_notice.alt_text") }
   end
 
   def important_metadata
     super.tap do |m|
       if field_of_operation
-        m.merge!("Field of operation" => view_context.link_to(field_of_operation.title, field_of_operation.path, class: "govuk-link app-link"))
+        m.merge!(I18n.t("fatality_notice.field_of_operation") => view_context.link_to(field_of_operation.title, field_of_operation.path, class: "govuk-link app-link"))
       end
     end
   end
@@ -26,7 +26,7 @@ class FatalityNoticePresenter < ContentItemPresenter
   def title_and_context
     super.tap do |t|
       if field_of_operation
-        t[:context] = "Operations in #{field_of_operation.try(:title)}"
+        t[:context] = I18n.t("fatality_notice.operations_in", location: field_of_operation.try(:title))
       end
     end
   end

--- a/app/presenters/gone_presenter.rb
+++ b/app/presenters/gone_presenter.rb
@@ -8,6 +8,6 @@ class GonePresenter < ContentItemPresenter
   end
 
   def page_title
-    "No longer available"
+    I18n.t("gone.page_title")
   end
 end

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -64,15 +64,15 @@ class SpecialistDocumentPresenter < ContentItemPresenter
     {
       "protected-designation-of-origin-pdo" => {
         "url" => view_context.image_url("protected-food-drink-names/protected-designation-of-origin-pdo.png"),
-        "alt_text" => "The scheme logo is a black stamp with the words Designated Origin UK Protected",
+        "alt_text" => I18n.t("specialist_document.pdo_alt_text"),
       },
       "protected-geographical-indication-pgi" => {
         "url" => view_context.image_url("protected-food-drink-names/protected-geographical-indication-pgi.png"),
-        "alt_text" => "The scheme logo is a black stamp with the words Geographic Origin UK Protected",
+        "alt_text" => I18n.t("specialist_document.pgi_alt_text"),
       },
       "traditional-speciality-guaranteed-tsg" => {
         "url" => view_context.image_url("protected-food-drink-names/traditional-speciality-guaranteed-tsg.png"),
-        "alt_text" => "The scheme logo is a black stamp with the words Traditional Speciality UK Protected",
+        "alt_text" => I18n.t("specialist_document.tsg_alt_text"),
       },
     }
   end

--- a/app/presenters/speech_presenter.rb
+++ b/app/presenters/speech_presenter.rb
@@ -9,9 +9,9 @@ class SpeechPresenter < ContentItemPresenter
 
   def delivery_type
     if document_type == "authored_article"
-      "Written on"
+      I18n.t("speech.written_on")
     else
-      "Delivered on"
+      I18n.t("speech.delivered_on")
     end
   end
 
@@ -27,7 +27,7 @@ class SpeechPresenter < ContentItemPresenter
 
   def important_metadata
     super.tap do |m|
-      m.merge!("Location" => location, delivery_type => delivered_on_metadata)
+      m.merge!(I18n.t("speech.location") => location, delivery_type => delivered_on_metadata)
     end
   end
 

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -4,7 +4,7 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
   include ContentItem::TitleAndContext
   include StatisticsAnnouncementHelper
 
-  FORTHCOMING_NOTICE = "These statistics will be released".freeze
+  FORTHCOMING_NOTICE = I18n.t("statistics_announcement.forthcoming").freeze
 
   def release_date
     content_item["details"]["display_date"]
@@ -28,11 +28,11 @@ class StatisticsAnnouncementPresenter < ContentItemPresenter
     super.tap do |m|
       if cancelled?
         m.merge!(
-          "Proposed release" => release_date,
-          "Cancellation date" => cancellation_date,
+          I18n.t("statistics_announcement.proposed_date") => release_date,
+          I18n.t("statistics_announcement.cancellation_date") => cancellation_date,
         )
       else
-        m.merge!("Release date" => release_date_and_status)
+        m.merge!(I18n.t("statistics_announcement.release_date") => release_date_and_status)
       end
     end
   end

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -16,8 +16,8 @@ class TravelAdvicePresenter < ContentItemPresenter
     updated_at = content_item["details"]["updated_at"]
 
     other = {
-      "Still current at" => I18n.l(Time.zone.now, format: "%-d %B %Y"),
-      "Updated" => display_date(reviewed_at || updated_at),
+      I18n.t("travel_advice.still_current_at") => I18n.l(Time.zone.now, format: "%-d %B %Y"),
+      I18n.t("travel_advice.updated") => display_date(reviewed_at || updated_at),
     }
 
     other["Latest update"] = view_context.simple_format(latest_update) if latest_update.present?
@@ -29,7 +29,7 @@ class TravelAdvicePresenter < ContentItemPresenter
 
   def title_and_context
     {
-      context: "Foreign travel advice",
+      context: I18n.t("travel_advice.context"),
       title: country_name,
     }
   end
@@ -111,7 +111,7 @@ private
 
   def summary_part
     {
-      "title" => "Summary",
+      "title" => I18n.t("travel_advice.summary"),
       "slug" => "",
       "body" => content_item["details"]["summary"],
     }

--- a/app/presenters/unpublishing_presenter.rb
+++ b/app/presenters/unpublishing_presenter.rb
@@ -8,6 +8,6 @@ class UnpublishingPresenter < ContentItemPresenter
   end
 
   def page_title
-    "No longer available"
+    I18n.t("unpublishing.page_title")
   end
 end

--- a/app/presenters/working_group_presenter.rb
+++ b/app/presenters/working_group_presenter.rb
@@ -30,8 +30,8 @@ private
 
   def extra_headings
     extra_headings = []
-    extra_headings << { id: "policies", text: "Policies" } if policies.any?
-    extra_headings << { id: "contact-details", text: "Contact details" } if email.present?
+    extra_headings << { id: "policies", text: I18n.t("working_group.policies") } if policies.any?
+    extra_headings << { id: "contact-details", text: I18n.t("working_group.contact_details") } if email.present?
     extra_headings
   end
 

--- a/app/views/content_items/coming_soon.html.erb
+++ b/app/views/content_items/coming_soon.html.erb
@@ -3,7 +3,7 @@
     <%= render 'govuk_publishing_components/components/title', title: 'Coming soon' %>
 
     <p class="summary">
-      This document will be published on<br />
+      <%= t("content_item.coming_soon") %><br />
       <%= content_tag(:time, class: 'publish_time', datetime: @content_item.iso8601_publish_time) do %>
         <%= @content_item.formatted_publish_date + " at " + @content_item.formatted_publish_time %>
       <% end %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -21,18 +21,18 @@
 
     <% if @content_item.unopened? %>
       <% content_item_unopened = capture do %>
-        This consultation opens
-        <% if @content_item.opening_date_midnight? %>on<% else %>at<% end %>
+        <%= t("consultation.opens") %>
+        <%= @content_item.opening_date_midnight? ? t("consultation.on") : t("consultation.at") %>
         <time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time>
       <% end %>
       <%= render 'govuk_publishing_components/components/notice', {
-        title: "This consultation isn't open yet",
+        title: t("consultation.not_open_yet"),
         description_text: content_item_unopened,
       } %>
 
     <% elsif @content_item.pending_final_outcome? %>
       <% content_item_final_outcome = capture do %>
-        Visit this page again soon to download the outcome to this public&nbsp;feedback.
+        <%= t("consultation.visit_soon") %>
       <% end %>
       <%= render 'govuk_publishing_components/components/notice',
         title: 'We are analysing your feedback',
@@ -44,11 +44,11 @@
       <%= render 'govuk_publishing_components/components/notice', title: 'This consultation has concluded' %>
 
       <%= render "attachments",
-          title: "Download the full outcome",
+          title: t("consultation.download_outcome"),
           legacy_pre_rendered_documents: @content_item.final_outcome_documents,
           attachments: @content_item.final_outcome_attachments %>
 
-      <%= render 'govuk_publishing_components/components/heading', text: "Detail of outcome", mobile_top_margin: true %>
+      <%= render 'govuk_publishing_components/components/heading', text: t("consultation.detail_of_outcome"), mobile_top_margin: true %>
       <div class="consultation-outcome-detail">
         <%= render 'govuk_publishing_components/components/govspeak', {
           direction: page_text_direction,
@@ -59,14 +59,14 @@
     <% end %>
 
     <%= render "attachments",
-        title: "Feedback received",
+        title: t("consultation.feedback_received"),
         legacy_pre_rendered_documents: @content_item.public_feedback_documents,
         attachments: @content_item.public_feedback_attachments %>
 
     <% if @content_item.public_feedback_detail %>
       <%= render 'govuk_publishing_components/components/heading', {
         mobile_top_margin: true,
-        text: "Detail of feedback received",
+        text: t("consultation.detail_of_feedback_received"),
       } %>
       <div class="consultation-feedback">
         <%= render 'govuk_publishing_components/components/govspeak', {
@@ -84,22 +84,22 @@
             heading_level: 2,
             id: "original-consultation-title",
             mobile_top_margin: true,
-            text: "Original consultation",
+            text: t("consultation.original_consultation"),
           } %>
         </header>
     <% end %>
 
     <% consultation_date = capture do %>
       <% if @content_item.closed? %>
-        This consultation ran from<br /><span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time> to
+        <%= t("consultation.ran_from") %><br /><span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time> to
         <time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
       <% elsif @content_item.open? %>
-        This consultation closes at<br />
+        <%= t("consultation.closes_at") %><br />
         <span class="consultation-date"><time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
       <% elsif @content_item.unopened? %>
-        This consultation opens <% if @content_item.opening_date_midnight? %>on<% else %>at<% end %><br />
+        <%= t("consultation.opens") %> <%= @content_item.opening_date_midnight? ? t("consultation.on") : t("consultation.at") %><br />
         <span class="consultation-date"><time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time></span><br />
-        It closes at<br />
+        <%= t("consultation.closes") %><br />
         <span class="consultation-date"><time datetime="<%= @content_item.closing_date_time %>"><%= @content_item.closing_date %></time></span>
       <% end %>
     <% end %>
@@ -109,7 +109,7 @@
       <% if @content_item.held_on_another_website? %>
         <p class="govuk-!-margin-top-2">
           <strong>
-            This consultation <% if @content_item.closed? %>was<% else %>is being<% end %> held on <a href="<%= @content_item.held_on_another_website_url %>">another website</a>.
+            <%= t("consultation.another_website_html", closed: @content_item.closed? ? t("consultation.was") : t("consultation.is_being"), url: @content_item.held_on_another_website_url) %>.
           </strong>
         </p>
       <% end %>
@@ -128,7 +128,7 @@
     <div class="consultation-description">
       <%= render 'govuk_publishing_components/components/heading', {
         mobile_top_margin: true,
-        text: "Consultation description",
+        text: t("consultation.description"),
       } %>
 
       <%= render 'govuk_publishing_components/components/govspeak', {} do %>
@@ -136,18 +136,18 @@
       <% end %>
 
       <%= render "attachments",
-          title: "Documents",
+          title: t("consultation.documents"),
           legacy_pre_rendered_documents: @content_item.documents,
           attachments: @content_item.featured_attachments %>
     </div>
 
     <% if @content_item.ways_to_respond? %>
       <div class="consultation-ways-to-respond">
-        <%= render 'govuk_publishing_components/components/heading', text: "Ways to respond", mobile_top_margin: true %>
+        <%= render 'govuk_publishing_components/components/heading', text: t("consultation.ways_to_respond"), mobile_top_margin: true %>
           <% @ways_to_respond_body = capture do %>
             <% if @content_item.respond_online_url %>
               <div class="call-to-action">
-                <p><%= link_to 'Respond online', @content_item.respond_online_url %></p>
+                <p><%= link_to t("consultation.respond_online"), @content_item.respond_online_url %></p>
               </div>
 
               <% if @content_item.email || @content_item.postal_address %>
@@ -157,18 +157,18 @@
 
             <% if @content_item.response_form? %>
               <p>
-                Complete a <%= link_to 'response form', @content_item.attachment_url %> and
-                <% if @content_item.email && @content_item.postal_address %>either<% end %>
+                <%= t("consultation.complete_a") %> <%= link_to 'response form', @content_item.attachment_url %> <%= t("consultation.and") %>
+                <%= t("consultation.either") if @content_item.email && @content_item.postal_address %>
               </p>
             <% end %>
 
             <% if @content_item.email %>
-              <h3>Email to:</h3>
+              <h3><%= t("consultation.email_to") %></h3>
               <p><%= mail_to @content_item.email, @content_item.email %></p>
             <% end %>
 
             <% if @content_item.postal_address %>
-              <h3>Write to:</h3>
+              <h3><%= t("consultation.write_to") %></h3>
               <div class="contact">
                 <div class="content">
                   <%= simple_format(@content_item.postal_address) %>

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -17,7 +17,7 @@
 
     <% body = capture do %>
       <% if @content_item.online_form_links.any? %>
-        <h2 id="online-forms-title">Online</h2>
+        <h2 id="online-forms-title"><%= t("contact.online") %></h2>
         <% @content_item.online_form_links.each do |link| %>
           <p>
             <%= link_to(link[:title], link[:url]) %>
@@ -28,12 +28,12 @@
       <% end %>
 
       <% if @content_item.show_webchat? %>
-        <h2 id="webchat-title">Webchat</h2>
+        <h2 id="webchat-title"><%= t("contact.webchat") %></h2>
         <%= render 'shared/webchat' %>
       <% end %>
 
       <% if @content_item.email.any? %>
-        <h2 id="email-title">Email</h2>
+        <h2 id="email-title"><%= t("contact.email") %></h2>
         <% @content_item.email.each do |email_group| %>
           <p class="vcard">
             <% email_group[:v_card].each do |v_card_part| %>
@@ -50,7 +50,7 @@
       <% end %>
 
       <% if @content_item.phone.any? %>
-        <h2 id="phone-title">Phone</h2>
+        <h2 id="phone-title"><%= t("contact.phone") %></h2>
         <% @content_item.phone.each do |phone_group| %>
           <% if @content_item.phone.size > 1 %>
             <h3><%= phone_group[:title] %></h3>
@@ -77,7 +77,7 @@
         <%= @content_item.phone_body %>
 
         <p class="call-charges">
-          <%= link_to "Find out about call charges", "/call-charges" %>
+          <%= link_to t("contact.find_call_charges"), "/call-charges" %>
         </p>
       <% end %>
 

--- a/app/views/content_items/gone.html.erb
+++ b/app/views/content_items/gone.html.erb
@@ -14,7 +14,7 @@
 
     <% if @content_item.alternative_path.present? %>
       <p class="alternative">
-        <%= t("gone.visit") %> <%= alternative_path_link(request, @content_item.alternative_path)%>
+        <%= t("common.visit") %> <%= alternative_path_link(request, @content_item.alternative_path)%>
       </p>
     <% end %>
   </div>

--- a/app/views/content_items/gone.html.erb
+++ b/app/views/content_items/gone.html.erb
@@ -1,11 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
-      title: "The page you're looking for is no longer available",
+      title: t("gone.title"),
     } %>
 
     <p class="summary">
-      The information on this page has been removed because it was published in error.
+      <%= t("gone.published_in_error") %>
     </p>
 
     <%= render "govuk_publishing_components/components/govspeak", {} do %>
@@ -14,7 +14,7 @@
 
     <% if @content_item.alternative_path.present? %>
       <p class="alternative">
-        Visit: <%= alternative_path_link(request, @content_item.alternative_path)%>
+        <%= t("gone.visit") %> <%= alternative_path_link(request, @content_item.alternative_path)%>
       </p>
     <% end %>
   </div>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -20,11 +20,11 @@
 
     <% if @content_item.show_guide_navigation? %>
       <%= render "govuk_publishing_components/components/skip_link", {
-        text: "Skip to contents of guide",
+        text: t("guide.skip_to_contents"),
         href: "#guide-contents"
       } %>
       <aside class="part-navigation-container" role="complementary">
-        <%= render "govuk_publishing_components/components/contents_list", aria_label: 'Pages in this guide', contents: @content_item.part_link_elements, underline_links: true %>
+        <%= render "govuk_publishing_components/components/contents_list", aria_label: t("guide.pages_in_guide"), contents: @content_item.part_link_elements, underline_links: true %>
       </aside>
     <% end %>
   </div>

--- a/app/views/content_items/guide_single.html.erb
+++ b/app/views/content_items/guide_single.html.erb
@@ -20,7 +20,7 @@
 
     <% if @content_item.show_guide_navigation? %>
       <aside class="part-navigation-container" role="complementary">
-        <%= render "govuk_publishing_components/components/contents_list", aria_label: 'Pages in this guide', contents: @content_item.part_link_elements, underline_links: true %>
+        <%= render "govuk_publishing_components/components/contents_list", aria_label: t("guide.pages_in_guide"), contents: @content_item.part_link_elements, underline_links: true %>
       </aside>
     <% end %>
   </div>

--- a/app/views/content_items/html_publication/_print_meta_data.html.erb
+++ b/app/views/content_items/html_publication/_print_meta_data.html.erb
@@ -2,20 +2,20 @@
   <%= image_tag "open-government-licence-min.png", class: "print-meta-data-licence" %>
 </p>
 <p>
-  © Crown copyright <%= @content_item.copyright_year %>
+  <%= t("html_publication.print_meta_data.copyright", year: @content_item.copyright_year) %>
 </p>
 <p>
-  This publication is licensed under the terms of the Open Government Licence v3.0 except where otherwise stated. To view this licence, visit <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a> or write to the Information Policy Team, The National Archives, Kew, London TW9 4DU, or email: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.
+  <%= t("html_publication.print_meta_data.licence_html") %>
 </p>
 <p>
-  Where we have identified any third party copyright information you will need to obtain permission from the copyright holders concerned.
+  <%= t("html_publication.print_meta_data.third_party") %>
 </p>
 <p>
-  This publication is available at <%= @content_item.full_path(request) %>
+  <%= t("html_publication.print_meta_data.available_at", url: @content_item.full_path(request)) %>
 </p>
 
 <% unless @content_item.isbn.blank? %>
     <p>
-      ISBN: <%= @content_item.isbn %>
+      <%= t("html_publication.print_meta_data.isbn") %> <%= @content_item.isbn %>
     </p>
 <% end %>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -22,10 +22,10 @@
     <% if @content_item.release_date_changed? %>
       <div class="release-date-changed">
         <%= render "components/important-metadata",
-        title: "The release date has been changed",
+        title: t("statistics_announcement.changed_date"),
         items: {
-          "Previous date" => @content_item.previous_release_date,
-          "Reason for change" => @content_item.release_date_change_reason,
+          t("statistics_announcement.previous_date") => @content_item.previous_release_date,
+          t("statistics_announcement.reason_for_change") => @content_item.release_date_change_reason,
         },
         margin_bottom: true
         %>
@@ -34,7 +34,7 @@
 
     <% if @content_item.cancelled? %>
       <%= render 'govuk_publishing_components/components/notice',
-          title: 'Statistics release cancelled',
+          title: t("statistics_announcement.cancelled"),
           description_text: @content_item.cancellation_reason %>
     <% end %>
 

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -18,25 +18,14 @@
     <div class="travel-advice-notice">
       <div class="travel-advice-notice__header">
         <%= render "govuk_publishing_components/components/warning_text", {
-          text: "Coronavirus (COVID-19) travel",
-          text_assistive: "Important",
+          text: t("travel_advice.coronavirus_warning.title"),
+          text_assistive: t("travel_advice.coronavirus_warning.text_assistive"),
           large_font: true,
           heading_level: 2
         } %>
       </div>
       <div class="travel-advice-notice__content">
-        <p class="govuk-body">
-          Follow current COVID-19 rules where you live: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/covid-19-alert-levels">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>.
-        </p>
-        <p class="govuk-body">
-          To prevent new COVID variants from entering the UK, you should not travel to <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">amber or red list countries</a>.
-        </p>
-        <p class="govuk-body">
-          To understand the risks in a country follow <a href="/guidance/travel-advice-novel-coronavirus">FCDO Travel Advice</a>.
-        </p>
-        <p class="govuk-body">
-          When you return, follow the rules to <a href="/uk-border-control">enter the UK from abroad</a> (except from Ireland).
-        </p>
+        <%= t("travel_advice.coronavirus_warning.content_html") %>
       </div>
     </div>
 

--- a/app/views/content_items/unpublishing.html.erb
+++ b/app/views/content_items/unpublishing.html.erb
@@ -1,9 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', title: 'The page you\'re looking for is no longer available' %>
+    <%= render 'govuk_publishing_components/components/title', title: t("unpublishing.title") %>
 
     <p class="summary">
-      The information on this page has been removed because it was published in error.
+      <%= t("unpublishing.summary") %>
     </p>
 
     <%= render "govuk_publishing_components/components/govspeak", {} do %>
@@ -12,7 +12,7 @@
 
     <% if @content_item.alternative_url.present? %>
       <p class="alternative">
-        Visit: <%= link_to(@content_item.alternative_url, @content_item.alternative_url, class: "govuk-link") %>
+        <%= t("common.visit") %> <%= link_to(@content_item.alternative_url, @content_item.alternative_url, class: "govuk-link") %>
       </p>
     <% end %>
   </div>

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -6,7 +6,7 @@
 
 <% @additional_body = capture do %>
   <% if @content_item.policies.any? %>
-    <h2 id="policies">Policies</h2>
+    <h2 id="policies"><%= t("working_group.policies") %></h2>
     <ul>
       <% @content_item.policies.each do |policy| %>
         <li><%= link_to policy["title"], policy["base_path"] %></li>
@@ -15,7 +15,7 @@
   <% end %>
 
   <% if @content_item.email.present? %>
-    <h2 id="contact-details">Contact details</h2>
+    <h2 id="contact-details"><%= t("working_group.contact_details") %></h2>
     <p><%= mail_to @content_item.email, @content_item.email %></p>
   <% end %>
 <% end %>

--- a/app/views/shared/_history_notice.html.erb
+++ b/app/views/shared/_history_notice.html.erb
@@ -1,3 +1,3 @@
 <% if content_item.historically_political? %>
-  <%= render 'components/banner', text: "This was published under the #{content_item.publishing_government}" %>
+  <%= render 'components/banner', text: t("shared.historically_political", government: content_item.publishing_government) %>
 <% end %>

--- a/app/views/shared/_webchat.html.erb
+++ b/app/views/shared/_webchat.html.erb
@@ -10,17 +10,17 @@
       <%= unavailability_message %>
     <% else %>
       <span class="js-webchat-advisers-error">
-        Webchat is unavailable at the moment because of technical problems.
+        <%= t("shared.webchat.technical_problem") %>
       </span>
       <span class="js-webchat-advisers-unavailable hidden">
-        Webchat is closed at the moment.
+        <%= t("shared.webchat.closed") %>
       </span>
       <span class="js-webchat-advisers-busy hidden">
-        All webchat advisers are busy at the moment.
+        <%= t("shared.webchat.busy") %>
       </span>
       <span class="js-webchat-advisers-available hidden">
-        Advisers are available to chat.
-        <a href="#" data-redirect="<%=  @content_item.webchat.open_url_redirect.present? ? 'true' : 'false' %>" rel="external" class="js-webchat-open-button">Speak to an adviser now</a>.
+        <%= t("shared.webchat.available") %>
+        <a href="#" data-redirect="<%=  @content_item.webchat.open_url_redirect.present? ? 'true' : 'false' %>" rel="external" class="js-webchat-open-button"><%= t("shared.webchat.speak_to_adviser") %></a>.
       </span>
     <% end %>
   </span>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -2,6 +2,7 @@
 ar:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ ar:
       show_all:
     share_links:
       share_this_page: شارك هذه الصفحة
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: نشر
@@ -549,6 +584,24 @@ ar:
     publication_scheme_html: إقرأ عن أنواع المعلومات التي ننشرها بشكل روتيني في موقعنا %{link} الرابط.
     social_media_use_html: اقرأ عن سياستنا تجاه %{link}
     welsh_language_scheme_html: معرفة التزامنا النشر في%{link} الرابط.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction: rtl
   language_names:
@@ -634,9 +687,49 @@ ar:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -2,6 +2,7 @@
 az:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ az:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: dərc olunub
@@ -179,6 +214,24 @@ az:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -259,9 +312,49 @@ az:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -2,6 +2,7 @@
 be:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ be:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: Апублікаваны
@@ -401,6 +436,24 @@ be:
     publication_scheme_html: Чытайце пра тыпы інфармацыі, якую мы рэгулярна публікуем, у нашым %{link}.
     social_media_use_html: Прачытайце пра нашу палітыку датычна %{link}.
     welsh_language_scheme_html: Даведайцеся аб нашых абавязках да публікацыі ў %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -484,9 +537,49 @@ be:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -2,6 +2,7 @@
 bg:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ bg:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: Публикувано
@@ -253,6 +288,24 @@ bg:
     publication_scheme_html: Прочетете какви видове информация публикуваме в нашия %{link}.
     social_media_use_html: Вижте политиката ни по %{link}.
     welsh_language_scheme_html: Разберете повече за нашето задължение да публикуваме в %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ bg:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -2,6 +2,7 @@
 bn:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ bn:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -253,6 +288,24 @@ bn:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ bn:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -2,6 +2,7 @@
 cs:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ cs:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: Publikováno
@@ -327,6 +362,24 @@ cs:
     publication_scheme_html: Více o typech informací, které pravidelně zveřejňujeme na %{link}.
     social_media_use_html: Více o naší strategii o %{link}.
     welsh_language_scheme_html: Více o našem závazku zvěřejňovat informace na %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -409,9 +462,49 @@ cs:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -2,6 +2,7 @@
 cy:
   common:
     last_updated: Diweddarwyd diwethaf
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ cy:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents: Cynnwys
     metadata:
       published: Cyhoeddwyd
@@ -549,6 +584,24 @@ cy:
     publication_scheme_html: Darllenwch am y mathau o wybodaeth rydym yn eu cyhoeddi'n rheolaidd yn ein %{link}.
     social_media_use_html: Darllenwch ein polisi ar %{link}
     welsh_language_scheme_html: Dysgwch am ein hymrwymiad i %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -634,9 +687,49 @@ cy:
     error:
       option: Dewiswch
       title: Dydych chi ddim wedi dewis
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -2,6 +2,7 @@
 da:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ da:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -253,6 +288,24 @@ da:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ da:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2,6 +2,7 @@
 de:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ de:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: Veröffentlicht
@@ -253,6 +288,24 @@ de:
     publication_scheme_html: Lesen Sie hier %{link}, welche Informationen wir routinemäßig publizieren
     social_media_use_html: Unsere Politik zu %{link}
     welsh_language_scheme_html: Mehr zu unserer Verpflichtung zur Veröffentlichung in %{link}
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ de:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -2,6 +2,7 @@
 dr:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ dr:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: نشر شده
@@ -253,6 +288,24 @@ dr:
     publication_scheme_html: در مورد انواع معلوماتی بخوانید که ما به طور منظم نشر می کنیم.
     social_media_use_html: پالیسی ما را در %{link} بخوانید
     welsh_language_scheme_html: در مورد تعهد ما به نشر در %{link} معلومات حاصل نمایید
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction: rtl
   language_names:
@@ -334,9 +387,49 @@ dr:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -2,6 +2,7 @@
 el:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ el:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: Δημοσιευμένο
@@ -253,6 +288,24 @@ el:
     publication_scheme_html: Μάθετε περισσότερα για τις πληροφορίας που δημοσιεύουμε συνήθως στο %{link}
     social_media_use_html: Μάθετε περισσότερα για την πολιτική μας στο %{link}.
     welsh_language_scheme_html: Μάθετε περισσότερα για την δέσμευση μας στη δημοσίευση στο %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ el:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -438,6 +438,7 @@ en:
     summary: Summary
     updated: Updated
   unpublishing:
+    page_title: No longer available
     summary: The information on this page has been removed because it was published in error.
     title: The page you're looking for is no longer available
   working_group:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,12 @@ en:
     was: was
     ways_to_respond: Ways to respond
     write_to: 'Write to:'
+  contact:
+    email: Email
+    find_call_charges: Find out about call charges
+    online: Online
+    phone: Phone
+    webchat: Webchat
   content_item:
     coming_soon: This document will be published on
     contents: Contents

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -404,3 +404,6 @@ en:
   unpublishing:
     summary: The information on this page has been removed because it was published in error.
     title: The page you're looking for is no longer available
+  working_group:
+    contact_details: Contact details
+    policies: Policies

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -293,6 +293,13 @@ en:
   guide:
     pages_in_guide: Pages in this guide
     skip_to_contents: Skip to contents of guide
+  html_publication:
+    print_meta_data:
+      available_at: This publication is available at %{url}
+      copyright: "© Crown copyright %{year}"
+      isbn: 'ISBN:'
+      licence_html: 'This publication is licensed under the terms of the Open Government Licence v3.0 except where otherwise stated. To view this licence, visit <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a> or write to the Information Policy Team, The National Archives, Kew, London TW9 4DU, or email: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: Where we have identified any third party copyright information you will need to obtain permission from the copyright holders concerned.
   i18n:
     direction:
   language_names:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -290,6 +290,9 @@ en:
     published_in_error: The information on this page has been removed because it was published in error.
     title: The page you're looking for is no longer available
     visit: 'Visit:'
+  guide:
+    pages_in_guide: Pages in this guide
+    skip_to_contents: Skip to contents of guide
   i18n:
     direction:
   language_names:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,6 +286,10 @@ en:
     publication_scheme_html: Read about the types of information we routinely publish in our %{link}.
     social_media_use_html: Read our policy on %{link}.
     welsh_language_scheme_html: Find out about our commitment to %{link}.
+  gone:
+    published_in_error: The information on this page has been removed because it was published in error.
+    title: The page you're looking for is no longer available
+    visit: 'Visit:'
   i18n:
     direction:
   language_names:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -394,6 +394,10 @@ en:
       closed: Webchat is closed at the moment.
       speak_to_adviser: Speak to an adviser now
       technical_problem: Webchat is unavailable at the moment because of technical problems.
+  specialist_document:
+    pdo_alt_text: The scheme logo is a black stamp with the words Designated Origin UK Protected
+    pgi_alt_text: The scheme logo is a black stamp with the words Geographic Origin UK Protected
+    tsg_alt_text: The scheme logo is a black stamp with the words Traditional Speciality UK Protected
   statistics_announcement:
     cancelled: Statistics release cancelled
     changed_date: The release date has been changed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,6 +292,7 @@ en:
     field_of_operation: Field of operation
     operations_in: Operations in %{location}
   gone:
+    page_title: No longer available
     published_in_error: The information on this page has been removed because it was published in error.
     title: The page you're looking for is no longer available
   guide:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
     share_links:
       share_this_page: Share this page
   content_item:
+    coming_soon: This document will be published on
     contents: Contents
     metadata:
       published: Published

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,32 @@ en:
       show_all: show all
     share_links:
       share_this_page: Share this page
+  consultation:
+    and: and
+    another_website_html: 'This consultation %{closed} held on <a href="%{url}">another website</a>'
+    at: at
+    closes: It closes at
+    closes_at: This consultation closes at
+    complete_a: Complete a
+    description: Consultation description
+    detail_of_feedback_received: Detail of feedback received
+    detail_of_outcome: Detail of outcome
+    documents: Documents
+    download_outcome: Download the full outcome
+    either: either
+    email_to: 'Email to:'
+    feedback_received: Feedback received
+    is_being: is being
+    not_open_yet: This consultation isn't open yet
+    opens: This consultation opens
+    original_consultation: Original consultation
+    ran_from: This consultation ran from
+    respond_online: Respond online
+    'true': true
+    visit_soon: Visit this page again soon to download the outcome to this public&nbsp;feedback.
+    was: was
+    ways_to_respond: Ways to respond
+    write_to: 'Write to:'
   content_item:
     coming_soon: This document will be published on
     contents: Contents

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -385,3 +385,19 @@ en:
       avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to the whole country.
       avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all travel to parts of the country.
       avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all travel to the whole country.
+    coronavirus_warning:
+      content_html: |
+        <p class="govuk-body">
+          Follow current COVID-19 rules where you live: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/covid-19-alert-levels">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>.
+        </p>
+        <p class="govuk-body">
+          To prevent new COVID variants from entering the UK, you should not travel to <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">amber or red list countries</a>.
+        </p>
+        <p class="govuk-body">
+          To understand the risks in a country follow <a href="/guidance/travel-advice-novel-coronavirus">FCDO Travel Advice</a>.
+        </p>
+        <p class="govuk-body">
+          When you return, follow the rules to <a href="/uk-border-control">enter the UK from abroad</a> (except from Ireland).
+        </p>
+      text_assistive: Important
+      title: Coronavirus (COVID-19) travel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -374,6 +374,11 @@ en:
     error:
       option: Please select an option
       title: You haven’t selected an option
+  statistics_announcement:
+    cancelled: Statistics release cancelled
+    changed_date: The release date has been changed
+    previous_date: Previous date
+    reason_for_change: Reason for change
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to parts of the country.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -403,10 +403,14 @@ en:
     location: Location
     written_on: Written on
   statistics_announcement:
+    cancellation_date: Cancellation date
     cancelled: Statistics release cancelled
     changed_date: The release date has been changed
+    forthcoming: These statistics will be released
     previous_date: Previous date
+    proposed_date: Proposed release
     reason_for_change: Reason for change
+    release_date: Release date
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to parts of the country.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -383,6 +383,12 @@ en:
       title: You haven’t selected an option
   shared:
     historically_political: This was published under the %{government}
+    webchat:
+      available: Advisers are available to chat.
+      busy: All webchat advisers are busy at the moment.
+      closed: Webchat is closed at the moment.
+      speak_to_adviser: Speak to an adviser now
+      technical_problem: Webchat is unavailable at the moment because of technical problems.
   statistics_announcement:
     cancelled: Statistics release cancelled
     changed_date: The release date has been changed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,7 @@ en:
       share_this_page: Share this page
   consultation:
     and: and
-    another_website_html: 'This consultation %{closed} held on <a href="%{url}">another website</a>'
+    another_website_html: This consultation %{closed} held on <a href="%{url}">another website</a>
     at: at
     closes: It closes at
     closes_at: This consultation closes at
@@ -36,6 +36,7 @@ en:
     feedback_received: Feedback received
     is_being: is being
     not_open_yet: This consultation isn't open yet
+    'on':
     opens: This consultation opens
     original_consultation: Original consultation
     ran_from: This consultation ran from

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -381,6 +381,8 @@ en:
     error:
       option: Please select an option
       title: You haven’t selected an option
+  shared:
+    historically_political: This was published under the %{government}
   statistics_announcement:
     cancelled: Statistics release cancelled
     changed_date: The release date has been changed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -417,6 +417,7 @@ en:
       avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to the whole country.
       avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all travel to parts of the country.
       avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all travel to the whole country.
+    context: Foreign travel advice
     coronavirus_warning:
       content_html: |
         <p class="govuk-body">
@@ -433,6 +434,9 @@ en:
         </p>
       text_assistive: Important
       title: Coronavirus (COVID-19) travel
+    still_current_at: Still current at
+    summary: Summary
+    updated: Updated
   unpublishing:
     summary: The information on this page has been removed because it was published in error.
     title: The page you're looking for is no longer available

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -287,6 +287,10 @@ en:
     publication_scheme_html: Read about the types of information we routinely publish in our %{link}.
     social_media_use_html: Read our policy on %{link}.
     welsh_language_scheme_html: Find out about our commitment to %{link}.
+  fatality_notice:
+    alt_text: Ministry of Defence crest
+    field_of_operation: Field of operation
+    operations_in: Operations in %{location}
   gone:
     published_in_error: The information on this page has been removed because it was published in error.
     title: The page you're looking for is no longer available

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,7 @@
 en:
   common:
     last_updated:
+    visit: 'Visit:'
   components:
     figure:
       image_credit: 'Image credit: %{credit}'
@@ -289,7 +290,6 @@ en:
   gone:
     published_in_error: The information on this page has been removed because it was published in error.
     title: The page you're looking for is no longer available
-    visit: 'Visit:'
   guide:
     pages_in_guide: Pages in this guide
     skip_to_contents: Skip to contents of guide
@@ -401,3 +401,6 @@ en:
         </p>
       text_assistive: Important
       title: Coronavirus (COVID-19) travel
+  unpublishing:
+    summary: The information on this page has been removed because it was published in error.
+    title: The page you're looking for is no longer available

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,6 +398,10 @@ en:
     pdo_alt_text: The scheme logo is a black stamp with the words Designated Origin UK Protected
     pgi_alt_text: The scheme logo is a black stamp with the words Geographic Origin UK Protected
     tsg_alt_text: The scheme logo is a black stamp with the words Traditional Speciality UK Protected
+  speech:
+    delivered_on: Delivered on
+    location: Location
+    written_on: Written on
   statistics_announcement:
     cancelled: Statistics release cancelled
     changed_date: The release date has been changed

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -2,6 +2,7 @@
 es-419:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ es-419:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: publicado
@@ -253,6 +288,24 @@ es-419:
     publication_scheme_html: Lea sobre los tipos de información que usualmente publicamos en nuestro %{link}
     social_media_use_html: Lea nuestra política en %{link}
     welsh_language_scheme_html: Descubra sobre nuestro compromiso de publicar en el %{link}
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ es-419:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2,6 +2,7 @@
 es:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ es:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: Publicado
@@ -253,6 +288,24 @@ es:
     publication_scheme_html: Lea acerca del tipo de información que publicamos en el siguiente enlace %{link}
     social_media_use_html: Lea nuestra política en %{link}
     welsh_language_scheme_html: 'Encuentre más sobre nuestro compromiso de publicar en %{link} '
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ es:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -2,6 +2,7 @@
 et:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ et:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents: Sisukord
     metadata:
       published: avaldatud
@@ -253,6 +288,24 @@ et:
     publication_scheme_html: 'Lugege lisaks infoliikide kohta, mida me regulaarselt avalikustame: %{link}'
     social_media_use_html: 'Lugege meie poliitika kohta: %{link}'
     welsh_language_scheme_html: 'Lugege lisaks meie pühandumusest avaldamise osas: %{link}'
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ et:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -2,6 +2,7 @@
 fa:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ fa:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: منتشر شده
@@ -179,6 +214,24 @@ fa:
     publication_scheme_html: 'درباره نوع اطلاعاتی که ما به طور روال در %{link} منتشر می کنیم بخوانید '
     social_media_use_html: سیاست ما را درباره  %{link} بخوانید
     welsh_language_scheme_html: درباره تعهد ما به انتشار مطالب به %{link} بخوانید
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction: rtl
   language_names:
@@ -259,9 +312,49 @@ fa:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -2,6 +2,7 @@
 fi:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ fi:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -253,6 +288,24 @@ fi:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ fi:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2,6 +2,7 @@
 fr:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ fr:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: publié
@@ -253,6 +288,24 @@ fr:
     publication_scheme_html: En savoir plus sur les types d'informations régulièrement publiés dans notre %{link}.
     social_media_use_html: Lire notre politique d' %{link}.
     welsh_language_scheme_html: En savoir plus sur notre engagement à l'édition en %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ fr:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -2,6 +2,7 @@
 gd:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ gd:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -401,6 +436,24 @@ gd:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -484,9 +537,49 @@ gd:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -2,6 +2,7 @@
 gu:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ gu:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -253,6 +288,24 @@ gu:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ gu:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2,6 +2,7 @@
 he:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ he:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: פורסם
@@ -253,6 +288,24 @@ he:
     publication_scheme_html: קרא/י אודות סוגי מידע שאנחנו מפרסמים %{link}
     social_media_use_html: קרא/י אודות המדיניות שלנו %{link}
     welsh_language_scheme_html: מידע נוסף על המחויבות שלנו לפרסום %{link}
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction: rtl
   language_names:
@@ -334,9 +387,49 @@ he:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -2,6 +2,7 @@
 hi:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ hi:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: प्रकाशित
@@ -253,6 +288,24 @@ hi:
     publication_scheme_html: सूचना के उन प्रकारों के बारे में पढ़ें, जिन्हें हम अपने %{link} में नियमित रूप से प्रकाशित करते हैं।
     social_media_use_html: इस बारे में हमारी नीतियां पढ़ें %{link}
     welsh_language_scheme_html: हमारी प्रकाशन के प्रति वचनबद्धता के बारे में जानें %(link)।
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ hi:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -2,6 +2,7 @@
 hr:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ hr:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -401,6 +436,24 @@ hr:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -484,9 +537,49 @@ hr:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -2,6 +2,7 @@
 hu:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ hu:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: közzététel dátuma
@@ -253,6 +288,24 @@ hu:
     publication_scheme_html: 'Tekintse meg, hogy milyen jellegű információkat teszünk közzé: %{link}'
     social_media_use_html: 'Bővebb információk az alábbi témával kapcsolatban: %{link}'
     welsh_language_scheme_html: 'Tájékozódjon az információk közzétételével kapcsolatos elkötelezettségünkről: %{link}'
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ hu:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -2,6 +2,7 @@
 hy:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ hy:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: հրապարակված
@@ -253,6 +288,24 @@ hy:
     publication_scheme_html: Կարդացեք այն ամնենի մասին ինչ մենք հրապարակում ենք մեր %{link} ում
     social_media_use_html: Կարդացեք մեր քաղաքականության մասին
     welsh_language_scheme_html: Գտեք այստեղ %{link} ում հրապարակելու մեր պարտավորության մասին
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ hy:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -2,6 +2,7 @@
 id:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ id:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: Diterbitkan
@@ -179,6 +214,24 @@ id:
     publication_scheme_html: Baca jenis-jenis informasi yang secara rutin kami muat di %{link}
     social_media_use_html: Baca kebijakan kami di %{link}
     welsh_language_scheme_html: Informasi lebih lanjut mengenai komitmen kami dalam memuat informasi di %{link}
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -259,9 +312,49 @@ id:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -2,6 +2,7 @@
 is:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ is:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -253,6 +288,24 @@ is:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ is:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -2,6 +2,7 @@
 it:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ it:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: pubblicato
@@ -253,6 +288,24 @@ it:
     publication_scheme_html: Per maggiori dettagli sul tipo di documenti pubblicati di routine, consulta la pagina %{link}.
     social_media_use_html: Per saperne di più sulla nostra politica, consulta la pagina %{link}.
     welsh_language_scheme_html: Per maggiori informazioni sul nostro impegno a pubblicare quante più informazioni possibili, consulta la pagina %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ it:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,7 @@
 ja:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ ja:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: 掲載日
@@ -179,6 +214,24 @@ ja:
     publication_scheme_html: 情報公開の種類については %{link} をご覧下さい
     social_media_use_html: "%{link}に関する政策を読む"
     welsh_language_scheme_html: 情報公開の詳細については %{link} をご覧下さい
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -259,9 +312,49 @@ ja:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -2,6 +2,7 @@
 ka:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ ka:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -179,6 +214,24 @@ ka:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -259,9 +312,49 @@ ka:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -2,6 +2,7 @@
 kk:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ kk:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -253,6 +288,24 @@ kk:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ kk:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -2,6 +2,7 @@
 ko:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ ko:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: 발행
@@ -179,6 +214,24 @@ ko:
     publication_scheme_html: 정기적으로 공개되는 %{link} 정보에 대한 안내
     social_media_use_html: "%{link} 에서 정책 정보 확인"
     welsh_language_scheme_html: "%{link} 에서 정보 공개에 대한 내용"
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -259,9 +312,49 @@ ko:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -2,6 +2,7 @@
 lt:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ lt:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: publikuota
@@ -327,6 +362,24 @@ lt:
     publication_scheme_html: Sužinokite, kokią informaciją mes pastoviai pateikiame puslapyje %{link}.
     social_media_use_html: Perskaitykite mūsų strategiją %{link}.
     welsh_language_scheme_html: Sužinokite apie mūsų įsipareigojimą skelbti %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -409,9 +462,49 @@ lt:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -2,6 +2,7 @@
 lv:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ lv:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: publicēts
@@ -253,6 +288,24 @@ lv:
     publication_scheme_html: Iepazīsties ar informāciju, kāda parasti tiek publicēta mūsu %{link}
     social_media_use_html: Iepazīsties ar mūsu nostāju par %{link}.
     welsh_language_scheme_html: Vairāk par mūsu apņemšanos nodrošināt informācijas pieejamību %{link}
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ lv:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -2,6 +2,7 @@
 ms:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ ms:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -179,6 +214,24 @@ ms:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -259,9 +312,49 @@ ms:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -2,6 +2,7 @@
 mt:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ mt:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -401,6 +436,24 @@ mt:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -484,9 +537,49 @@ mt:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -2,6 +2,7 @@
 nl:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ nl:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -253,6 +288,24 @@ nl:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ nl:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -2,6 +2,7 @@
 'no':
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -253,6 +288,24 @@
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -2,6 +2,7 @@
 pa-pk:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ pa-pk:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -253,6 +288,24 @@ pa-pk:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction: rtl
   language_names:
@@ -334,9 +387,49 @@ pa-pk:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -2,6 +2,7 @@
 pa:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ pa:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -253,6 +288,24 @@ pa:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ pa:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -2,6 +2,7 @@
 pl:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ pl:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: opublikowano
@@ -401,6 +436,24 @@ pl:
     publication_scheme_html: Przeczytaj, jakiego rodzaju wiadomości publikujemy zwykle w naszym %{link}
     social_media_use_html: Przeczytaj naszą politykę dotyczącą %{link}
     welsh_language_scheme_html: Poznaj nasze zobowiązania związane z publikowaniem w %{link}
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -484,9 +537,49 @@ pl:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -2,6 +2,7 @@
 ps:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ ps:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: خپور شوی
@@ -253,6 +288,24 @@ ps:
     publication_scheme_html: زموږ د هغو معلوماتو په اړه ولولۍ چې هره ورڅ یې موږ خپروو %{link}.
     social_media_use_html: زموږه پالسی ولولی %{link}.
     welsh_language_scheme_html: د نشریاتو په اړه  زموږ د ژمنو  معلومات ترلاسه کړۍ %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction: rtl
   language_names:
@@ -334,9 +387,49 @@ ps:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -2,6 +2,7 @@
 pt:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ pt:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: publicado
@@ -253,6 +288,24 @@ pt:
     publication_scheme_html: Leia sobre os tipos de informações que publicamos rotineiramente em nosso %{link}.
     social_media_use_html: Leia nossa política sobre %{link}
     welsh_language_scheme_html: Saiba mais sobre nosso comprometimento em publicar em %{link}
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ pt:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -2,6 +2,7 @@
 ro:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ ro:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents: Conținut
     metadata:
       published: Data publicării
@@ -327,6 +362,24 @@ ro:
     publication_scheme_html: Citește mai multe despre informațiile pe care le publigăm în mod regulat pe  %{link}.
     social_media_use_html: 'Citește mai multe despre strategia noastră pe '
     welsh_language_scheme_html: Află mai multe despre angajamentul nostru față de accesul la informații publice pe %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -409,9 +462,49 @@ ro:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -2,6 +2,7 @@
 ru:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ ru:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: Опубликовано
@@ -401,6 +436,24 @@ ru:
     publication_scheme_html: Прочитать информацию, которая обычно публикуется,  по указанной %{link}.
     social_media_use_html: Ознакомиться с нашей политикой по %{link}.
     welsh_language_scheme_html: Выяснить о наших обязательствах по публикации можно по %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -484,9 +537,49 @@ ru:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -2,6 +2,7 @@
 si:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ si:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: පල කරන ලදී
@@ -253,6 +288,24 @@ si:
     publication_scheme_html: අප නිතර අපේ %{link} පල කරන තොරතුරු වර්ගයන් ගැන කියවන්න
     social_media_use_html: " %{link}හිදී අපේ ප්‍රතිපත්ති කියවන්න"
     welsh_language_scheme_html: " %{link} හි පල කිරීමට අපේ ඇති කැපවීම ගැන කියවන්න"
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ si:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -2,6 +2,7 @@
 sk:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ sk:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -327,6 +362,24 @@ sk:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -409,9 +462,49 @@ sk:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -2,6 +2,7 @@
 sl:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ sl:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -401,6 +436,24 @@ sl:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -484,9 +537,49 @@ sl:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -2,6 +2,7 @@
 so:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ so:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: La-daabacay/nashriyey
@@ -253,6 +288,24 @@ so:
     publication_scheme_html: Akhri noocyada macluumaadka aan caadi ahaan ku daabacno/nashrinno %{link} aan soo saarno.
     social_media_use_html: Akhri siyaasaddeenna ku saabsan %{link}.
     welsh_language_scheme_html: Wax ka ogow sida aan ugu dadaalno ku daabacadda/nashrinta %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ so:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -2,6 +2,7 @@
 sq:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ sq:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: publikuar
@@ -253,6 +288,24 @@ sq:
     publication_scheme_html: Lexo mbi llojet e informacionit qe ne publikojme rregullisht ne %{link}.
     social_media_use_html: Lexo politikat tona ne %{link}
     welsh_language_scheme_html: Meso mbi angazhimin tone ndaj publikimit ne %{link}
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ sq:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -2,6 +2,7 @@
 sr:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ sr:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: objavljeno
@@ -401,6 +436,24 @@ sr:
     publication_scheme_html: Čitajte o tipovima informacija koje redovno objavljujemo u  %{link}.
     social_media_use_html: Pročitajte o našoj politici prema  %{link}.
     welsh_language_scheme_html: Saznajte naš stav o objavljivanju u %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -484,9 +537,49 @@ sr:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -2,6 +2,7 @@
 sv:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ sv:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -253,6 +288,24 @@ sv:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ sv:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -2,6 +2,7 @@
 sw:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ sw:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -253,6 +288,24 @@ sw:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ sw:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -2,6 +2,7 @@
 ta:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ ta:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: பிரசுரிக்கப்பட்டது
@@ -253,6 +288,24 @@ ta:
     publication_scheme_html: எங்களது %{link} நாங்கள் வழமையாக வெளியிடும் தகவல்களின்  வகைகள் பற்றி வாசிக்கவும்
     social_media_use_html: எங்களது  கொள்கையை %{link} இல் வாசிக்கவும்
     welsh_language_scheme_html: "%{link} இல் பிரசுரிப்பதற்கான எங்களது பற்றுறுதி பற்றி கண்டறியவும்"
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ ta:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -2,6 +2,7 @@
 th:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ th:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: ตีพิมพ์
@@ -179,6 +214,24 @@ th:
     publication_scheme_html: อ่านประเภทข้อมูลซึ่งเราเผยแพร่เป็นประจำได้ที่ %{link}
     social_media_use_html: อ่านนโยบายของเราได้ที่ %{link}
     welsh_language_scheme_html: ค้นหาข้อมูลเกี่ยวกับพันธสัญญาในการตีพิมพ์ของเราได้ที่ %{link}.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -259,9 +312,49 @@ th:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -2,6 +2,7 @@
 tk:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ tk:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published:
@@ -253,6 +288,24 @@ tk:
     publication_scheme_html:
     social_media_use_html:
     welsh_language_scheme_html:
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ tk:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -2,6 +2,7 @@
 tr:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ tr:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: Yayında
@@ -253,6 +288,24 @@ tr:
     publication_scheme_html: Rutin olarak yayınladığımız bilgiler için bu %{link} 'e bakınız
     social_media_use_html: Konuyla ilgili politikamız hakkında daha fazla bilgi için %{link}
     welsh_language_scheme_html: Yayın hedefimiz ile ilgili bilgilere bu  %{link}ten ulaşabilirsiniz.
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ tr:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -2,6 +2,7 @@
 uk:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ uk:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: опубліковано
@@ -401,6 +436,24 @@ uk:
     publication_scheme_html: Прочитайти, яку інформацію ми регулярно публікуємо у %{link}.
     social_media_use_html: Прочитайне про наші принципи роботи щодо %{link}.
     welsh_language_scheme_html: 'Дізнайтеся про наші зобов''язання щодо публікації інформації у %{link}. '
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -484,9 +537,49 @@ uk:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -2,6 +2,7 @@
 ur:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ ur:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: شائع شدہ
@@ -253,6 +288,24 @@ ur:
     publication_scheme_html: 'ہماری معمول کے مطابق  شائع کردہ معلومات کی نوعیت  %{link} پرملاحظہ کیجئیے '
     social_media_use_html: ہماری پالیسی  %{link} پر ملاحظہ کیجئیے
     welsh_language_scheme_html: اشاعت کے باب میں ہمارے کمٹ منٹ %{link} میں ملاحظہ کیجئیے
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction: rtl
   language_names:
@@ -334,9 +387,49 @@ ur:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -2,6 +2,7 @@
 uz:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ uz:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: nashr qilindi
@@ -253,6 +288,24 @@ uz:
     publication_scheme_html: "%{link} Biz doimiy tarzda nashr etayotgan ma'lumot haqida o'qing"
     social_media_use_html: "%{link} Bizning dasturimiz haqida batafsil ma'lumot"
     welsh_language_scheme_html: "%{link} Nashr etish uchun biz olib borayotgan faoliyatimiz haqida o'qing"
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ uz:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -2,6 +2,7 @@
 vi:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ vi:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: Đã xuất bản
@@ -179,6 +214,24 @@ vi:
     publication_scheme_html: Xem các loại thông tin mà chúng tôi cập nhật thường xuyên tại %{link}
     social_media_use_html: Đọc chính sách của chúng tôi tại %{link}
     welsh_language_scheme_html: Tìm hiểu các cam kết của chúng tôi trong việc công bố thông tin tại %{link}
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -259,9 +312,49 @@ vi:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -2,6 +2,7 @@
 zh-hk:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ zh-hk:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: 已發布
@@ -253,6 +288,24 @@ zh-hk:
     publication_scheme_html: 查閱我們在%{link}定期發布的資訊。
     social_media_use_html: 查閱我們在%{link}的政策。
     welsh_language_scheme_html: 查閱我們在%{link}的發布承諾。
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ zh-hk:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -2,6 +2,7 @@
 zh-tw:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ zh-tw:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: 發行
@@ -253,6 +288,24 @@ zh-tw:
     publication_scheme_html: 查閱我們在%{link}定期發布的資訊。
     social_media_use_html: 查閱我們在%{link}的政策。
     welsh_language_scheme_html: 查閱我們在%{link}的發佈承諾。
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction:
   language_names:
@@ -334,9 +387,49 @@ zh-tw:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -2,6 +2,7 @@
 zh:
   common:
     last_updated:
+    visit:
   components:
     figure:
       image_credit:
@@ -18,7 +19,41 @@ zh:
       show_all:
     share_links:
       share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents:
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
     contents:
     metadata:
       published: 已发布
@@ -179,6 +214,24 @@ zh:
     publication_scheme_html: 阅读我们在%{link}定期发布的信息。
     social_media_use_html: 阅读我们在%{link}的政策
     welsh_language_scheme_html: 查阅我们在%{link}发布的信息。
+  fatality_notice:
+    alt_text:
+    field_of_operation:
+    operations_in:
+  gone:
+    page_title:
+    published_in_error:
+    title:
+  guide:
+    pages_in_guide:
+    skip_to_contents:
+  html_publication:
+    print_meta_data:
+      available_at:
+      copyright:
+      isbn:
+      licence_html:
+      third_party:
   i18n:
     direction: ltr
   language_names:
@@ -259,9 +312,49 @@ zh:
     error:
       option:
       title:
+  shared:
+    historically_political:
+    webchat:
+      available:
+      busy:
+      closed:
+      speak_to_adviser:
+      technical_problem:
+  specialist_document:
+    pdo_alt_text:
+    pgi_alt_text:
+    tsg_alt_text:
+  speech:
+    delivered_on:
+    location:
+    written_on:
+  statistics_announcement:
+    cancellation_date:
+    cancelled:
+    changed_date:
+    forthcoming:
+    previous_date:
+    proposed_date:
+    reason_for_change:
+    release_date:
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts:
       avoid_all_but_essential_travel_to_whole_country:
       avoid_all_travel_to_parts:
       avoid_all_travel_to_whole_country:
+    context:
+    coronavirus_warning:
+      content_html:
+      text_assistive:
+      title:
+    still_current_at:
+    summary:
+    updated:
+  unpublishing:
+    page_title:
+    summary:
+    title:
+  working_group:
+    contact_details:
+    policies:


### PR DESCRIPTION
Moves all hardcoded English strings from controllers, presenters and views to the English locale file and adds placeholder keys for these in all other languages.

This will allow us to gain visibility of content that needs to be translated in order to fully support non-English content on GOV.UK.

This does not translate [the "histories" pages](https://github.com/alphagov/government-frontend/tree/release_1749/app/views/histories) which contain substantial amounts of hardcoded English content.

[Trello card](https://trello.com/c/vbFb9GT2)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
