### PR TITLE
Remove unused div from get involved inset text

### DIFF
--- a/app/views/content_items/get_involved.html.erb
+++ b/app/views/content_items/get_involved.html.erb
@@ -68,7 +68,6 @@
     <%# Attention to closing consultation  %>
     <%= render "govuk_publishing_components/components/inset_text", {
     } do %>
-      <div>
       <%= render "govuk_publishing_components/components/heading", {
         text: time_until_closure(@next_closing_consultation),
         heading_level: 3
@@ -77,7 +76,6 @@
         <%= @next_closing_consultation['title'] %>
       </p>
       <%= link_to t('get_involved.read_respond'), @next_closing_consultation['link'], class: "govuk-link" %>
-      </div>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
There appears to be a `<div>..</div>` that isn't necessary in the get involved page's "next closing" inset text component.

This was causing Smokey to fail on [this following selector](https://github.com/alphagov/smokey/blob/09fb94026e55061d4f1b4d870bde54db22b1cf3b/features/step_definitions/get_involved_page_steps.rb#L8).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
