### PR TITLE
Update links get involved

### DIFF
--- a/app/views/content_items/get_involved.html.erb
+++ b/app/views/content_items/get_involved.html.erb
@@ -157,7 +157,7 @@
       items: [
         sanitize("<a href=\"https://history.blog.gov.uk\" rel=\"noopener\" class=\"govuk-link\">#{t('get_involved.gov_past')}</a>"),
         sanitize("<a href=\"https://quarterly.blog.gov.uk\" rel=\"noopener\" class=\"govuk-link\">#{ t('get_involved.civil_service_quarterly')}</a>"),
-        sanitize("<a href=\"/donating-to-charity\" rel=\"noopener\" class=\"govuk-link\">#{t('get_involved.make_donation')}</a>"),
+        sanitize("<a href=\"http://blogs.fco.gov.uk\" rel=\"noopener\" class=\"govuk-link\">#{t('get_involved.fco_bloggers')}</a>"),
         sanitize("<a href=\"https://gds.blog.gov.uk/\" rel=\"noopener\" class=\"govuk-link\">#{t('get_involved.gds_blog')}</a>"),
         sanitize("<a href=\"https://civilservice.blog.gov.uk/\" rel=\"noopener\" class=\"govuk-link\">#{t('get_involved.civil_service')}</a>"),
       ]
@@ -217,7 +217,6 @@
       sanitize("<a href=\"http://www.volunteerics.org/\" class=\"govuk-link\">#{t('get_involved.join_ics')}</a>"),
       sanitize("<a href=\"http://www.ourwatch.org.uk/knowledge-base-category/how-to-get-involved/\" class=\"govuk-link\">#{t('get_involved.neighbourhood_watch')}</a>"),
       sanitize("<a href=\"/donating-to-charity\" class=\"govuk-link\">#{t('get_involved.make_donation')}</a>"),
-      sanitize("<a href=\"https://gds.blog.gov.uk/\" class=\"govuk-link\">#{t('get_involved.gds_blog')}</a>"),
       sanitize("<a href=\"https://schoolsonline.britishcouncil.org/about-schools-online/about-programmes/connecting-classrooms\" rel=\"noopener\" class=\"govuk-link\">#{t('get_involved.school_overseas')}</a>"),
     ]
   } %>

--- a/app/views/content_items/get_involved.html.erb
+++ b/app/views/content_items/get_involved.html.erb
@@ -157,7 +157,7 @@
       items: [
         sanitize("<a href=\"https://history.blog.gov.uk\" rel=\"noopener\" class=\"govuk-link\">#{t('get_involved.gov_past')}</a>"),
         sanitize("<a href=\"https://quarterly.blog.gov.uk\" rel=\"noopener\" class=\"govuk-link\">#{ t('get_involved.civil_service_quarterly')}</a>"),
-        sanitize("<a href=\"http://blogs.fco.gov.uk\" rel=\"noopener\" class=\"govuk-link\">#{t('get_involved.fco_bloggers')}</a>"),
+        sanitize("<a href=\"http://blogs.fcdo.gov.uk\" rel=\"noopener\" class=\"govuk-link\">#{t('get_involved.fcdo_bloggers')}</a>"),
         sanitize("<a href=\"https://gds.blog.gov.uk/\" rel=\"noopener\" class=\"govuk-link\">#{t('get_involved.gds_blog')}</a>"),
         sanitize("<a href=\"https://civilservice.blog.gov.uk/\" rel=\"noopener\" class=\"govuk-link\">#{t('get_involved.civil_service')}</a>"),
       ]

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -631,7 +631,7 @@ ar:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -335,7 +335,7 @@ az:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -483,7 +483,7 @@ be:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -335,7 +335,7 @@ bg:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -335,7 +335,7 @@ bn:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -409,7 +409,7 @@ cs:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -631,7 +631,7 @@ cy:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -347,7 +347,7 @@ da:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -335,7 +335,7 @@ de:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -335,7 +335,7 @@ dr:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -335,7 +335,7 @@ el:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -335,7 +335,7 @@ en:
     closing_tomorrow: Closing tomorrow
     days_left: "%{number_of_days} days left"
     engage_with_gov: Engage with government
