### PR TITLE
Fix button colour

### DIFF
--- a/app/assets/stylesheets/helpers/_organisation-links.scss
+++ b/app/assets/stylesheets/helpers/_organisation-links.scss
@@ -5,7 +5,7 @@
 @mixin organisation-links {
   @each $organisation in map-keys($govuk-colours-organisations) {
     .#{$organisation}-brand-colour {
-      a:not(.gem-c-organisation-logo__link) {
+      a:not(.gem-c-organisation-logo__link, .gem-c-button) {
         color: govuk-organisation-colour($organisation);
 
         &:focus {


### PR DESCRIPTION
## What 

Fix to resolve buttons text colours on buttons
https://www.gov.uk/government/organisations/department-for-work-pensions/about/accessible-documents-policy

## Why

Button text colours are being overwritten due to the styles applying department branding, this is an WCAG fails as the colour contrast makes this text unreadable therefore impact low vision and blind users.

## Visuals

![image](https://user-images.githubusercontent.com/71266765/123786216-56be2b00-d8d1-11eb-92dc-92586dfb7222.png)

## Anything else

As part of an on-going Epic corporate information templates will be updated entirely so this will act as a temporally fix until this work is complete 

