### PR TITLE
Use devolved nations component in place of important metadata component on publication page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/contents-list';
 @import 'govuk_publishing_components/components/contextual-sidebar';
 @import 'govuk_publishing_components/components/details';
+@import 'govuk_publishing_components/components/devolved-nations';
 @import 'govuk_publishing_components/components/document-list';
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/error-summary';

--- a/app/presenters/content_item/national_applicability.rb
+++ b/app/presenters/content_item/national_applicability.rb
@@ -2,43 +2,8 @@ module ContentItem
   module NationalApplicability
     include Metadata
 
-    def applies_to
-      return nil unless national_applicability
-
-      all_nations = national_applicability.values
-      applicable_nations = all_nations.select { |n| n["applicable"] }
-      inapplicable_nations = all_nations - applicable_nations
-
-      applies_to = applicable_nations.map { |n| n["label"] }.to_sentence
-
-      if inapplicable_nations.any?
-        nations_with_alt_urls = inapplicable_nations.select { |n| n["alternative_url"].present? }
-        if nations_with_alt_urls.any?
-          alternate_links = nations_with_alt_urls
-            .map { |n| view_context.link_to(n["label"], n["alternative_url"], rel: :external, class: "govuk-link govuk-link--inverse") }
-            .to_sentence
-
-          applies_to += " (see #{translated_schema_name(nations_with_alt_urls.count)} for #{alternate_links})"
-        end
-      end
-
-      applies_to
-    end
-
-    def important_metadata
-      super.tap do |m|
-        m.merge!("Applies to" => applies_to)
-      end
-    end
-
-  private
-
-    def translated_schema_name(count)
-      I18n.t("content_item.schema_name.#{schema_name}", count: count).downcase
-    end
-
     def national_applicability
-      content_item["details"]["national_applicability"]
+      content_item["details"]["national_applicability"]&.deep_symbolize_keys
     end
   end
 end

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -17,7 +17,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'components/important-metadata', items: @content_item.important_metadata %>
+    <%= render "govuk_publishing_components/components/devolved_nations", national_applicability: @content_item.national_applicability || {} %>
 
     <% if @content_item.unopened? %>
       <% content_item_unopened = capture do %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -40,7 +40,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'components/important-metadata', items: @content_item.important_metadata %>
