### PR TITLE
Update mentions of FCO

### DIFF
--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -67,7 +67,7 @@ class TravelAdvicePresenter < ContentItemPresenter
   end
 
   # Deprecated feature
-  # Exists in travel advice publisher but isn't used by FCO
+  # Exists in travel advice publisher but isn't used by FCDO
   # Feature included as it _could_ still be used
   # Remove when alert status boxes no longer in travel advice publisher
   def alert_status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -431,10 +431,10 @@ en:
     release_date: Release date
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to parts of the country.
-      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all but essential travel to the whole country.
-      avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all travel to parts of the country.
-      avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> advise against all travel to the whole country.
+      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all but essential travel to parts of the country.
+      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all but essential travel to the whole country.
+      avoid_all_travel_to_parts: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all travel to parts of the country.
+      avoid_all_travel_to_whole_country: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all travel to the whole country.
     context: Foreign travel advice
     coronavirus_warning:
       content_html: |


### PR DESCRIPTION
FCO (Foreign and Commonwealth Office) changed to FCDO (Foreign, Commonwealth and Development Office) - this updates mentions of it

 ⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
