### PR TITLE
Add some analytics to the brexit child taxon pages

### DIFF
--- a/app/lib/body_parser.rb
+++ b/app/lib/body_parser.rb
@@ -1,0 +1,67 @@
+class BodyParser
+  def initialize(body)
+    @body = body
+  end
+
+  def title_and_link_sections
+    if raw_title_and_link_sections.any?
+      raw_title_and_link_sections.map do |section|
+        s = parse(section)
+        {
+          title: parsed_title(s),
+          links: parsed_links(s),
+        }
+      end
+    end
+  end
+
+private
+
+  attr_reader :body
+
+  def parse(html)
+    Nokogiri::HTML.parse(html)
+  rescue Nokogiri::XML::SyntaxError
+    ""
+  end
+
+  def parsed_body
+    @parsed_body ||= parse(body)
+  end
+
+  def raw_body_content
+    if parsed_body.present?
+      parsed_body.search("div.govspeak").children
+    end
+  end
+
+  def raw_title_and_link_sections
+    if raw_body_content.any?
+      raw_body_content.to_s.split(/(?=<h2 )/)
+    end
+  end
+
+  def parsed_links(section)
+    raw_links = section.present? ? section.css("a") : []
+    if raw_links.any?
+      raw_links.map do |link|
+        {
+          path: format_path(link["href"]),
+          text: link.content,
+        }
+      end
+    else
+      []
+    end
+  end
+
+  def parsed_title(section)
+    raw_title = section.present? ? section.at_css("h2") : ""
+    raw_title.present? ? raw_title.content : ""
+  end
+
+  def format_path(raw_url)
+    uri = URI.parse(raw_url)
+    uri.host == "www.gov.uk" ? uri.path : raw_url
+  end
+end

--- a/app/presenters/content_item/body.rb
+++ b/app/presenters/content_item/body.rb
@@ -10,5 +10,9 @@ module ContentItem
         direction: text_direction,
       }
     end
+
+    def title_and_link_sections
+      BodyParser.new(body.html_safe).title_and_link_sections
+    end
   end
 end

--- a/app/presenters/content_item/brexit_hub_page.rb
+++ b/app/presenters/content_item/brexit_hub_page.rb
@@ -11,10 +11,12 @@ module ContentItem
         ContentItem::BrexitHubPage::BREXIT_BUSINESS_PAGE_CONTENT_ID => {
           text: I18n.t("brexit.citizen_link"),
           path: BREXIT_CITIZEN_PAGE_PATH,
+          track_category: "brexit-business-page",
         },
         ContentItem::BrexitHubPage::BREXIT_CITIZEN_PAGE_CONTENT_ID => {
           text: I18n.t("brexit.business_link"),
           path: BREXIT_BUSINESS_PAGE_PATH,
+          track_category: "brexit-citizen-page",
         },
       }
     end

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -6,15 +6,16 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% title_and_context = @content_item.brexit_link ? { title: @content_item.title } : @content_item.title_and_context %>
+    <% brexit_link = @content_item.brexit_link %>
+    <% title_and_context = brexit_link ? { title: @content_item.title } : @content_item.title_and_context %>
     <%= render 'govuk_publishing_components/components/title', title_and_context %>
   </div>
   <%= render 'shared/translations' %>
   <div class="govuk-grid-column-two-thirds">
-    <% if @content_item.brexit_link %>
+    <% if brexit_link %>
       <div class="govuk-body-l govuk-!-margin-bottom-7">
         <p class="govuk-body">
-          <%= I18n.t("brexit.heading_prefix") %> <%= link_to @content_item.brexit_link[:text], @content_item.brexit_link[:path] %>.
+          <%= I18n.t("brexit.heading_prefix") %> <%= link_to brexit_link[:text], brexit_link[:path] %>.
         </p>
       </div>
     <% else %>
@@ -23,7 +24,7 @@
   </div>
 </div>
 
