### PR TITLE
Fix brexit links partial alignment

### DIFF
--- a/app/views/content_items/detailed_guide/_brexit_links.html.erb
+++ b/app/views/content_items/detailed_guide/_brexit_links.html.erb
@@ -1,28 +1,26 @@
-<div class="govuk-grid-row">
-  <% @content_item.title_and_link_sections.each do |section| %>
-    <% if section[:title].present? %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: section[:title],
-        heading_level: 2,
-        font_size: "m",
-        margin_bottom: 6,
-      } %>
-    <% end %>
-    <% if section[:links].present? %>
-      <% track_category = brexit_link[:track_category] %>
-        <% links = section[:links].map do |link|
-            link_to(link[:text], link[:path], class: "govuk-link", data: {
-              track_action: link[:path],
-              track_category: track_category,
-              track_label: section[:title] || "",
-              module: 'gem-track-click',
-            })
-          end
-        %>
-      <%= render "govuk_publishing_components/components/list", {
-        items: links,
-        visible_counters: true,
-        } %>
-    <% end %>
+<% @content_item.title_and_link_sections.each do |section| %>
+  <% if section[:title].present? %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: section[:title],
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 6,
+    } %>
   <% end %>
-</div>
+  <% if section[:links].present? %>
+    <% track_category = brexit_link[:track_category] %>
+      <% links = section[:links].map do |link|
+          link_to(link[:text], link[:path], class: "govuk-link", data: {
+            track_action: link[:path],
+            track_category: track_category,
+            track_label: section[:title] || "",
+            module: 'gem-track-click',
+          })
+        end
+      %>
+    <%= render "govuk_publishing_components/components/list", {
+      items: links,
+      visible_counters: true,
+      } %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
This partial is already rendered in a `govuk-grid-row` so adding an extra one here is causing a container misalignment.

[Recommend reviewing without whitespace changes](https://github.com/alphagov/government-frontend/pull/2140/files?diff=split&w=1).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
