### PR TITLE
Add the single page notification button to publication template

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,6 +6,7 @@
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/radio
+//= require govuk_publishing_components/components/single-page-notification-button
 //= require govuk_publishing_components/components/step-by-step-nav
 
 //= require_tree ./modules

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -42,6 +42,7 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/radio';
 @import 'govuk_publishing_components/components/related-navigation';
 @import 'govuk_publishing_components/components/share-links';
+@import 'govuk_publishing_components/components/single-page-notification-button';
 @import 'govuk_publishing_components/components/step-by-step-nav';
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/step-by-step-nav-related';

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -134,6 +134,10 @@ private
       return
     end
 
+    # use these and `@content_item.base_path` in the template
+    @notification_button_visible = in_single_page_notifications_trial?
+    @include_single_page_notification_button_js = account_session_header.present?
+
     request.variant = :print if params[:variant] == "print"
 
     respond_to do |format|
@@ -205,6 +209,13 @@ private
   def set_account_vary_header
     # Override the default from GovukPersonalisation::ControllerConcern so pages are cached on each flash message
     # variation, rather than caching pages per user
-    response.headers["Vary"] = [response.headers["Vary"], "GOVUK-Account-Session-Flash"].compact.join(", ")
+    response.headers["Vary"] = [response.headers["Vary"], "GOVUK-Account-Session-Exists", "GOVUK-Account-Session-Flash"].compact.join(", ")
+  end
+
+  def in_single_page_notifications_trial?
+    %w[
+      /government/publications/open-standards-for-government
+      /government/publications/identity-proofing-and-verification-of-an-individual
+    ].include? @content_item.base_path
   end
 end

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -4,10 +4,13 @@
   history = Array(history)
   last_updated ||= false
   link_to_history ||= false
-  history_class = "app-c-published-dates--history" if history.any?
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  classes = %w(app-c-published-dates)
+  classes << "app-c-published-dates--history" if history.any?
+  classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
 %>
 <% if published || last_updated %>
-<div class="app-c-published-dates <%= history_class %>" <% if history.any? %>id="history" data-module="gem-toggle"<% end %> lang="en">
+<div class="<%= classes.join(' ') %>" <% if history.any? %>id="history" data-module="gem-toggle"<% end %> lang="en">
   <% if published %>
     <%= t('components.published_dates.published', date: published) %>
   <% end %>

--- a/app/views/components/docs/published-dates.yml
+++ b/app/views/components/docs/published-dates.yml
@@ -40,3 +40,9 @@ examples:
       - display_time: 14th October 2000
         note: Updated information on pupil premium reviews and what information schools need to publish on their websites.
         timestamp: 2000-10-14T15:42:37.000+00:00
+  with_custom_margin_bottom:
+    description: |
+      The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). By default, the component does not have a bottom margin.
+    data:
+      published: 1st January 1990
+      margin_bottom: 8

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -18,6 +18,12 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'govuk_publishing_components/components/single_page_notification_button', {
+  base_path: @content_item.base_path,
+  js_enhancement: @include_single_page_notification_button_js,
+  margin_bottom: 6,
+  button_location: "top",
+} if @notification_button_visible %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
@@ -53,8 +59,15 @@
       <%= render 'components/published-dates', {
         published: @content_item.published,
         last_updated: @content_item.updated,
-        history: @content_item.history
+        history: @content_item.history,
+        margin_bottom: 3
       } %>
+
+      <%= render 'govuk_publishing_components/components/single_page_notification_button', {
+        base_path: @content_item.base_path,
+        js_enhancement: @include_single_page_notification_button_js,
+        button_location: "bottom",
+      } if @notification_button_visible %>
     </div>
   </div>
   <%= render 'shared/sidebar_navigation' %>

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -1,7 +1,11 @@
+<%
+  metadata_component_options = @content_item.publisher_metadata
+  metadata_component_options[:margin_bottom] = 3 if @notification_button_visible
+%>
 <div class="govuk-grid-row">
   <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if @content_item.try(:logo) %>">
     <div class="govuk-grid-column-two-thirds metadata-column">
-      <%= render 'govuk_publishing_components/components/metadata', @content_item.publisher_metadata %>
+      <%= render 'govuk_publishing_components/components/metadata', metadata_component_options %>
     </div>
     <div class="govuk-grid-column-one-third">
       <% if @content_item.try(:logo) %>

--- a/test/components/published_dates_test.rb
+++ b/test/components/published_dates_test.rb
@@ -86,4 +86,9 @@ class PublishedDatesTest < ComponentTestCase
     assert_select ".app-c-published-dates--history a[href=\"#full-history\"][data-controls=\"full-history\"]"
     assert_select ".app-c-published-dates--history a[href=\"#full-history\"][data-expanded=\"false\"]"
   end
+
+  test "applies a custom margin-bottom class if margin_bottom is specified" do
+    render_component(published: "1st November 2000", margin_bottom: 5)
+    assert_select '.app-c-published-dates.govuk-\!-margin-bottom-5'
+  end
 end


### PR DESCRIPTION
This adds the [Single page notification button](https://components.publishing.service.gov.uk/component-guide/single_page_notification_button) to the `publication` template, after the metadata blocks at the top and bottom of the page.

We only want to launch with a couple of pages in the initial stages, therefore the button will initially show up only on the pages listed on `in_single_page_notifications_trial?` under `content_items_controller.rb`

| Top  | Bottom |
| ------------- | ------------- |
|<img width="386" alt="Screenshot 2021-11-18 at 12 19 40" src="https://user-images.githubusercontent.com/7116819/142414509-00553860-7261-4cf3-8f16-3e2197eac738.png"> | <img width="391" alt="Screenshot 2021-11-18 at 12 19 51" src="https://user-images.githubusercontent.com/7116819/142414530-847106e4-5180-4f21-a3be-4a76e0eb0aff.png"> |
| <img width="1031" alt="Screenshot 2021-11-18 at 12 19 08" src="https://user-images.githubusercontent.com/7116819/142414641-90d4adf3-70cd-4f0e-b555-7e9737cfae05.png"> |<img width="1009" alt="Screenshot 2021-11-18 at 12 19 25" src="https://user-images.githubusercontent.com/7116819/142414671-83237722-a136-49ae-9d37-cd0ad0fabd2c.png"> |



------

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
