### PR TITLE
Remove conditional from A/B test meta tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
     <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
   <% end %>
 
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 
   <%= yield :extra_head_content %>
 </head>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove the conditional from the explore variant meta tag.

https://trello.com/c/8Y8tYYzk

## Why

This was only being output on the page when on the "B" side of the test; the meta tag should be added to the page for all sides of the test so it can be picked up by analytics and the browser extension.

## Visual changes

None