### PR TITLE
Add AB Test for Explore Super Menu Navigation

### DIFF
--- a/app/controllers/ab_tests/explore_menu_ab_testable.rb
+++ b/app/controllers/ab_tests/explore_menu_ab_testable.rb
@@ -1,0 +1,26 @@
+module AbTests::ExploreMenuAbTestable
+  CUSTOM_DIMENSION = 47
+
+  ALLOWED_VARIANTS = %w[A B Z].freeze
+
+  def explore_menu_test
+    @explore_menu_test ||= GovukAbTesting::AbTest.new(
+      "ExploreMenuAbTestable",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+    )
+  end
+
+  def explore_menu_variant
+    explore_menu_test.requested_variant(request.headers)
+  end
+
+  def set_explore_menu_response
+    explore_menu_variant.configure_response(response) if explore_menu_testable?
+  end
+
+  def explore_menu_testable?
+    explore_menu_variant.variant?("B")
+  end
+end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,5 +1,8 @@
 class ContentItemsController < ApplicationController
   include GovukPersonalisation::AccountConcern
+  include Slimmer::Template
+  include AbTests::ExploreMenuAbTestable
+
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from GdsApi::HTTPNotFound, with: :error_notfound
   rescue_from GdsApi::HTTPGone, with: :error_410
@@ -9,6 +12,11 @@ class ContentItemsController < ApplicationController
   rescue_from PresenterBuilder::RedirectRouteReturned, with: :error_redirect
   rescue_from PresenterBuilder::SpecialRouteReturned, with: :error_notfound
   rescue_from PresenterBuilder::GovernmentReturned, with: :error_notfound
+
+  before_action :set_explore_menu_response
+  after_action :set_slimmer_template
+
+  helper_method :explore_menu_variant, :explore_menu_testable?
 
   attr_accessor :content_item, :taxonomy_navigation
 
@@ -46,6 +54,14 @@ class ContentItemsController < ApplicationController
   end
 
 private
+
+  def set_slimmer_template
+    if explore_menu_testable?
+      slimmer_template "core_layout_explore_header"
+    else
+      slimmer_template "core_layout"
+    end
+  end
 
   def is_history_page?
     @content_item.document_type == "history"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,10 +27,12 @@
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
 
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+
   <%= yield :extra_head_content %>
 </head>
 <body>
-  <% unless content_for(:simple_header) %>
+  <% unless content_for(:simple_header) || explore_menu_testable? %>
     <%= render 'govuk_publishing_components/components/government_navigation', active: active_proposition %>
   <% end %>
 

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class ContentItemsControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::ContentStore
   include GovukAbTesting::MinitestHelpers
+  include AbTests::ExploreMenuAbTestable
 
   test "routing handles paths with no format or locale" do
     assert_routing(
@@ -364,6 +365,12 @@ class ContentItemsControllerTest < ActionController::TestCase
     get :show, params: { path: "foreign-travel-advice/albania", format: "atom" }
 
     assert_equal response.headers["Access-Control-Allow-Origin"], "*"
+  end
+
+  test "request for Explore navigational super menu from slimmer" do
+    content_item = content_store_has_schema_example("case_study", "case_study")
+    get :show, params: { path: path_for(content_item) }
+    assert_response_not_modified_for_ab_test(AbTests::ExploreMenuAbTestable)
   end
 
   def path_for(content_item, locale = nil)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


## What

Shows users in B variant of AB test the new Explore Super Menu header.

Static has a new header that the GOV.UK Explore team want to AB test as part of their beta.
https://github.com/alphagov/static/pull/2515


Trello https://trello.com/c/LUhrajXF/323-prepare-the-new-menu-a-b-test-for-sections-of-govuk

## Why 

We are slowly rolling out to users a redesigned header.

## Visual changes


https://user-images.githubusercontent.com/424772/123002723-23980b00-d3aa-11eb-8f6b-cf76b6cb0812.mov


https://user-images.githubusercontent.com/424772/123840676-889db480-d906-11eb-9991-1a3f12f91f60.mov
