### PR TITLE
Revert "Add scroll tracking to foreign travel advice pages"

### DIFF
--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -9,8 +9,6 @@
     title: @content_item.page_title,
     body: @content_item.current_part_body
     ) %>
-
-  <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker" data-track-type="headings"/>
 <% end %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
## What

Remove scroll tracking from the foreign travel advice pages. 

(Reverts alphagov/government-frontend#2224)

## Why

Scroll tracking on the foreign travel advice pages isn't needed anymore - we've gathered enough data for analysis.

## Visual changes

None.

Trello card: https://trello.com/c/pzumje19/234-remove-scroll-tracking-from-fcdo-pages
