### PR TITLE
Replace context link with breadcrumb

### DIFF
--- a/app/views/histories/10_downing_street.html.erb
+++ b/app/views/histories/10_downing_street.html.erb
@@ -1,9 +1,20 @@
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/breadcrumbs", {
+      breadcrumbs: [
+        {
+          title: "Home",
+          url: "/",
+        },
+        {
+          title: "History of the UK Government",
+          url: "/government/history",
+        },
+      ]
+    } %>
     <%= render "govuk_publishing_components/components/title", {
       context: {
         text: "History",
-        href: "/government/history",
       },
       title: "10 Downing Street",
     } %>

--- a/app/views/histories/11_downing_street.html.erb
+++ b/app/views/histories/11_downing_street.html.erb
@@ -1,9 +1,20 @@
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/breadcrumbs", {
+      breadcrumbs: [
+        {
+          title: "Home",
+          url: "/",
+        },
+        {
+          title: "History of the UK Government",
+          url: "/government/history",
+        },
+      ]
+    } %>
     <%= render "govuk_publishing_components/components/title", {
       context: {
         text: "History",
-        href: "/government/history",
       },
       title: "11 Downing Street",
     } %>

--- a/app/views/histories/1_horse_guards_road.html.erb
+++ b/app/views/histories/1_horse_guards_road.html.erb
@@ -1,9 +1,20 @@
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/breadcrumbs", {
+      breadcrumbs: [
+        {
+          title: "Home",
+          url: "/",
+        },
+        {
+          title: "History of the UK Government",
+          url: "/government/history",
+        },
+      ]
+    } %>
     <%= render "govuk_publishing_components/components/title", {
       context: {
         text: "History",
-        href: "/government/history",
       },
       title: "1 Horse Guards Road",
     } %>

--- a/app/views/histories/king_charles_street.html.erb
+++ b/app/views/histories/king_charles_street.html.erb
@@ -1,9 +1,20 @@
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/breadcrumbs", {
+      breadcrumbs: [
+        {
+          title: "Home",
+          url: "/",
+        },
+        {
+          title: "History of the UK Government",
+          url: "/government/history",
+        },
+      ]
+    } %>
     <%= render "govuk_publishing_components/components/title", {
       context: {
         text: "History",
-        href: "/government/history",
       },
       title: "King Charles Street",
     } %>

--- a/app/views/histories/lancaster_house.html.erb
+++ b/app/views/histories/lancaster_house.html.erb
@@ -1,9 +1,20 @@
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/breadcrumbs", {
+      breadcrumbs: [
+        {
+          title: "Home",
+          url: "/",
+        },
+        {
+          title: "History of the UK Government",
+          url: "/government/history",
+        },
+      ]
+    } %>
     <%= render "govuk_publishing_components/components/title", {
       context: {
         text: "History",
-        href: "/government/history",
       },
       title: "Lancaster House",
     } %>


### PR DESCRIPTION
## What
https://trello.com/c/3ENWcE93/729-confusing-contextual-link-on-some-pages
Remove the link from the context text on the main heading, add breadcrumb to replace it.

## Why

The styling of the contextual text in the component doesn't indicate in any way that it is a link without user interaction. We plan to remove the ability to add links from the components gem.  We decided to preserve the linking back to the History page by adding a breadcrumb. The wording there more explicitly describes where the link goes.

## Screenshots

### Before
![Screenshot 2021-05-25 at 15 44 16](https://user-images.githubusercontent.com/31649453/119518050-13234f00-bd70-11eb-8e03-9e30d14d967c.png)


### After
![Screenshot 2021-05-25 at 15 43 10](https://user-images.githubusercontent.com/31649453/119517907-ed964580-bd6f-11eb-8258-3755cc6de042.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
