### PR TITLE
Add "overview:" to titles where an attachment has the same name

### DIFF
--- a/app/views/content_items/_context_and_title.html.erb
+++ b/app/views/content_items/_context_and_title.html.erb
@@ -1,0 +1,23 @@
+<% context_string =  t("content_item.schema_name.#{@content_item.document_type}", count: 1) %>
+
+<% @content_item&.featured_attachments.each do |fa| %>
+  <% return if !@content_item.attachment_details(fa).present? %>
+  <% if @content_item.attachment_details(fa)['title'] == @content_item.title %>
+      <% content_for :title do %>
+        <%= t("content_item.schema_name.#{@content_item.document_type}.overview", count: 1) %>: <%= @content_item.title %>
+      <% end %>
+      <%
+         context_string =  t("content_item.schema_name.#{@content_item.document_type}.overview", count: 1) << ":"
+         context_inside = true
+      %>
+      <% break %>
+    <% end %>
+<% end %>
+
+<%= render 'govuk_publishing_components/components/title',
+   context: context_string,
+   context_locale: t_locale_fallback("content_item.schema_name.#{@content_item.document_type}", count: 1),
+   context_inside: context_inside ||= false,
+   title: @content_item.title,
+   average_title_length: "long"
+ %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'context_and_title' %>
   </div>
   <%= render 'shared/translations' %>
 </div>
@@ -21,7 +21,6 @@
       national_applicability: @content_item.national_applicability || {},
       type: @content_item.schema_name
     } %>
-
     <% if @content_item.unopened? %>
       <% content_item_unopened = capture do %>
         <%= raw(t("consultation.opens")) %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -6,11 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title',
-      context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
-      context_locale: t_locale_fallback("content_item.schema_name.#{@content_item.document_type}", count: 1),
-      title: @content_item.title,
-      average_title_length: "long" %>
+    <%= render 'context_and_title' %>
   </div>
   <%= render 'shared/translations' %>
 
@@ -31,7 +27,6 @@
         national_applicability: @content_item.national_applicability || {},
         type: @content_item.schema_name
       } %>
-
       <div class="responsive-bottom-margin">
         <%= render "attachments",
           title: t("publication.documents", count: 5), # This should always be pluralised.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,6 +88,7 @@ en:
       closed_consultation:
         one: Closed consultation
         other: Closed consultations
+        overview: Closed consultation overview
       cma_case:
         one: Competition and Markets Authority case
         other: Competition and Markets Authority cases
@@ -100,21 +101,25 @@ en:
       consultation_outcome:
         one: Consultation outcome
         other: Consultation outcomes
+        overview: Consultation outcome overview
       corporate_information_page:
         one: Information page
         other: Information pages
       corporate_report:
         one: Corporate report
         other: Corporate reports
+        overview: Corporate reports overview
       correspondence:
         one: Correspondence
         other: Correspondences
+        overview: Correspondence overview
       countryside_stewardship_grant:
         one: Countryside Stewardship grant
         other: Countryside Stewardship grants
       decision:
         one: Decision
         other: Decisions
+        overview: Decision overview
       detailed_guide:
         one: Guidance
         other: Guidance
@@ -145,36 +150,43 @@ en:
       foi_release:
         one: FOI release
         other: FOI releases
+        overview: FOI release overview
       form:
         one: Form
         other: Forms
+        overview: Forms overview
       government_response:
         one: Government response
         other: Government responses
       guidance:
         one: Guidance
         other: Guidance
+        overview: Guidance overview
       impact_assessment:
         one: Impact assessment
         other: Impact assessments
+        overview: Impact assessment overview
       imported:
         one: imported - awaiting type
         other: imported - awaiting type
       independent_report:
         one: Independent report
         other: Independent reports
+        overview: Independent report overview
       international_development_fund:
         one: International development funding
         other: International development funding
       international_treaty:
         one: International treaty
         other: International treaties
+        overview: International treaty overview
       maib_report:
         one: Marine Accident Investigation Branch report
         other: Marine Accident Investigation Branch reports
       map:
         one: Map
         other: Maps
+        overview: Map overview
       medical_safety_alert:
         one: Alerts and recalls for drugs and medical devices
         other: Alerts and recalls for drugs and medical devices
@@ -182,8 +194,9 @@ en:
         one: National statistics announcement
         other: National statistics announcements
       national_statistics:
-        one: National Statistics
-        other: National Statistics
+        one: National statistics
+        other: National statistics
+        overview: National statistics overview
       national_statistics_announcement:
         one: National statistics announcement
         other: National statistics announcements
@@ -196,18 +209,21 @@ en:
       notice:
         one: Notice
         other: Notices
+        overview: Notice overview
       official:
         one: Official statistics announcement
         other: Official statistics announcements
       official_statistics:
         one: Official Statistics
-        other: Official Statistics
+        other: Official statistics
+        overview: Official statistics overview
       official_statistics_announcement:
         one: Official statistics announcement
         other: Official statistics announcements
       open_consultation:
         one: Open consultation
         other: Open consultations
+        overview: Open consultation overview
       oral_statement:
         one: Oral statement to Parliament
         other: Oral statements to Parliament
