### PR TITLE
Fix summary layout on travel advice

### DIFF
--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -18,3 +18,8 @@
     }
   }
 }
+
+.metadata__update {
+  display: block;
+  margin-bottom: govuk-spacing(2);
+}

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -20,7 +20,7 @@ class TravelAdvicePresenter < ContentItemPresenter
       I18n.t("travel_advice.updated") => display_date(reviewed_at || updated_at),
     }
 
-    other["Latest update"] = view_context.simple_format(latest_update) if latest_update.present?
+    other["Latest update"] = view_context.simple_format(latest_update, { class: "metadata__update" }, wrapper_tag: "span") if latest_update.present?
 
     {
       other: other,

--- a/test/presenters/travel_advice_presenter_test.rb
+++ b/test/presenters/travel_advice_presenter_test.rb
@@ -240,10 +240,11 @@ class TravelAdvicePresenterTest
 
     test "metadata avoids duplication of 'Latest update' from change description" do
       [
-        { original: "Latest update: Changes", presented: "<p>Changes</p>" },
-        { original: "Latest update - changes", presented: "<p>Changes</p>" },
-        { original: "Latest update changes", presented: "<p>Changes</p>" },
-        { original: "Latest Update: Summary of changes. Next sentence", presented: "<p>Summary of changes. Next sentence</p>" },
+        { original: "Latest update: Changes", presented: "<span class=\"metadata__update\">Changes</span>" },
+        { original: "Latest update - changes", presented: "<span class=\"metadata__update\">Changes</span>" },
+        { original: "Latest update changes", presented: "<span class=\"metadata__update\">Changes</span>" },
+        { original: "Latest Update: Summary of changes. Next sentence", presented: "<span class=\"metadata__update\">Summary of changes. Next sentence</span>" },
+        { original: "Latest update: Changes\n\nMore changes", presented: "<span class=\"metadata__update\">Changes</span>\n\n<span class=\"metadata__update\">More changes</span>" },
       ].each do |i|
         assert_equal i[:presented], present_latest(i[:original])
       end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why

Fix the summary section of the [travel advice pages](https://www.gov.uk/foreign-travel-advice/denmark). The 'Latest update' content is being output using [`simple_format`](https://apidock.com/rails/v5.2.3/ActionView/Helpers/TextHelper/simple_format), a Rails helper that detects line breaks and is automatically wrapping the content of this item in a `P` tag, which is being automatically styled with a margin top and bottom, causing the alignment issue shown.

Fix is to tell `simple_format` to use a `SPAN` instead of a `P`, which doesn't cause this issue. Also adds some margin bottom to this element in case there's ever more than one line of text in a 'Latest update' (but I can't see any evidence of this).

## Visual changes

Before:

![Screenshot 2021-10-15 at 09 09 05](https://user-images.githubusercontent.com/861310/137455136-3ad7d3f2-f50d-4b49-a4e9-9401216511c1.png)

Before (showing paragraph styling):

![Screenshot 2021-10-15 at 09 09 11](https://user-images.githubusercontent.com/861310/137455155-7c2f28cd-60ac-478b-91ea-7cdf642c4589.png)

After:

![Screenshot 2021-10-15 at 09 09 25](https://user-images.githubusercontent.com/861310/137455198-36e89a23-b21e-418e-aafa-0011c4a6475c.png)

After (if there were ever more than one line output):

![Screenshot 2021-10-15 at 09 10 28](https://user-images.githubusercontent.com/861310/137455238-53f74d75-d371-4770-97a4-6cbbe967c26f.png)

Thanks to @gclssvglx for putting this together.