### PR TITLE
Add missing keys to locales files

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -2,7 +2,11 @@
 ar:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -671,6 +675,7 @@ ar:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -2,7 +2,11 @@
 az:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -301,6 +305,7 @@ az:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -2,7 +2,11 @@
 be:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -523,6 +527,7 @@ be:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -2,7 +2,11 @@
 bg:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ bg:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -2,7 +2,11 @@
 bn:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ bn:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -2,7 +2,11 @@
 cs:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -449,6 +453,7 @@ cs:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -2,11 +2,11 @@
 cy:
   brexit:
     business_link:
-      text: canllawiau Brexit gwahanol ar gyfer busnesau
       path: "/guidance/brexit-guidance-for-businesses.cy"
+      text: canllawiau Brexit gwahanol ar gyfer busnesau
     citizen_link:
-      text: canllawiau Brexit gwahanol ar gyfer unigolion a theuluoedd
       path: "/guidance/brexit-guidance-for-individuals-and-families.cy"
+      text: canllawiau Brexit gwahanol ar gyfer unigolion a theuluoedd
     heading_prefix: Ceir
   common:
     last_updated: Diweddarwyd diwethaf
@@ -675,6 +675,7 @@ cy:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -2,7 +2,11 @@
 da:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ da:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2,7 +2,11 @@
 de:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ de:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -2,7 +2,11 @@
 dr:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ dr:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -2,7 +2,11 @@
 el:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ el:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,11 +2,11 @@
 en:
   brexit:
     business_link:
-      text: Brexit guidance for businesses
       path: "/guidance/brexit-guidance-for-businesses"
+      text: Brexit guidance for businesses
     citizen_link:
-      text: Brexit guidance for individuals and families
       path: "/guidance/brexit-guidance-for-individuals-and-families"
+      text: Brexit guidance for individuals and families
     heading_prefix: There’s different
   common:
     last_updated:
@@ -441,7 +441,7 @@ en:
           Check what you need to do to <a href="/guidance/travel-abroad-from-england-during-coronavirus-covid-19" class="govuk-link">travel abroad and return to England</a>, or read travel guidance for <a href="https://www.gov.scot/publications/coronavirus-covid-19-guidance-on-travel-and-transport/" class="govuk-link">Scotland</a>, <a href="https://gov.wales/coronavirus-travel" class="govuk-link">Wales</a> or <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-travel-advice" class="govuk-link">Northern Ireland</a>.
         </p>
       text_assistive: Important
-      title: "COVID-19: travel is different"
+      title: 'COVID-19: travel is different'
     still_current_at: Still current at
     summary: Summary
     updated: Updated

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -2,7 +2,11 @@
 es-419:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ es-419:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2,7 +2,11 @@
 es:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ es:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -2,7 +2,11 @@
 et:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ et:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -2,7 +2,11 @@
 fa:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -301,6 +305,7 @@ fa:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -2,7 +2,11 @@
 fi:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ fi:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2,7 +2,11 @@
 fr:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ fr:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -2,7 +2,11 @@
 gd:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -523,6 +527,7 @@ gd:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -2,7 +2,11 @@
 gu:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ gu:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2,7 +2,11 @@
 he:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ he:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -2,7 +2,11 @@
 hi:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ hi:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -2,7 +2,11 @@
 hr:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -523,6 +527,7 @@ hr:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -2,7 +2,11 @@
 hu:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ hu:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -2,7 +2,11 @@
 hy:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ hy:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -2,7 +2,11 @@
 id:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -301,6 +305,7 @@ id:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -2,7 +2,11 @@
 is:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ is:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -2,7 +2,11 @@
 it:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ it:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,7 +2,11 @@
 ja:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -301,6 +305,7 @@ ja:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -2,7 +2,11 @@
 ka:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -301,6 +305,7 @@ ka:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -2,7 +2,11 @@
 kk:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ kk:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -2,7 +2,11 @@
 ko:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -301,6 +305,7 @@ ko:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -2,7 +2,11 @@
 lt:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -449,6 +453,7 @@ lt:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -2,7 +2,11 @@
 lv:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ lv:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -2,7 +2,11 @@
 ms:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -301,6 +305,7 @@ ms:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -2,7 +2,11 @@
 mt:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -523,6 +527,7 @@ mt:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -2,7 +2,11 @@
 ne:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ ne:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -2,7 +2,11 @@
 nl:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ nl:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -2,7 +2,11 @@
 'no':
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -2,7 +2,11 @@
 pa-pk:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ pa-pk:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -2,7 +2,11 @@
 pa:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ pa:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -2,7 +2,11 @@
 pl:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -523,6 +527,7 @@ pl:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -2,7 +2,11 @@
 ps:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ ps:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -2,7 +2,11 @@
 pt:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ pt:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -2,7 +2,11 @@
 ro:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -449,6 +453,7 @@ ro:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -2,7 +2,11 @@
 ru:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -523,6 +527,7 @@ ru:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -2,7 +2,11 @@
 si:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ si:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -2,7 +2,11 @@
 sk:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -449,6 +453,7 @@ sk:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -2,7 +2,11 @@
 sl:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -523,6 +527,7 @@ sl:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -2,7 +2,11 @@
 so:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ so:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -2,7 +2,11 @@
 sq:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ sq:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -2,7 +2,11 @@
 sr:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -523,6 +527,7 @@ sr:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -2,7 +2,11 @@
 sv:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ sv:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -2,7 +2,11 @@
 sw:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ sw:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -2,7 +2,11 @@
 ta:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ ta:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -2,7 +2,11 @@
 th:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -301,6 +305,7 @@ th:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -2,7 +2,11 @@
 tk:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ tk:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -2,7 +2,11 @@
 tr:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ tr:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -2,7 +2,11 @@
 uk:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -523,6 +527,7 @@ uk:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -2,7 +2,11 @@
 ur:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ ur:
     ur: اردو
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -2,7 +2,11 @@
 uz:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ uz:
     ur:
     uz: O'zbekcha
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -2,7 +2,11 @@
 vi:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -301,6 +305,7 @@ vi:
     ur:
     uz:
     vi: Tiếng Việt
