### PR TITLE
Make intervention component future-proof

### DIFF
--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -9,7 +9,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="responsive-bottom-margin">
-      <%= render 'govuk_publishing_components/components/intervention' if should_show_sab_intervention? %>
+      <%= render 'govuk_publishing_components/components/intervention', { suggestion_text: "OK" } if should_show_sab_intervention? %>
 
       <%= render 'govuk_publishing_components/components/govspeak', {
         direction: page_text_direction,

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -26,7 +26,7 @@
     <%= render 'components/important-metadata',
         items: @content_item.important_metadata %>
 
-    <%= render 'govuk_publishing_components/components/intervention' if should_show_sab_intervention? %>
+    <%= render 'govuk_publishing_components/components/intervention', { suggestion_text: "OK" } if should_show_sab_intervention? %>
 
     <%= render "components/contents-list-with-body", contents: @content_item.contents do %>
       <div class="responsive-bottom-margin">

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -18,7 +18,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', { title: @content_item.content_title } %>
 
-    <%= render 'govuk_publishing_components/components/intervention' if should_show_sab_intervention? %>
+    <%= render 'govuk_publishing_components/components/intervention', { suggestion_text: "OK" } if should_show_sab_intervention? %>
 
     <% if @content_item.show_guide_navigation? %>
       <%= render "govuk_publishing_components/components/skip_link", {


### PR DESCRIPTION
The next version of the intervention component (starting from
govuk_publishing_components v27.8.2) doesn't render at all
when no parameter is passed. So in order to make the current tests
still pass in the future, we add a dummy parameter now

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
