### PR TITLE
Remove jQuery from track-radio-group.js

### DIFF
--- a/app/assets/javascripts/modules/track-radio-group.js
+++ b/app/assets/javascripts/modules/track-radio-group.js
@@ -1,95 +1,101 @@
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-(function (global, GOVUK) {
-  'use strict'
+(function (Modules) {
+  function TrackRadioGroup (element) {
+    this.element = element.querySelector('form') || element
+  }
 
-  var $ = global.jQuery
+  TrackRadioGroup.prototype.init = function () {
+    this.track(this.element)
 
-  GOVUK.Modules.TrackRadioGroup = function () {
-    this.start = function (element) {
-      track(element)
+    if (this.crossDomainTrackingEnabled(this.element)) {
+      this.addCrossDomainTracking(this.element)
+    }
 
-      if (crossDomainTrackingEnabled(element)) {
-        addCrossDomainTracking(element)
+    this.checkVerifyUser(this.element)
+  }
+
+  TrackRadioGroup.prototype.track = function (element, withHint) {
+    this.element.addEventListener('submit', function (event) {
+      var options = { transport: 'beacon' }
+      var submittedForm = event.target
+      var checkedOption = submittedForm.querySelector('input:checked')
+      var eventValue = this.eventTrackingValue(checkedOption, withHint)
+
+      GOVUK.analytics.trackEvent('Radio button chosen', eventValue, options)
+
+      if (this.crossDomainTrackingEnabled(submittedForm)) {
+        this.trackCrossDomainEvent(submittedForm, eventValue, options)
       }
+    }.bind(this))
+  }
 
-      checkVerifyUser(element)
-    }
+  TrackRadioGroup.prototype.checkVerifyUser = function (element) {
+    var that = this
 
-    function track (element, withHint) {
-      element.on('submit', function (event) {
-        var options = { transport: 'beacon' }
+    $.ajax({
+      url: 'https://www.signin.service.gov.uk/hint',
+      cache: false,
+      dataType: 'jsonp',
+      timeout: 3000
+    }).then(function (data) {
+      that.reportVerifyUser(element, data)
+    }, function (e) { console.log('error', e) })
+  }
 
-        var $submittedForm = $(event.target)
+  TrackRadioGroup.prototype.trackVerifyUser = function (element, data) {
+    this.reportVerifyUser(element, data)
+  }
 
-        var $checkedOption = $submittedForm.find('input:checked')
-
-        var eventValue = eventTrackingValue($checkedOption, withHint)
-
-        GOVUK.analytics.trackEvent('Radio button chosen', eventValue, options)
-
-        if (crossDomainTrackingEnabled($submittedForm)) {
-          trackCrossDomainEvent($submittedForm, eventValue, options)
-        }
-      })
-    }
-
-    function checkVerifyUser (element) {
-      $.ajax({
-        url: 'https://www.signin.service.gov.uk/hint',
-        cache: false,
-        dataType: 'jsonp',
-        timeout: 3000
-      }).then(function (data) {
-        reportVerifyUser(element, data)
-      }, function (e) { console.log('error', e) })
-    }
-
-    this.trackVerifyUser = function (element, data) {
-      reportVerifyUser(element, data)
-    }
-
-    function reportVerifyUser (element, data) {
-      if (data != null && data.value === true) {
-        GOVUK.analytics.trackEvent('verify-hint', 'shown', { transport: 'beacon' })
-        track(element, data.value)
-      }
-    }
-
-    function eventTrackingValue (element, withHint) {
-      var value = element.val()
-
-      if (typeof value === 'undefined') {
-        value = 'submitted-without-choosing'
-      }
-
-      if (withHint) {
-        value += '-with-hint'
-      }
-      return value
-    }
-
-    function addCrossDomainTracking (element) {
-      var code = element.attr('data-tracking-code')
-      var domain = element.attr('data-tracking-domain')
-      var name = element.attr('data-tracking-name')
-
-      GOVUK.analytics.addLinkedTrackerDomain(code, name, domain)
-    }
-
-    function trackCrossDomainEvent (element, eventValue, options) {
-      var name = element.attr('data-tracking-name')
-      var eventOptions = $.extend({ trackerName: name }, options)
-      GOVUK.analytics.trackEvent('Radio button chosen', eventValue, eventOptions)
-    }
-
-    function crossDomainTrackingEnabled (element) {
-      return (
-        typeof element.attr('data-tracking-code') !== 'undefined' &&
-        typeof element.attr('data-tracking-domain') !== 'undefined' &&
-        typeof element.attr('data-tracking-name') !== 'undefined'
-      )
+  TrackRadioGroup.prototype.reportVerifyUser = function (element, data) {
+    if (data != null && data.value === true) {
+      GOVUK.analytics.trackEvent('verify-hint', 'shown', { transport: 'beacon' })
+      this.track(element, data.value)
     }
   }
-})(window, window.GOVUK)
+
+  TrackRadioGroup.prototype.eventTrackingValue = function (element, withHint) {
+    var value = null
+
+    if (typeof element === 'undefined' || element === null) {
+      value = 'submitted-without-choosing'
+    } else {
+      value = element.value
+    }
+
+    if (withHint) {
+      value += '-with-hint'
+    }
+    return value
+  }
+
+  TrackRadioGroup.prototype.addCrossDomainTracking = function (element) {
+    var code = element.getAttribute('data-tracking-code')
+    var domain = element.getAttribute('data-tracking-domain')
+    var name = element.getAttribute('data-tracking-name')
+
+    GOVUK.analytics.addLinkedTrackerDomain(code, name, domain)
+  }
+
+  TrackRadioGroup.prototype.trackCrossDomainEvent = function (element, eventValue, options) {
+    var name = element.getAttribute('data-tracking-name')
+    var eventOptions = { trackerName: name }
+
+    for (var prop in options) {
+      eventOptions[prop] = options[prop]
+    }
+
+    GOVUK.analytics.trackEvent('Radio button chosen', eventValue, eventOptions)
+  }
+
+  TrackRadioGroup.prototype.crossDomainTrackingEnabled = function (element) {
+    return (
+      typeof element.getAttribute('data-tracking-code') !== 'undefined' &&
+      typeof element.getAttribute('data-tracking-domain') !== 'undefined' &&
+      typeof element.getAttribute('data-tracking-name') !== 'undefined'
+    )
+  }
+
+  Modules.TrackRadioGroup = TrackRadioGroup
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/modules/track-radio-group.js
+++ b/app/assets/javascripts/modules/track-radio-group.js
@@ -1,6 +1,9 @@
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 
+// This callback is triggered by the script attached to the DOM by the
+// checkVerifyUser function. It has to be outside the module because the script
+// can't access the running instance of TrackRadioGroup
 window.GOVUK.TrackRadioGroupVerify = function (data) {
   window.GOVUK.triggerEvent(document, 'have-verify-data', { detail: data })
 };
@@ -39,6 +42,9 @@ window.GOVUK.TrackRadioGroupVerify = function (data) {
     }.bind(this))
   }
 
+  // The analytics data should include whether the user has previously signed in
+  // to Verify this simulates the behaviour of JSONP, returning a true or false
+  // value from Verify
   TrackRadioGroup.prototype.checkVerifyUser = function (element) {
     var url = 'https://www.signin.service.gov.uk/hint'
     var timestamp = Math.floor(Date.now() / 1000)
@@ -83,20 +89,18 @@ window.GOVUK.TrackRadioGroupVerify = function (data) {
 
   TrackRadioGroup.prototype.trackCrossDomainEvent = function (element, eventValue, options) {
     var name = element.getAttribute('data-tracking-name')
-    var eventOptions = { trackerName: name }
-
-    for (var prop in options) {
-      eventOptions[prop] = options[prop]
+    if (name) {
+      options.trackerName = name
     }
 
-    GOVUK.analytics.trackEvent('Radio button chosen', eventValue, eventOptions)
+    GOVUK.analytics.trackEvent('Radio button chosen', eventValue, options)
   }
 
   TrackRadioGroup.prototype.crossDomainTrackingEnabled = function (element) {
     return (
-      typeof element.getAttribute('data-tracking-code') !== 'undefined' &&
-      typeof element.getAttribute('data-tracking-domain') !== 'undefined' &&
-      typeof element.getAttribute('data-tracking-name') !== 'undefined'
+      element.getAttribute('data-tracking-code') &&
+      element.getAttribute('data-tracking-domain') &&
+      element.getAttribute('data-tracking-name')
     )
   }
 

--- a/app/assets/javascripts/modules/track-radio-group.js
+++ b/app/assets/javascripts/modules/track-radio-group.js
@@ -7,7 +7,7 @@ window.GOVUK.TrackRadioGroupVerify = function (data) {
 
 (function (Modules) {
   function TrackRadioGroup (element) {
-    this.element = element.querySelector('form') || element
+    this.element = element
   }
 
   TrackRadioGroup.prototype.init = function () {

--- a/app/assets/javascripts/modules/track-radio-group.js
+++ b/app/assets/javascripts/modules/track-radio-group.js
@@ -1,5 +1,9 @@
 window.GOVUK = window.GOVUK || {}
-window.GOVUK.Modules = window.GOVUK.Modules || {};
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+
+window.GOVUK.TrackRadioGroupVerify = function (data) {
+  window.GOVUK.triggerEvent(document, 'have-verify-data', { detail: data })
+};
 
 (function (Modules) {
   function TrackRadioGroup (element) {
@@ -7,6 +11,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   TrackRadioGroup.prototype.init = function () {
+    document.addEventListener('have-verify-data', function (event) {
+      this.reportVerifyUser(this.element, event.detail)
+    }.bind(this))
+
     this.track(this.element)
 
     if (this.crossDomainTrackingEnabled(this.element)) {
@@ -32,16 +40,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   TrackRadioGroup.prototype.checkVerifyUser = function (element) {
-    var that = this
-
-    $.ajax({
-      url: 'https://www.signin.service.gov.uk/hint',
-      cache: false,
-      dataType: 'jsonp',
-      timeout: 3000
-    }).then(function (data) {
-      that.reportVerifyUser(element, data)
-    }, function (e) { console.log('error', e) })
+    var url = 'https://www.signin.service.gov.uk/hint'
+    var timestamp = Math.floor(Date.now() / 1000)
+    var script = document.createElement('script')
+    script.setAttribute('src', url + '?callback=window.GOVUK.TrackRadioGroupVerify&_=' + timestamp)
+    document.body.appendChild(script)
   }
 
   TrackRadioGroup.prototype.trackVerifyUser = function (element, data) {

--- a/spec/javascripts/track-radio-group.spec.js
+++ b/spec/javascripts/track-radio-group.spec.js
@@ -13,17 +13,15 @@ describe('A radio group tracker', function () {
     spyOn(GOVUK.analytics, 'trackEvent')
 
     element = $(
-      '<div>' +
-        '<form onsubmit="event.preventDefault()">' +
-          '<input type="radio" name="sign-in-option" value="government-gateway">' +
-          '<input type="radio" name="sign-in-option" value="govuk-verify">' +
-          '<input type="radio" name="sign-in-option" value="create-an-account">' +
-          '<button>Submit</button>' +
-        '</form>' +
-      '</div>'
+      '<form onsubmit="event.preventDefault()">' +
+        '<input type="radio" name="sign-in-option" value="government-gateway">' +
+        '<input type="radio" name="sign-in-option" value="govuk-verify">' +
+        '<input type="radio" name="sign-in-option" value="create-an-account">' +
+        '<button>Submit</button>' +
+      '</form>'
     )
 
-    $(document.body).append(element)
+    $('body').append(element)
 
     tracker = new GOVUK.Modules.TrackRadioGroup(element[0])
     tracker.init()
@@ -154,19 +152,16 @@ describe('A radio group tracker', function () {
   })
 
   describe('cross domain tracking enabled', function () {
-    var $form
-
     beforeEach(function () {
       tracker.trackVerifyUser(element, { status: 'OK', value: true })
 
       spyOn(GOVUK.analytics, 'addLinkedTrackerDomain')
 
-      $form = element.find('form')
-      $form.attr('data-tracking-code', 'UA-xxxxxx')
-      $form.attr('data-tracking-domain', 'test.service.gov.uk')
-      $form.attr('data-tracking-name', 'testTracker')
+      element.attr('data-tracking-code', 'UA-xxxxxx')
+      element.attr('data-tracking-domain', 'test.service.gov.uk')
+      element.attr('data-tracking-name', 'testTracker')
 
-      tracker = new GOVUK.Modules.TrackRadioGroup($form[0])
+      tracker = new GOVUK.Modules.TrackRadioGroup(element[0])
       tracker.init()
     })
 
@@ -177,8 +172,8 @@ describe('A radio group tracker', function () {
     })
 
     it('sends an event to the linked tracker when the form is submitted', function () {
-      $form.find('input[value="govuk-verify"]').trigger('click')
-      $form.find('button').trigger('click')
+      element.find('input[value="govuk-verify"]').trigger('click')
+      element.find('button').trigger('click')
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'Radio button chosen', 'govuk-verify-with-hint', { trackerName: 'testTracker', transport: 'beacon' }

--- a/spec/javascripts/track-radio-group.spec.js
+++ b/spec/javascripts/track-radio-group.spec.js
@@ -23,13 +23,19 @@ describe('A radio group tracker', function () {
       '</div>'
     )
 
-    tracker = new GOVUK.Modules.TrackRadioGroup()
-    tracker.start(element)
+    $(document.body).append(element)
+
+    tracker = new GOVUK.Modules.TrackRadioGroup(element[0])
+    tracker.init()
+  })
+
+  afterEach(function () {
+    element.remove()
   })
 
   it('tracks government-gateway checked radio when clicking submit', function () {
     element.find('input[value="government-gateway"]').trigger('click')
-    element.find('form').trigger('submit')
+    element.find('button').trigger('click')
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'Radio button chosen', 'government-gateway', { transport: 'beacon' }
@@ -38,7 +44,7 @@ describe('A radio group tracker', function () {
 
   it('tracks govuk-verify checked radio when clicking submit', function () {
     element.find('input[value="govuk-verify"]').trigger('click')
-    element.find('form').trigger('submit')
+    element.find('button').trigger('click')
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'Radio button chosen', 'govuk-verify', { transport: 'beacon' }
@@ -52,7 +58,7 @@ describe('A radio group tracker', function () {
     }
     tracker.trackVerifyUser(element, data)
     element.find('input[value="govuk-verify"]').trigger('click')
-    element.find('form').trigger('submit')
+    element.find('button').trigger('click')
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'verify-hint', 'shown', { transport: 'beacon' }
@@ -75,7 +81,7 @@ describe('A radio group tracker', function () {
       'verify-hint', 'shown', { transport: 'beacon' }
     )
     element.find('input[value="govuk-verify"]').trigger('click')
-    element.find('form').trigger('submit')
+    element.find('button').trigger('click')
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'Radio button chosen', 'govuk-verify', { transport: 'beacon' }
@@ -92,7 +98,7 @@ describe('A radio group tracker', function () {
     }
     tracker.trackVerifyUser(element, data)
     element.find('input[value="govuk-verify"]').trigger('click')
-    element.find('form').trigger('submit')
+    element.find('button').trigger('click')
 
     expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalledWith(
       'verify-hint', 'shown', { transport: 'beacon' }
@@ -109,7 +115,7 @@ describe('A radio group tracker', function () {
     var data = null
     tracker.trackVerifyUser(element, data)
     element.find('input[value="govuk-verify"]').trigger('click')
-    element.find('form').trigger('submit')
+    element.find('button').trigger('click')
 
     expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalledWith(
       'verify-hint', 'shown', { transport: 'beacon' }
@@ -126,7 +132,7 @@ describe('A radio group tracker', function () {
     var data = 'string'
     tracker.trackVerifyUser(element, data)
     element.find('input[value="govuk-verify"]').trigger('click')
-    element.find('form').trigger('submit')
+    element.find('button').trigger('click')
 
     expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalledWith(
       'verify-hint', 'shown', { transport: 'beacon' }
@@ -140,7 +146,7 @@ describe('A radio group tracker', function () {
   })
 
   it('tracks no choice when clicking submit and checked nothing', function () {
-    element.find('form').trigger('submit')
+    element.find('button').trigger('click')
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'Radio button chosen', 'submitted-without-choosing', { transport: 'beacon' }
@@ -160,8 +166,8 @@ describe('A radio group tracker', function () {
       $form.attr('data-tracking-domain', 'test.service.gov.uk')
       $form.attr('data-tracking-name', 'testTracker')
 
-      tracker = new GOVUK.Modules.TrackRadioGroup()
-      tracker.start($form)
+      tracker = new GOVUK.Modules.TrackRadioGroup($form[0])
+      tracker.init()
     })
 
     it('adds a linked tracker as the module is started', function () {
@@ -172,7 +178,7 @@ describe('A radio group tracker', function () {
 
     it('sends an event to the linked tracker when the form is submitted', function () {
       $form.find('input[value="govuk-verify"]').trigger('click')
-      $form.trigger('submit')
+      $form.find('button').trigger('click')
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'Radio button chosen', 'govuk-verify-with-hint', { trackerName: 'testTracker', transport: 'beacon' }


### PR DESCRIPTION
## What

This change removes jQuery from the `track-radio-group.js` module and replaces it with vanilla JS

## Why

We're removing jQuery from GOV.UK

[Trello](https://trello.com/c/IoQlSiAk/276-remove-jquery-from-government-frontend-track-radio-groupjs-reasonable-js-knowledge-required)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
