### PR TITLE
Fix syntax on context param

### DIFF
--- a/app/views/histories/10_downing_street.html.erb
+++ b/app/views/histories/10_downing_street.html.erb
@@ -13,9 +13,7 @@
       ]
     } %>
     <%= render "govuk_publishing_components/components/title", {
-      context: {
-        text: "History",
-      },
+      context: "History",
       title: "10 Downing Street",
     } %>
   </div>

--- a/app/views/histories/11_downing_street.html.erb
+++ b/app/views/histories/11_downing_street.html.erb
@@ -13,9 +13,7 @@
       ]
     } %>
     <%= render "govuk_publishing_components/components/title", {
-      context: {
-        text: "History",
-      },
+      context: "History",
       title: "11 Downing Street",
     } %>
   </div>

--- a/app/views/histories/1_horse_guards_road.html.erb
+++ b/app/views/histories/1_horse_guards_road.html.erb
@@ -13,9 +13,7 @@
       ]
     } %>
     <%= render "govuk_publishing_components/components/title", {
-      context: {
-        text: "History",
-      },
+      context: "History",
       title: "1 Horse Guards Road",
     } %>
   </div>

--- a/app/views/histories/king_charles_street.html.erb
+++ b/app/views/histories/king_charles_street.html.erb
@@ -13,9 +13,7 @@
       ]
     } %>
     <%= render "govuk_publishing_components/components/title", {
-      context: {
-        text: "History",
-      },
+      context: "History",
       title: "King Charles Street",
     } %>
   </div>

--- a/app/views/histories/lancaster_house.html.erb
+++ b/app/views/histories/lancaster_house.html.erb
@@ -13,9 +13,7 @@
       ]
     } %>
     <%= render "govuk_publishing_components/components/title", {
-      context: {
-        text: "History",
-      },
+      context:"History",
       title: "Lancaster House",
     } %>
   </div>


### PR DESCRIPTION
This is a bug fix for the exposed context hash on some history pages. We removed the ability to link context text in the gem and I removed the href from the context hash, but mistakenly left the hash in situ leading to the following visual bug:

![Screenshot 2021-08-24 at 16 35 09](https://user-images.githubusercontent.com/31649453/130646377-31005873-c36f-4dd2-9841-f84a73f8ccb5.png)

Sample broken page: https://www.gov.uk/government/history/lancaster-house

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
