### PR TITLE
Fix variable scope of context boolean

### DIFF
--- a/app/views/content_items/_context_and_title.html.erb
+++ b/app/views/content_items/_context_and_title.html.erb
@@ -1,4 +1,7 @@
-<% context_string =  t("content_item.schema_name.#{@content_item.document_type}", count: 1) %>
+<%
+  context_string =  t("content_item.schema_name.#{@content_item.document_type}", count: 1);
+  context_inside = false;
+ %>
 
 <% @content_item&.featured_attachments.each do |fa| %>
   <% return if !@content_item.attachment_details(fa).present? %>
@@ -17,7 +20,7 @@
 <%= render 'govuk_publishing_components/components/title',
    context: context_string,
    context_locale: t_locale_fallback("content_item.schema_name.#{@content_item.document_type}", count: 1),
-   context_inside: context_inside ||= false,
+   context_inside: context_inside,
    title: @content_item.title,
    average_title_length: "long"
  %>

--- a/test/views/content_items/attachments.html.erb_test.rb
+++ b/test/views/content_items/attachments.html.erb_test.rb
@@ -60,5 +60,6 @@ class ContentItemsAttachmentsTest < ActionView::TestCase
     )
 
     assert_includes rendered, "Correspondence overview:"
+    assert_select "h1 span"
   end
 end


### PR DESCRIPTION
In https://github.com/alphagov/government-frontend/pull/2238 we added the word overview to format titles where an attachment shared the name of the page. The intent was for this to appear inside the H1, using the context_inside parameter. Unfortunately a refactor after review meant that the variable was scoped too tightly and never available to the component call. This resolves that by initially setting the variable outside of the each loop, and adds extra testing to ensure it is there when necessary.

Sample affected url: https://www.gov.uk/government/consultations/call-for-evidence-to-inform-orbital-liability-and-insurance-policy

### Before:
![image](https://user-images.githubusercontent.com/31649453/142380503-4e7013dc-bab5-4e16-94cd-96a78383bc7c.png)


### After:
![image](https://user-images.githubusercontent.com/31649453/142380414-1978b98b-dd88-4cb0-a634-0fc9838a953d.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