-<%= render 'shared/publisher_metadata_with_logo' unless @content_item.brexit_link %>
+<%= render 'shared/publisher_metadata_with_logo' unless brexit_link %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
@@ -35,7 +36,7 @@
       <%= render "govuk_publishing_components/components/print_link", {
         margin_top: 0,
         margin_bottom: 6,
-      } unless @content_item.brexit_link %>
+      } unless brexit_link %>
 
       <%= render 'govuk_publishing_components/components/govspeak', {} do %>
         <%= raw(@content_item.govspeak_body[:content]) %>
@@ -46,13 +47,13 @@
             published: @content_item.published,
             last_updated: @content_item.updated,
             history: @content_item.history
-          } unless @content_item.brexit_link %>
+          } unless brexit_link %>
       </div>
     <% end %>
     <%= render "govuk_publishing_components/components/print_link", {
         margin_top: 0,
         margin_bottom: 6,
-      } unless @content_item.brexit_link %>
+      } unless brexit_link %>
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -15,7 +15,17 @@
     <% if brexit_link %>
       <div class="govuk-body-l govuk-!-margin-bottom-7">
         <p class="govuk-body">
-          <%= I18n.t("brexit.heading_prefix") %> <%= link_to brexit_link[:text], brexit_link[:path] %>.
+          <%= I18n.t("brexit.heading_prefix") %>
+          <%= link_to(
+              brexit_link[:text],
+              brexit_link[:path],
+              class: "govuk-link",
+              data: {
+                track_action: brexit_link[:path],
+                track_category: brexit_link[:track_category],
+                track_label: brexit_link[:text],
+                module: 'gem-track-click',
+              }) %>.
         </p>
       </div>
     <% else %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -38,8 +38,12 @@
         margin_bottom: 6,
       } unless brexit_link %>
 
-      <%= render 'govuk_publishing_components/components/govspeak', {} do %>
-        <%= raw(@content_item.govspeak_body[:content]) %>
+      <% if brexit_link %>
+        <%= render partial: 'content_items/detailed_guide/brexit_links', locals: { brexit_link: brexit_link } %>
+      <% else %>
+        <%= render 'govuk_publishing_components/components/govspeak', {} do %>
+          <%= raw(@content_item.govspeak_body[:content]) %>
+        <% end %>
       <% end %>
 
       <div class="responsive-bottom-margin">

--- a/app/views/content_items/detailed_guide/_brexit_links.html.erb
+++ b/app/views/content_items/detailed_guide/_brexit_links.html.erb
@@ -1,0 +1,23 @@
+<div class="govuk-grid-row">
+  <% @content_item.title_and_link_sections.each do |section| %>
+    <% if section[:title].present? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: section[:title],
+        heading_level: 2,
+        font_size: "m",
+        margin_bottom: 6,
+      } %>
+    <% end %>
+    <% if section[:links].present? %>
+      <% track_category = brexit_link[:track_category] %>
+        <% links = section[:links].map do |link|
+            link_to(link[:text], link[:path], class: "govuk-link")
+          end
+        %>
+      <%= render "govuk_publishing_components/components/list", {
+        items: links,
+        visible_counters: true,
+        } %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/content_items/detailed_guide/_brexit_links.html.erb
+++ b/app/views/content_items/detailed_guide/_brexit_links.html.erb
@@ -11,7 +11,12 @@
     <% if section[:links].present? %>
       <% track_category = brexit_link[:track_category] %>
         <% links = section[:links].map do |link|
