### PR TITLE
Remove `government_navigation` component

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,10 +33,6 @@
   <%= yield :extra_head_content %>
 </head>
 <body>
-  <% unless content_for(:simple_header) || explore_menu_variant_b? %>
-    <%= render 'govuk_publishing_components/components/government_navigation', active: active_proposition %>
-  <% end %>
-
   <div id="wrapper" class="<%= wrapper_class %>">
     <% if @content_item.show_phase_banner? %>
       <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase %>

--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -4,8 +4,6 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
   test "typical fatality notice" do
     setup_and_visit_content_item("fatality_notice")
 
-    assert_has_component_government_navigation_active("News and communications")
-
     assert page.has_title?(
       "Sir George Pomeroy Colley killed in Boer War - Fatality notice - GOV.UK",
     )

--- a/test/integration/news_article_test.rb
+++ b/test/integration/news_article_test.rb
@@ -3,7 +3,6 @@ require "test_helper"
 class NewsArticleTest < ActionDispatch::IntegrationTest
   test "news article renders title, description and body" do
     setup_and_visit_content_item("news_article")
-    assert_has_component_government_navigation_active("News and communications")
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
     assert page.has_text?("This year, the United Kingdom has had much to celebrate. Her Majesty The Queen celebrated her 90th birthday")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -69,10 +69,6 @@ class ActionDispatch::IntegrationTest
     assert page.has_css?(".gem-c-organisation-logo")
   end
 
-  def assert_has_component_government_navigation_active(active)
-    assert page.has_css?("a", class: "active", text: active)
-  end
-
   def assert_has_contents_list(contents)
     assert page.has_css?(".gem-c-contents-list"), "Failed to find an element with a class of contents-list"
     within ".gem-c-contents-list" do


### PR DESCRIPTION
## What

Remove use of the [government navigation component][gnc].

## Why

The [navigation header][nh] is being rolled out, so this is no longer needed.

---

The component is no longer needed as the navigation header is being rolled out.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[gnc]: https://components.publishing.service.gov.uk/component-guide/government_navigation

[nh]: https://components.publishing.service.gov.uk/component-guide/layout_super_navigation_header
