### PR TITLE
Fixes Nepali translation

### DIFF
--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -144,7 +144,7 @@ ne:
         one:
         other:
       guidance:
-        one:
+        one: मार्गदर्शन
         other:
       impact_assessment:
         one:
@@ -382,7 +382,7 @@ ne:
     details:
     documents:
       one:
-      other:
+      other: कागजातहरू
   service_sign_in:
     continue:
     error:


### PR DESCRIPTION
Nepali has two types of plural, [according to the Unicode rules](https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#ne), but the translations we received didn't specify pluralization, so I'm making these changes based on other languages.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