+    <%= render "govuk_publishing_components/components/devolved_nations", national_applicability: @content_item.national_applicability || {} %>
 
     <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
       <%= render "govuk_publishing_components/components/print_link", {

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -27,7 +27,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="responsive-bottom-margin">
-      <%= render 'components/important-metadata', items: @content_item.important_metadata %>
+      <%= render "govuk_publishing_components/components/devolved_nations", national_applicability: @content_item.national_applicability || {} %>
+
       <div class="responsive-bottom-margin">
         <%= render "attachments",
           title: t("publication.documents", count: 5), # This should always be pluralised.

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -127,8 +127,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
 
   test "consultation that only applies to a set of nations" do
     setup_and_visit_content_item("consultation_outcome_with_feedback")
-
-    assert_has_important_metadata("Applies to": "England")
+    assert_has_devolved_nations_component("Applies to England")
   end
 
   test "ways to respond renders" do

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -46,16 +46,17 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
 
   test "detailed guide that only applies to a set of nations" do
     setup_and_visit_content_item("national_applicability_detailed_guide")
-    assert_has_important_metadata("Applies to:": "England")
+    assert_has_devolved_nations_component("Applies to England")
   end
 
   test "detailed guide that only applies to a set of nations, with alternative urls" do
     setup_and_visit_content_item("national_applicability_alternative_url_detailed_guide")
-
-    assert_has_important_metadata(
-      'Applies to:':
-        "England, Scotland, and Wales (see guidance for Northern Ireland)",
-    )
+    assert_has_devolved_nations_component("Applies to England, Scotland and Wales", [
+      {
+        text: "Northern Ireland",
+        alternative_url: "http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for",
+      },
+    ])
   end
 
   test "translated detailed guide" do

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -76,15 +76,19 @@ class PublicationTest < ActionDispatch::IntegrationTest
 
   test "renders 'Applies to' block in important metadata when there are excluded nations" do
     setup_and_visit_content_item("statistics_publication")
-
-    assert_has_important_metadata(
-      "Applies to": {
-        "England (see publications for Northern Ireland, Scotland, and Wales)": nil,
-        "Northern Ireland":
-          "http://www.dsdni.gov.uk/index/stats_and_research/stats-publications/stats-housing-publications/housing_stats.htm",
-        "Scotland": "http://www.scotland.gov.uk/Topics/Statistics/Browse/Housing-Regeneration/HSfS",
-        "Wales": "http://wales.gov.uk/topics/statistics/headlines/housing2012/121025/?lang=en",
+    assert_has_devolved_nations_component("Applies to England", [
+      {
+        text: "Northern Ireland",
+        alternative_url: "http://www.dsdni.gov.uk/index/stats_and_research/stats-publications/stats-housing-publications/housing_stats.htm",
       },
-    )
+      {
+        text: "Scotland",
+        alternative_url: "http://www.scotland.gov.uk/Topics/Statistics/Browse/Housing-Regeneration/HSfS",
+      },
+      {
+        text: "Wales",
+        alternative_url: "http://wales.gov.uk/topics/statistics/headlines/housing2012/121025/?lang=en",
+      },
+    ])
   end
 end

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -96,7 +96,10 @@ class ConsultationPresenterTest
       presented = presented_item("consultation_outcome_with_feedback")
 
       assert example["details"].include?("national_applicability")
-      assert_equal presented.applies_to, "England"
+      assert_equal(presented.national_applicability[:england][:applicable], true)
+      assert_equal(presented.national_applicability[:northern_ireland][:applicable], false)
+      assert_equal(presented.national_applicability[:scotland][:applicable], false)
+      assert_equal(presented.national_applicability[:wales][:applicable], false)
     end
 
     test "presents ways to respond" do

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -50,15 +50,22 @@ class DetailedGuidePresenterTest < PresenterTestCase
     presented = presented_item("national_applicability_detailed_guide")
 
     assert example["details"].include?("national_applicability")
-    assert_equal presented.applies_to, "England"
+    assert_equal(presented.national_applicability[:england][:applicable], true)
+    assert_equal(presented.national_applicability[:northern_ireland][:applicable], false)
+    assert_equal(presented.national_applicability[:scotland][:applicable], false)
+    assert_equal(presented.national_applicability[:wales][:applicable], false)
   end
 
-  test "content can apply only to a set of nations with alternative urls" do
+  test "content can apply only to a set of nations (with alternative URLs where applicable)" do
     example = schema_item("national_applicability_alternative_url_detailed_guide")
     presented = presented_item("national_applicability_alternative_url_detailed_guide")
 
     assert example["details"].include?("national_applicability")
-    assert_equal presented.applies_to, 'England, Scotland, and Wales (see guidance for <a rel="external" class="govuk-link govuk-link--inverse" href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for">Northern Ireland</a>)'
+    assert_equal(presented.national_applicability[:england][:applicable], true)
+    assert_equal(presented.national_applicability[:northern_ireland][:applicable], false)
+    assert_equal(presented.national_applicability[:northern_ireland][:alternative_url], "http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for")
+    assert_equal(presented.national_applicability[:scotland][:applicable], true)
+    assert_equal(presented.national_applicability[:wales][:applicable], true)
   end
 
   test "context in title is overridden to display as guidance" do

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -61,14 +61,17 @@ class PublicationPresenterTest < PresenterTestCase
     assert_equal '<time datetime="2015-01-13T13:05:30Z">13 January 2015</time>', presented.withdrawal_notice_component[:time]
   end
 
-  test "content can apply only to a set of nations (with alternative urls when provided)" do
+  test "content can apply only to a set of nations (with alternative URLs where applicable)" do
     example = schema_item("statistics_publication")
     presented = presented_item("statistics_publication")
 
     assert example["details"].include?("national_applicability")
-    assert_equal(
-      presented.applies_to,
-      'England (see publications for <a rel="external" class="govuk-link govuk-link--inverse" href="http://www.dsdni.gov.uk/index/stats_and_research/stats-publications/stats-housing-publications/housing_stats.htm">Northern Ireland</a>, <a rel="external" class="govuk-link govuk-link--inverse" href="http://www.scotland.gov.uk/Topics/Statistics/Browse/Housing-Regeneration/HSfS">Scotland</a>, and <a rel="external" class="govuk-link govuk-link--inverse" href="http://wales.gov.uk/topics/statistics/headlines/housing2012/121025/?lang=en">Wales</a>)',
-    )
+    assert_equal(presented.national_applicability[:england][:applicable], true)
+    assert_equal(presented.national_applicability[:northern_ireland][:applicable], false)
+    assert_equal(presented.national_applicability[:northern_ireland][:alternative_url], "http://www.dsdni.gov.uk/index/stats_and_research/stats-publications/stats-housing-publications/housing_stats.htm")
+    assert_equal(presented.national_applicability[:scotland][:applicable], false)
+    assert_equal(presented.national_applicability[:scotland][:alternative_url], "http://www.scotland.gov.uk/Topics/Statistics/Browse/Housing-Regeneration/HSfS")
+    assert_equal(presented.national_applicability[:wales][:applicable], false)
+    assert_equal(presented.national_applicability[:wales][:alternative_url], "http://wales.gov.uk/topics/statistics/headlines/housing2012/121025/?lang=en")
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -148,6 +148,15 @@ class ActionDispatch::IntegrationTest
     end
   end
 
+  def assert_has_devolved_nations_component(text, nations = nil)
+    within(".gem-c-devolved-nations") do
+      assert page.has_text?(text)
+      nations&.each do |nation|
+        assert page.has_link?("Guidance for #{nation[:text]}", href: nation[:alternative_url])
+      end
+    end
+  end
+
   def assert_footer_has_published_dates(first_published = nil, last_updated = nil, history_link: false)
     assert_has_published_dates(first_published, last_updated, history_link: history_link)
   end


### PR DESCRIPTION
## What
https://trello.com/c/WVrZ35zt/793-dev-implementation-of-devolved-nations-task

Replace uses of 'Metadata block component' for new 'Devolved Nations component' for linking to guidance for other nations.

This change takes effect on the following page types -
- Publications e.g. https://www.gov.uk/government/publications/theory-and-practical-driving-tests-taken-at-wigan-and-atherton-with-a-voiceover-or-interpreter
- Statistics e.g. https://www.gov.uk/government/statistics/affordable-housing-supply-in-england-2011-to-2012
- Consultations e.g. https://www.gov.uk/government/consultations/setting-the-grade-standards-of-new-gcses-in-england-2017-2018
- Guidance e.g. https://www.gov.uk/guidance/report-lost-or-stolen-cattle

When no advice is available the component is not rendered e.g. https://www.gov.uk/government/publications/foi-release-technology-and-outserviced-contracts

## Why
- The list of countries are being read out without providing any context that individual guidance is available
- This task is to implement a fix to aid screen-reader users

## Visual changes
| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/87758239/133061607-e90679d9-44aa-4a03-8bc5-43894eacf71c.png" width="300"> | <img src="https://user-images.githubusercontent.com/87758239/133061832-e8c61a11-a0ac-4301-9908-c3e9492486e5.png" width="300"> |
| <img src="https://user-images.githubusercontent.com/87758239/133062376-a84c8281-5f27-4e4e-8d47-897328ec608d.png" width="300"> | <img src="https://user-images.githubusercontent.com/87758239/133062392-c9c417e5-2567-4de3-92a7-0e4f825ba663.png" width="300"> |
| <img src="https://user-images.githubusercontent.com/87758239/133062541-a1bee580-721c-441a-87f6-74e7e909642f.png" width="300"> | <img src="https://user-images.githubusercontent.com/87758239/133062562-362d5356-80a6-4263-aca2-abcda8699d59.png" width="300"> |

## Anything else
- Prerequisite now merged https://github.com/alphagov/government-frontend/commit/2a3d5d4c0fd03980bf60bc68f3659caaab0ddd5b