@@ -217,12 +233,14 @@ en:
       policy_paper:
         one: Policy paper
         other: Policy papers
+        overview: Policy paper overview
       press_release:
         one: Press release
         other: Press releases
       promotional:
         one: Promotional material
         other: Promotional material
+        overview: Promotional material overview
       publication:
         one: Publication
         other: Publications
@@ -232,9 +250,11 @@ en:
       regulation:
         one: Regulation
         other: Regulations
+        overview: Regulation overview
       research:
         one: Research and analysis
         other: Research and analysis
+        overview: Research and analysis overview
       residential_property_tribunal_decision:
         one: Residential property tribunal decision
         other: Residential property tribunal decisions
@@ -253,6 +273,7 @@ en:
       standard:
         one: Standard
         other: Standards
+        overview: Standard overview
       statement_to_parliament:
         one: Statement to Parliament
         other: Statements to Parliament
@@ -265,6 +286,7 @@ en:
       statutory_guidance:
         one: Statutory guidance
         other: Statutory guidance
+        overview: Statutory guidance overview
       take_part:
         one: Take part
         other: Take part
@@ -277,6 +299,7 @@ en:
       transparency:
         one: Transparency data
         other: Transparency data
+        overview: Transparency data overview
       utaac_decision:
         one: Administrative appeals tribunal decision
         other: Administrative appeals tribunal decisions

--- a/test/views/content_items/attachments.html.erb_test.rb
+++ b/test/views/content_items/attachments.html.erb_test.rb
@@ -43,4 +43,22 @@ class ContentItemsAttachmentsTest < ActionView::TestCase
     assert_includes rendered, "gem-c-govspeak"
     assert_includes rendered, "some html"
   end
+
+  test "renders overview title when attachment title matches parent" do
+    @content_item = PublicationPresenter.new(
+      { "document_type" => "correspondence",
+        "title" => "Matching",
+        "details" => { "attachments" => [{ "id" => "attachment_id",
+                                           "title" => "Matching",
+                                           "url" => "some/url" }],
+                       "featured_attachments" => %w[attachment_id] } },
+      "/publication",
+      ApplicationController.new.view_context,
+    )
+    render(
+      partial: "content_items/context_and_title",
+    )
+
+    assert_includes rendered, "Correspondence overview:"
+  end
 end


### PR DESCRIPTION
## What
We currently have live pages that have attachments that share the exact same title for a number of publications and consultations. This can make for confusing user journeys and in the case of HTML attachments can make it confusing for users of assistive technology navigating between the pages and can disorientate those with cognitive problems. Our solution to the issue to to adjust the parent page title in cases where this happens and add the word "overview". This will affect both the HTML page title (as seen in the browser tab), and the H1 for affected pages. In unaffected pages the H1 contains the name of the document with supporting document type context above it. Where a page is affected that contextual text has "overview:" appended and it is moved inside the H1 tag.  

https://trello.com/c/Z3D4CElD/841-update-heading-and-title-pattern-for-publication-and-consultation-pages

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/31649453/138906381-74d26b2a-f747-4abc-818a-02a099b057b8.png)

### After
![image](https://user-images.githubusercontent.com/31649453/138907935-1d5da2a4-f67c-4440-89e5-69451744208c.png)


## Examples
Some affected sample urls used during testing:

https://www.gov.uk/government/publications/warm-home-discount-better-targeted-support-from-2022-cfp-response-to-the-beis-consultation
https://www.gov.uk/government/government/publications/impact-assessment-of-the-mental-capacity-amendment-act-2019
https://www.gov.uk/government/publications/warm-home-discount-better-targeted-support-from-2022-cfp-response-to-the-beis-consultation
https://www.gov.uk/government/government/publications/impact-assessment-of-the-mental-capacity-amendment-act-2019
https://www.gov.uk/government/publications/economic-crime-research-strategy-home-office-research-priorities
https://www.gov.uk/government/publications/civil-procedure-rule-committee-annual-report-2011
https://www.gov.uk/government/publications/national-probation-service-england-and-wales-divisions-map
https://www.gov.uk/government/publications/electric-vehicle-homecharge-scheme-authorised-installers
https://www.gov.uk/government/publications/grade-and-salary-bands
https://www.gov.uk/government/publications/armed-forces-pay-review-body-fiftieth-report-2021
https://www.gov.uk/government/publications/agreement-establishing-an-association-between-the-uk-and-central-america-ms-no322019
https://www.gov.uk/government/publications/notice-143-a-guide-for-international-post-users
https://www.gov.uk/government/publications/general-medical-council
https://www.gov.uk/government/publications/government-functional-standard-govs-001-government-functions
https://www.gov.uk/government/publications/spending-review-2021-launch-letter
https://www.gov.uk/government/publications/staying-legal-heavy-goods-vehicle-drivers
https://www.gov.uk/government/publications/draft-online-safety-bill

https://www.gov.uk/government/consultations/appraisal-periods-consultation 
https://www.gov.uk/government/consultations/call-for-evidence-to-inform-orbital-liability-and-insurance-policy

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
