### PR TITLE
Bump Rails Translation Manager version and enable Dependabot 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
         dependency-type: direct
       - dependency-name: plek
         dependency-type: direct
+      - dependency-name: rails_translation_manager
+        dependency-type: direct
       - dependency-name: rubocop-govuk
         dependency-type: direct
       - dependency-name: slimmer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
+    csv (3.2.1)
     dalli (2.7.10)
     debug_inspector (0.0.3)
     docile (1.3.2)
@@ -268,8 +269,9 @@ GEM
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 7)
-    rails_translation_manager (1.1.0)
+    rails_translation_manager (1.1.2)
       activesupport
+      csv (~> 3.2)
       i18n-tasks
       rails-i18n
     railties (6.1.4.1)
@@ -363,7 +365,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
-    terminal-table (3.0.1)
+    terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.1.0)
     tilt (2.0.10)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Trello:
https://trello.com/c/rFcKFuXv/2521-add-railstranslationmanager-to-dependabot-configuration