### PR TITLE
Bump publishing components gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       unicorn (>= 5.4, < 5.9)
     govuk_personalisation (0.5.0)
       rails (~> 6)
-    govuk_publishing_components (24.15.3)
+    govuk_publishing_components (24.16.0)
       govuk_app_config
       kramdown
       plek


### PR DESCRIPTION
Manually bumping govuk-publishing-components to v.[24.16.0](https://github.com/alphagov/govuk_publishing_components/pull/2166) as we need the scroll tracking in this release of the gem to be live asap. 

( I wasn't able to kick off a dependabot as there's an edited [PR](https://github.com/alphagov/government-frontend/network/updates/165807409) needing a poke. )

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Trello: https://trello.com/c/OD132cuZ/1610-add-scroll-depth-tracking-to-new-rules-of-origin-triage-page