### PR TITLE
Fix get involved styles

### DIFF
--- a/app/assets/stylesheets/views/_get-involved.scss
+++ b/app/assets/stylesheets/views/_get-involved.scss
@@ -8,6 +8,10 @@
     line-height: 1.16;
   }
 
+  .govuk-section-break {
+    clear: both;
+  }
+
   #engage-with-government,
   #take-part {
     clear: both;

--- a/app/assets/stylesheets/views/_get-involved.scss
+++ b/app/assets/stylesheets/views/_get-involved.scss
@@ -98,10 +98,6 @@
     font-weight: bold;
   }
 
-  .keyline {
-    margin: 30px 15px;
-  }
-
   .comment-follow {
     li {
       border-bottom: 1px solid $govuk-border-colour;

--- a/app/assets/stylesheets/views/_get-involved.scss
+++ b/app/assets/stylesheets/views/_get-involved.scss
@@ -8,7 +8,9 @@
     line-height: 1.16;
   }
 
-  #engage-with-government {
+  #engage-with-government,
+  #take-part {
+    clear: both;
     border-bottom-style: solid;
     padding-bottom: 5px;
     border-bottom-width: 5px;

--- a/app/views/content_items/get_involved.html.erb
+++ b/app/views/content_items/get_involved.html.erb
@@ -1,14 +1,10 @@
 <% page_title %>
 <% page_class "get-involved" %>
 
-<header class="block headings-block">
-  <div class="inner-block floated-children">
-    <%= render "govuk_publishing_components/components/heading", { text: t('get_involved.page_heading'), font_size: "xl", padding: true } %>
-    <%= render "govuk_publishing_components/components/lead_paragraph", { text: t('get_involved.intro_paragraph.body_html',
-      engage_with_government: link_to(t('get_involved.intro_paragraph.engage_with_government'), "#engage-with-government", class: "govuk-link"),
-      take_part: link_to(t('get_involved.intro_paragraph.take_part'), "#take-part", class: "govuk-link")) } %>
-  </div>
-</header>
+<%= render "govuk_publishing_components/components/title", { title: t('get_involved.page_heading') } %>
+<%= render "govuk_publishing_components/components/lead_paragraph", { text: t('get_involved.intro_paragraph.body_html',
+  engage_with_government: link_to(t('get_involved.intro_paragraph.engage_with_government'), "#engage-with-government", class: "govuk-link"),
+  take_part: link_to(t('get_involved.intro_paragraph.take_part'), "#take-part", class: "govuk-link")) } %>
 
 <div class="block">
   <div class="inner-block floated-children">

--- a/app/views/content_items/get_involved.html.erb
+++ b/app/views/content_items/get_involved.html.erb
@@ -84,7 +84,9 @@
         </div>
       </div>
     </section>
-    <hr class="keyline">
+
+    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+
     <section class="start-a-petition">
       <div class="head-section govuk-grid-column-one-third-from-desktop">
       <%= render "govuk_publishing_components/components/heading", { text: t('get_involved.start_a_petition') } %>
@@ -96,7 +98,9 @@
         </div>
       </div>
     </section>
-    <hr class="keyline">
+
+    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+
     <section class="comment-follow">
       <div class="head-section govuk-grid-column-one-third-from-desktop">
         <%= render "govuk_publishing_components/components/heading", {text: t('get_involved.follow') } %>
@@ -137,7 +141,7 @@
         <% if index == @take_part_pages.size-1 %> </div> <% end %>
       <% end %>
     </section>
-    <hr class="keyline">
+    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
     <section class="more-ways">
       <div class="head-section govuk-grid-column-one-third-from-desktop">
         <%= render "govuk_publishing_components/components/heading", {text:t('get_involved.more_ways') } %>

--- a/app/views/content_items/get_involved.html.erb
+++ b/app/views/content_items/get_involved.html.erb
@@ -45,7 +45,6 @@
             <%= content_tag(:li, "consultation", class: 'document-row') do %>
               <%= render "govuk_publishing_components/components/heading", { text: @next_closing_consultation['title'], inverse: true, id: "closing-soon-title", margin_bottom: 2, heading_level: 3, font_size: "s" } %>
               <%= link_to t('get_involved.read_respond'), @next_closing_consultation['link'], class: "govuk-link govuk-link--inverse", id: "closing-soon-link" %>
-            </li>
             <% end %>
           </li>
         </div>

--- a/app/views/content_items/get_involved.html.erb
+++ b/app/views/content_items/get_involved.html.erb
@@ -5,8 +5,8 @@
   <div class="inner-block floated-children">
     <%= render "govuk_publishing_components/components/heading", { text: t('get_involved.page_heading'), font_size: "xl", padding: true } %>
     <%= render "govuk_publishing_components/components/lead_paragraph", { text: t('get_involved.intro_paragraph.body_html',
-      engage_with_government: link_to(t('get_involved.intro_paragraph.engage_with_government'), "#engage-with-government"),
-      take_part: link_to(t('get_involved.intro_paragraph.take_part'), "#take-part")) } %>
+      engage_with_government: link_to(t('get_involved.intro_paragraph.engage_with_government'), "#engage-with-government", class: "govuk-link"),
+      take_part: link_to(t('get_involved.intro_paragraph.take_part'), "#take-part", class: "govuk-link")) } %>
   </div>
 </header>
 