-            link_to(link[:text], link[:path], class: "govuk-link")
+            link_to(link[:text], link[:path], class: "govuk-link", data: {
+              track_action: link[:path],
+              track_category: track_category,
+              track_label: section[:title] || "",
+              module: 'gem-track-click',
+            })
           end
         %>
       <%= render "govuk_publishing_components/components/list", {

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -111,5 +111,14 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     assert_not page.has_text?(@content_item["description"])
     link_text = "Brexit guidance for businesses"
     assert page.has_link?(link_text, href: ContentItem::BrexitHubPage::BREXIT_BUSINESS_PAGE_PATH)
+
+    # adds GA tracking to the links
+    track_action = find_link("Foreign travel advice")["data-track-action"]
+    track_category = find_link("Foreign travel advice")["data-track-category"]
+    track_label = find_link("Foreign travel advice")["data-track-label"]
+
+    assert_equal "/foreign-travel-advice", track_action
+    assert_equal "brexit-citizen-page", track_category
+    assert_equal "Travel to the EU", track_label
   end
 end

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -112,7 +112,7 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     link_text = "Brexit guidance for businesses"
     assert page.has_link?(link_text, href: ContentItem::BrexitHubPage::BREXIT_BUSINESS_PAGE_PATH)
 
-    # adds GA tracking to the links
+    # adds GA tracking to the li links
     track_action = find_link("Foreign travel advice")["data-track-action"]
     track_category = find_link("Foreign travel advice")["data-track-category"]
     track_label = find_link("Foreign travel advice")["data-track-label"]
@@ -120,5 +120,14 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     assert_equal "/foreign-travel-advice", track_action
     assert_equal "brexit-citizen-page", track_category
     assert_equal "Travel to the EU", track_label
+
+    # adds GA tracking to the description field links
+    track_action = find_link("Brexit guidance for businesses")["data-track-action"]
+    track_category = find_link("Brexit guidance for businesses")["data-track-category"]
+    track_label = find_link("Brexit guidance for businesses")["data-track-label"]
+
+    assert_equal ContentItem::BrexitHubPage::BREXIT_BUSINESS_PAGE_PATH, track_action
+    assert_equal "brexit-citizen-page", track_category
+    assert_equal "Brexit guidance for businesses", track_label
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -179,6 +179,8 @@ class ActionDispatch::IntegrationTest
   def setup_and_visit_brexit_child_taxon(type = nil)
     @content_item = get_content_example("detailed_guide").tap do |item|
       item["content_id"] = type == "business" ? brexit_business_id : brexit_citizen_id
+      item["details"]["body"] = brexit_body_content
+
       stub_content_store_has_item(item["base_path"], item.to_json)
       visit_with_cachebust((item["base_path"]).to_s)
     end
@@ -190,6 +192,25 @@ class ActionDispatch::IntegrationTest
 
   def brexit_business_id
     ContentItem::BrexitHubPage::BREXIT_BUSINESS_PAGE_CONTENT_ID
+  end
+
+  def brexit_body_content
+    '<div class="govspeak">'\
+    '<h2 id="travel-to-the-eu">Travel to the EU</h2>\n \n'\
+    '<ul>\n'\
+    '<li><a rel="external" href="https://www.gov.uk/foreign-travel-advice" '\
+    'class="govuk-link">Foreign travel advice</a></li>\n'\
+    '<li><a rel="external" href="https://www.gov.uk/visit-eu"'\
+    'class="govuk-link">Travelling to the EU'\
+    '</a></li>\n</ul>\n'\
+    '<h2 id="travel-to-the-uk">Travel to the UK</h2>\n \n'\
+    '<ul>\n'\
+    '<li><a rel="external" href="https://www.gov.uk/local-travel-advice" '\
+    'class="govuk-link">Local travel advice</a></li>\n'\
+    '<li><a rel="external" href="https://www.gov.uk/visit-uk"'\
+    'class="govuk-link">Travelling to the UK'\
+    '</a></li>\n</ul>\n'\
+    "</div>"
   end
 
   def setup_and_visit_random_content_item(document_type: nil)

--- a/test/unit/body_parser_test.rb
+++ b/test/unit/body_parser_test.rb
@@ -1,0 +1,104 @@
+require "test_helper"
+
+class BodyParserTest < ActiveSupport::TestCase
+  def html
+    '<div class="govspeak">'\
+    '<h2 id="travel-to-the-eu">Travel to the EU</h2>\n \n'\
+    '<ul>\n'\
+    '<li><a rel="external" href="https://www.gov.uk/foreign-travel-advice" '\
+    'class="govuk-link">Foreign travel advice</a></li>\n'\
+    '<li><a rel="external" href="https://www.gov.uk/visit-eu"'\
+    'class="govuk-link">Travelling to the EU'\
+    '</a></li>\n</ul>\n'\
+    '<h2 id="travel-to-the-uk">Travel to the UK</h2>\n \n'\
+    '<ul>\n'\
+    '<li><a rel="external" href="https://www.gov.uk/local-travel-advice" '\
+    'class="govuk-link">Local travel advice</a></li>\n'\
+    '<li><a rel="external" href="https://www.gov.uk/visit-uk"'\
+    'class="govuk-link">Travelling to the UK'\
+    '</a></li>\n</ul>\n'\
+    "</div>"
+  end
+
+  def html_missing_section_headings
+    '<div class="govspeak">'\
+    '<ul>\n'\
+    '<li><a rel="external" href="https://www.gov.uk/foreign-travel-advice" '\
+    'class="govuk-link">Foreign travel advice</a></li>\n'\
+    '<li><a rel="external" href="https://www.gov.uk/visit-eu"'\
+    'class="govuk-link">Travelling to the EU'\
+    '</a></li>\n</ul>\n'\
+    '<ul>\n'\
+    '<li><a rel="external" href="https://www.gov.uk/local-travel-advice" '\
+    'class="govuk-link">Local travel advice</a></li>\n'\
+    '<li><a rel="external" href="https://www.gov.uk/visit-uk"'\
+    'class="govuk-link">Travelling to the UK'\
+    '</a></li>\n</ul>\n'\
+    "</div>"
+  end
+
+  def subject
+    @subject ||= BodyParser.new(html)
+  end
+
+  test "#title_and_link_sections" do
+    expected = [
+      {
+        title: "Travel to the EU",
+        links: [
+          {
+            path: "/foreign-travel-advice",
+            text: "Foreign travel advice",
+          },
+          {
+            path: "/visit-eu",
+            text: "Travelling to the EU",
+          },
+        ],
+      },
+      {
+        title: "Travel to the UK",
+        links: [
+          {
+            path: "/local-travel-advice",
+            text: "Local travel advice",
+          },
+          {
+            path: "/visit-uk",
+            text: "Travelling to the UK",
+          },
+        ],
+      },
+    ]
+
+    assert_equal expected, subject.title_and_link_sections
+  end
+
+  test "when parsing html missing the section headings" do
+    subject = BodyParser.new(html_missing_section_headings)
+    expected = [
+      {
+        title: "",
+        links: [
+          {
+            path: "/foreign-travel-advice",
+            text: "Foreign travel advice",
+          },
+          {
+            path: "/visit-eu",
+            text: "Travelling to the EU",
+          },
+          {
+            path: "/local-travel-advice",
+            text: "Local travel advice",
+          },
+          {
+            path: "/visit-uk",
+            text: "Travelling to the UK",
+          },
+        ],
+      },
+    ]
+    assert_equal expected, subject.title_and_link_sections
+  end
+end


### PR DESCRIPTION
## What

We need to add some tracking to the links on the new brexit child taxon pages. Because the content of detailed guides is sent to government-frontend as a string of html in the details hash of the content item, we need to parse it before we can add the data attributes. See commit [message](https://github.com/alphagov/government-frontend/commit/f61f705186099ab477e3f2af2258491ca5c39c49) for more information.

### To test this works:

- Once this #2097 is merged, the review apps for this pr will render the brexit pages correctly. 
- The review apps will need to be pointed at integration.
- The detailed guides will need to be published in integration:
  - https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/detailed-guides/1204514
  - https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/detailed-guides/1204414

But if that is a bit of a faff here are some screen shots:

<img width="725" alt="Screenshot 2021-05-28 at 23 22 41" src="https://user-images.githubusercontent.com/17908089/120047171-e12e1900-c00b-11eb-96a4-f3d779cc8aeb.png">
<img width="785" alt="Screenshot 2021-05-28 at 23 22 57" src="https://user-images.githubusercontent.com/17908089/120047173-e25f4600-c00b-11eb-8da4-785316a64e30.png">


trello https://trello.com/c/RqR5gkX2/1541-add-tracking-to-brexit-child-taxon-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
