### PR TITLE
Add print stylesheet for organisation logo component

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,10 +1,12 @@
 @import 'govuk_publishing_components/govuk_frontend_support';
+
 @import 'govuk_publishing_components/components/print/button';
 @import 'govuk_publishing_components/components/print/contents-list';
-@import 'govuk_publishing_components/components/print/govspeak';
 @import 'govuk_publishing_components/components/print/govspeak-html-publication';
-@import 'govuk_publishing_components/components/print/step-by-step-nav';
+@import 'govuk_publishing_components/components/print/govspeak';
+@import 'govuk_publishing_components/components/print/organisation-logo';
 @import 'govuk_publishing_components/components/print/step-by-step-nav-header';
+@import 'govuk_publishing_components/components/print/step-by-step-nav';
 @import 'govuk_publishing_components/components/print/title';
 
 @import 'print/html-publication';


### PR DESCRIPTION
## What
Adds the print stylesheet for the organisation logo component.

Reliant on https://github.com/alphagov/govuk_publishing_components/pull/2371 being released.

## Why

When a page containing the organisation logo is printed, the logo is printed out at the native dimensions of the image - this means that if an image is used that too large it can overwhelm the printed page.

## Visual differences

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/1732331/137738576-89bb76c7-1a58-465a-99da-5ab4a59260cb.png) | ![](https://user-images.githubusercontent.com/1732331/137738586-8eafe95e-50fb-41d4-a6fd-9a6109df7799.png) |

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
