### PR TITLE
Remove jq from set ga client

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,10 +12,8 @@
 //= require_tree ./modules
 //= require set-ga-client-id-on-form
 
-jQuery(function ($) {
-  var $form = $('.js-service-sign-in-form')
+var form = document.querySelector('.js-service-sign-in-form')
 
-  if ($form.length) {
-    new GOVUK.SetGaClientIdOnForm({ $form: $form }) // eslint-disable-line no-new
-  }
-})
+if (form) {
+  new GOVUK.SetGaClientIdOnForm(form) // eslint-disable-line no-new
+}

--- a/app/assets/javascripts/set-ga-client-id-on-form.js
+++ b/app/assets/javascripts/set-ga-client-id-on-form.js
@@ -4,15 +4,13 @@
   window.GOVUK = window.GOVUK || {}
   var GOVUK = window.GOVUK
 
-  function SetGaClientIdOnForm (options) {
-    if (!options.$form || !window.ga) { return }
-
-    var form = options.$form
+  function SetGaClientIdOnForm (form) {
+    if (!form || !window.ga) { return }
 
     window.ga(function (tracker) {
       var clientId = tracker.get('clientId')
-      var action = form.attr('action')
-      form.attr('action', action + '?_ga=' + clientId)
+      var action = form.getAttribute('action')
+      form.setAttribute('action', action + '?_ga=' + clientId)
     })
   }
 

--- a/spec/javascripts/set-ga-client-id-on-form.spec.js
+++ b/spec/javascripts/set-ga-client-id-on-form.spec.js
@@ -11,7 +11,7 @@ describe('SetGaClientIdOnForm', function () {
     form = $(
       '<form class="js-service-sign-in-form" action="/endpoint"></form>'
     )
-    new GOVUK.SetGaClientIdOnForm({ $form: form }) // eslint-disable-line no-new
+    new GOVUK.SetGaClientIdOnForm(form[0]) // eslint-disable-line no-new
   })
 
   it('sets the _ga client id as a query param on the form action', function () {

--- a/spec/javascripts/set-ga-client-id-on-form.spec.js
+++ b/spec/javascripts/set-ga-client-id-on-form.spec.js
@@ -2,9 +2,9 @@ var $ = window.jQuery
 
 describe('SetGaClientIdOnForm', function () {
   var GOVUK = window.GOVUK
-  var tracker = { clientId: 'clientId' }
-  tracker.get = function (arg) { return this[arg] }
-  window.ga = function (callback) { callback(tracker) }
+  var mockTracker = { clientId: 'clientId' }
+  mockTracker.get = function (arg) { return this[arg] }
+  window.ga = function (callback) { callback(mockTracker) }
   var form
 
   beforeEach(function () {


### PR DESCRIPTION
## What

Remove jQuery from the set ga client id file.

## Why

We're using an old and unsupported version of jQuery for browser support reasons. Rather than upgrade, it's far better to remove our dependence.

jQuery makes writing JavaScript easier, but it doesn't do anything that you can't do with vanilla JavaScript, because it's all written in JavaScript.

Once it's removed, we no longer have to worry about upgrading it, and users don't have to download the jQuery library when they visit GOV.UK.

## Trello

https://trello.com/c/bqdisKbm/277-from-jquery-from-government-frontend-set-ga-client-id-on-formjs-and-applicationjs-moderate-js-knowledge-required


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
