### PR TITLE
Restore check for window.ga

### DIFF
--- a/app/assets/javascripts/modules/set-ga-client-id-on-form.js
+++ b/app/assets/javascripts/modules/set-ga-client-id-on-form.js
@@ -8,11 +8,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   SetGaClientIdOnForm.prototype.init = function () {
     var form = this.$module
-    window.ga(function (tracker) {
-      var clientId = tracker.get('clientId')
-      var action = form.getAttribute('action')
-      form.setAttribute('action', action + '?_ga=' + clientId)
-    })
+
+    if (window.ga) {
+      window.ga(function (tracker) {
+        var clientId = tracker.get('clientId')
+        var action = form.getAttribute('action')
+        form.setAttribute('action', action + '?_ga=' + clientId)
+      })
+    }
   }
 
   Modules.SetGaClientIdOnForm = SetGaClientIdOnForm


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Restores a check for the `window.ga` object to this script. This problem is currently causing a smokey test to fail.

This script is used on pages like https://www.gov.uk/check-income-tax-current-year/sign-in/prove-identity to add the ga client ID to the form action attribute.

## Why

This was unintentionally removed in a recent change: https://github.com/alphagov/government-frontend/pull/2276

## Visual changes
None.