### PR TITLE
Fix jump links on history of government

### DIFF
--- a/app/views/histories/history.html.erb
+++ b/app/views/histories/history.html.erb
@@ -41,7 +41,7 @@
     <div class="govuk-grid-column-one-half">
       <%= render "govuk_publishing_components/components/heading", {
         text: "Notable people",
-        id: "notable-peoples",
+        id: "notable-people",
         margin_bottom: 3,
       } %>
 
@@ -115,6 +115,7 @@
     <div class="govuk-grid-column-one-half">
       <%= render "govuk_publishing_components/components/heading", {
         text: "Documents and records",
+        id: "documents-records",
         margin_bottom: 3,
       } %>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

Fix the jump links at the top of https://www.gov.uk/government/history, specifically:

- link to `notable people` was mistyped and wasn't working
- link to `online records` wasn't working because linked heading didn't have an ID

![Screenshot 2021-07-23 at 14 02 17](https://user-images.githubusercontent.com/861310/126785456-db494d5e-40bc-4921-a6f6-5d5ac4a8fb17.png)


## Visual changes

None.
