### PR TITLE
Update devolved nations component uses to pass type property

### DIFF
--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -17,7 +17,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/devolved_nations", national_applicability: @content_item.national_applicability || {} %>
+    <%= render "govuk_publishing_components/components/devolved_nations", {
+      national_applicability: @content_item.national_applicability || {},
+      type: @content_item.schema_name
+    } %>
 
     <% if @content_item.unopened? %>
       <% content_item_unopened = capture do %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -40,7 +40,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/devolved_nations", national_applicability: @content_item.national_applicability || {} %>
+    <%= render "govuk_publishing_components/components/devolved_nations", {
+      national_applicability: @content_item.national_applicability || {},
+      type: @content_item.schema_name
+    } %>
 
     <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
       <%= render "govuk_publishing_components/components/print_link", {

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -7,10 +7,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title',
-       context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
-       context_locale: t_locale_fallback("content_item.schema_name.#{@content_item.document_type}", count: 1),
-       title: @content_item.title,
-       average_title_length: "long" %>
+      context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
+      context_locale: t_locale_fallback("content_item.schema_name.#{@content_item.document_type}", count: 1),
+      title: @content_item.title,
+      average_title_length: "long" %>
   </div>
   <%= render 'shared/translations' %>
 
@@ -27,7 +27,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="responsive-bottom-margin">
-      <%= render "govuk_publishing_components/components/devolved_nations", national_applicability: @content_item.national_applicability || {} %>
+      <%= render "govuk_publishing_components/components/devolved_nations", {
+        national_applicability: @content_item.national_applicability || {},
+        type: @content_item.schema_name
+      } %>
 
       <div class="responsive-bottom-margin">
         <%= render "attachments",


### PR DESCRIPTION
## What
https://trello.com/b/NLbahOWX/doing-govuk-accessibility

- Update uses of devolved nations component uses to pass type property
- The content type is derived from the `schema_name` (similar to how this worked previously with the **important metadata component**). Code samples copied below.

https://github.com/alphagov/government-frontend/blob/4cdd0e3a4b8069c413c8451f2ae03af9b6e5c0b1/app/presenters/content_item/national_applicability.rb#L21

https://github.com/alphagov/government-frontend/blob/4cdd0e3a4b8069c413c8451f2ae03af9b6e5c0b1/app/presenters/content_item/national_applicability.rb#L36-L38

## Why
See https://github.com/alphagov/govuk_publishing_components/pull/2337

## Visual changes
https://www.gov.uk/government/statistics/affordable-housing-supply-in-england-2011-to-2012
`"schema_name": "publication",`
| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/87758239/136197638-537afc7b-2f0c-45cb-8838-55a9d3c81e9e.png" width="300"> | <img src="https://user-images.githubusercontent.com/87758239/136197632-1b4970ce-1637-4433-9109-ce21d5d33288.png" width="300"> |

https://www.gov.uk/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do
`"schema_name": "detailed_guide",` (equates to **Guidance**)
| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/87758239/136201481-04212268-8497-47e6-8500-435577c4242b.png" width="300"> | <img src="https://user-images.githubusercontent.com/87758239/136201476-6be0b9ca-d9f8-4f53-b415-63b2ba10c540.png" width="300"> |

## Example URLs
https://www.gov.uk/government/publications/eia-afforestation-application-form
https://www.gov.uk/guidance/travel-to-england-from-another-country-during-coronavirus-covid-19
https://www.gov.uk/government/statistics/affordable-housing-supply-in-england-2011-to-2012
https://www.gov.uk/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do
https://www.gov.uk/government/publications/map-request-form-forestry-commission

## Anything else
Prerequisites include:
- https://github.com/alphagov/govuk_publishing_components/pull/2337
- Dependabot bump (TBC)