### PR TITLE
Amend tracking category on Brexit child taxon pages

### DIFF
--- a/app/views/content_items/detailed_guide/_brexit_sections.html.erb
+++ b/app/views/content_items/detailed_guide/_brexit_sections.html.erb
@@ -12,7 +12,7 @@
     <% links = section[:links].map do |link|
         link_to(link[:text], link[:path], class: "govuk-link", data: {
           track_action: link[:path],
-          track_category: brexit_child_taxon[:track_category],
+          track_category: "Child taxon section links",
           track_label: section[:title][:text] || "",
           module: 'gem-track-click',
         })

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -118,7 +118,7 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     track_label = find_link("Foreign travel advice")["data-track-label"]
 
     assert_equal "/foreign-travel-advice", track_action
-    assert_equal "brexit-citizen-page", track_category
+    assert_equal "Child taxon section links", track_category
     assert_equal "Travel to the EU", track_label
 
     # adds GA tracking to the description field links


### PR DESCRIPTION
## What

When a user clicks on a link in a section on one of the Brexit child taxon pages, send the name of the section rather than the name of the page, as that's already recorded. Request from PA.

trello https://trello.com/c/RcOTINct/1653-change-event-category-value-on-child-taxon-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
