### PR TITLE
Remove brand colour for organisation logos on department about pages

### DIFF
--- a/app/assets/stylesheets/helpers/_organisation-links.scss
+++ b/app/assets/stylesheets/helpers/_organisation-links.scss
@@ -5,7 +5,7 @@
 @mixin organisation-links {
   @each $organisation in map-keys($govuk-colours-organisations) {
     .#{$organisation}-brand-colour {
-      a {
+      a:not(.gem-c-organisation-logo__link) {
         color: govuk-organisation-colour($organisation);
 
         &:focus {


### PR DESCRIPTION
##What
Update the brand colour link override seen on [about us pages](https://www.gov.uk/government/organisations/attorney-generals-office/about) so that the organisation logo is always the default black colour.

##Why
To ensure that our patterns are consistent across govuk. This pattern's default state is black and there is no value added to the user by changing the link colour to the brand colour of a given department.

[Card](https://trello.com/c/djz1Sxy3/740-update-organisation-component-to-be-consistent-throughout-govuk-and-remove-any-style-overrides)

##Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-06-03 at 17 32 50](https://user-images.githubusercontent.com/64783893/120682767-be30b880-c494-11eb-888a-7e57a84f4d8e.png) | ![Screenshot 2021-06-03 at 17 33 42](https://user-images.githubusercontent.com/64783893/120682801-ca1c7a80-c494-11eb-96fc-5363d03702ce.png) |