### PR TITLE
Amend tracking and anchor links on brexit child taxon pages

### DIFF
--- a/app/lib/body_parser.rb
+++ b/app/lib/body_parser.rb
@@ -42,17 +42,19 @@ private
   end
 
   def parsed_links(section)
-    raw_links = section.present? ? section.css("a") : []
+    raw_links = section.css("a") if section.present?
     if raw_links.any?
-      raw_links.map do |link|
-        {
-          path: format_path(link["href"]),
-          text: link.content,
-        }
-      end
+      raw_links.map { |link| parse_link(link) }
     else
       []
     end
+  end
+
+  def parse_link(raw_link)
+    {
+      path: format_path(raw_link["href"]),
+      text: raw_link.content,
+    }
   end
 
   def parsed_title(section)

--- a/app/lib/body_parser.rb
+++ b/app/lib/body_parser.rb
@@ -58,8 +58,15 @@ private
   end
 
   def parsed_title(section)
-    raw_title = section.present? ? section.at_css("h2") : ""
-    raw_title.present? ? raw_title.content : ""
+    parsed = { text: "", id: "" }
+
+    raw_header = section.at_css("h2") if section.present?
+    if raw_header.present?
+      id = raw_header.attribute("id")
+      parsed[:text] = raw_header.content
+      parsed[:id] = id.value if id.present?
+    end
+    parsed
   end
 
   def format_path(raw_url)

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -23,7 +23,7 @@
               data: {
                 track_action: brexit_link[:path],
                 track_category: brexit_link[:track_category],
-                track_label: brexit_link[:text],
+                track_label: "Guidance nav link",
                 module: 'gem-track-click',
               }) %>.
         </p>

--- a/app/views/content_items/detailed_guide/_brexit_links.html.erb
+++ b/app/views/content_items/detailed_guide/_brexit_links.html.erb
@@ -1,10 +1,11 @@
 <% @content_item.title_and_link_sections.each do |section| %>
-  <% if section[:title].present? %>
+  <% if section[:title][:text].present? %>
     <%= render "govuk_publishing_components/components/heading", {
-      text: section[:title],
+      text: section[:title][:text],
       heading_level: 2,
       font_size: "m",
       margin_bottom: 6,
+      id: section[:title][:id],
     } %>
   <% end %>
   <% if section[:links].present? %>
@@ -13,7 +14,7 @@
           link_to(link[:text], link[:path], class: "govuk-link", data: {
             track_action: link[:path],
             track_category: track_category,
-            track_label: section[:title] || "",
+            track_label: section[:title][:text] || "",
             module: 'gem-track-click',
           })
         end

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -128,6 +128,6 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
 
     assert_equal ContentItem::BrexitHubPage::BREXIT_BUSINESS_PAGE_PATH, track_action
     assert_equal "brexit-citizen-page", track_category
-    assert_equal "Brexit guidance for businesses", track_label
+    assert_equal "Guidance nav link", track_label
   end
 end

--- a/test/unit/body_parser_test.rb
+++ b/test/unit/body_parser_test.rb
@@ -44,7 +44,10 @@ class BodyParserTest < ActiveSupport::TestCase
   test "#title_and_link_sections" do
     expected = [
       {
-        title: "Travel to the EU",
+        title: {
+          text: "Travel to the EU",
+          id: "travel-to-the-eu",
+        },
         links: [
           {
             path: "/foreign-travel-advice",
@@ -57,7 +60,10 @@ class BodyParserTest < ActiveSupport::TestCase
         ],
       },
       {
-        title: "Travel to the UK",
+        title: {
+          text: "Travel to the UK",
+          id: "travel-to-the-uk",
+        },
         links: [
           {
             path: "/local-travel-advice",
@@ -78,7 +84,10 @@ class BodyParserTest < ActiveSupport::TestCase
     subject = BodyParser.new(html_missing_section_headings)
     expected = [
       {
-        title: "",
+        title: {
+          text: "",
+          id: "",
+        },
         links: [
           {
             path: "/foreign-travel-advice",


### PR DESCRIPTION
### Amend tracking

- As requested [here](https://docs.google.com/presentation/d/19bQ2ojvtlqGg9QmjMlNE6R55cxPRAnewh7MljV00KWU/edit?pli=1&disco=AAAAMgHfaLU) we would like to record a different value when a user clicks on this bit:
<img width="601" alt="Screenshot 2021-06-11 at 12 16 36" src="https://user-images.githubusercontent.com/17908089/121678302-f052a380-caae-11eb-800b-bb0196f26448.png">

### Fix broken anchor links

- The content list is generated based on the ID of the H2's, but due to the way we pull out those H2's on the child taxon pages the ID's were missing. See [commit](https://github.com/alphagov/government-frontend/pull/2143/commits/029ea0cdeed3c73981421a235edfb27ab604071a) for more info.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
