### PR TITLE
Add scroll tracking to foreign travel advice pages

### DIFF
--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -9,6 +9,8 @@
     title: @content_item.page_title,
     body: @content_item.current_part_body
     ) %>
+
+  <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker" data-track-type="headings"/>
 <% end %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds scroll tracking to the pages listed on https://www.gov.uk/foreign-travel-advice (but not that page itself). Should add tracking for all pages for all countries, for example on:

- https://www.gov.uk/foreign-travel-advice/afghanistan
- https://www.gov.uk/foreign-travel-advice/afghanistan/coronavirus
- https://www.gov.uk/foreign-travel-advice/afghanistan/safety-and-security

(etc.)

Uses the new AutoScrollTracker module, initialised as a meta tag, configured to track headings. This is included in the latest version of the gem, which has already been added to government-frontend (this PR rebased to match).

## Why
We want to understand user behaviour on these pages in order to improve them.

## Visual changes
None.

Trello card: https://trello.com/c/JREgQ2iv/579-spike-into-tracking-enhancements