### PR TITLE
Fix font colour being black

### DIFF
--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -13,7 +13,7 @@
 }
 
 .app-c-published-dates__change-history {
-  margin: 20px 0;
+  margin: govuk-spacing(4) 0;
 }
 
 .app-c-published-dates__list {
@@ -22,7 +22,7 @@
 
 .app-c-published-dates__change-item {
   list-style-type: none;
-  margin-bottom: 10px;
+  margin-bottom: govuk-spacing(2);
 }
 
 .app-c-published-dates__change-date {

--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -1,6 +1,7 @@
 .app-c-published-dates {
   direction: ltr;
   line-height: 1.45em;
+  color: govuk-colour("black");
 }
 
 .app-c-published-dates__toggle {


### PR DESCRIPTION
It should be #0b0c0c as per our designs.

Fixes https://github.com/alphagov/government-frontend/issues/2278

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## Before

![](https://user-images.githubusercontent.com/424772/141298224-944bbf44-f279-4316-9ba8-af8942f33445.png)

## After
![Screenshot 2021-11-11 at 1 26 05 pm](https://user-images.githubusercontent.com/424772/141306019-cb4c84cd-bb1b-488b-bf11-07af449ab463.png)


