### PR TITLE
Fix tracking Travel Advice links twice

### DIFF
--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -30,7 +30,7 @@
     </div>
 
     <aside class="part-navigation-container" role="complementary">
-      <nav role="navigation" class="govuk-grid-row part-navigation" aria-label="Travel advice pages" data-module="gem-track-click">
+      <nav role="navigation" class="govuk-grid-row part-navigation" aria-label="Travel advice pages">
         <%= render "govuk_publishing_components/components/contents_list", contents: @content_item.part_link_elements, underline_links: true %>
       </nav>
 


### PR DESCRIPTION
There is a bug where these navigation links are sending two GA events
per click. This is occurring because the contents-list component has an
undocumented [1] feature of tracking links which was presumably not
known about when this code was changed to use this component [2].

The resolution for this is to remove the usage of track links on the nav
element and just use the components one.

[1]: https://github.com/alphagov/govuk_publishing_components/blob/147a825fc7608eb3dfdaab0d418c5b2fdaaf08aa/app/views/govuk_publishing_components/components/docs/contents_list.yml
[2]: https://github.com/alphagov/government-frontend/pull/1877

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
