### PR TITLE
Add tracking to the travel advice pages

### DIFF
--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -52,11 +52,17 @@
       <%= render 'shared/travel_advice_summary', content_item: @content_item %>
     <% end %>
 
-    <%= render 'govuk_publishing_components/components/govspeak', {
-      direction: page_text_direction,
-    } do %>
-      <%= raw(@content_item.current_part_body) %>
-    <% end %>
+    <div data-module="gem-track-click"
+      data-track-category="SummaryTravelAdviceWarning"
+      data-track-action="callOutBoxClicked"
+      data-track-links-only
+      data-limit-to-element-class="call-to-action">
+      <%= render 'govuk_publishing_components/components/govspeak', {
+        direction: page_text_direction,
+      } do %>
+        <%= raw(@content_item.current_part_body) %>
+      <% end %>
+    </div>
 
     <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

- uses the new feature of the track click script to track link clicks only inside the grey callout box (the second callout box on the page)
- this is inside govspeak content so we can't directly apply tracking to it, hence the new feature of the track click script to limit tracking to a specific element

Trello card: https://trello.com/c/JREgQ2iv/579-spike-into-tracking-enhancements