### PR TITLE
Amend the tracking category on Brexit child taxon pages

### DIFF
--- a/app/presenters/content_item/brexit_taxons.rb
+++ b/app/presenters/content_item/brexit_taxons.rb
@@ -13,17 +13,22 @@ module ContentItem
             text: I18n.t("brexit.citizen_link.text"),
             path: I18n.t("brexit.citizen_link.path"),
             track_label: "Guidance nav link",
+            track_category: "brexit-business-page",
           },
-          track_category: "brexit-business-page",
+          sections: {
+            track_category: "Child taxon section links - business",
+          },
         },
         BREXIT_CITIZEN_PAGE_CONTENT_ID => {
           nav_link: {
             text: I18n.t("brexit.business_link.text"),
             path: I18n.t("brexit.business_link.path"),
             track_label: "Guidance nav link",
-
+            track_category: "brexit-citizen-page",
           },
-          track_category: "brexit-citizen-page",
+          sections: {
+            track_category: "Child taxon section links - citizen",
+          },
         },
       }
     end

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -22,7 +22,7 @@
               class: "govuk-link",
               data: {
                 track_action: brexit_child_taxon[:nav_link][:path],
-                track_category: brexit_child_taxon[:track_category],
+                track_category: brexit_child_taxon[:nav_link][:track_category],
                 track_label: brexit_child_taxon[:nav_link][:track_label],
                 module: 'gem-track-click',
               }) %>.

--- a/app/views/content_items/detailed_guide/_brexit_sections.html.erb
+++ b/app/views/content_items/detailed_guide/_brexit_sections.html.erb
@@ -12,7 +12,7 @@
     <% links = section[:links].map do |link|
         link_to(link[:text], link[:path], class: "govuk-link", data: {
           track_action: link[:path],
-          track_category: "Child taxon section links",
+          track_category: brexit_child_taxon[:sections][:track_category],
           track_label: section[:title][:text] || "",
           module: 'gem-track-click',
         })

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -118,7 +118,7 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     track_label = find_link("Foreign travel advice")["data-track-label"]
 
     assert_equal "/foreign-travel-advice", track_action
-    assert_equal "Child taxon section links", track_category
+    assert_equal "Child taxon section links - citizen", track_category
     assert_equal "Travel to the EU", track_label
 
     # adds GA tracking to the description field links


### PR DESCRIPTION
## What

Send a more specific event tracking label to GA for clicks on section links.

[Review app](https://government-f-amend-even-honozw.herokuapp.com/guidance/brexit-guidance-for-businesses)
[Trello](https://trello.com/c/vrMCwyUy/1667-trello-template-copy-me)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

<img width="1717" alt="Screenshot 2021-07-15 at 12 14 07" src="https://user-images.githubusercontent.com/17908089/125779149-2bc351b5-0029-4038-a8e1-af495892f2f6.png">