@@ -44,7 +44,7 @@
           <li class="document-list">
             <%= content_tag(:li, "consultation", class: 'document-row') do %>
               <%= render "govuk_publishing_components/components/heading", { text: @next_closing_consultation['title'], inverse: true, id: "closing-soon-title", margin_bottom: 2, heading_level: 3, font_size: "s" } %>
-              <%= link_to t('get_involved.read_respond'), @next_closing_consultation['link'], class: "govuk-link govuk-link--inverse", id: "closing-soon-link" %> 
+              <%= link_to t('get_involved.read_respond'), @next_closing_consultation['link'], class: "govuk-link govuk-link--inverse", id: "closing-soon-link" %>
             </li>
             <% end %>
           </li>
@@ -92,7 +92,7 @@
       <div class="column govuk-grid-column-two-thirds-from-desktop">
         <div class="content">
           <p class="govuk-body"><%= t('get_involved.petition_paragraph.body_html',
-            create_a_petition: link_to(t('get_involved.petition_paragraph.create_a_petition', class: "govuk-link", rel: "external"), "https://petition.parliament.uk/")) %>
+            create_a_petition: link_to(t('get_involved.petition_paragraph.create_a_petition'), "https://petition.parliament.uk/", class: "govuk-link", rel: "external")) %>
         </div>
       </div>
     </section>
@@ -126,7 +126,7 @@
         <% if index % 3 == 0 && index != 0 %> </div> <% end %>
         <% if index % 3 == 0 %> <div class="govuk-grid-row"> <% end %>
         <article class="govuk-grid-column-one-third-from-desktop">
-        <%= render "govuk_publishing_components/components/image_card", { 
+        <%= render "govuk_publishing_components/components/image_card", {
           href: take_part_page['base_path'],
           image_src: take_part_page['details']['image']['url'],
           image_alt: take_part_page['details']['image']['alt_text'],

--- a/app/views/content_items/get_involved.html.erb
+++ b/app/views/content_items/get_involved.html.erb
@@ -120,7 +120,7 @@
 <div class="block">
   <div class="inner-block floated-children">
     <section class="take-part-pages">
-      <%= render "govuk_publishing_components/components/heading", { text: t('get_involved.take_part'), font_size: "l", id: "engage-with-government" } %>
+      <%= render "govuk_publishing_components/components/heading", { text: t('get_involved.take_part'), font_size: "l", id: "take-part" } %>
       <% @take_part_pages.each_with_index do |take_part_page, index| %>
         <% if index % 3 == 0 && index != 0 %> </div> <% end %>
         <% if index % 3 == 0 %> <div class="govuk-grid-row"> <% end %>


### PR DESCRIPTION
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![www gov uk_government_get-involved](https://user-images.githubusercontent.com/788096/139866451-1189ee82-98a8-4ad3-a866-df3751a9df53.png)


</td><td valign="top">

![localhost_3090_government_get-involved](https://user-images.githubusercontent.com/788096/139866485-0ddbe425-ab23-4b4b-b8dc-103ee8b178bb.png)


</td></tr>
</table>


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
