### PR TITLE
Trigger new link styles for government-frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Not all schemas that this app can handle are rendered by it in production.
 | Fatality notice | [View on GOV.UK](https://www.gov.uk/government/fatalities/corporal-lee-churcher-dies-in-iraq) | Migrated |
 | Help page | [View on GOV.UK](https://www.gov.uk/help/about-govuk) | Migrated |
 | HTML Publication | [View on GOV.UK](https://www.gov.uk/government/publications/budget-2016-documents/budget-2016)| Migrated |
+| Guide | [View on GOV.UK](https://www.gov.uk/log-in-register-hmrc-online-services)| Migrated |
 | News Article | [View on GOV.UK](https://www.gov.uk/government/news/the-personal-independence-payment-amendment-regulations-2017-statement-by-paul-gray) | Migrated |
 | Publication | [View on GOV.UK](https://www.gov.uk/government/publications/budget-2016-documents) | Migrated |
 | Specialist document | [View on GOV.UK](https://www.gov.uk/business-finance-support/access-to-finance-advice-north-west-england) | Migrated

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@
 $govuk-compatibility-govuktemplate: true;
 $govuk-typography-use-rem: false;
 $govuk-use-legacy-palette: false;
+$govuk-new-link-styles: true;
 
 // Components from govuk_publishing_components gem
 @import 'govuk_publishing_components/govuk_frontend_support';

--- a/app/assets/stylesheets/components/_important-metadata.scss
+++ b/app/assets/stylesheets/components/_important-metadata.scss
@@ -28,12 +28,4 @@
 
 .app-c-important-metadata__definition {
   font-weight: bold;
-
-  .app-link {
-    color: govuk-colour("white");
-
-    &:focus {
-      color: $govuk-text-colour;
-    }
-  }
 }

--- a/app/presenters/content_item/national_applicability.rb
+++ b/app/presenters/content_item/national_applicability.rb
@@ -15,7 +15,7 @@ module ContentItem
         nations_with_alt_urls = inapplicable_nations.select { |n| n["alternative_url"].present? }
         if nations_with_alt_urls.any?
           alternate_links = nations_with_alt_urls
-            .map { |n| view_context.link_to(n["label"], n["alternative_url"], rel: :external, class: "govuk-link app-link") }
+            .map { |n| view_context.link_to(n["label"], n["alternative_url"], rel: :external, class: "govuk-link govuk-link--inverse") }
             .to_sentence
 
           applies_to += " (see #{translated_schema_name(nations_with_alt_urls.count)} for #{alternate_links})"

--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -18,7 +18,7 @@ class FatalityNoticePresenter < ContentItemPresenter
   def important_metadata
     super.tap do |m|
       if field_of_operation
-        m.merge!(I18n.t("fatality_notice.field_of_operation") => view_context.link_to(field_of_operation.title, field_of_operation.path, class: "govuk-link app-link"))
+        m.merge!(I18n.t("fatality_notice.field_of_operation") => view_context.link_to(field_of_operation.title, field_of_operation.path, class: "govuk-link govuk-link--inverse"))
       end
     end
   end

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -189,7 +189,7 @@ private
     view_context.link_to(
       label,
       "#{finder_base_path}?#{key}%5B%5D=#{value}",
-      class: "govuk-link app-link",
+      class: "govuk-link govuk-link--inverse",
     )
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -443,16 +443,16 @@ en:
     coronavirus_warning:
       content_html: |
         <p class="govuk-body">
-          Follow current COVID-19 rules where you live: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/coronavirus-travel">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Northern Ireland</a>.
+          Follow current COVID-19 rules where you live: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do" class="govuk-link">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/" class="govuk-link">Scotland</a>, <a href="https://gov.wales/coronavirus-travel" class="govuk-link">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you" class="govuk-link">Northern Ireland</a>.
         </p>
         <p class="govuk-body">
-          To prevent new COVID variants from entering the UK, you should not travel to <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">amber or red list countries</a>.
+          To prevent new COVID variants from entering the UK, you should not travel to <a href="/guidance/red-amber-and-green-list-rules-for-entering-england" class="govuk-link">amber or red list countries</a>.
         </p>
         <p class="govuk-body">
-          To understand the risks in a country follow <a href="/guidance/travel-advice-novel-coronavirus">FCDO Travel Advice</a>.
+          To understand the risks in a country follow <a href="/guidance/travel-advice-novel-coronavirus" class="govuk-link">FCDO Travel Advice</a>.
         </p>
         <p class="govuk-body">
-          When you return, follow the rules to <a href="/uk-border-control">enter the UK from abroad</a> (except from Ireland).
+          When you return, follow the rules to <a href="/uk-border-control" class="govuk-link">enter the UK from abroad</a> (except from Ireland).
         </p>
       text_assistive: Important
       title: Coronavirus (COVID-19) travel

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -58,7 +58,7 @@ class DetailedGuidePresenterTest < PresenterTestCase
     presented = presented_item("national_applicability_alternative_url_detailed_guide")
 
     assert example["details"].include?("national_applicability")
-    assert_equal presented.applies_to, 'England, Scotland, and Wales (see guidance for <a rel="external" class="govuk-link app-link" href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for">Northern Ireland</a>)'
+    assert_equal presented.applies_to, 'England, Scotland, and Wales (see guidance for <a rel="external" class="govuk-link govuk-link--inverse" href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for">Northern Ireland</a>)'
   end
 
   test "context in title is overridden to display as guidance" do

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -68,7 +68,7 @@ class PublicationPresenterTest < PresenterTestCase
     assert example["details"].include?("national_applicability")
     assert_equal(
       presented.applies_to,
-      'England (see publications for <a rel="external" class="govuk-link app-link" href="http://www.dsdni.gov.uk/index/stats_and_research/stats-publications/stats-housing-publications/housing_stats.htm">Northern Ireland</a>, <a rel="external" class="govuk-link app-link" href="http://www.scotland.gov.uk/Topics/Statistics/Browse/Housing-Regeneration/HSfS">Scotland</a>, and <a rel="external" class="govuk-link app-link" href="http://wales.gov.uk/topics/statistics/headlines/housing2012/121025/?lang=en">Wales</a>)',
+      'England (see publications for <a rel="external" class="govuk-link govuk-link--inverse" href="http://www.dsdni.gov.uk/index/stats_and_research/stats-publications/stats-housing-publications/housing_stats.htm">Northern Ireland</a>, <a rel="external" class="govuk-link govuk-link--inverse" href="http://www.scotland.gov.uk/Topics/Statistics/Browse/Housing-Regeneration/HSfS">Scotland</a>, and <a rel="external" class="govuk-link govuk-link--inverse" href="http://wales.gov.uk/topics/statistics/headlines/housing2012/121025/?lang=en">Wales</a>)',
     )
   end
 end

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -282,7 +282,7 @@ class SpecialistDocumentPresenterTest
       example = example_with_finder_facets([example_facet(overrides)], values)
 
       presented = present_example(example)
-      expected_link = "<a class=\"govuk-link app-link\" href=\"/finder-base-path?facet-key%5B%5D=something\">Something</a>"
+      expected_link = "<a class=\"govuk-link govuk-link--inverse\" href=\"/finder-base-path?facet-key%5B%5D=something\">Something</a>"
       assert_equal expected_link, presented.important_metadata["Facet name"]
     end
 


### PR DESCRIPTION
## What
Apply the feature flag for new link styles, from the latest release of GOV.UK Frontend, on this app.

Additionally updates the readme to include an example of a guide document and replaces instances of the `.app-link` class with `.govuk-link--inverse`.

## Why
Part of an ongoing effort by the GOV.UK frontend community and GOV.UK Accessibility team to ensure that we are using the new design system link styles across our apps, ensuring that users reap the benefit of better link visibility.

## Notes
- The government navigation menu at the top of some government frontend pages isn't using the new link styles properly. This is because this component is reliant on styles from the old "core" layout in static. I won't be pursuing getting these to work perfectly at the moment as the layout is due to be updated to the new "gem" layout in the immediate future, making any changes I make to this layout obsolete.
- I won't be including visual changes for all views as part of this PR as government-frontend pages all follow the same broad shape of breadcrumb, title, metadata, content. I will include one page to illustrate the link change.

<details>
<summary>List of links tested against by view</summary>

| Link | Associated view |
| --- | --- |
| https://www.gov.uk/get-coronavirus-test | Answer |
| https://www.gov.uk/government/case-studies/how-the-dvla-deployed-a-chatbot-and-improved-customer-engagement | Case study |
| https://www.gov.uk/government/consultations/aligning-the-upper-age-for-nhs-prescription-charge-exemptions-with-the-state-pension-age | Consultation |
| https://www.gov.uk/government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees | Contact |
| https://www.gov.uk/government/organisations/driver-and-vehicle-licensing-agency/about/complaints-procedure | Corporate info page |
| https://www.gov.uk/guidance/waste-exemption-nwfd-2-temporary-storage-at-the-place-of-production--2 | Detailed guide |
| https://www.gov.uk/government/collections/eu-settlement-scheme-applicant-information | Detailed guide |
| https://www.gov.uk/government/fatalities/sergeant-simon-alexander-hamilton-jewell | Fatality notice |
| https://www.gov.uk/help/terms-conditions | Help page |
| https://www.gov.uk/government/publications/budget-2016-documents/budget-2016 | HTML publication |
| https://www.gov.uk/log-in-register-hmrc-online-services | Guide |
| https://www.gov.uk/government/news/uk-travel-update-malta-added-to-green-list-and-green-watchlist-extended-as-plans-for-quarantine-free-travel-for-fully-vaccinated-passengers-from-ambe | News article |
| https://www.gov.uk/government/publications/the-national-minimum-wage-in-2021 | Publication |
| https://www.gov.uk/business-finance-support/access-to-finance-advice-north-west-england | Specialist document |
| https://www.gov.uk/government/statistics/announcements/initial-findings-from-the-2021-census-in-england-and-wales | Statistics announcement |
| https://www.gov.uk/government/statistical-data-sets/unclaimed-estates-list | Statistical data set |
| https://www.gov.uk/government/speeches/19-july-remains-our-target-date-for-ending-restrictions | Speech |
| https://www.gov.uk/government/get-involved/take-part/volunteer | Take part |
| https://www.gov.uk/government/topical-events/2014-overseas-territories-joint-ministerial-council/about | Topical event about page |
| https://www.gov.uk/foreign-travel-advice/spain | Travel advice |
| https://www.gov.uk/government/groups/abstraction-reform | Working group |
| https://www.gov.uk/government/news/changes-to-secure-english-language-test-providers-for-uk-visas | World news story |
</details>

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-07-12 at 12 11 20](https://user-images.githubusercontent.com/64783893/125278275-6d6d7480-e30a-11eb-8538-bf93d217a5d0.png) | ![Screenshot 2021-07-12 at 12 11 32](https://user-images.githubusercontent.com/64783893/125278292-72cabf00-e30a-11eb-8a9a-21f0aa11df9b.png) |