+    yi:
     zh:
     zh-hk:
     zh-tw:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -1,5 +1,83 @@
+---
 yi:
+  brexit:
+    business_link:
+      path:
+      text:
+    citizen_link:
+      path:
+      text:
+    heading_prefix:
+  common:
+    last_updated:
+    visit:
+  components:
+    figure:
+      image_credit:
+    published_dates:
+      hide_all_updates:
+      last_updated:
+      published:
+      see_all_updates:
+      show_all_updates:
+    publisher_metadata:
+      collections:
+      from:
+      hide_all:
+      show_all:
+    save_this_page:
+      add_page_button:
+      confirmations:
+        page_removed:
+          message:
+        page_saved:
+          message:
+      page_not_saved_heading:
+      page_was_saved_heading:
+      remove_page_button:
+      see_saved_pages_signed_in:
+      see_saved_pages_signed_out:
+    share_links:
+      share_this_page:
+  consultation:
+    and:
+    another_website_html:
+    at:
+    closes:
+    closes_at:
+    complete_a:
+    description:
+    detail_of_feedback_received:
+    detail_of_outcome:
+    documents: דאָקומענטן
+    download_outcome:
+    either:
+    email_to:
+    feedback_received:
+    is_being:
+    not_open_yet:
+    'on':
+    opens:
+    original_consultation:
+    ran_from:
+    respond_online:
+    'true':
+    visit_soon:
+    was:
+    ways_to_respond:
+    write_to:
+  contact:
+    email:
+    find_call_charges:
+    online:
+    phone:
+    webchat:
   content_item:
+    coming_soon:
+    contents:
+    metadata:
+      published:
+      updated:
     schema_name:
       aaib_report:
         one:
@@ -223,76 +301,6 @@ yi:
       written_statement:
         one:
         other:
-    coming_soon:
-    contents:
-    metadata:
-      published:
-      updated:
-  publication:
-    documents:
-      one:
-      other: דאָקומענטן
-    details:
-  brexit:
-    business_link:
-      path:
-      text:
-    citizen_link:
-      path:
-      text:
-    heading_prefix:
-  common:
-    last_updated:
-    visit:
-  components:
-    figure:
-      image_credit:
-    published_dates:
-      hide_all_updates:
-      last_updated:
-      published:
-      see_all_updates:
-      show_all_updates:
-    publisher_metadata:
-      collections:
-      from:
-      hide_all:
-      show_all:
-    share_links:
-      share_this_page:
-  consultation:
-    and:
-    another_website_html:
-    at:
-    closes:
-    closes_at:
-    complete_a:
-    description:
-    detail_of_feedback_received:
-    detail_of_outcome:
-    documents: דאָקומענטן
-    download_outcome:
-    either:
-    email_to:
-    feedback_received:
-    is_being:
-    not_open_yet:
-    'on':
-    opens:
-    original_consultation:
-    ran_from:
-    respond_online:
-    'true':
-    visit_soon:
-    was:
-    ways_to_respond:
-    write_to:
-  contact:
-    email:
-    find_call_charges:
-    online:
-    phone:
-    webchat:
   corporate_information_page:
     about_our_services_html:
     corporate_information:
@@ -321,11 +329,81 @@ yi:
   i18n:
     direction: rtl
   language_names:
+    ar:
+    az:
+    be:
+    bg:
+    bn:
+    cs:
+    cy:
+    da:
+    de:
+    dr:
+    el:
+    en:
+    es:
+    es-419:
+    et:
+    fa:
+    fi:
+    fr:
+    gd:
+    gu:
+    he:
+    hi:
+    hr:
+    hu:
+    hy:
+    id:
+    is:
+    it:
+    ja:
+    ka:
+    kk:
+    ko:
+    lt:
+    lv:
+    ms:
+    mt:
+    ne:
+    nl:
+    'no':
+    pa:
+    pa-pk:
+    pl:
+    ps:
+    pt:
+    ro:
+    ru:
+    si:
+    sk:
+    sl:
+    so:
+    sq:
+    sr:
+    sv:
+    sw:
+    ta:
+    th:
+    tk:
+    tr:
+    uk:
+    ur:
+    uz:
+    vi:
     yi: יידיש
+    zh:
+    zh-hk:
+    zh-tw:
   multi_page:
     next_page:
     previous_page:
     print_entire_guide:
+  publication:
+    details:
+    documents:
+      one:
+      other: דאָקומענטן
   service_sign_in:
     continue:
     error:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -2,7 +2,11 @@
 zh-hk:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ zh-hk:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk: 中文
     zh-tw:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -2,7 +2,11 @@
 zh-tw:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -375,6 +379,7 @@ zh-tw:
     ur:
     uz:
     vi:
+    yi:
     zh:
     zh-hk:
     zh-tw: 中文

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -2,7 +2,11 @@
 zh:
   brexit:
     business_link:
+      path:
+      text:
     citizen_link:
+      path:
+      text:
     heading_prefix:
   common:
     last_updated:
@@ -301,6 +305,7 @@ zh:
     ur:
     uz:
     vi:
+    yi:
     zh: 中文
     zh-hk:
     zh-tw:


### PR DESCRIPTION
During work on the Get Involved frontend, we found that many of the
files were missing extra required keys (such as the key for yiddish
support). This commit adds those keys separate to the Get Involved work.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
