### PR TITLE
Fix exposed html from translation

### DIFF
--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -21,7 +21,7 @@
 
     <% if @content_item.unopened? %>
       <% content_item_unopened = capture do %>
-        <%= t("consultation.opens") %>
+        <%= raw(t("consultation.opens")) %>
         <%= @content_item.opening_date_midnight? ? t("consultation.on") : t("consultation.at") %>
         <time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time>
       <% end %>
@@ -32,7 +32,7 @@
 
     <% elsif @content_item.pending_final_outcome? %>
       <% content_item_final_outcome = capture do %>
-        <%= t("consultation.visit_soon") %>
+        <%= raw(t("consultation.visit_soon")) %>
       <% end %>
       <%= render 'govuk_publishing_components/components/notice',
         title: 'We are analysing your feedback',


### PR DESCRIPTION
### What

The text content from this page comes from a translation file. This means that any coding gets exposed unless we deliberately render it as raw. Since we control the translations we can be confident that doing this is safe. The error that was exposed was noted by a user in https://govuk.zendesk.com/agent/tickets/4582865

Sample URL: https://www.gov.uk/government/consultations/tobacco-and-related-products-legislation-introduced-between-2015-to-2016-reviewing-effectiveness

### Before
![Screenshot 2021-06-09 at 13 13 28](https://user-images.githubusercontent.com/31649453/121352991-4bf12580-c925-11eb-96bf-8e5e6bcfc6af.png)

### After
![Screenshot 2021-06-09 at 13 13 14](https://user-images.githubusercontent.com/31649453/121352981-4a276200-c925-11eb-936c-5ca095a3f7ee.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
