### PR TITLE
Do not check if a page is saved if a user has no session header

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -225,6 +225,8 @@ private
   helper_method :logged_in?
 
   def user_has_saved_page?
+    return false unless @account_session_header
+
     GdsApi.account_api.get_saved_page(
       page_path: request.path,
       govuk_account_session: @account_session_header,

--- a/test/controllers/save_a_page_test.rb
+++ b/test/controllers/save_a_page_test.rb
@@ -17,6 +17,13 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   test "logged out - shows the add_page_button when the feature flag is on" do
     stub_feature_flag_on
+    set_up_and_visit_content_item("detailed_guide", "detailed_guide")
+
+    assert has_save_page_button("/guidance/salary-sacrifice-and-the-effects-on-paye")
+  end
+
+  test "invalid session - shows the add_page_button when the feature flag is on" do
+    stub_feature_flag_on
     stub_account_api_unauthorized_get_saved_page(page_path: "/guidance/salary-sacrifice-and-the-effects-on-paye")
     set_up_and_visit_content_item("detailed_guide", "detailed_guide")
 


### PR DESCRIPTION
I spotted that the account-api was getting a *lot* of saved-page
queries in staging, which I tracked down to this: we're checking if
the page is saved even if the user has no session (which will always
fail).  We can skip the API call in that case.

We had a similar issue once in the Transition Checker, where we were
trying to fetch saved results regardless of whether the user had a
session or not.  Since this has come up twice now we should think
about how this problem can be solved generically.  Maybe we could put
more logic in gds-api-adapters, for example?
