### PR TITLE
Add notification button to publisher metadata

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,6 +39,7 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/radio';
 @import 'govuk_publishing_components/components/related-navigation';
 @import 'govuk_publishing_components/components/share-links';
+@import 'govuk_publishing_components/components/single-page-notification-button';
 @import 'govuk_publishing_components/components/step-by-step-nav';
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/step-by-step-nav-related';

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -1,13 +1,22 @@
 <%
   published ||= false
-  history ||= []
-  history = Array(history)
+  data ||= {}
   last_updated ||= false
   link_to_history ||= false
-  history_class = "app-c-published-dates--history" if history.any?
+  notification_button_visible ||= false
+
+  history ||= []
+  history = Array(history)
+  id = "history" if history.any?
+  data[:module] = "gem-toggle" if history.any?
+
+  classes = %w(app-c-published-dates)
+  classes << "app-c-published-dates--history" if history.any?
+  # the wrapper needs some extra margin on the bottom when it is followed by the page notification button
+  classes << GovukPublishingComponents::Presenters::SharedHelper.new({margin_bottom: 2}).get_margin_bottom if notification_button_visible
 %>
 <% if published || last_updated %>
-<div class="app-c-published-dates <%= history_class %>" <% if history.any? %>id="history" data-module="gem-toggle"<% end %> lang="en">
+<%= content_tag :div, class: classes, data: data, id: id, lang: "en" do %>
   <% if published %>
     <%= t('components.published_dates.published', date: published) %>
   <% end %>
@@ -33,5 +42,5 @@
       </div>
     <% end %>
   <% end %>
-</div>
+<% end %>
 <% end %>

--- a/app/views/components/_publisher-metadata.html.erb
+++ b/app/views/components/_publisher-metadata.html.erb
@@ -5,10 +5,13 @@
   other ||= {}
   other_has_values = other.values.compact.reject(&:blank?).any?
   metadata = [published, last_updated]
+  base_path ||= nil
+  notification_button_visible = base_path && local_assigns.include?(:include_notification_button) && link_to_history
 %>
 <% if metadata.any? || other_has_values %>
   <div class="app-c-publisher-metadata" lang="en">
-    <%= render 'components/published-dates', published: published, last_updated: last_updated, link_to_history: link_to_history %>
+    <%= render 'components/published-dates', published: published, last_updated: last_updated, link_to_history: link_to_history, notification_button_visible: notification_button_visible %>
+    <%= render 'govuk_publishing_components/components/single_page_notification_button', base_path: base_path if notification_button_visible %>
     <% if other_has_values %>
       <div class="app-c-publisher-metadata__other">
         <dl data-module="gem-track-click">

--- a/app/views/components/docs/publisher-metadata.yml
+++ b/app/views/components/docs/publisher-metadata.yml
@@ -89,3 +89,17 @@ examples:
             - <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>
     context:
       right_to_left: true
+  with_single_page_notification_button:
+    description: |
+      The component can render with a single page email notification button which allows the user to subscribe to email notifications about the current page. The button should only appear on pages with an update history (therefore it has been set to appear only if `link_to_history` is true).
+
+      In the initial stages, there is a requirement to control which pages the button appears on – hence the presence of an additional `include_notification_button` flag.
+    data:
+      published: 31 July 2017
+      last_updated: 20 September 2017
+      link_to_history: true
+      include_notification_button: true
+      base_path: '/the-current-page'
+      other:
+        from:
+          - <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>

--- a/test/components/publisher_metadata_test.rb
+++ b/test/components/publisher_metadata_test.rb
@@ -72,4 +72,23 @@ class PublisherMetadataTest < ComponentTestCase
     assert_select ".app-c-publisher-metadata__other a[href='/government/collections/civil-justice-statistics-quarterly']", text: "Civil justice statistics quarterly"
     assert_select ".app-c-publisher-metadata__other a[href='/government/collections/offender-management-statistics-quarterly']", text: "Offender management statistics quarterly"
   end
+
+  test "can render the component with a single page notification button, when link_to_history is true and base_path is present" do
+    render_component(other: { from: ["<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"] }, published: "31 July 2017", last_updated: "20 September 2017", link_to_history: true, include_notification_button: true, base_path: "/current-page")
+
+    assert_select ".app-c-publisher-metadata .gem-c-single-page-notification-button"
+    assert_select ".app-c-publisher-metadata .gem-c-single-page-notification-button input[type='hidden'][value='/current-page']"
+  end
+
+  test "does not render a single page notification button when link_to_history is not present" do
+    render_component(other: { from: ["<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"] }, published: "31 July 2017", last_updated: "20 September 2017", include_notification_button: true, base_path: "/current-page")
+
+    assert_select ".app-c-publisher-metadata .gem-c-single-page-notification-button", false
+  end
+
+  test "does not render a single page notification button when base_path is not present" do
+    render_component(other: { from: ["<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"] }, published: "31 July 2017", last_updated: "20 September 2017", link_to_history: true, include_notification_button: true)
+
+    assert_select ".app-c-publisher-metadata .gem-c-single-page-notification-button", false
+  end
 end


### PR DESCRIPTION
Add the single page notification button to the version of the publisher
metadata component that includes a "See all updates" link (so, when
`link_to_history` is `true`)

The notification button requires a `base_path` therefore a `base_path` must
be passed to the publisher metadata component where we want the button
to appear.

In the initial stages we do not want the button to appear everywhere
(i.e on every single page that uses a certain type of template or
publishing format) so there is an additional `include_notification_button`
flag to fine-tune where the button should appear.

-----

https://trello.com/c/oOpGMmxF/1126-put-the-single-page-signup-button-on-some-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
