### PR TITLE
Add welsh translation to brexit child taxon pages

### DIFF
--- a/app/presenters/content_item/brexit_taxons.rb
+++ b/app/presenters/content_item/brexit_taxons.rb
@@ -10,16 +10,16 @@ module ContentItem
       {
         BREXIT_BUSINESS_PAGE_CONTENT_ID => {
           nav_link: {
-            text: I18n.t("brexit.citizen_link"),
-            path: BREXIT_CITIZEN_PAGE_PATH,
+            text: I18n.t("brexit.citizen_link.text"),
+            path: I18n.t("brexit.citizen_link.path"),
             track_label: "Guidance nav link",
           },
           track_category: "brexit-business-page",
         },
         BREXIT_CITIZEN_PAGE_CONTENT_ID => {
           nav_link: {
-            text: I18n.t("brexit.business_link"),
-            path: BREXIT_BUSINESS_PAGE_PATH,
+            text: I18n.t("brexit.business_link.text"),
+            path: I18n.t("brexit.business_link.path"),
             track_label: "Guidance nav link",
 
           },

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -2,8 +2,12 @@
 cy:
   brexit:
     business_link:
+      text: canllawiau Brexit gwahanol ar gyfer busnesau
+      path: "/guidance/brexit-guidance-for-businesses.cy"
     citizen_link:
-    heading_prefix:
+      text: canllawiau Brexit gwahanol ar gyfer unigolion a theuluoedd
+      path: "/guidance/brexit-guidance-for-individuals-and-families.cy"
+    heading_prefix: Ceir
   common:
     last_updated: Diweddarwyd diwethaf
     visit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,8 +1,12 @@
 ---
 en:
   brexit:
-    business_link: Brexit guidance for businesses
-    citizen_link: Brexit guidance for individuals and families
+    business_link:
+      text: Brexit guidance for businesses
+      path: "/guidance/brexit-guidance-for-businesses"
+    citizen_link:
+      text: Brexit guidance for individuals and families
+      path: "/guidance/brexit-guidance-for-individuals-and-families"
     heading_prefix: There’s different
   common:
     last_updated:


### PR DESCRIPTION
## What

The majority of the content of the brexit child taxon pages is stored in the body of the content item. As such the translations are handled by whitehall and rendered by gov-frontend as a detailed guide. However the guidance nav link is hardcoded, so must be amended here.

## Before

https://draft-origin.publishing.service.gov.uk/guidance/brexit-guidance-for-businesses.cy
<img width="1066" alt="Screenshot 2021-07-08 at 11 47 50" src="https://user-images.githubusercontent.com/17908089/124909469-61b84000-dfe2-11eb-83ae-d9383ecbd0dd.png">

## After

https://government-f-translate--splmdt.herokuapp.com/guidance/brexit-guidance-for-businesses.cy

<img width="1155" alt="Screenshot 2021-07-08 at 12 13 36" src="https://user-images.githubusercontent.com/17908089/124912523-f5d7d680-dfe5-11eb-83d0-9952de15e96b.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Trello https://trello.com/c/0chnMRTQ/1642-create-welsh-versions-of-the-brexit-child-taxon-pages