-    fco_bloggers: FCO bloggers
+    fcdo_bloggers: FCDO blogs
     follow: Follow a blog or social media channel
     follow_paragraph: For an instant way to interact with government departments, try their social media streams. These are listed under 'Follow us' on the department's home page. As well as access to blogs, audio, video and more, you can comment, debate and rate.
     follow_links: Some active government blogs include

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -335,7 +335,7 @@ es-419:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -335,7 +335,7 @@ es:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -335,7 +335,7 @@ et:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -335,7 +335,7 @@ fa:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -335,7 +335,7 @@ fi:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -335,7 +335,7 @@ fr:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -483,7 +483,7 @@ gd:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -335,7 +335,7 @@ gu:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -335,7 +335,7 @@ he:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -335,7 +335,7 @@ hi:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -483,7 +483,7 @@ hr:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -335,7 +335,7 @@ hu:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -335,7 +335,7 @@ hy:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -335,7 +335,7 @@ id:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -335,7 +335,7 @@ is:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -335,7 +335,7 @@ it:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -335,7 +335,7 @@ ja:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -284,7 +284,7 @@ ka:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -335,7 +335,7 @@ kk:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -335,7 +335,7 @@ ko:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -409,7 +409,7 @@ lt:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -335,7 +335,7 @@ lv:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -284,7 +284,7 @@ ms:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -483,7 +483,7 @@ mt:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -335,7 +335,7 @@ ne:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -335,7 +335,7 @@ nl:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -335,7 +335,7 @@
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -335,7 +335,7 @@ pa-pk:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -335,7 +335,7 @@ pa:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -483,7 +483,7 @@ pl:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -335,7 +335,7 @@ ps:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -335,7 +335,7 @@ pt:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -409,7 +409,7 @@ ro:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -483,7 +483,7 @@ ru:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -335,7 +335,7 @@ si:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -409,7 +409,7 @@ sk:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -483,7 +483,7 @@ sl:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -335,7 +335,7 @@ so:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -335,7 +335,7 @@ sq:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -483,7 +483,7 @@ sr:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -335,7 +335,7 @@ sv:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -335,7 +335,7 @@ sw:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -335,7 +335,7 @@ ta:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -335,7 +335,7 @@ th:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -335,7 +335,7 @@ tk:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -335,7 +335,7 @@ tr:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -483,7 +483,7 @@ uk:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -335,7 +335,7 @@ ur:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -335,7 +335,7 @@ uz:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -335,7 +335,7 @@ vi:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -335,7 +335,7 @@ yi:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -335,7 +335,7 @@ zh-hk:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -335,7 +335,7 @@ zh-tw:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -335,7 +335,7 @@ zh:
     closing_tomorrow:
     days_left:
     engage_with_gov:
-    fco_bloggers:
+    fcdo_bloggers:
     follow:
     follow_paragraph:
     gds_blog:


### PR DESCRIPTION
## What

Update links on [get involved](https://www.gov.uk/government/get-involved) page

## Why

Restore links to [match previous Content](https://web.archive.org/web/20211113224017/http://www.gov.uk/government/get-involved)
 
## Visuals

### Previous Content > Updated to match

![Screenshot 2021-11-19 at 16 26 36](https://user-images.githubusercontent.com/71266765/142657252-7a904545-f996-473f-b5cc-1fcb61739941.png)

![Screenshot 2021-11-19 at 16 26 16](https://user-images.githubusercontent.com/71266765/142657261-5eeb230e-14d3-4b24-b3ff-698cf70e78bf.png)

## Before > After

![Screenshot 2021-11-19 at 16 48 13](https://user-images.githubusercontent.com/71266765/142660440-afd853c1-1d38-409a-ad3a-993779c2ceb0.png)

![Screenshot 2021-11-19 at 16 47 58](https://user-images.githubusercontent.com/71266765/142660449-48928e4f-5545-4ca8-8bb8-03ce45ddf520.png)

## Anything else

Updated 

_FCO Bloggers_ to 
_FCDO Blogs_ 
as department changed name.