### PR TITLE
Update publication pages

### DIFF
--- a/app/presenters/content_item/withdrawable.rb
+++ b/app/presenters/content_item/withdrawable.rb
@@ -5,7 +5,15 @@ module ContentItem
     end
 
     def page_title
-      withdrawn? ? "[Withdrawn] #{title}" : title
+      if withdrawn? && context_title? && publication_overview?
+        "[Withdrawn] #{context_title}: #{title}"
+      elsif withdrawn?
+        "[Withdrawn] #{title}"
+      elsif context_title? && publication_overview?
+        "#{context_title}: #{title}"
+      else
+        title
+      end
     end
 
     def withdrawal_notice_component
@@ -21,12 +29,31 @@ module ContentItem
 
   private
 
+    def context_title?
+      context_title.present?
+    end
+
+    def publication_overview?
+      publication_overview.present?
+    end
+
+    def publication_overview
+      overview = (I18n.exists?("content_item.#{schema_name}") == "publication" || "statistical_data_set")
+      overview.presence
+    end
+
     def withdrawal_notice
       content_item["withdrawn_notice"]
     end
 
     def withdrawal_notice_title
       "This #{withdrawal_notice_context.downcase} was withdrawn on #{withdrawal_notice_time}".html_safe
+    end
+
+    def context_title
+      if I18n.exists?("content_item.schema_name.#{document_type}", count: 1, locale: :en)
+        I18n.t("content_item.schema_name.#{document_type}", count: 1, locale: :en)
+      end
     end
 
     def withdrawal_notice_context

--- a/app/views/content_items/_context_and_title.html.erb
+++ b/app/views/content_items/_context_and_title.html.erb
@@ -1,26 +1,7 @@
-<%
-  context_string =  t("content_item.schema_name.#{@content_item.document_type}", count: 1);
-  context_inside = false;
- %>
-
-<% @content_item&.featured_attachments.each do |fa| %>
-  <% return if !@content_item.attachment_details(fa).present? %>
-  <% if @content_item.attachment_details(fa)['title'] == @content_item.title %>
-      <% content_for :title do %>
-        <%= t("content_item.schema_name.#{@content_item.document_type}.overview", count: 1) %>: <%= @content_item.title %>
-      <% end %>
-      <%
-         context_string =  t("content_item.schema_name.#{@content_item.document_type}.overview", count: 1) << ":"
-         context_inside = true
-      %>
-      <% break %>
-    <% end %>
-<% end %>
-
 <%= render 'govuk_publishing_components/components/title',
-   context: context_string,
-   context_locale: t_locale_fallback("content_item.schema_name.#{@content_item.document_type}", count: 1),
-   context_inside: context_inside,
+   context: t("content_item.schema_name.#{@content_item.document_type}", count: 1) << ":",
+   context_locale: t_locale_fallback("content_item.schema_name.#{@content_item.document_type}", count: 1) ,
+   context_inside: true,
    title: @content_item.title,
    average_title_length: "long"
  %>

--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -69,7 +69,7 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item("withdrawn_fatality_notice")
 
     assert page.has_title?(
-      "[Withdrawn] Sir George Pomeroy Colley killed in Boer War - Fatality notice - GOV.UK",
+      "[Withdrawn] Fatality notice: Sir George Pomeroy Colley killed in Boer War - Fatality notice - GOV.UK",
     )
 
     within ".gem-c-notice" do

--- a/test/presenters/content_item/withdrawable_test.rb
+++ b/test/presenters/content_item/withdrawable_test.rb
@@ -33,17 +33,26 @@ class ContentItemWithdrawableTest < ActiveSupport::TestCase
         content_item["title"]
       end
 
+      def schema_name
+        content_item["schema_name"]
+      end
+
+      def document_type
+        content_item["document_type"]
+      end
+
       def content_item
         {
           "title" => "Proportion of residents who do any walking or cycling (at local authority level) (CW010)",
           "withdrawn_notice" => {
             "withdrawn_at" => "2016-07-12T09:47:15Z",
           },
+          "document_type" => "statistical_data_set",
         }
       end
     end
 
-    assert_equal @withdrawable.page_title, "[Withdrawn] Proportion of residents who do any walking or cycling (at local authority level) (CW010)"
+    assert_equal @withdrawable.page_title, "[Withdrawn] Statistical data set: Proportion of residents who do any walking or cycling (at local authority level) (CW010)"
   end
 
   test "notice title and description are generated correctly" do

--- a/test/views/content_items/attachments.html.erb_test.rb
+++ b/test/views/content_items/attachments.html.erb_test.rb
@@ -43,23 +43,4 @@ class ContentItemsAttachmentsTest < ActionView::TestCase
     assert_includes rendered, "gem-c-govspeak"
     assert_includes rendered, "some html"
   end
-
-  test "renders overview title when attachment title matches parent" do
-    @content_item = PublicationPresenter.new(
-      { "document_type" => "correspondence",
-        "title" => "Matching",
-        "details" => { "attachments" => [{ "id" => "attachment_id",
-                                           "title" => "Matching",
-                                           "url" => "some/url" }],
-                       "featured_attachments" => %w[attachment_id] } },
-      "/publication",
-      ApplicationController.new.view_context,
-    )
-    render(
-      partial: "content_items/context_and_title",
-    )
-
-    assert_includes rendered, "Correspondence overview:"
-    assert_select "h1 span"
-  end
 end


### PR DESCRIPTION
## What

Apply the `context_inside` option to the [title component](https://components.publishing.service.gov.uk/component-guide/title) to all publications, remove the word "overview" yet keep translations.

## Why

Recently some work made the 'grey text' of publication pages `h1`.  This provided various benefits including for screen readers and tabs.  However, we only did this for pages where the title of the page and attachment are the same. For consistency this change applies to all publication pages.  So that we don't have some pages that operate in one way, and others that do it differently. Also it adds benefits.

## Visuals

![image](https://user-images.githubusercontent.com/71266765/143481620-3453bda0-508a-4c6f-aa82-952c14144954.png)

## Anything else

Checked against:
http://government-frontend.dev.gov.uk/government/consultations/appraisal-periods-consultation

Add context title
`Consultation outcome: Appraisal periods consultation`

http://government-frontend.dev.gov.uk/government/publications/information-superiority-jdn-213

Adds withdrawn and keep context title
`[Withdrawn] Guidance: Information superiority: more than managing information`

http://government-frontend.dev.gov.uk/government/organisations/department-of-health-and-social-care/about

No context title
`About us - Department of Health and Social Care`

http://government-frontend.dev.gov.uk/government/statistical-data-sets/cw010-proportion-of-residents-walking-or-cycling-at-least-once-a-month

Adds withdrawn and no context title (as not a publication or consultation)
`[Withdrawn] Proportion of residents who do any walking or cycling (at local authority level) (CW010)`

### Related PRs

https://github.com/alphagov/government-frontend/pull/2238/
https://github.com/alphagov/government-frontend/pull/2292