### PR TITLE
Import missing translations

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -631,6 +631,7 @@ ar:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -620,12 +620,10 @@ ar:
     field_of_operation: ساحة العمليات
     operations_in: العمليات الدائرة في %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -335,6 +335,7 @@ az:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -324,12 +324,10 @@ az:
     field_of_operation: Əməliyyat sahəsi
     operations_in: "%{location}-də olan əməliyyatlar"
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -483,6 +483,7 @@ be:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -472,12 +472,10 @@ be:
     field_of_operation: Сфера дзейнасці
     operations_in: Дзейнасць у %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -324,12 +324,10 @@ bg:
     field_of_operation: Област на действие
     operations_in: Операции в %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -335,6 +335,7 @@ bg:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -324,12 +324,10 @@ bn:
     field_of_operation: কার্যক্রমের ক্ষেত্র
     operations_in: "%{location}-এ পরিচালনা"
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -335,6 +335,7 @@ bn:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -409,6 +409,7 @@ cs:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -398,12 +398,10 @@ cs:
     field_of_operation: Oblast provozu
     operations_in: Operace v %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -631,6 +631,7 @@ cy:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -620,12 +620,10 @@ cy:
     field_of_operation: Maes gweithredu
     operations_in: Gweithrediadau yn %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -336,12 +336,10 @@ da:
     field_of_operation: Operationsområde
     operations_in: Handlinger i %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -347,6 +347,7 @@ da:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -335,6 +335,7 @@ de:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -324,12 +324,10 @@ de:
     field_of_operation: Tätigkeitsbereich
     operations_in: Tätigkeiten in %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -324,12 +324,10 @@ dr:
     field_of_operation: ساحهء عملیات
     operations_in: عملیات در%{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -335,6 +335,7 @@ dr:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -335,6 +335,7 @@ el:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -324,12 +324,10 @@ el:
     field_of_operation: Πεδίο λειτουργίας
     operations_in: Λειτουργίες στην τοποθεσία %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -324,12 +324,10 @@ en:
     field_of_operation: Field of operation
     operations_in: Operations in %{location}
   get_involved:
-    active_blogs: 'Some active government blogs include:'
     civil_service: Civil Service
     civil_service_quarterly: Civil Service Quarterly
     closed: Closed
     closed_consultations: Closed consultations in the past 12 months
-    closed_with_date: Closed %{closing_date}
     closes: Closes
     closing_today: Closing today
     closing_tomorrow: Closing tomorrow

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -337,8 +337,8 @@ en:
     engage_with_gov: Engage with government
     fcdo_bloggers: FCDO blogs
     follow: Follow a blog or social media channel
-    follow_paragraph: For an instant way to interact with government departments, try their social media streams. These are listed under 'Follow us' on the department's home page. As well as access to blogs, audio, video and more, you can comment, debate and rate.
     follow_links: Some active government blogs include
+    follow_paragraph: For an instant way to interact with government departments, try their social media streams. These are listed under 'Follow us' on the department's home page. As well as access to blogs, audio, video and more, you can comment, debate and rate.
     gds_blog: Government Digital Service
     gov_past: History of Government
     intro_paragraph:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -335,6 +335,7 @@ es-419:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -324,12 +324,10 @@ es-419:
     field_of_operation: Campo de operación
     operations_in: Operaciones en %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -324,12 +324,10 @@ es:
     field_of_operation: Campo de operación
     operations_in: Operaciones en %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -335,6 +335,7 @@ es:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -324,12 +324,10 @@ et:
     field_of_operation: Tegevusvaldkond
     operations_in: Toimingud asukohas %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -335,6 +335,7 @@ et:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -324,12 +324,10 @@ fa:
     field_of_operation: زمینه فعالیت
     operations_in: فعالیت در %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -335,6 +335,7 @@ fa:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -335,6 +335,7 @@ fi:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -324,12 +324,10 @@ fi:
     field_of_operation: Toiminta -alue
     operations_in: Toiminnot paikassa %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -324,12 +324,10 @@ fr:
     field_of_operation: Champ d'opération
     operations_in: Opérations à %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -335,6 +335,7 @@ fr:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -472,12 +472,10 @@ gd:
     field_of_operation: Réimse oibríochta
     operations_in: Idirbhearta I %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -483,6 +483,7 @@ gd:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -292,10 +292,55 @@ gu:
     publication_scheme_html: અમે અમારી %{link} માં સામાન્ય રીતે કઈ પ્રકારની માહિતી પ્રકાશિત કરીએ છીએ તે વાંચો.
     social_media_use_html: "%{link} માં અમારી નીતિ વાંચો."
     welsh_language_scheme_html: "%{link} પ્રત્યે અમારી પ્રતિબદ્ધતા અંગે જાણો."
+  email:
+    description_html:
+    subscribe_title:
+    unsubscribe_title:
   fatality_notice:
     alt_text: સંરક્ષણ મંત્રાલય ક્રેસ્ટ
     field_of_operation: કામગીરીનું ક્ષેત્ર
     operations_in: "%{location} માં સંચાલનો"
+  get_involved:
+    civil_service:
+    civil_service_quarterly:
+    closed:
+    closed_consultations:
+    closes:
+    closing_today:
+    closing_tomorrow:
+    days_left:
+    engage_with_gov:
+    fcdo_bloggers:
+    follow:
+    follow_links:
+    follow_paragraph:
+    gds_blog:
+    gov_past:
+    intro_paragraph:
+      body_html:
+      engage_with_government:
+      take_part:
+    join_ics:
+    make_donation:
+    more_ways:
+    neighbourhood_watch:
+    open_consultations:
+    page_heading:
+    page_title:
+    petition_paragraph:
+      body_html:
+      create_a_petition:
+    read_respond:
+    recent_outcomes:
+    recently_opened:
+    respond_to_consultations:
+    school_overseas:
+    search_all:
+    see_all_dept:
+    start_a_petition:
+    take_part:
+    take_part_suggestions:
+    your_views:
   gone:
     page_title: હવે ઉપલબ્ધ નથી
     published_in_error: આ પેજ ઉપરની માહિતી હટાવી દેવામાં આવી છે, કારણ કે તે ભૂલથી પ્રકાશિત કરાઇ હતી.
@@ -313,7 +358,72 @@ gu:
   i18n:
     direction:
   language_names:
+    ar:
+    az:
+    be:
+    bg:
+    bn:
+    cs:
+    cy:
+    da:
+    de:
+    dr:
+    el:
+    en:
+    es:
+    es-419:
+    et:
+    fa:
+    fi:
+    fr:
+    gd:
     gu: જોર્જિયન
+    he:
+    hi:
+    hr:
+    hu:
+    hy:
+    id:
+    is:
+    it:
+    ja:
+    ka:
+    kk:
+    ko:
+    lt:
+    lv:
+    ms:
+    mt:
+    ne:
+    nl:
+    'no':
+    pa:
+    pa-pk:
+    pl:
+    ps:
+    pt:
+    ro:
+    ru:
+    si:
+    sk:
+    sl:
+    so:
+    sq:
+    sr:
+    sv:
+    sw:
+    ta:
+    th:
+    tk:
+    tr:
+    uk:
+    ur:
+    uz:
+    vi:
+    yi:
+    zh:
+    zh-hk:
+    zh-tw:
   multi_page:
     next_page: આગળનું
     previous_page: પહેલાનું

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -234,8 +234,12 @@ gu:
       other: દસ્તાવેજો
     details: વિગતો
   brexit:
-    business_link: વ્યવસાયો માટે બ્રેક્ઝિટ માર્ગદર્શન
-    citizen_link: વ્યક્તિઓ અને પરિવારો માટે બ્રેક્ઝિટ માર્ગદર્શન
+    business_link:
+      path: "/guidance/brexit-guidance-for-businesses"
+      text: વ્યવસાયો માટે બ્રેક્ઝિટ માર્ગદર્શન
+    citizen_link:
+      path: "/guidance/brexit-guidance-for-individuals-and-families"
+      text: વ્યક્તિઓ અને પરિવારો માટે બ્રેક્ઝિટ માર્ગદર્શન
     heading_prefix: અલગ
   common:
     last_updated:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -9,7 +9,6 @@ gu:
       text: વ્યક્તિઓ અને પરિવારો માટે બ્રેક્ઝિટ માર્ગદર્શન
     heading_prefix: અલગ
   common:
-    last_updated:
     visit: 'મુલાકાત લો:'
   components:
     figure:
@@ -21,22 +20,8 @@ gu:
       see_all_updates: બધા અપડેટ્સ જુઓ
       show_all_updates: બધા અપડેટ્સ બતાવો
     publisher_metadata:
-      collections:
-      from:
       hide_all: બધા હાઈડ કરો
       show_all: બધા બતાવો
-    save_this_page:
-      add_page_button: તમારા સેવ કરેલ પેજિસમાં ઉમેરો
-      confirmations:
-        page_removed:
-          message: 'તમારા સેવ કરેલ પેજિસ માંથી તમે આને હટાવી દીધું છે '
-        page_saved:
-          message: 'તમારા સેવ કરેલ પેજિસ માંથી તમે આને ઉમેરી દીધું છે '
-      page_not_saved_heading: આ પેજને સેવ કરો, જેથી તમે અહીં પાછા આવી શકો
-      page_was_saved_heading: તમે આ પેજ સેવ કરેલ છે
-      remove_page_button: તમારા સેવ કરેલ પેજિસ માંથી હટાવો
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">તમે સેવ કરેલ પેજિસ જુઓ</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">સાઇન ઇન કરો</a> તમારા સેવ કરેલ પેજિસને જોવા માટે.
     share_links:
       share_this_page: આ પેજ શેર કરો
   consultation:
@@ -61,7 +46,6 @@ gu:
     original_consultation: મૂળ પરામર્શ
     ran_from: આ પરામર્શ થી ચાલુ
     respond_online: ઓનલાઇન પ્રતિભાવ આપો
-    'true': સાચું
     visit_soon: આ public&nbspના પરિણામો ડાઉનલોડ કરવા માટે આ પેજની જલ્દી મુલાકાત લો;ફીડબૅક.
     was: હતું
     ways_to_respond: પ્રતિભાવ આપવાની રીતો
@@ -376,22 +360,6 @@ gu:
       avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> દેશના કેટલાક ભાગોમાં કોઈ પણ પ્રકારનો પ્રવાસ ન કરવાની સલાહ આપે છે.
       avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> સંપૂર્ણ દેશમાં કોઈ પણ પ્રકારનો પ્રવાસ ન કરવાની સલાહ આપે છે.
     context: વિદેશ પ્રવાસ અંગે સલાહ
-    coronavirus_warning:
-      content_html: |
-        <p class="govuk-body">
-          <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">, <a href="https://www.gov.scot/coronavirus-covid-19/">સ્કોટલેંડ</a>, <a href="https://gov.wales/coronavirus-travel">વેલ્સ</a> અને <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">ઉત્તરી આયર્લેન્ડ</a>.
-        </p>
-        <p class="govuk-body">
-          COVID ના નવા વેરિયન્ટને UKમાં પ્રવેશ કરવાથી રોકવા માટે, તમારે <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">અંબર અથવા લાલ રંગની યાદીમાના દેશો</a>માં પ્રવાસ કરવો જોઈએ નહીં.</a>.
-        </p>
-        <p class="govuk-body">
-          કોઈ પણ દેશમાં રહેલ જોખમો સમજવા માટે <a href="/guidance/travel-advice-novel-coronavirus">વિદેશ, કોમનવેલ્થ અને વિકાસ કાર્યાલય મુસાફરી સલાહ</a>નું પાલન કરો.
-        </p>
-        <p class="govuk-body">
-          જ્યારે તમે પાછા ફરો ત્યારે, <a href="/uk-border-control">વિદેશથી UKમાં પ્રવેશ</a> કરવા અંગેના નિયમોનું પાલન કરો. (આયર્લેંડ સિવાય).
-        </p>
-      text_assistive: મહત્ત્વનું
-      title: કોરોનાવાઇરસ (COVID-19) પ્રવાસ
     still_current_at: પર હજુ પણ ચાલુ
     summary: સારાંશ
     updated: અપડેટ કરેલ

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -371,10 +371,10 @@ gu:
     release_date: રીલીઝ તારીખ
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> જરૂરી મુસાફરી સિવાય દેશના કેટલાક ભાગોમાં પ્રવાસ ન કરવાની સલાહ આપે છે.
-      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> જરૂરી મુસાફરી સિવાય, સંપૂર્ણ દેશમાં પ્રવાસ ન કરવાની સલાહ આપે છે.
-      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> દેશના કેટલાક ભાગોમાં કોઈ પણ પ્રકારનો પ્રવાસ ન કરવાની સલાહ આપે છે.
-      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> સંપૂર્ણ દેશમાં કોઈ પણ પ્રકારનો પ્રવાસ ન કરવાની સલાહ આપે છે.
+      avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> જરૂરી મુસાફરી સિવાય દેશના કેટલાક ભાગોમાં પ્રવાસ ન કરવાની સલાહ આપે છે.
+      avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> જરૂરી મુસાફરી સિવાય, સંપૂર્ણ દેશમાં પ્રવાસ ન કરવાની સલાહ આપે છે.
+      avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> દેશના કેટલાક ભાગોમાં કોઈ પણ પ્રકારનો પ્રવાસ ન કરવાની સલાહ આપે છે.
+      avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> સંપૂર્ણ દેશમાં કોઈ પણ પ્રકારનો પ્રવાસ ન કરવાની સલાહ આપે છે.
     context: વિદેશ પ્રવાસ અંગે સલાહ
     coronavirus_warning:
       content_html: |

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -1,5 +1,83 @@
+---
 gu:
+  brexit:
+    business_link:
+      path: "/guidance/brexit-guidance-for-businesses"
+      text: વ્યવસાયો માટે બ્રેક્ઝિટ માર્ગદર્શન
+    citizen_link:
+      path: "/guidance/brexit-guidance-for-individuals-and-families"
+      text: વ્યક્તિઓ અને પરિવારો માટે બ્રેક્ઝિટ માર્ગદર્શન
+    heading_prefix: અલગ
+  common:
+    last_updated:
+    visit: 'મુલાકાત લો:'
+  components:
+    figure:
+      image_credit: ઇમેજ ક્રેડિટ:%{credit}
+    published_dates:
+      hide_all_updates: બધા અપડેટ્સને હાઈડ કરો
+      last_updated: છેલ્લો અપડેટ %{date}
+      published: પ્રકાશિત થયો %{date}
+      see_all_updates: બધા અપડેટ્સ જુઓ
+      show_all_updates: બધા અપડેટ્સ બતાવો
+    publisher_metadata:
+      collections:
+      from:
+      hide_all: બધા હાઈડ કરો
+      show_all: બધા બતાવો
+    save_this_page:
+      add_page_button: તમારા સેવ કરેલ પેજિસમાં ઉમેરો
+      confirmations:
+        page_removed:
+          message: 'તમારા સેવ કરેલ પેજિસ માંથી તમે આને હટાવી દીધું છે '
+        page_saved:
+          message: 'તમારા સેવ કરેલ પેજિસ માંથી તમે આને ઉમેરી દીધું છે '
+      page_not_saved_heading: આ પેજને સેવ કરો, જેથી તમે અહીં પાછા આવી શકો
+      page_was_saved_heading: તમે આ પેજ સેવ કરેલ છે
+      remove_page_button: તમારા સેવ કરેલ પેજિસ માંથી હટાવો
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">તમે સેવ કરેલ પેજિસ જુઓ</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">સાઇન ઇન કરો</a> તમારા સેવ કરેલ પેજિસને જોવા માટે.
+    share_links:
+      share_this_page: આ પેજ શેર કરો
+  consultation:
+    and: અને
+    another_website_html: આ પરામર્શ %{closed} ના રોજ <a href="%{url}">અન્ય વેબસાઇટ</a> પર આયોજિત કરેલ છે
+    at: ખાતે
+    closes: તે સમાપ્ત થાય છે
+    closes_at: આ પરામર્શ ના રોજ સમાપ્ત થાય છે
+    complete_a: પૂર્ણ કરો
+    description: પરામર્શ વર્ણન
+    detail_of_feedback_received: પ્રાપ્ત ફીડબૅકની વિગતો
+    detail_of_outcome: પરિણામોની વિગતો
+    documents: દસ્તાવેજો
+    download_outcome: સંપૂર્ણ પરિણામ ડાઉનલોડ કરો
+    either: અથવા
+    email_to: 'અહીં ઈમેલ કરો:'
+    feedback_received: 'પ્રાપ્ત ફીડબૅક '
+    is_being: છે
+    not_open_yet: આ પરામર્શ હજુ સુધી શરૂ થયેલ નથી
+    'on':
+    opens: આ પરામર્શ શરૂ થાય છે
+    original_consultation: મૂળ પરામર્શ
+    ran_from: આ પરામર્શ થી ચાલુ
+    respond_online: ઓનલાઇન પ્રતિભાવ આપો
+    'true': સાચું
+    visit_soon: આ public&nbspના પરિણામો ડાઉનલોડ કરવા માટે આ પેજની જલ્દી મુલાકાત લો;ફીડબૅક.
+    was: હતું
+    ways_to_respond: પ્રતિભાવ આપવાની રીતો
+    write_to: 'ને લખો:'
+  contact:
+    email: ઈમેલ
+    find_call_charges: કૉલ ચાર્જિસ અંગે શોધો
+    online: ઓનલાઇન
+    phone: ફોન
+    webchat: વેબચેટ
   content_item:
+    coming_soon: આ દસ્તાવેજ ના રોજ પ્રકાશિત થશે
+    contents: વિષયવસ્તુ
+    metadata:
+      published: પ્રકાશિત
+      updated: અપડેટ થયેલ
     schema_name:
       aaib_report:
         one: હવાઈ અકસ્માતોની તપાસનો શાખા અહેવાલ
@@ -223,98 +301,11 @@ gu:
       written_statement:
         one: સંસદમાં લેખિત નિવેદન
         other: સંસદમાં લેખિત નિવેદનો
-    coming_soon: આ દસ્તાવેજ ના રોજ પ્રકાશિત થશે
-    contents: વિષયવસ્તુ
-    metadata:
-      published: પ્રકાશિત
-      updated: અપડેટ થયેલ
-  publication:
-    documents:
-      one: દસ્તાવેજ
-      other: દસ્તાવેજો
-    details: વિગતો
-  brexit:
-    business_link:
-      path: "/guidance/brexit-guidance-for-businesses"
-      text: વ્યવસાયો માટે બ્રેક્ઝિટ માર્ગદર્શન
-    citizen_link:
-      path: "/guidance/brexit-guidance-for-individuals-and-families"
-      text: વ્યક્તિઓ અને પરિવારો માટે બ્રેક્ઝિટ માર્ગદર્શન
-    heading_prefix: અલગ
-  common:
-    last_updated:
-    visit: 'મુલાકાત લો:'
-  components:
-    figure:
-      image_credit: ઇમેજ ક્રેડિટ:%{credit}
-    published_dates:
-      hide_all_updates: બધા અપડેટ્સને હાઈડ કરો
-      last_updated: છેલ્લો અપડેટ %{date}
-      published: પ્રકાશિત થયો %{date}
-      see_all_updates: બધા અપડેટ્સ જુઓ
-      show_all_updates: બધા અપડેટ્સ બતાવો
-    publisher_metadata:
-      collections:
-      from:
-      hide_all: બધા હાઈડ કરો
-      show_all: બધા બતાવો
-    save_this_page:
-      add_page_button: તમારા સેવ કરેલ પેજિસમાં ઉમેરો
-      confirmations:
-        page_removed:
-          message: 'તમારા સેવ કરેલ પેજિસ માંથી તમે આને હટાવી દીધું છે '
-        page_saved:
-          message: 'તમારા સેવ કરેલ પેજિસ માંથી તમે આને ઉમેરી દીધું છે '
-      page_not_saved_heading: આ પેજને સેવ કરો, જેથી તમે અહીં પાછા આવી શકો
-      page_was_saved_heading: તમે આ પેજ સેવ કરેલ છે
-      remove_page_button: તમારા સેવ કરેલ પેજિસ માંથી હટાવો
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">તમે
-        સેવ કરેલ પેજિસ જુઓ</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">સાઇન
-        ઇન કરો</a> તમારા સેવ કરેલ પેજિસને જોવા માટે.
-    share_links:
-      share_this_page: આ પેજ શેર કરો
-  consultation:
-    and: અને
-    another_website_html: આ પરામર્શ %{closed} ના રોજ <a href="%{url}">અન્ય વેબસાઇટ</a>
-      પર આયોજિત કરેલ છે
-    at: ખાતે
-    closes: તે સમાપ્ત થાય છે
-    closes_at: આ પરામર્શ ના રોજ સમાપ્ત થાય છે
-    complete_a: પૂર્ણ કરો
-    description: પરામર્શ વર્ણન
-    detail_of_feedback_received: પ્રાપ્ત ફીડબૅકની વિગતો
-    detail_of_outcome: પરિણામોની વિગતો
-    documents: દસ્તાવેજો
-    download_outcome: સંપૂર્ણ પરિણામ ડાઉનલોડ કરો
-    either: અથવા
-    email_to: 'અહીં ઈમેલ કરો:'
-    feedback_received: 'પ્રાપ્ત ફીડબૅક '
-    is_being: છે
-    not_open_yet: આ પરામર્શ હજુ સુધી શરૂ થયેલ નથી
-    'on':
-    opens: આ પરામર્શ શરૂ થાય છે
-    original_consultation: મૂળ પરામર્શ
-    ran_from: આ પરામર્શ થી ચાલુ
-    respond_online: ઓનલાઇન પ્રતિભાવ આપો
-    'true': સાચું
-    visit_soon: આ public&nbspના પરિણામો ડાઉનલોડ કરવા માટે આ પેજની જલ્દી મુલાકાત લો;ફીડબૅક.
-    was: હતું
-    ways_to_respond: પ્રતિભાવ આપવાની રીતો
-    write_to: 'ને લખો:'
-  contact:
-    email: ઈમેલ
-    find_call_charges: કૉલ ચાર્જિસ અંગે શોધો
-    online: ઓનલાઇન
-    phone: ફોન
-    webchat: વેબચેટ
   corporate_information_page:
     about_our_services_html: "%{link} શોધી કાઢો."
     corporate_information: કોર્પોરેટ માહિતી
-    personal_information_charter_html: અમારી %{link} માં સમજાવ્યું છે કે અમે તમારી
-      વ્યક્તિગત માહિતી સાથે કેવી રીતે વર્તીએ છીએ.
-    publication_scheme_html: અમે અમારી %{link} માં સામાન્ય રીતે કઈ પ્રકારની માહિતી
-      પ્રકાશિત કરીએ છીએ તે વાંચો.
+    personal_information_charter_html: અમારી %{link} માં સમજાવ્યું છે કે અમે તમારી વ્યક્તિગત માહિતી સાથે કેવી રીતે વર્તીએ છીએ.
+    publication_scheme_html: અમે અમારી %{link} માં સામાન્ય રીતે કઈ પ્રકારની માહિતી પ્રકાશિત કરીએ છીએ તે વાંચો.
     social_media_use_html: "%{link} માં અમારી નીતિ વાંચો."
     welsh_language_scheme_html: "%{link} પ્રત્યે અમારી પ્રતિબદ્ધતા અંગે જાણો."
   fatality_notice:
@@ -323,8 +314,7 @@ gu:
     operations_in: "%{location} માં સંચાલનો"
   gone:
     page_title: હવે ઉપલબ્ધ નથી
-    published_in_error: આ પેજ ઉપરની માહિતી હટાવી દેવામાં આવી છે, કારણ કે તે ભૂલથી
-      પ્રકાશિત કરાઇ હતી.
+    published_in_error: આ પેજ ઉપરની માહિતી હટાવી દેવામાં આવી છે, કારણ કે તે ભૂલથી પ્રકાશિત કરાઇ હતી.
     title: તમે જે પેજ શોધો છો, તે હવે ઉપલબ્ધ નથી
   guide:
     pages_in_guide: આ માર્ગદર્શિકામાંના પૃષ્ઠો
@@ -334,12 +324,8 @@ gu:
       available_at: આ પ્રકાશન %{url} પર ઉપલબ્ધ છે
       copyright: "© ક્રાઉન કૉપીરાઇટ %{year}"
       isbn: 'ISBN:'
-      licence_html: આ પ્રકાશન ઓપન ગવર્નમેંટ લાઇસન્સ v3.0ની શરતો હેઠળ લાઇસન્સ પ્રાપ્ત
-        છે, સિવાય કે અન્યથા જણાવેલ હોય.લાઇસન્સ જોવા માટે, <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>ની
-        મુલાકાત લો અથવા ઇન્ફોર્મેશન પોલિસી ટીમ, ધ નેશનલ આર્કાઇવ્સ, કિઉ, લંડન TW- 4DU
-        ને લખો અથવા ઈમેલ કરો:<a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.
-      third_party: જ્યાં અમે કોઈ તૃતીય પક્ષની કૉપીરાઇટ માહિતી આપી છે, ત્યાં તમારે
-        સંબંધિત કૉપીરાઇટ ધારકોની પરવાનગી મેળવવી આવશ્યક રહેશે.
+      licence_html: આ પ્રકાશન ઓપન ગવર્નમેંટ લાઇસન્સ v3.0ની શરતો હેઠળ લાઇસન્સ પ્રાપ્ત છે, સિવાય કે અન્યથા જણાવેલ હોય.લાઇસન્સ જોવા માટે, <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>ની મુલાકાત લો અથવા ઇન્ફોર્મેશન પોલિસી ટીમ, ધ નેશનલ આર્કાઇવ્સ, કિઉ, લંડન TW- 4DU ને લખો અથવા ઈમેલ કરો:<a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.
+      third_party: જ્યાં અમે કોઈ તૃતીય પક્ષની કૉપીરાઇટ માહિતી આપી છે, ત્યાં તમારે સંબંધિત કૉપીરાઇટ ધારકોની પરવાનગી મેળવવી આવશ્યક રહેશે.
   i18n:
     direction:
   language_names:
@@ -348,6 +334,11 @@ gu:
     next_page: આગળનું
     previous_page: પહેલાનું
     print_entire_guide: સંપૂર્ણ માર્ગદર્શિકા પ્રિન્ટ કરો
+  publication:
+    details: વિગતો
+    documents:
+      one: દસ્તાવેજ
+      other: દસ્તાવેજો
   service_sign_in:
     continue: જારી રાખો
     error:
@@ -362,12 +353,9 @@ gu:
       speak_to_adviser: હવે સલાહકાર સાથે વાત કરો
       technical_problem: ટેક્નિકલ સમસ્યાને લીધે અત્યારે વેબચેટ ઉપલબ્ધ નથી.
   specialist_document:
-    pdo_alt_text: આ યોજનાનો લોગો એક કાળા રંગનો સ્ટેમ્પ છે, જેમાં ડેઝીગ્નેટેડ ઓરિજિન
-      UK પ્રોટેક્ટેડ શબ્દો છે
-    pgi_alt_text: આ યોજનાનો લોગો એક કાળા રંગનો સ્ટેમ્પ છે, જેમાં જ્યોગ્રાફિક ઓરિજિન
-      UK પ્રોટેક્ટેડ શબ્દો છે
-    tsg_alt_text: આ યોજનાનો લોગો એક કાળા રંગનો સ્ટેમ્પ છે, જેમાં ટ્રેડિશનલ સ્પેશિયાલિટી
-      UK પ્રોટેક્ટેડ શબ્દો છે
+    pdo_alt_text: આ યોજનાનો લોગો એક કાળા રંગનો સ્ટેમ્પ છે, જેમાં ડેઝીગ્નેટેડ ઓરિજિન UK પ્રોટેક્ટેડ શબ્દો છે
+    pgi_alt_text: આ યોજનાનો લોગો એક કાળા રંગનો સ્ટેમ્પ છે, જેમાં જ્યોગ્રાફિક ઓરિજિન UK પ્રોટેક્ટેડ શબ્દો છે
+    tsg_alt_text: આ યોજનાનો લોગો એક કાળા રંગનો સ્ટેમ્પ છે, જેમાં ટ્રેડિશનલ સ્પેશિયાલિટી UK પ્રોટેક્ટેડ શબ્દો છે
   speech:
     delivered_on: ના રોજ ડિલિવર થયું
     location: સ્થાન
@@ -383,18 +371,10 @@ gu:
     release_date: રીલીઝ તારીખ
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth
-        Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> જરૂરી મુસાફરી સિવાય દેશના
-        કેટલાક ભાગોમાં પ્રવાસ ન કરવાની સલાહ આપે છે.
-      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth
-        Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> જરૂરી મુસાફરી સિવાય, સંપૂર્ણ
-        દેશમાં પ્રવાસ ન કરવાની સલાહ આપે છે.
-      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">વિદેશી
-        - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> દેશના કેટલાક ભાગોમાં કોઈ પણ પ્રકારનો પ્રવાસ
-        ન કરવાની સલાહ આપે છે.
-      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">વિદેશી
-        - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> સંપૂર્ણ દેશમાં કોઈ પણ પ્રકારનો પ્રવાસ ન
-        કરવાની સલાહ આપે છે.
+      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> જરૂરી મુસાફરી સિવાય દેશના કેટલાક ભાગોમાં પ્રવાસ ન કરવાની સલાહ આપે છે.
+      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> જરૂરી મુસાફરી સિવાય, સંપૂર્ણ દેશમાં પ્રવાસ ન કરવાની સલાહ આપે છે.
+      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> દેશના કેટલાક ભાગોમાં કોઈ પણ પ્રકારનો પ્રવાસ ન કરવાની સલાહ આપે છે.
+      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> સંપૂર્ણ દેશમાં કોઈ પણ પ્રકારનો પ્રવાસ ન કરવાની સલાહ આપે છે.
     context: વિદેશ પ્રવાસ અંગે સલાહ
     coronavirus_warning:
       content_html: |
@@ -417,8 +397,7 @@ gu:
     updated: અપડેટ કરેલ
   unpublishing:
     page_title: હવે ઉપલબ્ધ નથી
-    summary: આ પેજ ઉપરની માહિતી હટાવી દેવામાં આવી છે, કારણ કે તે ભૂલથી પ્રકાશિત કરાઇ
-      હતી.
+    summary: આ પેજ ઉપરની માહિતી હટાવી દેવામાં આવી છે, કારણ કે તે ભૂલથી પ્રકાશિત કરાઇ હતી.
     title: તમે જે પેજ શોધો છો, તે હવે ઉપલબ્ધ નથી
   working_group:
     contact_details: સંપર્ક વિગતો

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -1,506 +1,421 @@
----
 gu:
-  brexit:
-    business_link:
-      path:
-      text:
-    citizen_link:
-      path:
-      text:
-    heading_prefix:
-  common:
-    visit:
-  components:
-    figure:
-      image_credit:
-    published_dates:
-      hide_all_updates:
-      last_updated:
-      published:
-      see_all_updates:
-      show_all_updates:
-    publisher_metadata:
-      hide_all:
-      show_all:
-    share_links:
-      share_this_page:
-  consultation:
-    and:
-    another_website_html:
-    at:
-    closes:
-    closes_at:
-    complete_a:
-    description:
-    detail_of_feedback_received:
-    detail_of_outcome:
-    documents:
-    download_outcome:
-    either:
-    email_to:
-    feedback_received:
-    is_being:
-    not_open_yet:
-    'on':
-    opens:
-    original_consultation:
-    ran_from:
-    respond_online:
-    visit_soon:
-    was:
-    ways_to_respond:
-    write_to:
-  contact:
-    email:
-    find_call_charges:
-    online:
-    phone:
-    webchat:
   content_item:
-    coming_soon:
-    contents:
-    metadata:
-      published:
-      updated:
     schema_name:
       aaib_report:
-        one:
-        other:
+        one: હવાઈ અકસ્માતોની તપાસનો શાખા અહેવાલ
+        other: હવાઈ અકસ્માતોની તપાસનો શાખા અહેવાલ
       announcement:
-        one:
-        other:
+        one: જાહેરાત
+        other: જાહેરાતો
       asylum_support_decision:
-        one:
-        other:
+        one: અસાયલમ સપોર્ટ ટ્રિબ્યુનલ નિર્ણય
+        other: અસાયલમ સપોર્ટ ટ્રિબ્યુનલ નિર્ણયો
       authored_article:
-        one:
-        other:
+        one: લેખિત લેખ
+        other: લેખિત લેખો
       business_finance_support_scheme:
-        one:
-        other:
+        one: વ્યાપાર નાણાંકીય સહાય યોજના
+        other: વ્યાપાર નાણાંકીય સહાય યોજનાઓ
       case_study:
-        one:
-        other:
+        one: કેસ સ્ટડી
+        other: કેસ સ્ટડીઝ
       closed_consultation:
-        one:
-        other:
-        overview:
+        one: બંધ થયેલ પરામર્શ
+        other: બંધ થયેલા પરામર્શ
       cma_case:
-        one:
-        other:
+        one: સ્પર્ધા અને માર્કેટ ઓથોરીટી કેસ
+        other: સ્પર્ધા અને માર્કેટ ઓથોરીટી કેસો
       coming_soon:
-        one:
-        other:
+        one: જલ્દી આવી રહ્યું છે
+        other: જલ્દી આવી રહ્યું છે
       consultation:
-        one:
-        other:
+        one: પરામર્શ
+        other: પરામર્શ
       consultation_outcome:
-        one:
-        other:
-        overview:
+        one: પરામર્શનો પરિણામ
+        other: પરમર્શના પરિણામો
       corporate_information_page:
-        one:
-        other:
+        one: માહિતી પૃષ્ઠ
+        other: માહિતી પૃષ્ઠો
       corporate_report:
-        one:
-        other:
-        overview:
+        one: કોર્પોરેટ અહેવાલ
+        other: કોર્પોરેટ અહેવાલો
       correspondence:
-        one:
-        other:
-        overview:
+        one: પત્રવ્યવહાર
+        other: પત્રવ્યવહાર
       countryside_stewardship_grant:
-        one:
-        other:
+        one: 'કન્ટ્રીસાઇડ સ્ટુઅર્ડશિપ ગ્રાન્ટ '
+        other: કન્ટ્રીસાઇડ સ્ટુઅર્ડશિપ ગ્રાન્ટ્સ
       decision:
-        one:
-        other:
-        overview:
+        one: નિર્ણય
+        other: નિર્ણયો
       detailed_guide:
-        one:
-        other:
+        one: માર્ગદર્શન
+        other: માર્ગદર્શન
       dfid_research_output:
-        one:
-        other:
+        one: વિકાસ આઉટપુટ માટે સંશોધન
+        other: વિકાસ આઉટપુટ્સ માટે સંશોધન
       document_collection:
-        one:
-        other:
+        one: સંગ્રહ
+        other: સંગ્રહો
       draft_text:
-        one:
-        other:
+        one: ડ્રાફ્ટ ટેક્સ્ટ
+        other: ડ્રાફ્ટ ટેક્સ્ટ્સ
       drug_safety_update:
-        one:
-        other:
+        one: ડ્રગ સુરક્ષા અપડેટ
+        other: ડ્રગ સુરક્ષા અપડેટ્સ
       employment_appeal_tribunal_decision:
-        one:
-        other:
+        one: રોજગાર અપીલ ટ્રિબ્યુનલ નિર્ણય
+        other: રોજગાર અપીલ ટ્રિબ્યુનલ નિર્ણયો
       employment_tribunal_decision:
-        one:
-        other:
+        one: રોજગાર ટ્રિબ્યુનલ નિર્ણય
+        other: રોજગાર ટ્રિબ્યુનલ નિર્ણયો
       esi_fund:
-        one:
-        other:
+        one: યુરોપીયન સ્ટ્રક્ચરલ એંડ ઈન્વેસ્ટમેન્ટ ફંડ (ESIF)
+        other: યુરોપીયન સ્ટ્રક્ચરલ એંડ ઈન્વેસ્ટમેન્ટ ફંડ્સ (ESIF)
       fatality_notice:
-        one:
-        other:
+        one: મૃત્યુ અંગેની સૂચના
+        other: મૃત્યુ અંગેની સૂચનાઓ
       foi_release:
-        one:
-        other:
-        overview:
+        one: માહિતીની સ્વતંત્રતા રીલીઝ
+        other: માહિતીની સ્વતંત્રતા રીલીઝ
       form:
-        one:
-        other:
-        overview:
+        one: પત્રક
+        other: પત્રકો
       government_response:
-        one:
-        other:
+        one: સરકારનો પ્રતિભાવ
+        other: સરકારના પ્રતિભાવો
       guidance:
-        one:
-        other:
-        overview:
+        one: માર્ગદર્શન
+        other: માર્ગદર્શન
       impact_assessment:
-        one:
-        other:
-        overview:
+        one: અસરનું મૂલ્યાંકન
+        other: અસરના મૂલ્યાંકનો
       imported:
-        one:
-        other:
+        one: આયાત કરેલ – પ્રતિક્ષા પ્રકાર
+        other: આયાત કરેલ – પ્રતિક્ષા પ્રકાર
       independent_report:
-        one:
-        other:
-        overview:
+        one: સ્વતંત્ર અહેવાલ
+        other: સ્વતંત્ર અહેવાલો
       international_development_fund:
-        one:
-        other:
+        one: આંતરરાષ્ટ્રીય વિકાસ ફંડિંગ
+        other: આંતરરાષ્ટ્રીય વિકાસ ફંડિંગ
       international_treaty:
-        one:
-        other:
-        overview:
+        one: આંતરરાષ્ટ્રીય સંધિ
+        other: આંતરરાષ્ટ્રીય સંધિઓ
       maib_report:
-        one:
-        other:
+        one: દરિયાઈ અકસ્માતની તપાસનો શાખા અહેવાલ
+        other: દરિયાઈ અકસ્માતની તપાસના શાખા અહેવાલો
       map:
-        one:
-        other:
-        overview:
+        one: નકશો
+        other: નકશાઓ
       medical_safety_alert:
-        one:
-        other:
+        one: દવાઓ અને તબીબી ઉપકરણો માટે ચેતવણીઓ અને રીકોલ
+        other: 'દવાઓ અને તબીબી ઉપકરણો માટે ચેતવણીઓ અને રીકોલ '
       national:
-        one:
-        other:
+        one: રાષ્ટ્રીય આંકડાની જાહેરાત
+        other: રાષ્ટ્રીય આંકડાની જાહેરાતો
       national_statistics:
-        one:
-        other:
-        overview:
+        one: રાષ્ટ્રીય આંકડા
+        other: રાષ્ટ્રીય આંકડા
       national_statistics_announcement:
-        one:
-        other:
+        one: રાષ્ટ્રીય આંકડાની જાહેરાત
+        other: રાષ્ટ્રીય આંકડાની જાહેરાતો
       news_article:
-        one:
-        other:
+        one: ન્યૂઝ આર્ટિકલ
+        other: ન્યૂઝ આર્ટિકલ્સ
       news_story:
-        one:
-        other:
+        one: ન્યૂઝ સ્ટોરી
+        other: ન્યૂઝ સ્ટોરીઝ
       notice:
-        one:
-        other:
-        overview:
+        one: સૂચના
+        other: સૂચનાઓ
       official:
-        one:
-        other:
+        one: અધિકૃત આંકડાની જાહેરાત
+        other: અધિકૃત આંકડાની જાહેરાતો
       official_statistics:
-        one:
-        other:
-        overview:
+        one: અધિકૃત આંકડા
+        other: અધિકૃત આંકડા
       official_statistics_announcement:
-        one:
-        other:
+        one: અધિકૃત આંકડાની જાહેરાત
+        other: અધિકૃત આંકડાની જાહેરાતો
       open_consultation:
-        one:
-        other:
-        overview:
+        one: ખુલ્લો પરામર્શ
+        other: ખુલ્લા પરામર્શ
       oral_statement:
-        one:
-        other:
+        one: સંસદમાં મૌખિક નિવેદન
+        other: સંસદમાં મૌખિક નિવેદનો
       policy:
-        one:
-        other:
+        one: નીતિ
+        other: નીતિઓ
       policy_paper:
-        one:
-        other:
-        overview:
+        one: પોલિસી પેપર
+        other: પોલિસી પેપર્સ
       press_release:
-        one:
-        other:
+        one: પ્રેસ રીલીઝ
+        other: પ્રેસ રીલીઝ
       promotional:
-        one:
-        other:
-        overview:
+        one: પ્રચાર સામગ્રી
+        other: પ્રચાર સામગ્રી
       publication:
-        one:
-        other:
+        one: પ્રકાશન
+        other: પ્રકાશનો
       raib_report:
-        one:
-        other:
+        one: રેલ અકસ્માતની તપાસનો શાખા અહેવાલ
+        other: રેલ અકસ્માતની તપાસના શાખા અહેવાલો
       regulation:
-        one:
-        other:
-        overview:
+        one: નિયમન
+        other: નિયમનો
       research:
-        one:
-        other:
-        overview:
+        one: સંશોધન અને વિશ્લેષણ
+        other: સંશોધન અને વિશ્લેષણ
       residential_property_tribunal_decision:
-        one:
-        other:
+        one: રહેઠાણ મિલકત ટ્રિબ્યુનલનો નિર્ણય
+        other: રહેઠાણ મિલકત ટ્રિબ્યુનલના નિર્ણયો
       service_sign_in:
-        one:
-        other:
+        one: 'સર્વિસ સાઇન ઇન '
+        other: સર્વિસ સાઇન ઇન
       service_standard_report:
-        one:
-        other:
+        one: સર્વિસ સ્ટાન્ડર્ડ રિપોર્ટ
+        other: સર્વિસ સ્ટાન્ડર્ડ રિપોર્ટ્સ
       speaking_notes:
-        one:
-        other:
+        one: સ્પીકિંગ નોટ્સ
+        other: સ્પીકિંગ નોટ્સ
       speech:
-        one:
-        other:
+        one: ભાષણ
+        other: ભાષણો
       standard:
-        one:
-        other:
-        overview:
+        one: સ્ટાન્ડર્ડ
+        other: સ્ટાન્ડર્ડ્સ
       statement_to_parliament:
-        one:
-        other:
+        one: સંસદમાં નિવેદન
+        other: સંસદમાં નિવેદનો
       statistical_data_set:
-        one:
-        other:
+        one: આંકડાકીય ડેટા સેટ
+        other: આંકડાકીય ડેટા સેટ્સ
       statistics_announcement:
-        one:
-        other:
+        one: આંકડા જારી કરવાની જાહેરાત
+        other: આંકડા જારી કરવાની જાહેરાતો
       statutory_guidance:
-        one:
-        other:
-        overview:
+        one: વૈધાનિક માર્ગદર્શન
+        other: વૈધાનિક માર્ગદર્શન
       take_part:
-        one:
-        other:
+        one: ભાગ લો
+        other: ભાગ લો
       tax_tribunal_decision:
-        one:
-        other:
+        one: ટૅક્સ અને ચાન્સરી ટ્રિબ્યુનલનો નિર્ણય
+        other: ટૅક્સ અને ચાન્સરી ટ્રિબ્યુનલના નિર્ણયો
       transcript:
-        one:
-        other:
+        one: ટ્રાન્સસ્ક્રિપ્ટ
+        other: ટ્રાન્સસ્ક્રિપ્ટ્સ
       transparency:
-        one:
-        other:
-        overview:
+        one: પારદર્શિતા ડેટા
+        other: પારદર્શિતા ડેટા
       utaac_decision:
-        one:
-        other:
+        one: વહીવટી અપીલ્સ ટ્રિબ્યુનલનો નિર્ણય
+        other: વહીવટી અપીલ્સ ટ્રિબ્યુનલના નિર્ણયો
       world_location_news_article:
-        one:
-        other:
+        one: ન્યૂઝ આર્ટિકલ
+        other: ન્યૂઝ આર્ટિકલ્સ
       world_news_story:
-        one:
-        other:
+        one: વૈશ્વિક ન્યૂઝ સ્ટોરી
+        other: વૈશ્વિક ન્યૂઝ સ્ટોરીઝ
       written_statement:
-        one:
-        other:
+        one: સંસદમાં લેખિત નિવેદન
+        other: સંસદમાં લેખિત નિવેદનો
+    coming_soon: આ દસ્તાવેજ ના રોજ પ્રકાશિત થશે
+    contents: વિષયવસ્તુ
+    metadata:
+      published: પ્રકાશિત
+      updated: અપડેટ થયેલ
+  publication:
+    documents:
+      one: દસ્તાવેજ
+      other: દસ્તાવેજો
+    details: વિગતો
+  brexit:
+    business_link: વ્યવસાયો માટે બ્રેક્ઝિટ માર્ગદર્શન
+    citizen_link: વ્યક્તિઓ અને પરિવારો માટે બ્રેક્ઝિટ માર્ગદર્શન
+    heading_prefix: અલગ
+  common:
+    last_updated:
+    visit: 'મુલાકાત લો:'
+  components:
+    figure:
+      image_credit: ઇમેજ ક્રેડિટ:%{credit}
+    published_dates:
+      hide_all_updates: બધા અપડેટ્સને હાઈડ કરો
+      last_updated: છેલ્લો અપડેટ %{date}
+      published: પ્રકાશિત થયો %{date}
+      see_all_updates: બધા અપડેટ્સ જુઓ
+      show_all_updates: બધા અપડેટ્સ બતાવો
+    publisher_metadata:
+      collections:
+      from:
+      hide_all: બધા હાઈડ કરો
+      show_all: બધા બતાવો
+    save_this_page:
+      add_page_button: તમારા સેવ કરેલ પેજિસમાં ઉમેરો
+      confirmations:
+        page_removed:
+          message: 'તમારા સેવ કરેલ પેજિસ માંથી તમે આને હટાવી દીધું છે '
+        page_saved:
+          message: 'તમારા સેવ કરેલ પેજિસ માંથી તમે આને ઉમેરી દીધું છે '
+      page_not_saved_heading: આ પેજને સેવ કરો, જેથી તમે અહીં પાછા આવી શકો
+      page_was_saved_heading: તમે આ પેજ સેવ કરેલ છે
+      remove_page_button: તમારા સેવ કરેલ પેજિસ માંથી હટાવો
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">તમે
+        સેવ કરેલ પેજિસ જુઓ</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">સાઇન
+        ઇન કરો</a> તમારા સેવ કરેલ પેજિસને જોવા માટે.
+    share_links:
+      share_this_page: આ પેજ શેર કરો
+  consultation:
+    and: અને
+    another_website_html: આ પરામર્શ %{closed} ના રોજ <a href="%{url}">અન્ય વેબસાઇટ</a>
+      પર આયોજિત કરેલ છે
+    at: ખાતે
+    closes: તે સમાપ્ત થાય છે
+    closes_at: આ પરામર્શ ના રોજ સમાપ્ત થાય છે
+    complete_a: પૂર્ણ કરો
+    description: પરામર્શ વર્ણન
+    detail_of_feedback_received: પ્રાપ્ત ફીડબૅકની વિગતો
+    detail_of_outcome: પરિણામોની વિગતો
+    documents: દસ્તાવેજો
+    download_outcome: સંપૂર્ણ પરિણામ ડાઉનલોડ કરો
+    either: અથવા
+    email_to: 'અહીં ઈમેલ કરો:'
+    feedback_received: 'પ્રાપ્ત ફીડબૅક '
+    is_being: છે
+    not_open_yet: આ પરામર્શ હજુ સુધી શરૂ થયેલ નથી
+    'on':
+    opens: આ પરામર્શ શરૂ થાય છે
+    original_consultation: મૂળ પરામર્શ
+    ran_from: આ પરામર્શ થી ચાલુ
+    respond_online: ઓનલાઇન પ્રતિભાવ આપો
+    'true': સાચું
+    visit_soon: આ public&nbspના પરિણામો ડાઉનલોડ કરવા માટે આ પેજની જલ્દી મુલાકાત લો;ફીડબૅક.
+    was: હતું
+    ways_to_respond: પ્રતિભાવ આપવાની રીતો
+    write_to: 'ને લખો:'
+  contact:
+    email: ઈમેલ
+    find_call_charges: કૉલ ચાર્જિસ અંગે શોધો
+    online: ઓનલાઇન
+    phone: ફોન
+    webchat: વેબચેટ
   corporate_information_page:
-    about_our_services_html:
-    corporate_information:
-    personal_information_charter_html:
-    publication_scheme_html:
-    social_media_use_html:
-    welsh_language_scheme_html:
-  email:
-    description_html:
-    subscribe_title:
-    unsubscribe_title:
+    about_our_services_html: "%{link} શોધી કાઢો."
+    corporate_information: કોર્પોરેટ માહિતી
+    personal_information_charter_html: અમારી %{link} માં સમજાવ્યું છે કે અમે તમારી
+      વ્યક્તિગત માહિતી સાથે કેવી રીતે વર્તીએ છીએ.
+    publication_scheme_html: અમે અમારી %{link} માં સામાન્ય રીતે કઈ પ્રકારની માહિતી
+      પ્રકાશિત કરીએ છીએ તે વાંચો.
+    social_media_use_html: "%{link} માં અમારી નીતિ વાંચો."
+    welsh_language_scheme_html: "%{link} પ્રત્યે અમારી પ્રતિબદ્ધતા અંગે જાણો."
   fatality_notice:
-    alt_text:
-    field_of_operation:
-    operations_in:
-  get_involved:
-    active_blogs:
-    civil_service:
-    civil_service_quarterly:
-    closed:
-    closed_consultations:
-    closed_with_date:
-    closes:
-    closing_today:
-    closing_tomorrow:
-    days_left:
-    engage_with_gov:
-    fcdo_bloggers:
-    follow:
-    follow_paragraph:
-    gds_blog:
-    gov_past:
-    intro_paragraph:
-      body_html:
-      engage_with_government:
-      take_part:
-    join_ics:
-    make_donation:
-    more_ways:
-    neighbourhood_watch:
-    open_consultations:
-    page_heading:
-    page_title:
-    petition_paragraph:
-      body_html:
-      create_a_petition:
-    read_respond:
-    recent_outcomes:
-    recently_opened:
-    respond_to_consultations:
-    school_overseas:
-    search_all:
-    see_all_dept:
-    start_a_petition:
-    take_part:
-    take_part_suggestions:
-    your_views:
+    alt_text: સંરક્ષણ મંત્રાલય ક્રેસ્ટ
+    field_of_operation: કામગીરીનું ક્ષેત્ર
+    operations_in: "%{location} માં સંચાલનો"
   gone:
-    page_title:
-    published_in_error:
-    title:
+    page_title: હવે ઉપલબ્ધ નથી
+    published_in_error: આ પેજ ઉપરની માહિતી હટાવી દેવામાં આવી છે, કારણ કે તે ભૂલથી
+      પ્રકાશિત કરાઇ હતી.
+    title: તમે જે પેજ શોધો છો, તે હવે ઉપલબ્ધ નથી
   guide:
-    pages_in_guide:
-    skip_to_contents:
+    pages_in_guide: આ માર્ગદર્શિકામાંના પૃષ્ઠો
+    skip_to_contents: માર્ગદર્શિકાની સામગ્રી પર જાઓ
   html_publication:
     print_meta_data:
-      available_at:
-      copyright:
-      isbn:
-      licence_html:
-      third_party:
+      available_at: આ પ્રકાશન %{url} પર ઉપલબ્ધ છે
+      copyright: "© ક્રાઉન કૉપીરાઇટ %{year}"
+      isbn: 'ISBN:'
+      licence_html: આ પ્રકાશન ઓપન ગવર્નમેંટ લાઇસન્સ v3.0ની શરતો હેઠળ લાઇસન્સ પ્રાપ્ત
+        છે, સિવાય કે અન્યથા જણાવેલ હોય.લાઇસન્સ જોવા માટે, <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>ની
+        મુલાકાત લો અથવા ઇન્ફોર્મેશન પોલિસી ટીમ, ધ નેશનલ આર્કાઇવ્સ, કિઉ, લંડન TW- 4DU
+        ને લખો અથવા ઈમેલ કરો:<a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.
+      third_party: જ્યાં અમે કોઈ તૃતીય પક્ષની કૉપીરાઇટ માહિતી આપી છે, ત્યાં તમારે
+        સંબંધિત કૉપીરાઇટ ધારકોની પરવાનગી મેળવવી આવશ્યક રહેશે.
   i18n:
     direction:
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu: ગુજરાતી
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    gu: જોર્જિયન
   multi_page:
-    next_page:
-    previous_page:
-    print_entire_guide:
-  publication:
-    details:
-    documents:
-      one:
-      other:
+    next_page: આગળનું
+    previous_page: પહેલાનું
+    print_entire_guide: સંપૂર્ણ માર્ગદર્શિકા પ્રિન્ટ કરો
   service_sign_in:
-    continue:
+    continue: જારી રાખો
     error:
-      option:
-      title:
+      option: કૃપા કરીને એક વિકલ્પ પસંદ કરો
+      title: તમે કોઈ વિકલ્પ પસંદ કરેલ નથી
   shared:
-    historically_political:
+    historically_political: આ %{government} હેઠળ પ્રકાશિત કરવામાં આવ્યું હતું.
     webchat:
-      available:
-      busy:
-      closed:
-      speak_to_adviser:
-      technical_problem:
+      available: ચેટ કરવા માટે સલાહકારો ઉપસ્થિત છે.
+      busy: તમામ વેબચેટ સલાહકારો અત્યારે વ્યસ્ત છે.
+      closed: વેબચેટ અત્યારે બંધ છે.
+      speak_to_adviser: હવે સલાહકાર સાથે વાત કરો
+      technical_problem: ટેક્નિકલ સમસ્યાને લીધે અત્યારે વેબચેટ ઉપલબ્ધ નથી.
   specialist_document:
-    pdo_alt_text:
-    pgi_alt_text:
-    tsg_alt_text:
+    pdo_alt_text: આ યોજનાનો લોગો એક કાળા રંગનો સ્ટેમ્પ છે, જેમાં ડેઝીગ્નેટેડ ઓરિજિન
+      UK પ્રોટેક્ટેડ શબ્દો છે
+    pgi_alt_text: આ યોજનાનો લોગો એક કાળા રંગનો સ્ટેમ્પ છે, જેમાં જ્યોગ્રાફિક ઓરિજિન
+      UK પ્રોટેક્ટેડ શબ્દો છે
+    tsg_alt_text: આ યોજનાનો લોગો એક કાળા રંગનો સ્ટેમ્પ છે, જેમાં ટ્રેડિશનલ સ્પેશિયાલિટી
+      UK પ્રોટેક્ટેડ શબ્દો છે
   speech:
-    delivered_on:
-    location:
-    written_on:
+    delivered_on: ના રોજ ડિલિવર થયું
+    location: સ્થાન
+    written_on: પર લખેલ
   statistics_announcement:
-    cancellation_date:
-    cancelled:
-    changed_date:
-    forthcoming:
-    previous_date:
-    proposed_date:
-    reason_for_change:
-    release_date:
+    cancellation_date: રદ કર્યાની તારીખ
+    cancelled: આંકડાનું પ્રકશન રદ થયું
+    changed_date: રીલીઝ તારીખ બદલવામાં આવી છે
+    forthcoming: આ આંકડાઓ રીલીઝ કરાશે
+    previous_date: પાછલી તારીખ
+    proposed_date: પ્રસ્તાવિત રીલીઝ
+    reason_for_change: પરીવર્તન માટેનું કારણ
+    release_date: રીલીઝ તારીખ
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts_html:
-      avoid_all_but_essential_travel_to_whole_country_html:
-      avoid_all_travel_to_parts_html:
-      avoid_all_travel_to_whole_country_html:
-    context:
-    still_current_at:
-    summary:
-    updated:
+      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth
+        Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> જરૂરી મુસાફરી સિવાય દેશના
+        કેટલાક ભાગોમાં પ્રવાસ ન કરવાની સલાહ આપે છે.
+      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth
+        Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> જરૂરી મુસાફરી સિવાય, સંપૂર્ણ
+        દેશમાં પ્રવાસ ન કરવાની સલાહ આપે છે.
+      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">વિદેશી
+        - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> દેશના કેટલાક ભાગોમાં કોઈ પણ પ્રકારનો પ્રવાસ
+        ન કરવાની સલાહ આપે છે.
+      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">વિદેશી
+        - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> સંપૂર્ણ દેશમાં કોઈ પણ પ્રકારનો પ્રવાસ ન
+        કરવાની સલાહ આપે છે.
+    context: વિદેશ પ્રવાસ અંગે સલાહ
+    coronavirus_warning:
+      content_html: |
+        <p class="govuk-body">
+          <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">, <a href="https://www.gov.scot/coronavirus-covid-19/">સ્કોટલેંડ</a>, <a href="https://gov.wales/coronavirus-travel">વેલ્સ</a> અને <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">ઉત્તરી આયર્લેન્ડ</a>.
+        </p>
+        <p class="govuk-body">
+          COVID ના નવા વેરિયન્ટને UKમાં પ્રવેશ કરવાથી રોકવા માટે, તમારે <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">અંબર અથવા લાલ રંગની યાદીમાના દેશો</a>માં પ્રવાસ કરવો જોઈએ નહીં.</a>.
+        </p>
+        <p class="govuk-body">
+          કોઈ પણ દેશમાં રહેલ જોખમો સમજવા માટે <a href="/guidance/travel-advice-novel-coronavirus">વિદેશ, કોમનવેલ્થ અને વિકાસ કાર્યાલય મુસાફરી સલાહ</a>નું પાલન કરો.
+        </p>
+        <p class="govuk-body">
+          જ્યારે તમે પાછા ફરો ત્યારે, <a href="/uk-border-control">વિદેશથી UKમાં પ્રવેશ</a> કરવા અંગેના નિયમોનું પાલન કરો. (આયર્લેંડ સિવાય).
+        </p>
+      text_assistive: મહત્ત્વનું
+      title: કોરોનાવાઇરસ (COVID-19) પ્રવાસ
+    still_current_at: પર હજુ પણ ચાલુ
+    summary: સારાંશ
+    updated: અપડેટ કરેલ
   unpublishing:
-    page_title:
-    summary:
-    title:
+    page_title: હવે ઉપલબ્ધ નથી
+    summary: આ પેજ ઉપરની માહિતી હટાવી દેવામાં આવી છે, કારણ કે તે ભૂલથી પ્રકાશિત કરાઇ
+      હતી.
+    title: તમે જે પેજ શોધો છો, તે હવે ઉપલબ્ધ નથી
   working_group:
-    contact_details:
-    policies:
+    contact_details: સંપર્ક વિગતો
+    policies: નીતિઓ

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -324,12 +324,10 @@ he:
     field_of_operation: תחום הפעולה
     operations_in: פעולות ב- %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -335,6 +335,7 @@ he:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -335,6 +335,7 @@ hi:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -324,12 +324,10 @@ hi:
     field_of_operation: संचालन का क्षेत्र
     operations_in: "%{location} में संचालन"
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -483,6 +483,7 @@ hr:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -472,12 +472,10 @@ hr:
     field_of_operation: Područje djelovanja
     operations_in: Operacije u %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -324,12 +324,10 @@ hu:
     field_of_operation: Működési terület
     operations_in: 'Tevékenységek itt: %{location}'
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -335,6 +335,7 @@ hu:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -335,6 +335,7 @@ hy:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -324,12 +324,10 @@ hy:
     field_of_operation: Գործունեության ոլորտ
     operations_in: Գործունեություն % {location}-ում
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -324,12 +324,10 @@ id:
     field_of_operation: Bidang operasi
     operations_in: Operasi di %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -335,6 +335,7 @@ id:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -335,6 +335,7 @@ is:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -324,12 +324,10 @@ is:
     field_of_operation: Starfsvið
     operations_in: Starfsemi á %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -324,12 +324,10 @@ it:
     field_of_operation: Campo operativo
     operations_in: Operazioni in %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -335,6 +335,7 @@ it:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -335,6 +335,7 @@ ja:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -324,12 +324,10 @@ ja:
     field_of_operation: 運用分野
     operations_in: "％{location} での操作"
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -371,10 +371,10 @@ ka:
     release_date: გამოშვების თარიღი
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველას წინააღმდეგ, გარდა ესენციური მოგზაურობებისა ქვეყნის ზოგიერთ ნაწილებში.
-      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველას წინააღმდეგ, გარდა ესენციური მოგზაურობებისა მთელს ქვეყანაში.
-      avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველა მოგზაურობების წინააღმდეგ ქვეყნის ზოგიერთ ნაწილებში.
-      avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველა მოგზაურობების წინააღმდეგ მთელ ქვეყანაში.
+      avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველას წინააღმდეგ, გარდა ესენციური მოგზაურობებისა ქვეყნის ზოგიერთ ნაწილებში.
+      avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველას წინააღმდეგ, გარდა ესენციური მოგზაურობებისა მთელს ქვეყანაში.
+      avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველა მოგზაურობების წინააღმდეგ ქვეყნის ზოგიერთ ნაწილებში.
+      avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველა მოგზაურობების წინააღმდეგ მთელ ქვეყანაში.
     context: უცხოეთში მოგზაურობის რჩევა
     coronavirus_warning:
       content_html: |

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -1,455 +1,418 @@
----
 ka:
   brexit:
-    business_link:
-      path:
-      text:
-    citizen_link:
-      path:
-      text:
-    heading_prefix:
+    business_link: ბრექსიტის სახელმძღვანელო ბიზნესებისთვის
+    citizen_link: ბრექსიტის სახელმძღვანელო ინდივიდუალებისთვის და ოჯახებისთვის
+    heading_prefix: არსებობს სხვადასხვა
   common:
-    visit:
+    last_updated:
+    visit: 'ეწვიეთ:'
   components:
     figure:
-      image_credit:
+      image_credit: 'სურათ: %{credit}'
     published_dates:
-      hide_all_updates:
-      last_updated:
-      published:
-      see_all_updates:
-      show_all_updates:
+      hide_all_updates: ყველა ცვლილების დაფარვა
+      last_updated: ბოლოს განახლდა %{date}
+      published: გამოქვეყნდა %{date}
+      see_all_updates: ყველა ცვლილების ნახვა
+      show_all_updates: ყველა ცვლილების ჩვენება
     publisher_metadata:
-      hide_all:
-      show_all:
+      collections:
+      from:
+      hide_all: ყველას დაფარვა
+      show_all: ყველას ჩვენება
+    save_this_page:
+      add_page_button: თქვენს შენახულ გვერდებში დამატება
+      confirmations:
+        page_removed:
+          message: თქვენ ეს ამოიღეთ თქვენი შენახული გვერდებიდან
+        page_saved:
+          message: თქვენ დაამატეთ ეს თქვენს შენახულ გვერდებს
+      page_not_saved_heading: შეინახეთ ეს გვერდი, რათა დაუბრუნდეთ მოგვიანებით
+      page_was_saved_heading: თქვენ შეინახეთ ეს გვერდი
+      remove_page_button: თქვენი შენახული გვერდებიდან ამოღება
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">თქვენი
+        შენახული გვერდების ნახვა</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">შესვლა</a>
+        თქვენი შენახული გვერდების სანახავად.
     share_links:
-      share_this_page:
+      share_this_page: ამ გვერდის გაზიარება
   consultation:
-    and:
-    another_website_html:
-    at:
-    closes:
-    closes_at:
-    complete_a:
-    description:
-    detail_of_feedback_received:
-    detail_of_outcome:
-    documents:
-    download_outcome:
-    either:
-    email_to:
-    feedback_received:
-    is_being:
-    not_open_yet:
+    and: და
+    another_website_html: ეს კონსულტაცია %{closed} ჩატარდა <a href="%{url}">სხვა ვებგვერდზე</a>
+    at: ზე
+    closes: იხურება
+    closes_at: ეს კონსულტაცია იხურება
+    complete_a: დასრულება
+    description: კონსულტაციის აღწერილობა
+    detail_of_feedback_received: ფიდბეკის დეტალი მიღებულია
+    detail_of_outcome: შედეგის დეტალი
+    documents: დოკუმენტები
+    download_outcome: სრული შედეგის გადმოწერა
+    either: ან
+    email_to: 'მიწერეთ ელ.ფოსტით:'
+    feedback_received: ფიდბეკი მიღებულია
+    is_being: არის
+    not_open_yet: ეს კონსულტაცია ჯერ არ გახსნილა
     'on':
-    opens:
-    original_consultation:
-    ran_from:
-    respond_online:
-    visit_soon:
-    was:
-    ways_to_respond:
-    write_to:
+    opens: ეს კონსულტაცია იხსნება
+    original_consultation: ორიგინალი კონსულტაცია
+    ran_from: ეს კონსულტაცია ამოიწურა
+    respond_online: ონლაინ პასუხი
+    'true': სიმართლე
+    visit_soon: ეწვიეთ გვერდს ისევ მალე, რათა გადმოწეროთ შედეგი ამ public&nbsp;ფიდბექისთვის.
+    was: იყო
+    ways_to_respond: პასუხის გზები
+    write_to: 'მიწერეთ:'
   contact:
-    email:
-    find_call_charges:
-    online:
-    phone:
-    webchat:
+    email: ელ.ფოსტა
+    find_call_charges: გაიგეთ ზარის ფასების შესახებ
+    online: ონლაინ
+    phone: ტელეფონი
+    webchat: ვებ-ჩატი
   content_item:
-    coming_soon:
-    contents:
+    coming_soon: ეს დოკუმენტი გამოქვეყნდება
+    contents: შინაარსი
     metadata:
-      published:
-      updated:
+      published: პუბლიკაცია
+      updated: განახლება
     schema_name:
       aaib_report:
-        other:
+        one: ავიაკატასტროფების გამოძიების ფილიალის ანგარიში
+        other: ავიაკატასტროფების გამოძიების ფილიალის ანგარიშები
       announcement:
-        other:
+        one: განცხადება
+        other: განცხადებები
       asylum_support_decision:
-        other:
+        one: თავშესაფრის მხარდაჭერის ტრიბუნალის გადაწყვეტილება
+        other: თავშესაფრის მხარდამჭერი სასამართლო გადაწყვეტილებები
       authored_article:
-        other:
+        one: ავტორიზებული სტატია
+        other: ავტორიზებული სტატიები
       business_finance_support_scheme:
-        other:
+        one: ბიზნესის დაფინანსების მხარდაჭერის სქემა
+        other: ბიზნესის დაფინანსების მხარდაჭერის სქემები
       case_study:
-        other:
+        one: შემთხვევის კვლევა
+        other: შემთხვევის კვლევები
       closed_consultation:
-        one:
-        other:
-        overview:
+        one: დახურული კონსულტაცია
+        other: დახურული კონსულტაციები
       cma_case:
-        other:
+        one: კონკურენციისა და ბაზრების უფლებამოსილების საქმე
+        other: კონკურენციისა და ბაზრების ორგანოების საქმეები
       coming_soon:
-        other:
+        one: მალე
+        other: მალე
       consultation:
-        other:
+        one: კონსულტაცია
+        other: კონსულტაციები
       consultation_outcome:
-        one:
-        other:
-        overview:
+        one: კონსულტაციის შედეგი
+        other: კონსულტაციის შედეგები
       corporate_information_page:
-        other:
+        one: საინფორმაციო გვერდი
+        other: საინფორმაციო გვერდები
       corporate_report:
-        one:
-        other:
-        overview:
+        one: კორპორატიული ანგარიში
+        other: კორპორატიული ანგარიშები
       correspondence:
-        one:
-        other:
-        overview:
+        one: მიმოწერა
+        other: მიმოწერები
       countryside_stewardship_grant:
-        other:
+        one: სოფლის მეურნეობის გრანტი
+        other: სოფლის მეურნეობის გრანტები
       decision:
-        one:
-        other:
-        overview:
+        one: გადაწყვეტილება
+        other: გადაწყვეტილებები
       detailed_guide:
-        other:
+        one: ხელძღვანელობა
+        other: ხელძღვანელობა
       dfid_research_output:
-        other:
+        one: კვლევა განვითარების შედეგისათვის
+        other: კვლევა განვითარების შედეგებისათვის
       document_collection:
-        other:
+        one: კოლექცია
+        other: კოლექციები
       draft_text:
-        other:
+        one: სამუშაო ტექსტი
+        other: სამუშაო ტექსტები
       drug_safety_update:
-        other:
+        one: ნარკოტიკების უსაფრთხოების განახლება
+        other: ნარკოტიკების უსაფრთხოების განახლებები
       employment_appeal_tribunal_decision:
-        other:
+        one: დასაქმების სააპელაციო სასამართლოს გადაწყვეტილება
+        other: დასაქმების სააპელაციო სასამართლოს გადაწყვეტილებები
       employment_tribunal_decision:
-        other:
+        one: დასაქმების სასამართლოს გადაწყვეტილება
+        other: დასაქმების სასამართლოს გადაწყვეტილებები
       esi_fund:
-        other:
+        one: ევროპის სტრუქტურული და საინვესტიციო ფონდი (ESIF)
+        other: ევროპული სტრუქტურული და საინვესტიციო ფონდები (ESIF)
       fatality_notice:
-        other:
+        one: ფატალურობის შეტყობინება
+        other: ფატალურობის შეტყობინებები
       foi_release:
-        one:
-        other:
-        overview:
+        one: ინფორმაციის თავისუფლების გამოცემა
+        other: ინფორმაციის თავისუფლების გამოცემებ
       form:
-        one:
-        other:
-        overview:
+        one: ფორმა
+        other: ფორმები
       government_response:
-        other:
+        one: მთავრობის პასუხი
+        other: მთავრობის პასუხები
       guidance:
-        one:
-        other:
-        overview:
+        one: ხელმძღვანელობა
+        other: ხელმძღვანელობა
       impact_assessment:
-        one:
-        other:
-        overview:
+        one: ზემოქმედების შეფასება
+        other: ზემოქმედების შეფასებები
       imported:
-        other:
+        one: იმპორტირებული - ლოდინის ტიპი
+        other: იმპორტირებული - ლოდინის ტიპი
       independent_report:
-        one:
-        other:
-        overview:
+        one: დამოუკიდებელი ანგარიში
+        other: დამოუკიდებელი ანგარიშები
       international_development_fund:
-        other:
+        one: საერთაშორისო განვითარების დაფინანსება
+        other: საერთაშორისო განვითარების დაფინანსება
       international_treaty:
-        one:
-        other:
-        overview:
+        one: საერთაშორისო ხელშეკრულება
+        other: საერთაშორისო ხელშეკრულებები
       maib_report:
-        other:
+        one: საზღვაო შემთხვევების გამოძიების ფილიალის ანგარიში
+        other: საზღვაო შემთხვევების გამოძიების ფილიალის ანგარიშები
       map:
-        one:
-        other:
-        overview:
+        one: რუკა
+        other: რუკები
       medical_safety_alert:
-        other:
+        one: გაფრთხილებები და შეტყობინებები წამლებისა და სამედიცინო მოწყობილობებისთვის
+        other: გაფრთხილებები და შეტყობინებები წამლებისა და სამედიცინო მოწყობილობებისთვის
       national:
-        other:
+        one: ნაციონალური სტატისტიკის განცხადება
+        other: ეროვნული სტატისტიკის განცხადებები
       national_statistics:
-        one:
-        other:
-        overview:
+        one: ეროვნული სტატისტიკა
+        other: ეროვნული სტატისტიკა
       national_statistics_announcement:
-        other:
+        one: ეროვნული სტატისტიკის განცხადება
+        other: ეროვნული სტატისტიკის განცხადებები
       news_article:
-        other:
+        one: ახალი ამბების სტატია
+        other: ახალი ამბების სტატიები
       news_story:
-        other:
+        one: ახალი ამბავი
+        other: ახალი ამბები
       notice:
-        one:
-        other:
-        overview:
+        one: შენიშვნა
+        other: შენიშვნები
       official:
-        other:
+        one: ოფიციალური სტატისტიკის განცხადება
+        other: ოფიციალური სტატისტიკის განცხადებები
       official_statistics:
-        one:
-        other:
-        overview:
+        one: ოფიციალური სტატისტიკა
+        other: ოფიციალური სტატისტიკა
       official_statistics_announcement:
-        other:
+        one: ოფიციალური სტატისტიკის განცხადება
+        other: ოფიციალური სტატისტიკის განცხადებები
       open_consultation:
-        one:
-        other:
-        overview:
+        one: ღია კონსულტაცია
+        other: ღია კონსულტაციები
       oral_statement:
-        other:
+        one: ზეპირი განცხადება პარლამენტში
+        other: ზეპირი განცხადებები პარლამენტში
       policy:
-        other:
+        one: კანონი
+        other: კანონები
       policy_paper:
-        one:
-        other:
-        overview:
+        one: საკანონომდებლო დოკუმენტი
+        other: საკანონომდებლო დოკუმენტები
       press_release:
-        other:
+        one: პრეს რელიზი
+        other: პრეს რელიზები
       promotional:
-        one:
-        other:
-        overview:
+        one: პრომო მასალა
+        other: პრომო მასალები
       publication:
-        other:
+        one: პუბლიკაცია
+        other: პუბლიკაციები
       raib_report:
-        other:
+        one: სარკინიგზო ავარიების გამოძიების ფილიალის ანგარიში
+        other: სარკინიგზო ავარიების გამოძიების ფილიალის ანგარიშები
       regulation:
-        one:
-        other:
-        overview:
+        one: რეგულირება
+        other: რეგულირებები
       research:
-        one:
-        other:
-        overview:
+        one: კვლევა და ანალიზი
+        other: კვლევა და ანალიზი
       residential_property_tribunal_decision:
-        other:
+        one: საცხოვრებელი ქონების ტრიბუნალის გადაწყვეტილება
+        other: საცხოვრებელი ქონების ტრიბუნალის გადაწყვეტილებები
       service_sign_in:
-        other:
+        one: სერვისში შესვლა
+        other: სერვისში შესვლა
       service_standard_report:
-        other:
+        one: სერვისის სტანდარტული ანგარიში
+        other: სერვისის სტანდარტული ანგარიშები
       speaking_notes:
-        other:
+        one: საუბრის შენიშვნა
+        other: საუბრის შენიშვნები
       speech:
-        other:
+        one: სიტყვით გამოსვლის შენიშვნა
+        other: სიტყვით გამოსვლის შენიშვნები
       standard:
-        one:
-        other:
-        overview:
+        one: სტანდარტი
+        other: სტანდარტები
       statement_to_parliament:
-        other:
+        one: განცხადება პარლამენტში
+        other: განცხადებები პარლამენტში
       statistical_data_set:
-        other:
+        one: სტატისტიკური მონაცემების ნაკრები
+        other: სტატისტიკური მონაცემების ნაკრებები
       statistics_announcement:
-        other:
+        one: სტატისტიკის გამოქვეყნების განცხადება
+        other: სტატისტიკის გამოქვეყნების განცხადებები
       statutory_guidance:
-        one:
-        other:
-        overview:
+        one: კანონიერი ხელმძღვანელობა
+        other: კანონიერი ხელმძღვანელობა
       take_part:
-        other:
+        one: მონაწილეობის მიღება
+        other: მონაწილეობის მიღება
       tax_tribunal_decision:
-        other:
+        one: საგადასახადო და კანცელარიის სასამართლოს გადაწყვეტილება
+        other: საგადასახადო და კანცელარიის სასამართლოს გადაწყვეტილებები
       transcript:
-        other:
+        one: ტრანსქრიფტი
+        other: ტრანსქრიფტები
       transparency:
-        one:
-        other:
-        overview:
+        one: გამჭვირვალობის მონაცემები
+        other: გამჭვირვალობის მონაცემები
       utaac_decision:
-        other:
+        one: ადმინისტრაციული სააპელაციო სასამართლოს გადაწყვეტილება
+        other: ადმინისტრაციული სააპელაციო სასამართლოს გადაწყვეტილებები
       world_location_news_article:
-        other:
+        one: ახალი ამბების სტატია
+        other: ახალი ამბების სტატიები
       world_news_story:
-        other:
+        one: მსოფლიო ამბავი
+        other: მსოფლიო ამბები
       written_statement:
-        other:
+        one: წერილობითი განცხადება პარლამენტში
+        other: წერილობითი განცხადებები პარლამენტში
   corporate_information_page:
-    about_our_services_html:
-    corporate_information:
-    personal_information_charter_html:
-    publication_scheme_html:
-    social_media_use_html:
-    welsh_language_scheme_html:
-  email:
-    description_html:
-    subscribe_title:
-    unsubscribe_title:
+    about_our_services_html: შეიტყვეთ %{link}.
+    corporate_information: კორპორატიული ინფორმაცია
+    personal_information_charter_html: ჩვენი %{link} განმარტავს, თუ როგორ ვამუშავებთ
+      ჩვენ თქვენს პირად ინფორმაციას.
+    publication_scheme_html: წაიკითხეთ ინფორმაციის ტიპების შესახებ, რომელსაც ჩვენ
+      რეგულარულად ვაქვეყნებთ ჩვენს %{link}-ზე.
+    social_media_use_html: წაიკითხეთ ჩვენი პოლიტიკის შესახებ %{link}.
+    welsh_language_scheme_html: გაეცანით ჩვენს ვალდებულებას %{link}.
   fatality_notice:
-    alt_text:
-    field_of_operation:
-    operations_in:
-  get_involved:
-    active_blogs:
-    civil_service:
-    civil_service_quarterly:
-    closed:
-    closed_consultations:
-    closed_with_date:
-    closes:
-    closing_today:
-    closing_tomorrow:
-    days_left:
-    engage_with_gov:
-    fcdo_bloggers:
-    follow:
-    follow_paragraph:
-    gds_blog:
-    gov_past:
-    intro_paragraph:
-      body_html:
-      engage_with_government:
-      take_part:
-    join_ics:
-    make_donation:
-    more_ways:
-    neighbourhood_watch:
-    open_consultations:
-    page_heading:
-    page_title:
-    petition_paragraph:
-      body_html:
-      create_a_petition:
-    read_respond:
-    recent_outcomes:
-    recently_opened:
-    respond_to_consultations:
-    school_overseas:
-    search_all:
-    see_all_dept:
-    start_a_petition:
-    take_part:
-    take_part_suggestions:
-    your_views:
+    alt_text: თავდაცვის სამინისტრო
+    field_of_operation: ოპერაციის სფერო
+    operations_in: ოპერაციები %{location}-ში
   gone:
-    page_title:
-    published_in_error:
-    title:
+    page_title: აღარ არის ხელმისაწვდომი
+    published_in_error: ამ გვერდზე არსებული ინფორმაცია ამოღებულია, რადგან ის გამოქვეყნდა
+      შეცდომით.
+    title: გვერდი, რომელსაც თქვენ ეძებთ, აღარ არის ხელმისაწვდომი
   guide:
-    pages_in_guide:
-    skip_to_contents:
+    pages_in_guide: გვერდები ამ სახელმძღვანელოში
+    skip_to_contents: გადადით სახელმძღვანელოს შინაარსზე
   html_publication:
     print_meta_data:
-      available_at:
-      copyright:
-      isbn:
-      licence_html:
-      third_party:
+      available_at: ეს პუბლიკაცია ხელმისაწვდომია %{url}-ზე
+      copyright: "© გვირგვინის საავტორო უფლებ ა%{year}"
+      isbn: 'ISBN:'
+      licence_html: 'ეს პუბლიკაცია ლიცენზირებულია ღია მმართველობის ლიცენზიის v3.0
+        პირობებით, გარდა სხვა შემთხვევებისა. ამ ლიცენზიის სანახავად ეწვიეთ <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>  ან
+        მოგვწერეთ საინფორმაციო პოლიტიკის ჯგუფში, ეროვნულ არქივში, Kew, London TW9
+        4DU, ან ელ.ფოსტაზე: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: სადაც ჩვენ გამოვავლინეთ მესამე მხარის საავტორო უფლებების შესახებ
+        ინფორმაცია, თქვენ დაგჭირდებათ ნებართვის მიღება შესაბამისი საავტორო უფლებების
+        მფლობელებისგან.
   i18n:
     direction:
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
     ka: ქართული
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
   multi_page:
-    next_page:
-    previous_page:
-    print_entire_guide:
+    next_page: შემდეგი
+    previous_page: წინა
+    print_entire_guide: მთელი სახელმძღვანელოს ბეჭდვა
   publication:
-    details:
+    details: დეტალები
     documents:
-      one:
-      other:
+      one: დოკუმენტი
+      other: დოკუმენტები
   service_sign_in:
-    continue:
+    continue: განაგრძეთ
     error:
-      option:
-      title:
+      option: გთხოვთ აირჩიოთ ვარიანტი
+      title: თქვენ არ გაქვთ არჩეული ვარიანტი
   shared:
-    historically_political:
+    historically_political: ეს გამოქვეყნდა %{government}
     webchat:
-      available:
-      busy:
-      closed:
-      speak_to_adviser:
-      technical_problem:
+      available: მრჩევლები ხელმისაწვდომია სასაუბროდ.
+      busy: ვებ-გვერდის ყველა მრჩეველი ამჟამად დაკავებულია.
+      closed: ამჟამად ვებ ჩეთი დახურულია.
+      speak_to_adviser: მრჩეველთან ახლა დალაპარაკება
+      technical_problem: ამჟამად ვებ ჩეთი მიუწვდომელია ტექნიკური პრობლემების გამო.
   specialist_document:
-    pdo_alt_text:
-    pgi_alt_text:
-    tsg_alt_text:
+    pdo_alt_text: 'სქემის ლოგო არის შავი შტამპი სიტყვებით: გაერთიანებული სამეფოს დაცული
+      დანიშნულების ადგილი'
+    pgi_alt_text: 'სქემის ლოგო არის შავი შტამპი სიტყვებით: გაერთიანებული სამეფოს დაცული
+      დანიშნულების ადგილი'
+    tsg_alt_text: სქემის ლოგო არის შავი ბეჭედი, რომელზეც წერია ტრადიციული სპეციალობა
+      დაცულია გაერთიანებული სამეფოს მიერ
   speech:
-    delivered_on:
-    location:
-    written_on:
+    delivered_on: გადაეცა
+    location: მდებარეობა
+    written_on: დაწერილი
   statistics_announcement:
-    cancellation_date:
-    cancelled:
-    changed_date:
-    forthcoming:
-    previous_date:
-    proposed_date:
-    reason_for_change:
-    release_date:
+    cancellation_date: გაუქმების თარიღი
+    cancelled: სტატისტიკის გამოშვება გაუქმდა
+    changed_date: გამოსვლის თარიღი შეიცვალა
+    forthcoming: ეს სტატისტიკა გამოქვეყნდება
+    previous_date: წინა თარიღი
+    proposed_date: შეთავაზებული გაცემა
+    reason_for_change: შეცვლის მიზეზი
+    release_date: გამოშვების თარიღი
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts_html:
-      avoid_all_but_essential_travel_to_whole_country_html:
-      avoid_all_travel_to_parts_html:
-      avoid_all_travel_to_whole_country_html:
-    context:
-    still_current_at:
-    summary:
-    updated:
+      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth
+        Office">FCO</abbr> რჩევა ყველას წინააღმდეგ, გარდა ესენციური მოგზაურობებისა
+        ქვეყნის ზოგიერთ ნაწილებში.
+      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and
+        Commonwealth Office">FCO</abbr> რჩევა ყველას წინააღმდეგ, გარდა ესენციური მოგზაურობებისა
+        მთელს ქვეყანაში.
+      avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr>
+        რჩევა ყველა მოგზაურობების წინააღმდეგ ქვეყნის ზოგიერთ ნაწილებში.
+      avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth
+        Office">FCO</abbr> რჩევა ყველა მოგზაურობების წინააღმდეგ მთელ ქვეყანაში.
+    context: უცხოეთში მოგზაურობის რჩევა
+    coronavirus_warning:
+      content_html: |
+        <p class="govuk-body">
+          დაიცავით მიმდინარე COVID-19 რეგულაციები იქ, სადაც ხართ: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/coronavirus-travel">Wales</a> და <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">ჩრდილოეთ ირლანდია</a>.
+        </p>
+        <p class="govuk-body">
+          ახალი COVID შტამების გაერთიანებულ სამეფოში შემოსვლის შესაფერხებლად, თქვენ არ უნდა იმოგზაუროთ <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">მუქი წითელი ან წითელი ზონის ქვეყნების სია</a>.
+        </p>
+        <p class="govuk-body">
+          ქვეყანაში რისკების შესახებ ინფორმაციის მისაღებად <a href="/guidance/travel-advice-novel-coronavirus">FCDO მოგზაურობის რჩევა</a>.
+        </p>
+        <p class="govuk-body">
+          უკან დაბრუნებისას დაიცავით წესების <a href="/uk-border-control">გაერთიანებულ სამეფოში შესვლა უცხოეთიდან</a> (გარდა ჩრდილოეთ ირლანდიისა).
+        </p>
+      text_assistive: მნიშვნელოვანი
+      title: კორონავირუსი (COVID-19) მოგზაურობა
+    still_current_at: ჯერ კიდევ აქტუალურია
+    summary: შეჯამება
+    updated: განახლებული
   unpublishing:
-    page_title:
-    summary:
-    title:
+    page_title: აღარ არის ხელმისაწვდომი
+    summary: ინფორმაცია ამ გვერდზე წაიშალა, რადგან შეცდომით იყო გამოქვეყნებული.
+    title: თქვენთვის სასურველი გვერდი აღარ არის ხელმისაწვდომი
   working_group:
-    contact_details:
-    policies:
+    contact_details: საკონტაქტო დეტალები
+    policies: კანონები

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -1,3 +1,4 @@
+---
 ka:
   brexit:
     business_link:
@@ -34,10 +35,8 @@ ka:
       page_not_saved_heading: შეინახეთ ეს გვერდი, რათა დაუბრუნდეთ მოგვიანებით
       page_was_saved_heading: თქვენ შეინახეთ ეს გვერდი
       remove_page_button: თქვენი შენახული გვერდებიდან ამოღება
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">თქვენი
-        შენახული გვერდების ნახვა</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">შესვლა</a>
-        თქვენი შენახული გვერდების სანახავად.
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">თქვენი შენახული გვერდების ნახვა</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">შესვლა</a> თქვენი შენახული გვერდების სანახავად.
     share_links:
       share_this_page: ამ გვერდის გაზიარება
   consultation:
@@ -305,10 +304,8 @@ ka:
   corporate_information_page:
     about_our_services_html: შეიტყვეთ %{link}.
     corporate_information: კორპორატიული ინფორმაცია
-    personal_information_charter_html: ჩვენი %{link} განმარტავს, თუ როგორ ვამუშავებთ
-      ჩვენ თქვენს პირად ინფორმაციას.
-    publication_scheme_html: წაიკითხეთ ინფორმაციის ტიპების შესახებ, რომელსაც ჩვენ
-      რეგულარულად ვაქვეყნებთ ჩვენს %{link}-ზე.
+    personal_information_charter_html: ჩვენი %{link} განმარტავს, თუ როგორ ვამუშავებთ ჩვენ თქვენს პირად ინფორმაციას.
+    publication_scheme_html: წაიკითხეთ ინფორმაციის ტიპების შესახებ, რომელსაც ჩვენ რეგულარულად ვაქვეყნებთ ჩვენს %{link}-ზე.
     social_media_use_html: წაიკითხეთ ჩვენი პოლიტიკის შესახებ %{link}.
     welsh_language_scheme_html: გაეცანით ჩვენს ვალდებულებას %{link}.
   fatality_notice:
@@ -317,8 +314,7 @@ ka:
     operations_in: ოპერაციები %{location}-ში
   gone:
     page_title: აღარ არის ხელმისაწვდომი
-    published_in_error: ამ გვერდზე არსებული ინფორმაცია ამოღებულია, რადგან ის გამოქვეყნდა
-      შეცდომით.
+    published_in_error: ამ გვერდზე არსებული ინფორმაცია ამოღებულია, რადგან ის გამოქვეყნდა შეცდომით.
     title: გვერდი, რომელსაც თქვენ ეძებთ, აღარ არის ხელმისაწვდომი
   guide:
     pages_in_guide: გვერდები ამ სახელმძღვანელოში
@@ -328,13 +324,8 @@ ka:
       available_at: ეს პუბლიკაცია ხელმისაწვდომია %{url}-ზე
       copyright: "© გვირგვინის საავტორო უფლებ ა%{year}"
       isbn: 'ISBN:'
-      licence_html: 'ეს პუბლიკაცია ლიცენზირებულია ღია მმართველობის ლიცენზიის v3.0
-        პირობებით, გარდა სხვა შემთხვევებისა. ამ ლიცენზიის სანახავად ეწვიეთ <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>  ან
-        მოგვწერეთ საინფორმაციო პოლიტიკის ჯგუფში, ეროვნულ არქივში, Kew, London TW9
-        4DU, ან ელ.ფოსტაზე: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
-      third_party: სადაც ჩვენ გამოვავლინეთ მესამე მხარის საავტორო უფლებების შესახებ
-        ინფორმაცია, თქვენ დაგჭირდებათ ნებართვის მიღება შესაბამისი საავტორო უფლებების
-        მფლობელებისგან.
+      licence_html: 'ეს პუბლიკაცია ლიცენზირებულია ღია მმართველობის ლიცენზიის v3.0 პირობებით, გარდა სხვა შემთხვევებისა. ამ ლიცენზიის სანახავად ეწვიეთ <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>  ან მოგვწერეთ საინფორმაციო პოლიტიკის ჯგუფში, ეროვნულ არქივში, Kew, London TW9 4DU, ან ელ.ფოსტაზე: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: სადაც ჩვენ გამოვავლინეთ მესამე მხარის საავტორო უფლებების შესახებ ინფორმაცია, თქვენ დაგჭირდებათ ნებართვის მიღება შესაბამისი საავტორო უფლებების მფლობელებისგან.
   i18n:
     direction:
   language_names:
@@ -362,12 +353,9 @@ ka:
       speak_to_adviser: მრჩეველთან ახლა დალაპარაკება
       technical_problem: ამჟამად ვებ ჩეთი მიუწვდომელია ტექნიკური პრობლემების გამო.
   specialist_document:
-    pdo_alt_text: 'სქემის ლოგო არის შავი შტამპი სიტყვებით: გაერთიანებული სამეფოს დაცული
-      დანიშნულების ადგილი'
-    pgi_alt_text: 'სქემის ლოგო არის შავი შტამპი სიტყვებით: გაერთიანებული სამეფოს დაცული
-      დანიშნულების ადგილი'
-    tsg_alt_text: სქემის ლოგო არის შავი ბეჭედი, რომელზეც წერია ტრადიციული სპეციალობა
-      დაცულია გაერთიანებული სამეფოს მიერ
+    pdo_alt_text: 'სქემის ლოგო არის შავი შტამპი სიტყვებით: გაერთიანებული სამეფოს დაცული დანიშნულების ადგილი'
+    pgi_alt_text: 'სქემის ლოგო არის შავი შტამპი სიტყვებით: გაერთიანებული სამეფოს დაცული დანიშნულების ადგილი'
+    tsg_alt_text: სქემის ლოგო არის შავი ბეჭედი, რომელზეც წერია ტრადიციული სპეციალობა დაცულია გაერთიანებული სამეფოს მიერ
   speech:
     delivered_on: გადაეცა
     location: მდებარეობა
@@ -383,16 +371,10 @@ ka:
     release_date: გამოშვების თარიღი
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth
-        Office">FCO</abbr> რჩევა ყველას წინააღმდეგ, გარდა ესენციური მოგზაურობებისა
-        ქვეყნის ზოგიერთ ნაწილებში.
-      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and
-        Commonwealth Office">FCO</abbr> რჩევა ყველას წინააღმდეგ, გარდა ესენციური მოგზაურობებისა
-        მთელს ქვეყანაში.
-      avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr>
-        რჩევა ყველა მოგზაურობების წინააღმდეგ ქვეყნის ზოგიერთ ნაწილებში.
-      avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth
-        Office">FCO</abbr> რჩევა ყველა მოგზაურობების წინააღმდეგ მთელ ქვეყანაში.
+      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველას წინააღმდეგ, გარდა ესენციური მოგზაურობებისა ქვეყნის ზოგიერთ ნაწილებში.
+      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველას წინააღმდეგ, გარდა ესენციური მოგზაურობებისა მთელს ქვეყანაში.
+      avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველა მოგზაურობების წინააღმდეგ ქვეყნის ზოგიერთ ნაწილებში.
+      avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველა მოგზაურობების წინააღმდეგ მთელ ქვეყანაში.
     context: უცხოეთში მოგზაურობის რჩევა
     coronavirus_warning:
       content_html: |

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -292,10 +292,55 @@ ka:
     publication_scheme_html: წაიკითხეთ ინფორმაციის ტიპების შესახებ, რომელსაც ჩვენ რეგულარულად ვაქვეყნებთ ჩვენს %{link}-ზე.
     social_media_use_html: წაიკითხეთ ჩვენი პოლიტიკის შესახებ %{link}.
     welsh_language_scheme_html: გაეცანით ჩვენს ვალდებულებას %{link}.
+  email:
+    description_html:
+    subscribe_title:
+    unsubscribe_title:
   fatality_notice:
     alt_text: თავდაცვის სამინისტრო
     field_of_operation: ოპერაციის სფერო
     operations_in: ოპერაციები %{location}-ში
+  get_involved:
+    civil_service:
+    civil_service_quarterly:
+    closed:
+    closed_consultations:
+    closes:
+    closing_today:
+    closing_tomorrow:
+    days_left:
+    engage_with_gov:
+    fcdo_bloggers:
+    follow:
+    follow_links:
+    follow_paragraph:
+    gds_blog:
+    gov_past:
+    intro_paragraph:
+      body_html:
+      engage_with_government:
+      take_part:
+    join_ics:
+    make_donation:
+    more_ways:
+    neighbourhood_watch:
+    open_consultations:
+    page_heading:
+    page_title:
+    petition_paragraph:
+      body_html:
+      create_a_petition:
+    read_respond:
+    recent_outcomes:
+    recently_opened:
+    respond_to_consultations:
+    school_overseas:
+    search_all:
+    see_all_dept:
+    start_a_petition:
+    take_part:
+    take_part_suggestions:
+    your_views:
   gone:
     page_title: აღარ არის ხელმისაწვდომი
     published_in_error: ამ გვერდზე არსებული ინფორმაცია ამოღებულია, რადგან ის გამოქვეყნდა შეცდომით.
@@ -313,7 +358,72 @@ ka:
   i18n:
     direction:
   language_names:
+    ar:
+    az:
+    be:
+    bg:
+    bn:
+    cs:
+    cy:
+    da:
+    de:
+    dr:
+    el:
+    en:
+    es:
+    es-419:
+    et:
+    fa:
+    fi:
+    fr:
+    gd:
+    gu:
+    he:
+    hi:
+    hr:
+    hu:
+    hy:
+    id:
+    is:
+    it:
+    ja:
     ka: ქართული
+    kk:
+    ko:
+    lt:
+    lv:
+    ms:
+    mt:
+    ne:
+    nl:
+    'no':
+    pa:
+    pa-pk:
+    pl:
+    ps:
+    pt:
+    ro:
+    ru:
+    si:
+    sk:
+    sl:
+    so:
+    sq:
+    sr:
+    sv:
+    sw:
+    ta:
+    th:
+    tk:
+    tr:
+    uk:
+    ur:
+    uz:
+    vi:
+    yi:
+    zh:
+    zh-hk:
+    zh-tw:
   multi_page:
     next_page: შემდეგი
     previous_page: წინა

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -9,7 +9,6 @@ ka:
       text: ბრექსიტის სახელმძღვანელო ინდივიდუალებისთვის და ოჯახებისთვის
     heading_prefix: არსებობს სხვადასხვა
   common:
-    last_updated:
     visit: 'ეწვიეთ:'
   components:
     figure:
@@ -21,22 +20,8 @@ ka:
       see_all_updates: ყველა ცვლილების ნახვა
       show_all_updates: ყველა ცვლილების ჩვენება
     publisher_metadata:
-      collections:
-      from:
       hide_all: ყველას დაფარვა
       show_all: ყველას ჩვენება
-    save_this_page:
-      add_page_button: თქვენს შენახულ გვერდებში დამატება
-      confirmations:
-        page_removed:
-          message: თქვენ ეს ამოიღეთ თქვენი შენახული გვერდებიდან
-        page_saved:
-          message: თქვენ დაამატეთ ეს თქვენს შენახულ გვერდებს
-      page_not_saved_heading: შეინახეთ ეს გვერდი, რათა დაუბრუნდეთ მოგვიანებით
-      page_was_saved_heading: თქვენ შეინახეთ ეს გვერდი
-      remove_page_button: თქვენი შენახული გვერდებიდან ამოღება
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">თქვენი შენახული გვერდების ნახვა</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">შესვლა</a> თქვენი შენახული გვერდების სანახავად.
     share_links:
       share_this_page: ამ გვერდის გაზიარება
   consultation:
@@ -61,7 +46,6 @@ ka:
     original_consultation: ორიგინალი კონსულტაცია
     ran_from: ეს კონსულტაცია ამოიწურა
     respond_online: ონლაინ პასუხი
-    'true': სიმართლე
     visit_soon: ეწვიეთ გვერდს ისევ მალე, რათა გადმოწეროთ შედეგი ამ public&nbsp;ფიდბექისთვის.
     was: იყო
     ways_to_respond: პასუხის გზები
@@ -376,22 +360,6 @@ ka:
       avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველა მოგზაურობების წინააღმდეგ ქვეყნის ზოგიერთ ნაწილებში.
       avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველა მოგზაურობების წინააღმდეგ მთელ ქვეყანაში.
     context: უცხოეთში მოგზაურობის რჩევა
-    coronavirus_warning:
-      content_html: |
-        <p class="govuk-body">
-          დაიცავით მიმდინარე COVID-19 რეგულაციები იქ, სადაც ხართ: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/coronavirus-travel">Wales</a> და <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">ჩრდილოეთ ირლანდია</a>.
-        </p>
-        <p class="govuk-body">
-          ახალი COVID შტამების გაერთიანებულ სამეფოში შემოსვლის შესაფერხებლად, თქვენ არ უნდა იმოგზაუროთ <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">მუქი წითელი ან წითელი ზონის ქვეყნების სია</a>.
-        </p>
-        <p class="govuk-body">
-          ქვეყანაში რისკების შესახებ ინფორმაციის მისაღებად <a href="/guidance/travel-advice-novel-coronavirus">FCDO მოგზაურობის რჩევა</a>.
-        </p>
-        <p class="govuk-body">
-          უკან დაბრუნებისას დაიცავით წესების <a href="/uk-border-control">გაერთიანებულ სამეფოში შესვლა უცხოეთიდან</a> (გარდა ჩრდილოეთ ირლანდიისა).
-        </p>
-      text_assistive: მნიშვნელოვანი
-      title: კორონავირუსი (COVID-19) მოგზაურობა
     still_current_at: ჯერ კიდევ აქტუალურია
     summary: შეჯამება
     updated: განახლებული

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -1,7 +1,11 @@
 ka:
   brexit:
-    business_link: ბრექსიტის სახელმძღვანელო ბიზნესებისთვის
-    citizen_link: ბრექსიტის სახელმძღვანელო ინდივიდუალებისთვის და ოჯახებისთვის
+    business_link:
+      path: "/guidance/brexit-guidance-for-businesses"
+      text: ბრექსიტის სახელმძღვანელო ბიზნესებისთვის
+    citizen_link:
+      path: "/guidance/brexit-guidance-for-individuals-and-families"
+      text: ბრექსიტის სახელმძღვანელო ინდივიდუალებისთვის და ოჯახებისთვის
     heading_prefix: არსებობს სხვადასხვა
   common:
     last_updated:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -324,12 +324,10 @@ kk:
     field_of_operation: Жұмыс аймағы
     operations_in: "%{location} орнындағы жұмыстар"
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -335,6 +335,7 @@ kk:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -335,6 +335,7 @@ ko:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -324,12 +324,10 @@ ko:
     field_of_operation: 운영 현장
     operations_in: "%{Location} 내 운영"
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -398,12 +398,10 @@ lt:
     field_of_operation: Veiklos sritis
     operations_in: Veikla vykdoma %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -409,6 +409,7 @@ lt:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -335,6 +335,7 @@ lv:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -324,12 +324,10 @@ lv:
     field_of_operation: Darbības joma
     operations_in: 'Darbības šeit: %{location}'
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -292,10 +292,55 @@ ms:
     publication_scheme_html: Baca tentang jenis maklumat yang kami biasa terbitkan dalam %{link} kami.
     social_media_use_html: Baca dasar kami di %{link}.
     welsh_language_scheme_html: Ketahui tentang komitmen kami kepada %{link}.
+  email:
+    description_html:
+    subscribe_title:
+    unsubscribe_title:
   fatality_notice:
     alt_text: Lambang Kementerian Pertahanan
     field_of_operation: Medan operasi
     operations_in: Operasi di %{location}
+  get_involved:
+    civil_service:
+    civil_service_quarterly:
+    closed:
+    closed_consultations:
+    closes:
+    closing_today:
+    closing_tomorrow:
+    days_left:
+    engage_with_gov:
+    fcdo_bloggers:
+    follow:
+    follow_links:
+    follow_paragraph:
+    gds_blog:
+    gov_past:
+    intro_paragraph:
+      body_html:
+      engage_with_government:
+      take_part:
+    join_ics:
+    make_donation:
+    more_ways:
+    neighbourhood_watch:
+    open_consultations:
+    page_heading:
+    page_title:
+    petition_paragraph:
+      body_html:
+      create_a_petition:
+    read_respond:
+    recent_outcomes:
+    recently_opened:
+    respond_to_consultations:
+    school_overseas:
+    search_all:
+    see_all_dept:
+    start_a_petition:
+    take_part:
+    take_part_suggestions:
+    your_views:
   gone:
     page_title: Sudah tiada
     published_in_error: Maklumat dalam laman ini telah dikeluarkan kerana ia telah diterbitkan secara salah.
@@ -313,7 +358,72 @@ ms:
   i18n:
     direction:
   language_names:
+    ar:
+    az:
+    be:
+    bg:
+    bn:
+    cs:
+    cy:
+    da:
+    de:
+    dr:
+    el:
+    en:
+    es:
+    es-419:
+    et:
+    fa:
+    fi:
+    fr:
+    gd:
+    gu:
+    he:
+    hi:
+    hr:
+    hu:
+    hy:
+    id:
+    is:
+    it:
+    ja:
+    ka:
+    kk:
+    ko:
+    lt:
+    lv:
     ms: Bahasa Melayu
+    mt:
+    ne:
+    nl:
+    'no':
+    pa:
+    pa-pk:
+    pl:
+    ps:
+    pt:
+    ro:
+    ru:
+    si:
+    sk:
+    sl:
+    so:
+    sq:
+    sr:
+    sv:
+    sw:
+    ta:
+    th:
+    tk:
+    tr:
+    uk:
+    ur:
+    uz:
+    vi:
+    yi:
+    zh:
+    zh-hk:
+    zh-tw:
   multi_page:
     next_page: Seterusnya
     previous_page: Sebelumnya

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -371,10 +371,10 @@ ms:
     release_date: Tarikh hebahan
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat perjalanan kecuali yang perlu sahaja ke bahagian-bahagian tertentu negara ini.
-      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat perjalanan kecuali yang perlu sahaja ke seluruh negara.
-      avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat sebarang perjalanan ke bahagian-bahagian tertentu negara ini.
-      avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat sebarang perjalanan ke seluruh negara..
+      avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat perjalanan kecuali yang perlu sahaja ke bahagian-bahagian tertentu negara ini.
+      avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat perjalanan kecuali yang perlu sahaja ke seluruh negara.
+      avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat sebarang perjalanan ke bahagian-bahagian tertentu negara ini.
+      avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat sebarang perjalanan ke seluruh negara..
     context: Nasihat perjalanan ke negara luar
     coronavirus_warning:
       content_html: |

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -1,455 +1,424 @@
----
 ms:
   brexit:
-    business_link:
-      path:
-      text:
-    citizen_link:
-      path:
-      text:
-    heading_prefix:
+    business_link: Panduan Brexit untuk perniagaan
+    citizen_link: Panduan Brexit untuk individu dan keluarga
+    heading_prefix: Ada perbezaan
   common:
-    visit:
+    last_updated:
+    visit: 'Lawati:'
   components:
     figure:
-      image_credit:
+      image_credit: 'Imej kredit: %{credit}'
     published_dates:
-      hide_all_updates:
-      last_updated:
-      published:
-      see_all_updates:
-      show_all_updates:
+      hide_all_updates: sorok semua kemas kini
+      last_updated: Kali terakhir dikemas kini %{date}
+      published: Diterbitkan %{date}
+      see_all_updates: lihat semua kemas kini
+      show_all_updates: tunjuk semua kemas kini
     publisher_metadata:
-      hide_all:
-      show_all:
+      collections:
+      from:
+      hide_all: sorok semua
+      show_all: tunjuk semua
+    save_this_page:
+      add_page_button: Tambah ke laman simpanan anda
+      confirmations:
+        page_removed:
+          message: Anda telah mengeluarkan ini daripada laman simpanan anda
+        page_saved:
+          message: Anda telah menambah ini ke laman simpanan anda
+      page_not_saved_heading: Simpan laman ini supaya anda boleh melawatnya semula
+        kemudian
+      page_was_saved_heading: Anda telah menyimpan laman ini
+      remove_page_button: Keluarkan daripada laman simpanan anda
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Lihat
+        laman simpanan anda</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Daftar
+        masuk</a> untuk melihat laman simpanan anda.
     share_links:
-      share_this_page:
+      share_this_page: Kongsi laman ini
   consultation:
-    and:
-    another_website_html:
-    at:
-    closes:
-    closes_at:
-    complete_a:
-    description:
-    detail_of_feedback_received:
-    detail_of_outcome:
-    documents:
-    download_outcome:
-    either:
-    email_to:
-    feedback_received:
-    is_being:
-    not_open_yet:
+    and: dan
+    another_website_html: Perundingan ini %{closed} telah diadakan di <a href="%{url}">laman
+      web lain</a>
+    at: di
+    closes: Ditutup pada
+    closes_at: Perundingan ini ditutup pada
+    complete_a: Lengkapkan
+    description: Huraian perundingan
+    detail_of_feedback_received: Butiran maklum balas diterima
+    detail_of_outcome: Butiran hasil
+    documents: Dokumen
+    download_outcome: Muat turun hasil penuh
+    either: sama ada
+    email_to: 'E-mel kepada:'
+    feedback_received: Maklum balas diterima
+    is_being: sedang
+    not_open_yet: Perundingan ini masih belum dibuka
     'on':
-    opens:
-    original_consultation:
-    ran_from:
-    respond_online:
-    visit_soon:
-    was:
-    ways_to_respond:
-    write_to:
+    opens: Perundingan ini dibuka
+    original_consultation: Perundingan asal
+    ran_from: Perundingan ini berjalan dari
+    respond_online: Jawab dalam talian
+    'true': betul
+    visit_soon: Lawati laman ini semula untuk muat turun hasil maklum balas&nbsp;awam
+      ini.
+    was: adalah
+    ways_to_respond: Cara untuk menjawab
+    write_to: 'Tulis kepada:'
   contact:
-    email:
-    find_call_charges:
-    online:
-    phone:
-    webchat:
+    email: E-mel
+    find_call_charges: Ketahui tentang caj panggilan
+    online: Dalam talian
+    phone: Telefon
+    webchat: Sembang web
   content_item:
-    coming_soon:
-    contents:
+    coming_soon: Dokumen ini akan diterbitkan pada
+    contents: Kandungan
     metadata:
-      published:
-      updated:
+      published: Diterbitkan
+      updated: Dikemas kini
     schema_name:
       aaib_report:
-        other:
+        one: Laporan Cawangan Penyiasatan Kemalangan Udara
+        other: Laporan Cawangan Penyiasatan Kemalangan Udara
       announcement:
-        other:
+        one: Pengumuman
+        other: Pengumuman
       asylum_support_decision:
-        other:
+        one: Suaka menyokong keputusan tribunal
+        other: Suaka menyokong keputusan tribunal
       authored_article:
-        other:
+        one: Artikel ditulis penulis
+        other: Artikel ditulis penulis
       business_finance_support_scheme:
-        other:
+        one: Skim sokongan kewangan perniagaan
+        other: Skim sokongan kewangan perniagaan
       case_study:
-        other:
+        one: Kajian kes
+        other: Kajian kes
       closed_consultation:
-        one:
-        other:
-        overview:
+        one: Rundingan tertutup
+        other: Rundingan tertutup
       cma_case:
-        other:
+        one: Kes Persaingan dan Pihak Berkuasa Pasaran
+        other: Kes Persaingan dan Pihak Berkuasa Pasaran
       coming_soon:
-        other:
+        one: Akan Datang
+        other: Akan Datang
       consultation:
-        other:
+        one: Rundingan
+        other: Rundingan
       consultation_outcome:
-        one:
-        other:
-        overview:
+        one: Hasil rundingan
+        other: Hasil rundingan
       corporate_information_page:
-        other:
+        one: Halaman maklumat
+        other: Halaman maklumat
       corporate_report:
-        one:
-        other:
-        overview:
+        one: Laporan korporat
+        other: Laporan korporat
       correspondence:
-        one:
-        other:
-        overview:
+        one: Perwakilan
+        other: Perwakilan
       countryside_stewardship_grant:
-        other:
+        one: Geran Pengawasan Desa
+        other: Geran Pengawasan Desa
       decision:
-        one:
-        other:
-        overview:
+        one: Keputusan
+        other: Keputusan
       detailed_guide:
-        other:
+        one: Panduan
+        other: Panduan
       dfid_research_output:
-        other:
+        one: Output Penyelidikan untuk Pembangunan
+        other: Output Penyelidikan untuk Pembangunan
       document_collection:
-        other:
+        one: Koleksi
+        other: Koleksi
       draft_text:
-        other:
+        one: Teks draf
+        other: Teks draf
       drug_safety_update:
-        other:
+        one: Kemas Kini Keselamatan Ubat-ubatan
+        other: Kemas Kini Keselamatan Ubat-ubatan
       employment_appeal_tribunal_decision:
-        other:
+        one: Keputusan tribunal rayuan pekerjaan
+        other: Keputusan tribunal rayuan pekerjaan
       employment_tribunal_decision:
-        other:
+        one: Keputusan tribunal pekerjaan
+        other: Keputusan tribunal pekerjaan
       esi_fund:
-        other:
+        one: Dana Struktur dan Pelaburan Eropah (ESIF)
+        other: Dana Struktur dan Pelaburan Eropah (ESIF)
       fatality_notice:
-        other:
+        one: Notis kematian
+        other: Notis kematian
       foi_release:
-        one:
-        other:
-        overview:
+        one: Hebahan Kebebasan Maklumat (FOI)
+        other: Hebahan Kebebasan Maklumat (FOI)
       form:
-        one:
-        other:
-        overview:
+        one: Borang
+        other: Borang
       government_response:
-        other:
+        one: Respons kerajaan
+        other: Respons kerajaan
       guidance:
-        one:
-        other:
-        overview:
+        one: Panduan
+        other: Panduan
       impact_assessment:
-        one:
-        other:
-        overview:
+        one: Penilaian impak
+        other: Penilaian impak
       imported:
-        other:
+        one: diimport - menunggu jenis
+        other: diimport - menunggu jenis
       independent_report:
-        one:
-        other:
-        overview:
+        one: Laporan bebas
+        other: Laporan bebas
       international_development_fund:
-        other:
+        one: Pembiayaan pembangunan antarabangsa
+        other: Pembiayaan pembangunan antarabangsa
       international_treaty:
-        one:
-        other:
-        overview:
+        one: Perjanjian antarabangsa
+        other: Perjanjian antarabangsa
       maib_report:
-        other:
+        one: Laporan Cawangan Penyiasatan Kemalangan Marin
+        other: Laporan Cawangan Penyiasatan Kemalangan Marin
       map:
-        one:
-        other:
-        overview:
+        one: Peta
+        other: Peta
       medical_safety_alert:
-        other:
+        one: Amaran dan penarikan balik untuk ubat-ubatan dan peranti perubatan
+        other: Amaran dan penarikan balik untuk ubat-ubatan dan peranti perubatan
       national:
-        other:
+        one: Pengumuman statistik nasional
+        other: Pengumuman statistik nasional
       national_statistics:
-        one:
-        other:
-        overview:
+        one: Statistik Nasional
+        other: Statistik Nasional
       national_statistics_announcement:
-        other:
+        one: Pengumuman statistik nasional
+        other: Pengumuman statistik nasional
       news_article:
-        other:
+        one: Artikel berita
+        other: Artikel berita
       news_story:
-        other:
+        one: Berita
+        other: Berita
       notice:
-        one:
-        other:
-        overview:
+        one: Notis
+        other: Notis
       official:
-        other:
+        one: Pengumuman statistik rasmi
+        other: Pengumuman statistik rasmi
       official_statistics:
-        one:
-        other:
-        overview:
+        one: Statistik Rasmi
+        other: Statistik Rasmi
       official_statistics_announcement:
-        other:
+        one: Pengumuman statistik rasmi
+        other: Pengumuman statistik rasmi
       open_consultation:
-        one:
-        other:
-        overview:
+        one: Rundingan terbuka
+        other: Rundingan terbuka
       oral_statement:
-        other:
+        one: Kenyataan lisan kepada Parlimen
+        other: Kenyataan lisan kepada Parlimen
       policy:
-        other:
+        one: Dasar
+        other: Dasar
       policy_paper:
-        one:
-        other:
-        overview:
+        one: Kertas dasar
+        other: Kertas dasar
       press_release:
-        other:
+        one: Siaran akhbar
+        other: Siaran akhbar
       promotional:
-        one:
-        other:
-        overview:
+        one: Bahan promosi
+        other: Bahan promosi
       publication:
-        other:
+        one: Penerbitan
+        other: Penerbitan
       raib_report:
-        other:
+        one: Laporan Cawangan Penyiasatan Kemalangan Kereta Api
+        other: Laporan Cawangan Penyiasatan Kemalangan Kereta Api
       regulation:
-        one:
-        other:
-        overview:
+        one: Peraturan
+        other: Peraturan
       research:
-        one:
-        other:
-        overview:
+        one: Penyelidikan dan analisis
+        other: Penyelidikan dan analisis
       residential_property_tribunal_decision:
-        other:
+        one: Keputusan tribunal harta tanah kediaman
+        other: Keputusan tribunal harta tanah kediaman
       service_sign_in:
-        other:
+        one: Daftar masuk perkhidmatan
+        other: Daftar masuk perkhidmatan
       service_standard_report:
-        other:
+        one: Laporan Standard Perkhidmatan
+        other: Laporan Standard Perkhidmatan
       speaking_notes:
-        other:
+        one: Nota perbincangan
+        other: Nota perbincangan
       speech:
-        other:
+        one: Ucapan
+        other: Ucapan
       standard:
-        one:
-        other:
-        overview:
+        one: Standard
+        other: Standard
       statement_to_parliament:
-        other:
+        one: Kenyataan kepada Parlimen
+        other: Kenyataan kepada Parlimen
       statistical_data_set:
-        other:
+        one: Set data statistik
+        other: Set data statistik
       statistics_announcement:
-        other:
+        one: Pengumuman hebahan statistik
+        other: Pengumuman hebahan statistik
       statutory_guidance:
-        one:
-        other:
-        overview:
+        one: Panduan berkanun
+        other: Panduan berkanun
       take_part:
-        other:
+        one: Ambil bahagian
+        other: Ambil bahagian
       tax_tribunal_decision:
-        other:
+        one: Keputusan tribunal Cukai dan Canseri
+        other: Keputusan tribunal Cukai dan Canseri
       transcript:
-        other:
+        one: Transkrip
+        other: Transkrip
       transparency:
-        one:
-        other:
-        overview:
+        one: Data ketelusan
+        other: Data ketelusan
       utaac_decision:
-        other:
+        one: Keputusan tribunal rayuan pentadbiran
+        other: Keputusan tribunal rayuan pentadbiran
       world_location_news_article:
-        other:
+        one: Artikel berita
+        other: Artikel berita
       world_news_story:
-        other:
+        one: Berita dunia
+        other: Berita dunia
       written_statement:
-        other:
+        one: Kenyataan bertulis kepada Parlimen
+        other: Kenyataan bertulis kepada Parlimen
   corporate_information_page:
-    about_our_services_html:
-    corporate_information:
-    personal_information_charter_html:
-    publication_scheme_html:
-    social_media_use_html:
-    welsh_language_scheme_html:
-  email:
-    description_html:
-    subscribe_title:
-    unsubscribe_title:
+    about_our_services_html: Ketahui %{link}.
+    corporate_information: Maklumat korporat
+    personal_information_charter_html: "%{link} kami menerangkan bagaimana kami menggunakan
+      maklumat peribadi anda."
+    publication_scheme_html: Baca tentang jenis maklumat yang kami biasa terbitkan
+      dalam %{link} kami.
+    social_media_use_html: Baca dasar kami di %{link}.
+    welsh_language_scheme_html: Ketahui tentang komitmen kami kepada %{link}.
   fatality_notice:
-    alt_text:
-    field_of_operation:
-    operations_in:
-  get_involved:
-    active_blogs:
-    civil_service:
-    civil_service_quarterly:
-    closed:
-    closed_consultations:
-    closed_with_date:
-    closes:
-    closing_today:
-    closing_tomorrow:
-    days_left:
-    engage_with_gov:
-    fcdo_bloggers:
-    follow:
-    follow_paragraph:
-    gds_blog:
-    gov_past:
-    intro_paragraph:
-      body_html:
-      engage_with_government:
-      take_part:
-    join_ics:
-    make_donation:
-    more_ways:
-    neighbourhood_watch:
-    open_consultations:
-    page_heading:
-    page_title:
-    petition_paragraph:
-      body_html:
-      create_a_petition:
-    read_respond:
-    recent_outcomes:
-    recently_opened:
-    respond_to_consultations:
-    school_overseas:
-    search_all:
-    see_all_dept:
-    start_a_petition:
-    take_part:
-    take_part_suggestions:
-    your_views:
+    alt_text: Lambang Kementerian Pertahanan
+    field_of_operation: Medan operasi
+    operations_in: Operasi di %{location}
   gone:
-    page_title:
-    published_in_error:
-    title:
+    page_title: Sudah tiada
+    published_in_error: Maklumat dalam laman ini telah dikeluarkan kerana ia telah
+      diterbitkan secara salah.
+    title: Laman yang anda cari sudah tiada
   guide:
-    pages_in_guide:
-    skip_to_contents:
+    pages_in_guide: Laman dalam panduan ini
+    skip_to_contents: Langkau ke kandungan panduan
   html_publication:
     print_meta_data:
-      available_at:
-      copyright:
-      isbn:
-      licence_html:
-      third_party:
+      available_at: Penerbitan ini tersedia di %{url}
+      copyright: "© Crown copyright %{year}"
+      isbn: 'Nombor Buku Standard Antarabangsa (ISBN):'
+      licence_html: 'Penerbitan ini dilesenkan di bawah terma Lesen Kerajaan Terbuka
+        v3.0 kecuali dinyatakan sebaliknya. Untuk melihat lesen ini, lawati <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
+        atau tulis kepada Pasukan Dasar Maklumat, Arkib Negara, Kew, London TW9 4DU,
+        atau e-mel: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: Di mana kami telah mengenal pasti mana-mana maklumat hak cipta
+        pihak ketiga, anda perlu mendapatkan kebenaran daripada pemegang hak cipta
+        tersebut.
   i18n:
     direction:
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
     ms: Bahasa Melayu
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
   multi_page:
-    next_page:
-    previous_page:
-    print_entire_guide:
+    next_page: Seterusnya
+    previous_page: Sebelumnya
+    print_entire_guide: Cetak keseluruhan panduan
   publication:
-    details:
+    details: Butiran
     documents:
-      one:
-      other:
+      one: Dokumen
+      other: Dokumen
   service_sign_in:
-    continue:
+    continue: Teruskan
     error:
-      option:
-      title:
+      option: Sila buat satu pilihan
+      title: Anda telah membuat satu pilihan
   shared:
-    historically_political:
+    historically_political: Ini telah diterbitkan di bawah %{government}
     webchat:
-      available:
-      busy:
-      closed:
-      speak_to_adviser:
-      technical_problem:
+      available: Tidak ada penasihat sedia untuk bersembang.
+      busy: Semua penasihat sembang web sedang sibuk ketika ini.
+      closed: Sembang web ditutup ketika ini.
+      speak_to_adviser: Bercakap dengan seorang penasihat sekarang
+      technical_problem: Sembang web tidak tersedia ketika ini kerana masalah teknikal.
   specialist_document:
-    pdo_alt_text:
-    pgi_alt_text:
-    tsg_alt_text:
+    pdo_alt_text: Logo skema adalah cap hitam dengan perkataan Designated Origin UK
+      Protected
+    pgi_alt_text: Logo skema adalah cap hitam dengan perkataan Geographic Origin UK
+      Protected
+    tsg_alt_text: Logo skema adalah cap hitam dengan perkataan Traditional Speciality
+      UK Protected
   speech:
-    delivered_on:
-    location:
-    written_on:
+    delivered_on: Dihantar pada
+    location: Lokasi
+    written_on: Ditulis pada
   statistics_announcement:
-    cancellation_date:
-    cancelled:
-    changed_date:
-    forthcoming:
-    previous_date:
-    proposed_date:
-    reason_for_change:
-    release_date:
+    cancellation_date: Tarikh pembatalan
+    cancelled: Hebahan statistik dibatalkan
+    changed_date: Tarikh hebahan telah ditukar
+    forthcoming: Statistik ini akan dihebahkan
+    previous_date: Tarikh sebelumnya
+    proposed_date: Tarikh yang dicadangkan
+    reason_for_change: Sebab bagi penukaran
+    release_date: Tarikh hebahan
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts_html:
-      avoid_all_but_essential_travel_to_whole_country_html:
-      avoid_all_travel_to_parts_html:
-      avoid_all_travel_to_whole_country_html:
-    context:
-    still_current_at:
-    summary:
-    updated:
+      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth
+        Office">FCO</abbr> menasihati supaya tidak membuat perjalanan kecuali yang
+        perlu sahaja ke bahagian-bahagian tertentu negara ini.
+      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and
+        Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat perjalanan
+        kecuali yang perlu sahaja ke seluruh negara.
+      avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr>
+        menasihati supaya tidak membuat sebarang perjalanan ke bahagian-bahagian tertentu
+        negara ini.
+      avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth
+        Office">FCO</abbr> menasihati supaya tidak membuat sebarang perjalanan ke
+        seluruh negara..
+    context: Nasihat perjalanan ke negara luar
+    coronavirus_warning:
+      content_html: |
+        <p class="govuk-body">
+          Ikuti peraturan COVID-19 semasa tempat anda tinggal: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/coronavirus-travel">Wales</a> dan <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Ireland Utara</a>.
+        </p>
+        <p class="govuk-body">
+          Untuk mengelakkan varian COVID baharu daripada memasuki UK, anda tidak sepatutnya membuat perjalanan ke <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">negara-negara dalam senarai ambar atau merah</a>.
+        </p>
+        <p class="govuk-body">
+          Untuk memahami risko dalam sesebuah negara, ikuti <a href="/guidance/travel-advice-novel-coronavirus">Nasihat Perjalanan Pejabat Luar, Komanwel dan Pembangunan (FCDO)</a>.
+        </p>
+        <p class="govuk-body">
+         Apabila kembali, ikuti peraturan untuk <a href="/uk-border-control">memasuki UK dari negara luar</a> (kecuali dari Ireland).
+        </p>
+      text_assistive: Penting
+      title: Perjalanan koronavirus (COVID-19)
+    still_current_at: Masih semasa di
+    summary: Ringkasan
+    updated: Dikemas kini
   unpublishing:
-    page_title:
-    summary:
-    title:
+    page_title: Sudah tiada
+    summary: Maklumat dalam laman ini telah dikeluarkan kerana ia telah diterbitkan
+      secara salah.
+    title: Laman yang anda cari sudah tiada
   working_group:
-    contact_details:
-    policies:
+    contact_details: Butiran hubungan
+    policies: Dasar

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -1,3 +1,4 @@
+---
 ms:
   brexit:
     business_link:
@@ -31,20 +32,16 @@ ms:
           message: Anda telah mengeluarkan ini daripada laman simpanan anda
         page_saved:
           message: Anda telah menambah ini ke laman simpanan anda
-      page_not_saved_heading: Simpan laman ini supaya anda boleh melawatnya semula
-        kemudian
+      page_not_saved_heading: Simpan laman ini supaya anda boleh melawatnya semula kemudian
       page_was_saved_heading: Anda telah menyimpan laman ini
       remove_page_button: Keluarkan daripada laman simpanan anda
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Lihat
-        laman simpanan anda</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Daftar
-        masuk</a> untuk melihat laman simpanan anda.
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Lihat laman simpanan anda</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Daftar masuk</a> untuk melihat laman simpanan anda.
     share_links:
       share_this_page: Kongsi laman ini
   consultation:
     and: dan
-    another_website_html: Perundingan ini %{closed} telah diadakan di <a href="%{url}">laman
-      web lain</a>
+    another_website_html: Perundingan ini %{closed} telah diadakan di <a href="%{url}">laman web lain</a>
     at: di
     closes: Ditutup pada
     closes_at: Perundingan ini ditutup pada
@@ -65,8 +62,7 @@ ms:
     ran_from: Perundingan ini berjalan dari
     respond_online: Jawab dalam talian
     'true': betul
-    visit_soon: Lawati laman ini semula untuk muat turun hasil maklum balas&nbsp;awam
-      ini.
+    visit_soon: Lawati laman ini semula untuk muat turun hasil maklum balas&nbsp;awam ini.
     was: adalah
     ways_to_respond: Cara untuk menjawab
     write_to: 'Tulis kepada:'
@@ -308,10 +304,8 @@ ms:
   corporate_information_page:
     about_our_services_html: Ketahui %{link}.
     corporate_information: Maklumat korporat
-    personal_information_charter_html: "%{link} kami menerangkan bagaimana kami menggunakan
-      maklumat peribadi anda."
-    publication_scheme_html: Baca tentang jenis maklumat yang kami biasa terbitkan
-      dalam %{link} kami.
+    personal_information_charter_html: "%{link} kami menerangkan bagaimana kami menggunakan maklumat peribadi anda."
+    publication_scheme_html: Baca tentang jenis maklumat yang kami biasa terbitkan dalam %{link} kami.
     social_media_use_html: Baca dasar kami di %{link}.
     welsh_language_scheme_html: Ketahui tentang komitmen kami kepada %{link}.
   fatality_notice:
@@ -320,8 +314,7 @@ ms:
     operations_in: Operasi di %{location}
   gone:
     page_title: Sudah tiada
-    published_in_error: Maklumat dalam laman ini telah dikeluarkan kerana ia telah
-      diterbitkan secara salah.
+    published_in_error: Maklumat dalam laman ini telah dikeluarkan kerana ia telah diterbitkan secara salah.
     title: Laman yang anda cari sudah tiada
   guide:
     pages_in_guide: Laman dalam panduan ini
@@ -331,13 +324,8 @@ ms:
       available_at: Penerbitan ini tersedia di %{url}
       copyright: "© Crown copyright %{year}"
       isbn: 'Nombor Buku Standard Antarabangsa (ISBN):'
-      licence_html: 'Penerbitan ini dilesenkan di bawah terma Lesen Kerajaan Terbuka
-        v3.0 kecuali dinyatakan sebaliknya. Untuk melihat lesen ini, lawati <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
-        atau tulis kepada Pasukan Dasar Maklumat, Arkib Negara, Kew, London TW9 4DU,
-        atau e-mel: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
-      third_party: Di mana kami telah mengenal pasti mana-mana maklumat hak cipta
-        pihak ketiga, anda perlu mendapatkan kebenaran daripada pemegang hak cipta
-        tersebut.
+      licence_html: 'Penerbitan ini dilesenkan di bawah terma Lesen Kerajaan Terbuka v3.0 kecuali dinyatakan sebaliknya. Untuk melihat lesen ini, lawati <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a> atau tulis kepada Pasukan Dasar Maklumat, Arkib Negara, Kew, London TW9 4DU, atau e-mel: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: Di mana kami telah mengenal pasti mana-mana maklumat hak cipta pihak ketiga, anda perlu mendapatkan kebenaran daripada pemegang hak cipta tersebut.
   i18n:
     direction:
   language_names:
@@ -365,12 +353,9 @@ ms:
       speak_to_adviser: Bercakap dengan seorang penasihat sekarang
       technical_problem: Sembang web tidak tersedia ketika ini kerana masalah teknikal.
   specialist_document:
-    pdo_alt_text: Logo skema adalah cap hitam dengan perkataan Designated Origin UK
-      Protected
-    pgi_alt_text: Logo skema adalah cap hitam dengan perkataan Geographic Origin UK
-      Protected
-    tsg_alt_text: Logo skema adalah cap hitam dengan perkataan Traditional Speciality
-      UK Protected
+    pdo_alt_text: Logo skema adalah cap hitam dengan perkataan Designated Origin UK Protected
+    pgi_alt_text: Logo skema adalah cap hitam dengan perkataan Geographic Origin UK Protected
+    tsg_alt_text: Logo skema adalah cap hitam dengan perkataan Traditional Speciality UK Protected
   speech:
     delivered_on: Dihantar pada
     location: Lokasi
@@ -386,18 +371,10 @@ ms:
     release_date: Tarikh hebahan
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth
-        Office">FCO</abbr> menasihati supaya tidak membuat perjalanan kecuali yang
-        perlu sahaja ke bahagian-bahagian tertentu negara ini.
-      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and
-        Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat perjalanan
-        kecuali yang perlu sahaja ke seluruh negara.
-      avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr>
-        menasihati supaya tidak membuat sebarang perjalanan ke bahagian-bahagian tertentu
-        negara ini.
-      avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth
-        Office">FCO</abbr> menasihati supaya tidak membuat sebarang perjalanan ke
-        seluruh negara..
+      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat perjalanan kecuali yang perlu sahaja ke bahagian-bahagian tertentu negara ini.
+      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat perjalanan kecuali yang perlu sahaja ke seluruh negara.
+      avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat sebarang perjalanan ke bahagian-bahagian tertentu negara ini.
+      avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat sebarang perjalanan ke seluruh negara..
     context: Nasihat perjalanan ke negara luar
     coronavirus_warning:
       content_html: |
@@ -420,8 +397,7 @@ ms:
     updated: Dikemas kini
   unpublishing:
     page_title: Sudah tiada
-    summary: Maklumat dalam laman ini telah dikeluarkan kerana ia telah diterbitkan
-      secara salah.
+    summary: Maklumat dalam laman ini telah dikeluarkan kerana ia telah diterbitkan secara salah.
     title: Laman yang anda cari sudah tiada
   working_group:
     contact_details: Butiran hubungan

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -1,7 +1,11 @@
 ms:
   brexit:
-    business_link: Panduan Brexit untuk perniagaan
-    citizen_link: Panduan Brexit untuk individu dan keluarga
+    business_link:
+      path: "/guidance/brexit-guidance-for-businesses"
+      text: Panduan Brexit untuk perniagaan
+    citizen_link:
+      path: "/guidance/brexit-guidance-for-individuals-and-families"
+      text: Panduan Brexit untuk individu dan keluarga
     heading_prefix: Ada perbezaan
   common:
     last_updated:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -9,7 +9,6 @@ ms:
       text: Panduan Brexit untuk individu dan keluarga
     heading_prefix: Ada perbezaan
   common:
-    last_updated:
     visit: 'Lawati:'
   components:
     figure:
@@ -21,22 +20,8 @@ ms:
       see_all_updates: lihat semua kemas kini
       show_all_updates: tunjuk semua kemas kini
     publisher_metadata:
-      collections:
-      from:
       hide_all: sorok semua
       show_all: tunjuk semua
-    save_this_page:
-      add_page_button: Tambah ke laman simpanan anda
-      confirmations:
-        page_removed:
-          message: Anda telah mengeluarkan ini daripada laman simpanan anda
-        page_saved:
-          message: Anda telah menambah ini ke laman simpanan anda
-      page_not_saved_heading: Simpan laman ini supaya anda boleh melawatnya semula kemudian
-      page_was_saved_heading: Anda telah menyimpan laman ini
-      remove_page_button: Keluarkan daripada laman simpanan anda
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Lihat laman simpanan anda</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Daftar masuk</a> untuk melihat laman simpanan anda.
     share_links:
       share_this_page: Kongsi laman ini
   consultation:
@@ -61,7 +46,6 @@ ms:
     original_consultation: Perundingan asal
     ran_from: Perundingan ini berjalan dari
     respond_online: Jawab dalam talian
-    'true': betul
     visit_soon: Lawati laman ini semula untuk muat turun hasil maklum balas&nbsp;awam ini.
     was: adalah
     ways_to_respond: Cara untuk menjawab
@@ -376,22 +360,6 @@ ms:
       avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat sebarang perjalanan ke bahagian-bahagian tertentu negara ini.
       avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat sebarang perjalanan ke seluruh negara..
     context: Nasihat perjalanan ke negara luar
-    coronavirus_warning:
-      content_html: |
-        <p class="govuk-body">
-          Ikuti peraturan COVID-19 semasa tempat anda tinggal: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scotland</a>, <a href="https://gov.wales/coronavirus-travel">Wales</a> dan <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Ireland Utara</a>.
-        </p>
-        <p class="govuk-body">
-          Untuk mengelakkan varian COVID baharu daripada memasuki UK, anda tidak sepatutnya membuat perjalanan ke <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">negara-negara dalam senarai ambar atau merah</a>.
-        </p>
-        <p class="govuk-body">
-          Untuk memahami risko dalam sesebuah negara, ikuti <a href="/guidance/travel-advice-novel-coronavirus">Nasihat Perjalanan Pejabat Luar, Komanwel dan Pembangunan (FCDO)</a>.
-        </p>
-        <p class="govuk-body">
-         Apabila kembali, ikuti peraturan untuk <a href="/uk-border-control">memasuki UK dari negara luar</a> (kecuali dari Ireland).
-        </p>
-      text_assistive: Penting
-      title: Perjalanan koronavirus (COVID-19)
     still_current_at: Masih semasa di
     summary: Ringkasan
     updated: Dikemas kini

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -483,6 +483,7 @@ mt:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -472,12 +472,10 @@ mt:
     field_of_operation: Qasam tal-operazzjoni
     operations_in: Operazzjonijiet fil- %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -324,12 +324,10 @@ ne:
     field_of_operation: सञ्चालन क्षेत्र
     operations_in: "%{location} मा सञ्चालन"
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -335,6 +335,7 @@ ne:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -335,6 +335,7 @@ nl:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -324,12 +324,10 @@ nl:
     field_of_operation: Gebied van operatie
     operations_in: Operaties in %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -324,12 +324,10 @@
     field_of_operation: Operasjonsfelt
     operations_in: Operasjoner i %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -335,6 +335,7 @@
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -324,12 +324,10 @@ pa-pk:
     field_of_operation: عمل کرن دا حلقہ
     operations_in: ایندے بارے عمل {location}%
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -335,6 +335,7 @@ pa-pk:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -335,6 +335,7 @@ pa:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -324,12 +324,10 @@ pa:
     field_of_operation: ਕਾਰਜ ਖੇਤਰ
     operations_in: "%{location} ਵਿੱਚ ਕਾਰਜ"
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -472,12 +472,10 @@ pl:
     field_of_operation: Zakres działania
     operations_in: Działania w %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -483,6 +483,7 @@ pl:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -335,6 +335,7 @@ ps:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -324,12 +324,10 @@ ps:
     field_of_operation: د عملیاتو ساحه
     operations_in: په%{location} کې عملیات
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,5 +1,83 @@
+---
 pt:
+  brexit:
+    business_link:
+      path: "/guidance/brexit-guidance-for-businesses"
+      text: Guia Brexit para as empresas
+    citizen_link:
+      path: "/guidance/brexit-guidance-for-individuals-and-families"
+      text: Orientação Brexit para pessoas e famílias
+    heading_prefix: Há diferentes
+  common:
+    last_updated:
+    visit: 'Visite:'
+  components:
+    figure:
+      image_credit: 'Crédito da imagem: %{credit}'
+    published_dates:
+      hide_all_updates: ocultar todas as atualizações
+      last_updated: Última atualização a %{date}
+      published: Publicado a %{date}
+      see_all_updates: ver todas as atualizações
+      show_all_updates: mostrar todas as atualizações
+    publisher_metadata:
+      collections:
+      from:
+      hide_all: ocultar tudo
+      show_all: mostrar tudo
+    save_this_page:
+      add_page_button: Adicione às suas páginas guardadas
+      confirmations:
+        page_removed:
+          message: Removeu esta das suas páginas guardadas
+        page_saved:
+          message: Adicionou esta às suas páginas guardadas
+      page_not_saved_heading: Guarde esta página para que possa voltar a ela mais tarde
+      page_was_saved_heading: Guardou esta página
+      remove_page_button: Removida das suas páginas guardadas
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Veja as suas páginas guardadas</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Registe-se</a> para ver as suas páginas guardadas.
+    share_links:
+      share_this_page: Partilhar esta página
+  consultation:
+    and: e
+    another_website_html: Esta consulta %{closed} foi realizada <a href="%{url}">noutro site</a>
+    at: às
+    closes: Encerra às
+    closes_at: Esta consulta encerra às
+    complete_a: Preencha um
+    description: Descrição da consulta
+    detail_of_feedback_received: Detalhes do feedback recebido
+    detail_of_outcome: Detalhes do resultado
+    documents: Documentos
+    download_outcome: Transfira o resultado completo
+    either: ou
+    email_to: 'E-mail para:'
+    feedback_received: Feedback recebido
+    is_being: está a ser
+    not_open_yet: Esta consulta ainda não está aberta
+    'on':
+    opens: Esta consulta abre
+    original_consultation: Consulta original
+    ran_from: Esta consulta decorreu de
+    respond_online: Responder online
+    'true': verdadeiro
+    visit_soon: Visite esta página novamente em breve para transferir o resultado para este feedback público.
+    was: foi
+    ways_to_respond: Formas de resposta
+    write_to: 'Escreva para:'
+  contact:
+    email: E-mail
+    find_call_charges: Saiba quais são as tarifas para as chamadas
+    online: Online
+    phone: Telefone
+    webchat: Webchat
   content_item:
+    coming_soon: Este documento será publicado em
+    contents: Conteúdos
+    metadata:
+      published: Publicado em
+      updated: Atualizado em
     schema_name:
       aaib_report:
         one: Relatório da Divisão de Investigação de Acidentes Aéreos
@@ -223,100 +301,11 @@ pt:
       written_statement:
         one: Declaração escrita ao Parlamento
         other: Declarações escritas ao Parlamento
-    coming_soon: Este documento será publicado em
-    contents: Conteúdos
-    metadata:
-      published: Publicado em
-      updated: Atualizado em
-  publication:
-    documents:
-      one: Documento
-      other: Documentos
-    details: Detalhes
-  brexit:
-    business_link:
-      path: "/guidance/brexit-guidance-for-businesses"
-      text: Guia Brexit para as empresas
-    citizen_link:
-      path: "/guidance/brexit-guidance-for-individuals-and-families"
-      text: Orientação Brexit para pessoas e famílias
-    heading_prefix: Há diferentes
-  common:
-    last_updated:
-    visit: 'Visite:'
-  components:
-    figure:
-      image_credit: 'Crédito da imagem: %{credit}'
-    published_dates:
-      hide_all_updates: ocultar todas as atualizações
-      last_updated: Última atualização a %{date}
-      published: Publicado a %{date}
-      see_all_updates: ver todas as atualizações
-      show_all_updates: mostrar todas as atualizações
-    publisher_metadata:
-      collections:
-      from:
-      hide_all: ocultar tudo
-      show_all: mostrar tudo
-    save_this_page:
-      add_page_button: Adicione às suas páginas guardadas
-      confirmations:
-        page_removed:
-          message: Removeu esta das suas páginas guardadas
-        page_saved:
-          message: Adicionou esta às suas páginas guardadas
-      page_not_saved_heading: Guarde esta página para que possa voltar a ela mais
-        tarde
-      page_was_saved_heading: Guardou esta página
-      remove_page_button: Removida das suas páginas guardadas
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Veja
-        as suas páginas guardadas</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Registe-se</a>
-        para ver as suas páginas guardadas.
-    share_links:
-      share_this_page: Partilhar esta página
-  consultation:
-    and: e
-    another_website_html: Esta consulta %{closed} foi realizada <a href="%{url}">noutro
-      site</a>
-    at: às
-    closes: Encerra às
-    closes_at: Esta consulta encerra às
-    complete_a: Preencha um
-    description: Descrição da consulta
-    detail_of_feedback_received: Detalhes do feedback recebido
-    detail_of_outcome: Detalhes do resultado
-    documents: Documentos
-    download_outcome: Transfira o resultado completo
-    either: ou
-    email_to: 'E-mail para:'
-    feedback_received: Feedback recebido
-    is_being: está a ser
-    not_open_yet: Esta consulta ainda não está aberta
-    'on':
-    opens: Esta consulta abre
-    original_consultation: Consulta original
-    ran_from: Esta consulta decorreu de
-    respond_online: Responder online
-    'true': verdadeiro
-    visit_soon: Visite esta página novamente em breve para transferir o resultado
-      para este feedback público.
-    was: foi
-    ways_to_respond: Formas de resposta
-    write_to: 'Escreva para:'
-  contact:
-    email: E-mail
-    find_call_charges: Saiba quais são as tarifas para as chamadas
-    online: Online
-    phone: Telefone
-    webchat: Webchat
   corporate_information_page:
     about_our_services_html: Saiba mais %{link}.
     corporate_information: Informações da empresa
-    personal_information_charter_html: O nosso %{link} explica como tratamos as suas
-      informações pessoais.
-    publication_scheme_html: Leia sobre os tipos de informação que publicamos no nosso
-      %{link}.
+    personal_information_charter_html: O nosso %{link} explica como tratamos as suas informações pessoais.
+    publication_scheme_html: Leia sobre os tipos de informação que publicamos no nosso %{link}.
     social_media_use_html: Leia a nossa política em %{link}.
     welsh_language_scheme_html: Saiba mais sobre o nosso compromisso para com %{link}.
   fatality_notice:
@@ -325,8 +314,7 @@ pt:
     operations_in: Operações em %{location}
   gone:
     page_title: Já não está disponível
-    published_in_error: A informação contida nesta página foi retirada porque foi
-      publicada por engano.
+    published_in_error: A informação contida nesta página foi retirada porque foi publicada por engano.
     title: A página que procura já não está disponível
   guide:
     pages_in_guide: Páginas neste guia
@@ -336,14 +324,8 @@ pt:
       available_at: Esta publicação está disponível em %{url}
       copyright: "© Crown copyright %{year}"
       isbn: 'ISBN:'
-      licence_html: 'Esta publicação é licenciada nos termos da Licença de Governo
-        Aberto v3.0, salvo indicação em contrário. Para ver esta licença, visite <a
-        href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
-        escreva para Equipa de Política de Informação, The National Archives, Kew,
-        London TW9 4DU, ou envie-nos um e-mail para: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
-      third_party: Quando tivermos identificado qualquer informação sobre direitos
-        de autor de terceiros, será necessário obter permissão dos detentores dos
-        direitos de autor em questão.
+      licence_html: 'Esta publicação é licenciada nos termos da Licença de Governo Aberto v3.0, salvo indicação em contrário. Para ver esta licença, visite <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a> escreva para Equipa de Política de Informação, The National Archives, Kew, London TW9 4DU, ou envie-nos um e-mail para: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: Quando tivermos identificado qualquer informação sobre direitos de autor de terceiros, será necessário obter permissão dos detentores dos direitos de autor em questão.
   i18n:
     direction:
   language_names:
@@ -352,6 +334,11 @@ pt:
     next_page: Seguinte
     previous_page: Anterior
     print_entire_guide: Imprimir guia completo
+  publication:
+    details: Detalhes
+    documents:
+      one: Documento
+      other: Documentos
   service_sign_in:
     continue: Continuar
     error:
@@ -364,15 +351,11 @@ pt:
       busy: Todos os consultores por webchat estão ocupados neste momento.
       closed: O webchat está fechado neste momento.
       speak_to_adviser: Fale com um consultor agora
-      technical_problem: O webchat não está disponível de momento, devido a problemas
-        técnicos.
+      technical_problem: O webchat não está disponível de momento, devido a problemas técnicos.
   specialist_document:
-    pdo_alt_text: O logotipo do sistema é um carimbo preto com as palavras "Designated
-      Origin UK Protected" (Origem Designada Reino Unido Protegida)
-    pgi_alt_text: O logotipo do sistema é um carimbo preto com as palavras "Geographic
-      Origin UK Protected" (Origem Geográfica Reino Unido Protegida)
-    tsg_alt_text: O logotipo do sistema é um carimbo preto com as palavras "Traditional
-      Speciality UK Protected" (Especialidade Tradicional Reino Unido Protegida)
+    pdo_alt_text: O logotipo do sistema é um carimbo preto com as palavras "Designated Origin UK Protected" (Origem Designada Reino Unido Protegida)
+    pgi_alt_text: O logotipo do sistema é um carimbo preto com as palavras "Geographic Origin UK Protected" (Origem Geográfica Reino Unido Protegida)
+    tsg_alt_text: O logotipo do sistema é um carimbo preto com as palavras "Traditional Speciality UK Protected" (Especialidade Tradicional Reino Unido Protegida)
   speech:
     delivered_on: Entregue em
     location: Local
@@ -388,16 +371,10 @@ pt:
     release_date: Data de divulgação
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: O <abbr title="Foreign and Commonwealth
-        Office">FCO</abbr> desaconselha todas as viagens, exceto as essenciais, a
-        algumas zonas do país.
-      avoid_all_but_essential_travel_to_whole_country: O <abbr title="Foreign and
-        Commonwealth Office">FCO</abbr> desaconselha todas as viagens, exceto as essenciais,
-        a todo o país.
-      avoid_all_travel_to_parts: O <abbr title="Foreign and Commonwealth Office">FCO</abbr>
-        desaconselha todas as viagens a algumas zonas do país.
-      avoid_all_travel_to_whole_country: O <abbr title="Foreign and Commonwealth Office">FCO</abbr>
-        desaconselha todas as viagens a todo o país.
+      avoid_all_but_essential_travel_to_parts: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens, exceto as essenciais, a algumas zonas do país.
+      avoid_all_but_essential_travel_to_whole_country: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens, exceto as essenciais, a todo o país.
+      avoid_all_travel_to_parts: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens a algumas zonas do país.
+      avoid_all_travel_to_whole_country: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens a todo o país.
     context: Aconselhamento sobre viagens ao estrangeiro
     coronavirus_warning:
       content_html: |
@@ -420,8 +397,7 @@ pt:
     updated: Atualizado em
   unpublishing:
     page_title: Já não está disponível
-    summary: A informação contida nesta página foi retirada porque foi publicada por
-      engano.
+    summary: A informação contida nesta página foi retirada porque foi publicada por engano.
     title: A página que procura já não está disponível
   working_group:
     contact_details: Informações de contacto

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -9,7 +9,6 @@ pt:
       text: Orientação Brexit para pessoas e famílias
     heading_prefix: Há diferentes
   common:
-    last_updated:
     visit: 'Visite:'
   components:
     figure:
@@ -21,22 +20,8 @@ pt:
       see_all_updates: ver todas as atualizações
       show_all_updates: mostrar todas as atualizações
     publisher_metadata:
-      collections:
-      from:
       hide_all: ocultar tudo
       show_all: mostrar tudo
-    save_this_page:
-      add_page_button: Adicione às suas páginas guardadas
-      confirmations:
-        page_removed:
-          message: Removeu esta das suas páginas guardadas
-        page_saved:
-          message: Adicionou esta às suas páginas guardadas
-      page_not_saved_heading: Guarde esta página para que possa voltar a ela mais tarde
-      page_was_saved_heading: Guardou esta página
-      remove_page_button: Removida das suas páginas guardadas
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Veja as suas páginas guardadas</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Registe-se</a> para ver as suas páginas guardadas.
     share_links:
       share_this_page: Partilhar esta página
   consultation:
@@ -61,7 +46,6 @@ pt:
     original_consultation: Consulta original
     ran_from: Esta consulta decorreu de
     respond_online: Responder online
-    'true': verdadeiro
     visit_soon: Visite esta página novamente em breve para transferir o resultado para este feedback público.
     was: foi
     ways_to_respond: Formas de resposta
@@ -376,22 +360,6 @@ pt:
       avoid_all_travel_to_parts_html: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens a algumas zonas do país.
       avoid_all_travel_to_whole_country_html: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens a todo o país.
     context: Aconselhamento sobre viagens ao estrangeiro
-    coronavirus_warning:
-      content_html: |
-        <p class="govuk-body">
-          Siga as regras atuais para a COVID-19 na zona onde vive: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">Inglaterra</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Escócia</a>, <a href="https://gov.wales/coronavirus-travel">País de Gales</a> e <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Irlanda do Norte</a>.
-        </p>
-        <p class="govuk-body">
-          Para evitar que novas variantes da COVID-19 entrem no Reino Unido, não deve viajar para <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">países da lista amarela ou da lista vermelha</a>.
-        </p>
-        <p class="govuk-body">
-          Para compreender os riscos num país, siga os <a href="/guidance/travel-advice-novel-coronavirus">Conselhos de Viagem do Ministério dos Negócios Estrangeiros, Commonwealth e Desenvolvimento</a>.
-        </p>
-        <p class="govuk-body">
-          Quando regressar, siga as regras para <a href="/uk-border-control">entrar no Reino Unido quando se vem do estrangeiro</a> (exceto da Irlanda).
-        </p>
-      text_assistive: Importante
-      title: Viajar durante o Coronavírus (COVID-19)
     still_current_at: Continua atual às
     summary: Resumo
     updated: Atualizado em

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,506 +1,424 @@
----
 pt:
-  brexit:
-    business_link:
-      path:
-      text:
-    citizen_link:
-      path:
-      text:
-    heading_prefix:
-  common:
-    visit:
-  components:
-    figure:
-      image_credit:
-    published_dates:
-      hide_all_updates:
-      last_updated:
-      published:
-      see_all_updates:
-      show_all_updates:
-    publisher_metadata:
-      hide_all:
-      show_all:
-    share_links:
-      share_this_page:
-  consultation:
-    and:
-    another_website_html:
-    at:
-    closes:
-    closes_at:
-    complete_a:
-    description:
-    detail_of_feedback_received:
-    detail_of_outcome:
-    documents:
-    download_outcome:
-    either:
-    email_to:
-    feedback_received:
-    is_being:
-    not_open_yet:
-    'on':
-    opens:
-    original_consultation:
-    ran_from:
-    respond_online:
-    visit_soon:
-    was:
-    ways_to_respond:
-    write_to:
-  contact:
-    email:
-    find_call_charges:
-    online:
-    phone:
-    webchat:
   content_item:
-    coming_soon:
-    contents:
-    metadata:
-      published: publicado
-      updated: Atualizado
     schema_name:
       aaib_report:
-        one:
-        other:
+        one: Relatório da Divisão de Investigação de Acidentes Aéreos
+        other: Relatórios da Divisão de Investigação de Acidentes Aéreos
       announcement:
         one: Anúncio
         other: Anúncios
       asylum_support_decision:
-        one:
-        other:
+        one: Decisão do tribunal de apoio a asilo
+        other: Decisões do tribunal de apoio a asilo
       authored_article:
-        one: Artigo
-        other: Artigos
+        one: Artigo de autor
+        other: Artigos de autor
       business_finance_support_scheme:
-        one:
-        other:
+        one: Regime de apoio financeiro a empresas
+        other: Regimes de apoio financeiro a empresas
       case_study:
         one: Estudo de caso
         other: Estudos de caso
       closed_consultation:
-        one: Consulta fechada
-        other: Consultas fechadas
-        overview:
+        one: Consulta encerrada
+        other: Consultas encerradas
       cma_case:
-        one:
-        other:
+        one: Caso da Autoridade da Concorrência e Mercados
+        other: Casos da Autoridade da Concorrência e Mercados
       coming_soon:
-        one:
-        other:
+        one: Brevemente
+        other: Brevemente
       consultation:
         one: Consulta
         other: Consultas
       consultation_outcome:
-        one: Resultado de consulta
-        other: Resultados de consultas
-        overview:
+        one: Resultado da consulta
+        other: Resultados da consulta
       corporate_information_page:
-        one:
-        other:
+        one: Página de informação
+        other: Páginas de informação
       corporate_report:
-        one: Relatório Corporativo
-        other: Relatórios Corporativos
-        overview:
+        one: Relatório empresarial
+        other: Relatórios empresariais
       correspondence:
         one: Correspondência
         other: Correspondências
-        overview:
       countryside_stewardship_grant:
-        one:
-        other:
+        one: Subsídio de Conservação do Campo
+        other: Subsídios de Conservação do Campo
       decision:
-        one:
-        other:
-        overview:
+        one: Decisão
+        other: Decisões
       detailed_guide:
-        one: Guia detalhado
-        other: Guias detalhados
+        one: Orientação
+        other: Orientação
       dfid_research_output:
-        one:
-        other:
+        one: Resultado da Investigação para o Desenvolvimento
+        other: Resultados da Investigação para o Desenvolvimento
       document_collection:
-        one: Séries
-        other:
+        one: Coleção
+        other: Coleções
       draft_text:
-        one: Texto preliminar
-        other: Textos preliminares
+        one: Texto provisório
+        other: Textos provisórios
       drug_safety_update:
-        one:
-        other:
+        one: Atualização sobre Segurança dos Medicamentos
+        other: Atualizações sobre Segurança dos Medicamentos
       employment_appeal_tribunal_decision:
-        one:
-        other:
+        one: Decisão do tribunal de recurso em matéria de trabalho
+        other: Decisões do tribunal de recurso em matéria de trabalho
       employment_tribunal_decision:
-        one:
-        other:
+        one: Decisão do tribunal de trabalho
+        other: Decisões do tribunal de trabalho
       esi_fund:
-        one:
-        other:
+        one: Fundo Estrutural e de Investimento Europeus (ESIF)
+        other: Fundos Estruturais e de Investimento Europeus (ESIF)
       fatality_notice:
-        one: Aviso de Falecimento
-        other: Avisos de Falecimento
+        one: Aviso de fatalidade
+        other: Avisos de fatalidade
       foi_release:
-        one: Comunicado sobre pedido de acesso a informação
-        other: Comunicados sobre pedidos de acesso a informação
-        overview:
+        one: Comunicado de Liberdade de Informação
+        other: Comunicados de Liberdade de Informação
       form:
         one: Formulário
         other: Formulários
-        overview:
       government_response:
-        one: Resposta governamental
-        other: Respostas governamentais
+        one: Resposta do governo
+        other: Respostas do governo
       guidance:
-        one: Instrução
-        other: Instruções
-        overview:
+        one: Orientação
+        other: Orientação
       impact_assessment:
-        one: Relatório de Impacto
-        other: Relatórios de Impacto
-        overview:
+        one: Avaliação de impacto
+        other: Avaliações de impacto
       imported:
-        one: importado - esperando tipo
-        other: importados - esperando tipo
+        one: importado – a aguardar tipo
+        other: importado – a aguardar tipo
       independent_report:
         one: Relatório independente
         other: Relatórios independentes
-        overview:
       international_development_fund:
-        one:
-        other:
+        one: Financiamento do desenvolvimento internacional
+        other: Financiamento do desenvolvimento internacional
       international_treaty:
-        one:
-        other:
-        overview:
+        one: Tratado internacional
+        other: Tratados internacionais
       maib_report:
-        one:
-        other:
+        one: Relatório da Divisão de Investigação de Acidentes Marítimos
+        other: Relatórios da Divisão de Investigação de Acidentes Marítimos
       map:
         one: Mapa
         other: Mapas
-        overview:
       medical_safety_alert:
-        one:
-        other:
+        one: Alertas e recolhas para medicamentos e dispositivos médicos
+        other: Alertas e recolhas para medicamentos e dispositivos médicos
       national:
-        one:
-        other:
+        one: Anúncio de estatísticas nacionais
+        other: Anúncios de estatísticas nacionais
       national_statistics:
-        one: Estatística - estatística nacional
-        other: Estatísticas - estatísticas nacionais
-        overview:
+        one: Estatísticas Nacionais
+        other: Estatísticas Nacionais
       national_statistics_announcement:
-        one:
-        other:
+        one: Anúncio de estatísticas nacionais
+        other: Anúncios de estatísticas nacionais
       news_article:
-        one: Notícia - Artigo
-        other: Notícias - Artigos
+        one: Artigo noticioso
+        other: Artigos noticiosos
       news_story:
-        one: Notícia
-        other: Notícias
+        one: Reportagem
+        other: Reportagens
       notice:
-        one:
-        other:
-        overview:
+        one: Aviso
+        other: Avisos
       official:
-        one:
-        other:
+        one: Anúncio de estatísticas oficiais
+        other: Anúncios de estatísticas oficiais
       official_statistics:
-        one: Estatística
-        other: Estatísticas
-        overview:
+        one: Estatísticas Oficiais
+        other: Estatísticas Oficiais
       official_statistics_announcement:
-        one:
-        other:
+        one: Anúncio de estatísticas oficiais
+        other: Anúncios de estatísticas oficiais
       open_consultation:
         one: Consulta aberta
         other: Consultas abertas
-        overview:
       oral_statement:
-        one: Declaração verbal ao Parlamento
-        other: Declarações verbais ao Parlamento
+        one: Declaração oral ao Parlamento
+        other: Declarações orais ao Parlamento
       policy:
         one: Política
         other: Políticas
       policy_paper:
-        one: Relatório sobre políticas
-        other: Relatórios sobre políticas
-        overview:
+        one: Documento de política
+        other: Documentos de políticas
       press_release:
-        one: Comunicado de Imprensa
-        other: Comunicados de Imprensa
+        one: Comunicado de imprensa
+        other: Comunicados de imprensa
       promotional:
         one: Material promocional
-        other: Materiais promocionais
-        overview:
+        other: Material promocional
       publication:
         one: Publicação
         other: Publicações
       raib_report:
-        one:
-        other:
+        one: Relatório da Divisão de Investigação de Acidentes Ferroviários
+        other: Relatórios da Divisão de Investigação de Acidentes Ferroviários
       regulation:
-        one:
-        other:
-        overview:
+        one: Regulamento
+        other: Regulamentos
       research:
-        one: Pesquisa e análise
-        other: Pesquisas e análises
-        overview:
+        one: Investigação e análise
+        other: Investigação e análise
       residential_property_tribunal_decision:
-        one:
-        other:
+        one: Decisão do tribunal de propriedade residencial
+        other: Decisões do tribunal de propriedade residencial
       service_sign_in:
-        one:
-        other:
+        one: Registo no serviço
+        other: Registo no serviço
       service_standard_report:
-        one:
-        other:
+        one: Relatório Padrão de Serviço
+        other: Relatórios Padrão de Serviço
       speaking_notes:
-        one: Notas de discurso
-        other: Notas de discursos
+        one: Notas orais
+        other: Notas orais
       speech:
         one: Discurso
         other: Discursos
       standard:
-        one:
-        other:
-        overview:
+        one: Norma
+        other: Normas
       statement_to_parliament:
         one: Declaração ao Parlamento
         other: Declarações ao Parlamento
       statistical_data_set:
-        one: Conjunto de dados estastísticos
+        one: Conjunto de dados estatísticos
         other: Conjuntos de dados estatísticos
       statistics_announcement:
-        one:
-        other:
+        one: Anúncio de divulgação de estatísticas
+        other: Anúncios de divulgação de estatísticas
       statutory_guidance:
-        one:
-        other:
-        overview:
+        one: Orientação estatutária
+        other: Orientação estatutária
       take_part:
-        one:
-        other:
+        one: Participar
+        other: Participar
       tax_tribunal_decision:
-        one:
-        other:
+        one: Decisão do Tribunal Fiscal e de Chancelaria
+        other: Decisões do Tribunal Fiscal e de Chancelaria
       transcript:
         one: Transcrição
         other: Transcrições
       transparency:
-        one: Dado de Transparência
-        other: Dados de Transparência
-        overview:
+        one: Dados de transparência
+        other: Dados de transparência
       utaac_decision:
-        one:
-        other:
+        one: Decisão do tribunal de recurso administrativo
+        other: Decisões do tribunal de recurso administrativo
       world_location_news_article:
-        one: Notícia - Artigo
-        other: Notícias - Artigos
+        one: Artigo noticioso
+        other: Artigos noticiosos
       world_news_story:
-        one:
-        other:
+        one: Reportagem do mundo
+        other: Reportagens do mundo
       written_statement:
         one: Declaração escrita ao Parlamento
         other: Declarações escritas ao Parlamento
-  corporate_information_page:
-    about_our_services_html:
-    corporate_information: Informações administrativas
-    personal_information_charter_html: Nosso %{link} explica como nós tratamos suas informações pessoais
-    publication_scheme_html: Leia sobre os tipos de informações que publicamos rotineiramente em nosso %{link}.
-    social_media_use_html: Leia nossa política sobre %{link}
-    welsh_language_scheme_html: Saiba mais sobre nosso comprometimento em publicar em %{link}
-  email:
-    description_html:
-    subscribe_title:
-    unsubscribe_title:
-  fatality_notice:
-    alt_text:
-    field_of_operation:
-    operations_in:
-  get_involved:
-    active_blogs:
-    civil_service:
-    civil_service_quarterly:
-    closed:
-    closed_consultations:
-    closed_with_date:
-    closes:
-    closing_today:
-    closing_tomorrow:
-    days_left:
-    engage_with_gov:
-    fcdo_bloggers:
-    follow:
-    follow_paragraph:
-    gds_blog:
-    gov_past:
-    intro_paragraph:
-      body_html:
-      engage_with_government:
-      take_part:
-    join_ics:
-    make_donation:
-    more_ways:
-    neighbourhood_watch:
-    open_consultations:
-    page_heading:
-    page_title:
-    petition_paragraph:
-      body_html:
-      create_a_petition:
-    read_respond:
-    recent_outcomes:
-    recently_opened:
-    respond_to_consultations:
-    school_overseas:
-    search_all:
-    see_all_dept:
-    start_a_petition:
-    take_part:
-    take_part_suggestions:
-    your_views:
-  gone:
-    page_title:
-    published_in_error:
-    title:
-  guide:
-    pages_in_guide:
-    skip_to_contents:
-  html_publication:
-    print_meta_data:
-      available_at:
-      copyright:
-      isbn:
-      licence_html:
-      third_party:
-  i18n:
-    direction:
-  language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt: Português
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
-  multi_page:
-    next_page:
-    previous_page:
-    print_entire_guide:
+    coming_soon: Este documento será publicado em
+    contents: Conteúdos
+    metadata:
+      published: Publicado em
+      updated: Atualizado em
   publication:
-    details:
     documents:
       one: Documento
       other: Documentos
+    details: Detalhes
+  brexit:
+    business_link: Guia Brexit para as empresas
+    citizen_link: Orientação Brexit para pessoas e famílias
+    heading_prefix: Há diferentes
+  common:
+    last_updated:
+    visit: 'Visite:'
+  components:
+    figure:
+      image_credit: 'Crédito da imagem: %{credit}'
+    published_dates:
+      hide_all_updates: ocultar todas as atualizações
+      last_updated: Última atualização a %{date}
+      published: Publicado a %{date}
+      see_all_updates: ver todas as atualizações
+      show_all_updates: mostrar todas as atualizações
+    publisher_metadata:
+      collections:
+      from:
+      hide_all: ocultar tudo
+      show_all: mostrar tudo
+    save_this_page:
+      add_page_button: Adicione às suas páginas guardadas
+      confirmations:
+        page_removed:
+          message: Removeu esta das suas páginas guardadas
+        page_saved:
+          message: Adicionou esta às suas páginas guardadas
+      page_not_saved_heading: Guarde esta página para que possa voltar a ela mais
+        tarde
+      page_was_saved_heading: Guardou esta página
+      remove_page_button: Removida das suas páginas guardadas
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Veja
+        as suas páginas guardadas</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Registe-se</a>
+        para ver as suas páginas guardadas.
+    share_links:
+      share_this_page: Partilhar esta página
+  consultation:
+    and: e
+    another_website_html: Esta consulta %{closed} foi realizada <a href="%{url}">noutro
+      site</a>
+    at: às
+    closes: Encerra às
+    closes_at: Esta consulta encerra às
+    complete_a: Preencha um
+    description: Descrição da consulta
+    detail_of_feedback_received: Detalhes do feedback recebido
+    detail_of_outcome: Detalhes do resultado
+    documents: Documentos
+    download_outcome: Transfira o resultado completo
+    either: ou
+    email_to: 'E-mail para:'
+    feedback_received: Feedback recebido
+    is_being: está a ser
+    not_open_yet: Esta consulta ainda não está aberta
+    'on':
+    opens: Esta consulta abre
+    original_consultation: Consulta original
+    ran_from: Esta consulta decorreu de
+    respond_online: Responder online
+    'true': verdadeiro
+    visit_soon: Visite esta página novamente em breve para transferir o resultado
+      para este feedback público.
+    was: foi
+    ways_to_respond: Formas de resposta
+    write_to: 'Escreva para:'
+  contact:
+    email: E-mail
+    find_call_charges: Saiba quais são as tarifas para as chamadas
+    online: Online
+    phone: Telefone
+    webchat: Webchat
+  corporate_information_page:
+    about_our_services_html: Saiba mais %{link}.
+    corporate_information: Informações da empresa
+    personal_information_charter_html: O nosso %{link} explica como tratamos as suas
+      informações pessoais.
+    publication_scheme_html: Leia sobre os tipos de informação que publicamos no nosso
+      %{link}.
+    social_media_use_html: Leia a nossa política em %{link}.
+    welsh_language_scheme_html: Saiba mais sobre o nosso compromisso para com %{link}.
+  fatality_notice:
+    alt_text: Brasão do Ministério da Defesa
+    field_of_operation: Campo de operação
+    operations_in: Operações em %{location}
+  gone:
+    page_title: Já não está disponível
+    published_in_error: A informação contida nesta página foi retirada porque foi
+      publicada por engano.
+    title: A página que procura já não está disponível
+  guide:
+    pages_in_guide: Páginas neste guia
+    skip_to_contents: Saltar para o conteúdo do guia
+  html_publication:
+    print_meta_data:
+      available_at: Esta publicação está disponível em %{url}
+      copyright: "© Crown copyright %{year}"
+      isbn: 'ISBN:'
+      licence_html: 'Esta publicação é licenciada nos termos da Licença de Governo
+        Aberto v3.0, salvo indicação em contrário. Para ver esta licença, visite <a
+        href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
+        escreva para Equipa de Política de Informação, The National Archives, Kew,
+        London TW9 4DU, ou envie-nos um e-mail para: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: Quando tivermos identificado qualquer informação sobre direitos
+        de autor de terceiros, será necessário obter permissão dos detentores dos
+        direitos de autor em questão.
+  i18n:
+    direction:
+  language_names:
+    pt: Português
+  multi_page:
+    next_page: Seguinte
+    previous_page: Anterior
+    print_entire_guide: Imprimir guia completo
   service_sign_in:
-    continue:
+    continue: Continuar
     error:
-      option:
-      title:
+      option: Por favor, selecione uma opção
+      title: Ainda não selecionou uma opção
   shared:
-    historically_political:
+    historically_political: Isto foi publicado no âmbito do %{government}
     webchat:
-      available:
-      busy:
-      closed:
-      speak_to_adviser:
-      technical_problem:
+      available: Os consultores estão disponíveis para conversar.
+      busy: Todos os consultores por webchat estão ocupados neste momento.
+      closed: O webchat está fechado neste momento.
+      speak_to_adviser: Fale com um consultor agora
+      technical_problem: O webchat não está disponível de momento, devido a problemas
+        técnicos.
   specialist_document:
-    pdo_alt_text:
-    pgi_alt_text:
-    tsg_alt_text:
+    pdo_alt_text: O logotipo do sistema é um carimbo preto com as palavras "Designated
+      Origin UK Protected" (Origem Designada Reino Unido Protegida)
+    pgi_alt_text: O logotipo do sistema é um carimbo preto com as palavras "Geographic
+      Origin UK Protected" (Origem Geográfica Reino Unido Protegida)
+    tsg_alt_text: O logotipo do sistema é um carimbo preto com as palavras "Traditional
+      Speciality UK Protected" (Especialidade Tradicional Reino Unido Protegida)
   speech:
-    delivered_on:
-    location:
-    written_on:
+    delivered_on: Entregue em
+    location: Local
+    written_on: Escrito em
   statistics_announcement:
-    cancellation_date:
-    cancelled:
-    changed_date:
-    forthcoming:
-    previous_date:
-    proposed_date:
-    reason_for_change:
-    release_date:
+    cancellation_date: Data de cancelamento
+    cancelled: Divulgação de estatísticas cancelada
+    changed_date: A data de divulgação foi alterada
+    forthcoming: Estas estatísticas serão divulgadas
+    previous_date: Data anterior
+    proposed_date: Divulgação proposta
+    reason_for_change: Motivo de alteração
+    release_date: Data de divulgação
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts_html:
-      avoid_all_but_essential_travel_to_whole_country_html:
-      avoid_all_travel_to_parts_html:
-      avoid_all_travel_to_whole_country_html:
-    context:
-    still_current_at:
-    summary:
-    updated:
+      avoid_all_but_essential_travel_to_parts: O <abbr title="Foreign and Commonwealth
+        Office">FCO</abbr> desaconselha todas as viagens, exceto as essenciais, a
+        algumas zonas do país.
+      avoid_all_but_essential_travel_to_whole_country: O <abbr title="Foreign and
+        Commonwealth Office">FCO</abbr> desaconselha todas as viagens, exceto as essenciais,
+        a todo o país.
+      avoid_all_travel_to_parts: O <abbr title="Foreign and Commonwealth Office">FCO</abbr>
+        desaconselha todas as viagens a algumas zonas do país.
+      avoid_all_travel_to_whole_country: O <abbr title="Foreign and Commonwealth Office">FCO</abbr>
+        desaconselha todas as viagens a todo o país.
+    context: Aconselhamento sobre viagens ao estrangeiro
+    coronavirus_warning:
+      content_html: |
+        <p class="govuk-body">
+          Siga as regras atuais para a COVID-19 na zona onde vive: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">Inglaterra</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Escócia</a>, <a href="https://gov.wales/coronavirus-travel">País de Gales</a> e <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Irlanda do Norte</a>.
+        </p>
+        <p class="govuk-body">
+          Para evitar que novas variantes da COVID-19 entrem no Reino Unido, não deve viajar para <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">países da lista amarela ou da lista vermelha</a>.
+        </p>
+        <p class="govuk-body">
+          Para compreender os riscos num país, siga os <a href="/guidance/travel-advice-novel-coronavirus">Conselhos de Viagem do Ministério dos Negócios Estrangeiros, Commonwealth e Desenvolvimento</a>.
+        </p>
+        <p class="govuk-body">
+          Quando regressar, siga as regras para <a href="/uk-border-control">entrar no Reino Unido quando se vem do estrangeiro</a> (exceto da Irlanda).
+        </p>
+      text_assistive: Importante
+      title: Viajar durante o Coronavírus (COVID-19)
+    still_current_at: Continua atual às
+    summary: Resumo
+    updated: Atualizado em
   unpublishing:
-    page_title:
-    summary:
-    title:
+    page_title: Já não está disponível
+    summary: A informação contida nesta página foi retirada porque foi publicada por
+      engano.
+    title: A página que procura já não está disponível
   working_group:
-    contact_details:
-    policies:
+    contact_details: Informações de contacto
+    policies: Políticas

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -292,10 +292,55 @@ pt:
     publication_scheme_html: Leia sobre os tipos de informação que publicamos no nosso %{link}.
     social_media_use_html: Leia a nossa política em %{link}.
     welsh_language_scheme_html: Saiba mais sobre o nosso compromisso para com %{link}.
+  email:
+    description_html:
+    subscribe_title:
+    unsubscribe_title:
   fatality_notice:
     alt_text: Brasão do Ministério da Defesa
     field_of_operation: Campo de operação
     operations_in: Operações em %{location}
+  get_involved:
+    civil_service:
+    civil_service_quarterly:
+    closed:
+    closed_consultations:
+    closes:
+    closing_today:
+    closing_tomorrow:
+    days_left:
+    engage_with_gov:
+    fcdo_bloggers:
+    follow:
+    follow_links:
+    follow_paragraph:
+    gds_blog:
+    gov_past:
+    intro_paragraph:
+      body_html:
+      engage_with_government:
+      take_part:
+    join_ics:
+    make_donation:
+    more_ways:
+    neighbourhood_watch:
+    open_consultations:
+    page_heading:
+    page_title:
+    petition_paragraph:
+      body_html:
+      create_a_petition:
+    read_respond:
+    recent_outcomes:
+    recently_opened:
+    respond_to_consultations:
+    school_overseas:
+    search_all:
+    see_all_dept:
+    start_a_petition:
+    take_part:
+    take_part_suggestions:
+    your_views:
   gone:
     page_title: Já não está disponível
     published_in_error: A informação contida nesta página foi retirada porque foi publicada por engano.
@@ -313,7 +358,72 @@ pt:
   i18n:
     direction:
   language_names:
+    ar:
+    az:
+    be:
+    bg:
+    bn:
+    cs:
+    cy:
+    da:
+    de:
+    dr:
+    el:
+    en:
+    es:
+    es-419:
+    et:
+    fa:
+    fi:
+    fr:
+    gd:
+    gu:
+    he:
+    hi:
+    hr:
+    hu:
+    hy:
+    id:
+    is:
+    it:
+    ja:
+    ka:
+    kk:
+    ko:
+    lt:
+    lv:
+    ms:
+    mt:
+    ne:
+    nl:
+    'no':
+    pa:
+    pa-pk:
+    pl:
+    ps:
     pt: Português
+    ro:
+    ru:
+    si:
+    sk:
+    sl:
+    so:
+    sq:
+    sr:
+    sv:
+    sw:
+    ta:
+    th:
+    tk:
+    tr:
+    uk:
+    ur:
+    uz:
+    vi:
+    yi:
+    zh:
+    zh-hk:
+    zh-tw:
   multi_page:
     next_page: Seguinte
     previous_page: Anterior

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -234,8 +234,12 @@ pt:
       other: Documentos
     details: Detalhes
   brexit:
-    business_link: Guia Brexit para as empresas
-    citizen_link: Orientação Brexit para pessoas e famílias
+    business_link:
+      path: "/guidance/brexit-guidance-for-businesses"
+      text: Guia Brexit para as empresas
+    citizen_link:
+      path: "/guidance/brexit-guidance-for-individuals-and-families"
+      text: Orientação Brexit para pessoas e famílias
     heading_prefix: Há diferentes
   common:
     last_updated:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -371,10 +371,10 @@ pt:
     release_date: Data de divulgação
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens, exceto as essenciais, a algumas zonas do país.
-      avoid_all_but_essential_travel_to_whole_country: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens, exceto as essenciais, a todo o país.
-      avoid_all_travel_to_parts: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens a algumas zonas do país.
-      avoid_all_travel_to_whole_country: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens a todo o país.
+      avoid_all_but_essential_travel_to_parts_html: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens, exceto as essenciais, a algumas zonas do país.
+      avoid_all_but_essential_travel_to_whole_country_html: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens, exceto as essenciais, a todo o país.
+      avoid_all_travel_to_parts_html: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens a algumas zonas do país.
+      avoid_all_travel_to_whole_country_html: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens a todo o país.
     context: Aconselhamento sobre viagens ao estrangeiro
     coronavirus_warning:
       content_html: |

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,314 +1,5 @@
+---
 ro:
-  content_item:
-    schema_name:
-      aaib_report:
-        one: Raportul agenției pentru investigații privind accidentele aviatice
-        few:
-        other: Rapoartele agenției pentru investigații privind accidentele aviatice
-      announcement:
-        one: Anunț
-        few:
-        other: Anunțuri
-      asylum_support_decision:
-        one: Decizia tribunalului cu privire la sprijinul pentru azil
-        few:
-        other: Deciziile tribunalului cu privire la sprijinul pentru azil
-      authored_article:
-        one: Articol publicat
-        few:
-        other: Articole publicate
-      business_finance_support_scheme:
-        one: Schema de sprijin pentru finanțarea întreprinderilor
-        few:
-        other: Scheme de sprijin pentru finanțarea întreprinderilor
-      case_study:
-        one: Studiu de caz
-        few:
-        other: Studii de caz
-      closed_consultation:
-        one: Consultație închisă
-        few:
-        other: Consultații închise
-      cma_case:
-        one: Caz Autoritatea pentru concurență și piețe
-        few:
-        other: Cazuri Autoritatea pentru concurență și piețe
-      coming_soon:
-        one: În curând
-        few:
-        other: În curând
-      consultation:
-        one: Consultație
-        few:
-        other: Consultații
-      consultation_outcome:
-        one: Rezultatul consultației
-        few:
-        other: Rezultatele consultației
-      corporate_information_page:
-        one: Pagina de informații
-        few:
-        other: Pagini de informații
-      corporate_report:
-        one: Raport de companie
-        few:
-        other: Rapoarte de companie
-      correspondence:
-        one: Corespondență
-        few:
-        other: Corespondențe
-      countryside_stewardship_grant:
-        one: Finanțare pentru gestionarea zonelor rurale
-        few:
-        other: Finanțări pentru gestionarea zonelor rurale
-      decision:
-        one: Decizie
-        few:
-        other: Decizii
-      detailed_guide:
-        one: Orientări
-        few:
-        other: Orientări
-      dfid_research_output:
-        one: Cercetare pentru rezultatul dezvoltării
-        few:
-        other: Cercetare pentru rezultatele dezvoltării
-      document_collection:
-        one: Colecție
-        few:
-        other: Colecții
-      draft_text:
-        one: Proiect de text
-        few:
-        other: Proiecte de text
-      drug_safety_update:
-        one: Actualizare cu privire la siguranța medicamentelor
-        few:
-        other: Actualizări cu privire la siguranța medicamentelor
-      employment_appeal_tribunal_decision:
-        one: Decizie a tribunalului de recurs cu privire la dreptul muncii
-        few:
-        other: Decizii ale tribunalului de recurs cu privire la dreptul muncii
-      employment_tribunal_decision:
-        one: Decizie a tribunalului pentru dreptul muncii
-        few:
-        other: Decizii ale tribunalului pentru dreptul muncii
-      esi_fund:
-        one: Fondul European Structural și de Investiții (ESIF)
-        few:
-        other: Fonduri Europene Structurale și de Investiții (ESIF)
-      fatality_notice:
-        one: Notificare accident mortal
-        few:
-        other: Notificări accident mortal
-      foi_release:
-        one: Document eliberat privind libertatea informației
-        few:
-        other: Documente eliberate privind libertatea informației
-      form:
-        one: Formular
-        few:
-        other: Formulare
-      government_response:
-        one: Răspunsul guvernului
-        few:
-        other: Răspunsurile guvernului
-      guidance:
-        one: Orientări
-        few:
-        other: Orientări
-      impact_assessment:
-        one: Evaluarea impactului
-        few:
-        other: Evaluările impactului
-      imported:
-        one: importat - se așteaptă tipul
-        few:
-        other: importat - se așteaptă tipul
-      independent_report:
-        one: Raport independent
-        few:
-        other: Rapoarte independente
-      international_development_fund:
-        one: Finanțare dezvoltare internațională
-        few:
-        other: Finanțare dezvoltare internațională
-      international_treaty:
-        one: Tratat internațional
-        few:
-        other: Tratate internaționale
-      maib_report:
-        one: Raportul agenției pentru investigații privind accidentele maritime
-        few:
-        other: Rapoartele agenției pentru investigații privind accidentele maritime
-      map:
-        one: Hartă
-        few:
-        other: Hărți
-      medical_safety_alert:
-        one: Alerte și retragerea produselor pentru medicamente și dispozitive medicale
-        few:
-        other: Alerte și retragerea produselor pentru medicamente și dispozitive medicale
-      national:
-        one: Anunț de statistică națională
-        few:
-        other: Anunțuri de statistică națională
-      national_statistics:
-        one: Statistică națională
-        few:
-        other: Statistică națională
-      national_statistics_announcement:
-        one: Anunț de statistică națională
-        few:
-        other: Anunțuri de statistică națională
-      news_article:
-        one: Articol de știri
-        few:
-        other: Articole de știri
-      news_story:
-        one: Reportaj de știri
-        few:
-        other: Reportaje de știri
-      notice:
-        one: Notificare
-        few:
-        other: Notificări
-      official:
-        one: Anunț oficial de statistică
-        few:
-        other: Anunțuri oficiale de statistică
-      official_statistics:
-        one: Statistică oficială
-        few:
-        other: Statistică oficială
-      official_statistics_announcement:
-        one: Anunț oficial de statistică
-        few:
-        other: Anunțuri oficiale de statistică
-      open_consultation:
-        one: Consultație deschisă
-        few:
-        other: Consultație deschise
-      oral_statement:
-        one: Expunere orală către Parlament
-        few:
-        other: Expuneri orale către Parlament
-      policy:
-        one: Politică
-        few:
-        other: Politici
-      policy_paper:
-        one: Document de politică
-        few:
-        other: Documente de politică
-      press_release:
-        one: Comunicat de presă
-        few:
-        other: Comunicate de presă
-      promotional:
-        one: Material promoțional
-        few:
-        other: Material promoțional
-      publication:
-        one: Publicație
-        few:
-        other: Publicații
-      raib_report:
-        one: Raportul agenției pentru investigații privind accidentele pe căile ferate
-        few:
-        other: Rapoartele agenției pentru investigații privind accidentele pe căile
-          ferate
-      regulation:
-        one: Reglementare
-        few:
-        other: Reglementări
-      research:
-        one: Cercetare și analiză
-        few:
-        other: Cercetare și analiză
-      residential_property_tribunal_decision:
-        one: Decizia tribunalului pentru proprietatea rezidențială
-        few:
-        other: Deciziile tribunalului pentru proprietatea rezidențială
-      service_sign_in:
-        one: Conectare la serviciu
-        few:
-        other: Conectare la serviciu
-      service_standard_report:
-        one: Raport standard pentru serviciu
-        few:
-        other: Rapoarte standard pentru serviciu
-      speaking_notes:
-        one: Note de discuție
-        few:
-        other: Note de discuție
-      speech:
-        one: Discurs
-        few:
-        other: Discursuri
-      standard:
-        one: Standard
-        few:
-        other: Standarde
-      statement_to_parliament:
-        one: Declarație către Parlament
-        few:
-        other: Declarații către Parlament
-      statistical_data_set:
-        one: Set de date statistice
-        few:
-        other: Seturi de date statistice
-      statistics_announcement:
-        one: Anunț eliberare documente statistice
-        few:
-        other: Anunțuri eliberare documente statistice
-      statutory_guidance:
-        one: Orientări privind dispozițiile legale
-        few:
-        other: Orientări privind dispozițiile legale
-      take_part:
-        one: Participă
-        few:
-        other: Participă
-      tax_tribunal_decision:
-        one: Decizia tribunalului pentru Tax and Chancery
-        few:
-        other: Deciziile tribunalului pentru Tax and Chancery
-      transcript:
-        one: Transcriere
-        few:
-        other: Transcrieri
-      transparency:
-        one: Date privind transparența
-        few:
-        other: Date privind transparența
-      utaac_decision:
-        one: Decizie a tribunalului de recurs cu privire dreptul administrativ
-        few:
-        other: Decizii ale tribunalului de recurs cu privire la dreptul administrativ
-      world_location_news_article:
-        one: Articol de știri
-        few:
-        other: Articole de știri
-      world_news_story:
-        one: Reportaj de știri global
-        few:
-        other: Reportaje de știri globale
-      written_statement:
-        one: Declarație scrisă către Parlament
-        few:
-        other: Declarații scrise către Parlament
-    coming_soon: Acest document va fi publicat pe
-    contents: Conținut
-    metadata:
-      published: Publicat
-      updated: Actualizat
-  publication:
-    documents:
-      one: Document
-      few:
-      other: Documente
-    details: Detalii
   brexit:
     business_link:
       path: "/guidance/brexit-guidance-for-businesses"
@@ -344,16 +35,13 @@ ro:
       page_not_saved_heading: Salvați această pagină pentru a reveni la ea mai târziu
       page_was_saved_heading: Ați salvat această pagină
       remove_page_button: Eliminați din paginile salvate
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Vedeți
-        paginile salvate</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Conectați-vă</a>
-        pentru a vedea paginile salvate.
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Vedeți paginile salvate</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Conectați-vă</a> pentru a vedea paginile salvate.
     share_links:
       share_this_page: Distribuiți această pagină
   consultation:
     and: și
-    another_website_html: Această consultație %{closed} s-a ținut pe <a href="%{url}">un
-      alt website</a>
+    another_website_html: Această consultație %{closed} s-a ținut pe <a href="%{url}">un alt website</a>
     at: la
     closes: Se închide la
     closes_at: Această consultație se închide la
@@ -374,8 +62,7 @@ ro:
     ran_from: Această consultație a început la
     respond_online: Răspundeți online
     'true': adevărat
-    visit_soon: Accesați din această pagină în curând pentru a descărca rezultatul
-      acestui feedback&nbsp;public.
+    visit_soon: Accesați din această pagină în curând pentru a descărca rezultatul acestui feedback&nbsp;public.
     was: a fost
     ways_to_respond: Modalități de a răspunde
     write_to: 'Scrieți la:'
@@ -385,24 +72,323 @@ ro:
     online: Online
     phone: Telefon
     webchat: Webchat
+  content_item:
+    coming_soon: Acest document va fi publicat pe
+    contents: Conținut
+    metadata:
+      published: Publicat
+      updated: Actualizat
+    schema_name:
+      aaib_report:
+        few:
+        one: Raportul agenției pentru investigații privind accidentele aviatice
+        other: Rapoartele agenției pentru investigații privind accidentele aviatice
+      announcement:
+        few:
+        one: Anunț
+        other: Anunțuri
+      asylum_support_decision:
+        few:
+        one: Decizia tribunalului cu privire la sprijinul pentru azil
+        other: Deciziile tribunalului cu privire la sprijinul pentru azil
+      authored_article:
+        few:
+        one: Articol publicat
+        other: Articole publicate
+      business_finance_support_scheme:
+        few:
+        one: Schema de sprijin pentru finanțarea întreprinderilor
+        other: Scheme de sprijin pentru finanțarea întreprinderilor
+      case_study:
+        few:
+        one: Studiu de caz
+        other: Studii de caz
+      closed_consultation:
+        few:
+        one: Consultație închisă
+        other: Consultații închise
+      cma_case:
+        few:
+        one: Caz Autoritatea pentru concurență și piețe
+        other: Cazuri Autoritatea pentru concurență și piețe
+      coming_soon:
+        few:
+        one: În curând
+        other: În curând
+      consultation:
+        few:
+        one: Consultație
+        other: Consultații
+      consultation_outcome:
+        few:
+        one: Rezultatul consultației
+        other: Rezultatele consultației
+      corporate_information_page:
+        few:
+        one: Pagina de informații
+        other: Pagini de informații
+      corporate_report:
+        few:
+        one: Raport de companie
+        other: Rapoarte de companie
+      correspondence:
+        few:
+        one: Corespondență
+        other: Corespondențe
+      countryside_stewardship_grant:
+        few:
+        one: Finanțare pentru gestionarea zonelor rurale
+        other: Finanțări pentru gestionarea zonelor rurale
+      decision:
+        few:
+        one: Decizie
+        other: Decizii
+      detailed_guide:
+        few:
+        one: Orientări
+        other: Orientări
+      dfid_research_output:
+        few:
+        one: Cercetare pentru rezultatul dezvoltării
+        other: Cercetare pentru rezultatele dezvoltării
+      document_collection:
+        few:
+        one: Colecție
+        other: Colecții
+      draft_text:
+        few:
+        one: Proiect de text
+        other: Proiecte de text
+      drug_safety_update:
+        few:
+        one: Actualizare cu privire la siguranța medicamentelor
+        other: Actualizări cu privire la siguranța medicamentelor
+      employment_appeal_tribunal_decision:
+        few:
+        one: Decizie a tribunalului de recurs cu privire la dreptul muncii
+        other: Decizii ale tribunalului de recurs cu privire la dreptul muncii
+      employment_tribunal_decision:
+        few:
+        one: Decizie a tribunalului pentru dreptul muncii
+        other: Decizii ale tribunalului pentru dreptul muncii
+      esi_fund:
+        few:
+        one: Fondul European Structural și de Investiții (ESIF)
+        other: Fonduri Europene Structurale și de Investiții (ESIF)
+      fatality_notice:
+        few:
+        one: Notificare accident mortal
+        other: Notificări accident mortal
+      foi_release:
+        few:
+        one: Document eliberat privind libertatea informației
+        other: Documente eliberate privind libertatea informației
+      form:
+        few:
+        one: Formular
+        other: Formulare
+      government_response:
+        few:
+        one: Răspunsul guvernului
+        other: Răspunsurile guvernului
+      guidance:
+        few:
+        one: Orientări
+        other: Orientări
+      impact_assessment:
+        few:
+        one: Evaluarea impactului
+        other: Evaluările impactului
+      imported:
+        few:
+        one: importat - se așteaptă tipul
+        other: importat - se așteaptă tipul
+      independent_report:
+        few:
+        one: Raport independent
+        other: Rapoarte independente
+      international_development_fund:
+        few:
+        one: Finanțare dezvoltare internațională
+        other: Finanțare dezvoltare internațională
+      international_treaty:
+        few:
+        one: Tratat internațional
+        other: Tratate internaționale
+      maib_report:
+        few:
+        one: Raportul agenției pentru investigații privind accidentele maritime
+        other: Rapoartele agenției pentru investigații privind accidentele maritime
+      map:
+        few:
+        one: Hartă
+        other: Hărți
+      medical_safety_alert:
+        few:
+        one: Alerte și retragerea produselor pentru medicamente și dispozitive medicale
+        other: Alerte și retragerea produselor pentru medicamente și dispozitive medicale
+      national:
+        few:
+        one: Anunț de statistică națională
+        other: Anunțuri de statistică națională
+      national_statistics:
+        few:
+        one: Statistică națională
+        other: Statistică națională
+      national_statistics_announcement:
+        few:
+        one: Anunț de statistică națională
+        other: Anunțuri de statistică națională
+      news_article:
+        few:
+        one: Articol de știri
+        other: Articole de știri
+      news_story:
+        few:
+        one: Reportaj de știri
+        other: Reportaje de știri
+      notice:
+        few:
+        one: Notificare
+        other: Notificări
+      official:
+        few:
+        one: Anunț oficial de statistică
+        other: Anunțuri oficiale de statistică
+      official_statistics:
+        few:
+        one: Statistică oficială
+        other: Statistică oficială
+      official_statistics_announcement:
+        few:
+        one: Anunț oficial de statistică
+        other: Anunțuri oficiale de statistică
+      open_consultation:
+        few:
+        one: Consultație deschisă
+        other: Consultație deschise
+      oral_statement:
+        few:
+        one: Expunere orală către Parlament
+        other: Expuneri orale către Parlament
+      policy:
+        few:
+        one: Politică
+        other: Politici
+      policy_paper:
+        few:
+        one: Document de politică
+        other: Documente de politică
+      press_release:
+        few:
+        one: Comunicat de presă
+        other: Comunicate de presă
+      promotional:
+        few:
+        one: Material promoțional
+        other: Material promoțional
+      publication:
+        few:
+        one: Publicație
+        other: Publicații
+      raib_report:
+        few:
+        one: Raportul agenției pentru investigații privind accidentele pe căile ferate
+        other: Rapoartele agenției pentru investigații privind accidentele pe căile ferate
+      regulation:
+        few:
+        one: Reglementare
+        other: Reglementări
+      research:
+        few:
+        one: Cercetare și analiză
+        other: Cercetare și analiză
+      residential_property_tribunal_decision:
+        few:
+        one: Decizia tribunalului pentru proprietatea rezidențială
+        other: Deciziile tribunalului pentru proprietatea rezidențială
+      service_sign_in:
+        few:
+        one: Conectare la serviciu
+        other: Conectare la serviciu
+      service_standard_report:
+        few:
+        one: Raport standard pentru serviciu
+        other: Rapoarte standard pentru serviciu
+      speaking_notes:
+        few:
+        one: Note de discuție
+        other: Note de discuție
+      speech:
+        few:
+        one: Discurs
+        other: Discursuri
+      standard:
+        few:
+        one: Standard
+        other: Standarde
+      statement_to_parliament:
+        few:
+        one: Declarație către Parlament
+        other: Declarații către Parlament
+      statistical_data_set:
+        few:
+        one: Set de date statistice
+        other: Seturi de date statistice
+      statistics_announcement:
+        few:
+        one: Anunț eliberare documente statistice
+        other: Anunțuri eliberare documente statistice
+      statutory_guidance:
+        few:
+        one: Orientări privind dispozițiile legale
+        other: Orientări privind dispozițiile legale
+      take_part:
+        few:
+        one: Participă
+        other: Participă
+      tax_tribunal_decision:
+        few:
+        one: Decizia tribunalului pentru Tax and Chancery
+        other: Deciziile tribunalului pentru Tax and Chancery
+      transcript:
+        few:
+        one: Transcriere
+        other: Transcrieri
+      transparency:
+        few:
+        one: Date privind transparența
+        other: Date privind transparența
+      utaac_decision:
+        few:
+        one: Decizie a tribunalului de recurs cu privire dreptul administrativ
+        other: Decizii ale tribunalului de recurs cu privire la dreptul administrativ
+      world_location_news_article:
+        few:
+        one: Articol de știri
+        other: Articole de știri
+      world_news_story:
+        few:
+        one: Reportaj de știri global
+        other: Reportaje de știri globale
+      written_statement:
+        few:
+        one: Declarație scrisă către Parlament
+        other: Declarații scrise către Parlament
   corporate_information_page:
     about_our_services_html: Aflați %{link}.
     corporate_information: Informații despre corporație
-    personal_information_charter_html: "%{link} explică cum tratăm informațiile dvs.
-      cu caracter personal."
-    publication_scheme_html: Citiți despre tipurile de informații pe care le publicăm
-      de obicei în %{link}.
+    personal_information_charter_html: "%{link} explică cum tratăm informațiile dvs. cu caracter personal."
+    publication_scheme_html: Citiți despre tipurile de informații pe care le publicăm de obicei în %{link}.
     social_media_use_html: Citiți politica noastră pe %{link}.
-    welsh_language_scheme_html: Aflați mai multe despre angajamentul nostru pentru
-      %{link}.
+    welsh_language_scheme_html: Aflați mai multe despre angajamentul nostru pentru %{link}.
   fatality_notice:
     alt_text: Emblema Ministerului Apărării
     field_of_operation: Domeniul de activitate
     operations_in: Operațiuni în %{location}
   gone:
     page_title: Nu mai este disponibil
-    published_in_error: Informațiile de pe această pagină au fost șterse deoarece
-      au fost publicate din greșeală.
+    published_in_error: Informațiile de pe această pagină au fost șterse deoarece au fost publicate din greșeală.
     title: Pagina pe care o căutați nu mai este disponibilă.
   guide:
     pages_in_guide: Paginile din acest ghid
@@ -412,14 +398,8 @@ ro:
       available_at: Această publicație este disponibilă la %{url}
       copyright: "© Crown copyright %{year}"
       isbn: 'ISBN:'
-      licence_html: 'Această publicație este licență conform condițiilor Open Government
-        Licence v3.0, cu excepția cazurilor în care se specifică contrariul. Pentru
-        a vedea licența, accesați <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
-        sau scrieți echipei Information Policy, The National Archives, Kew, Londra
-        TW9 4DU, sau trimiteți e-mail la: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
-      third_party: Acolo unde am identificat informații de terță parte cu drept de
-        autor, va trebui să obțineți permisiunea de la deținătorii drepturilor de
-        autor în cauză.
+      licence_html: 'Această publicație este licență conform condițiilor Open Government Licence v3.0, cu excepția cazurilor în care se specifică contrariul. Pentru a vedea licența, accesați <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a> sau scrieți echipei Information Policy, The National Archives, Kew, Londra TW9 4DU, sau trimiteți e-mail la: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: Acolo unde am identificat informații de terță parte cu drept de autor, va trebui să obțineți permisiunea de la deținătorii drepturilor de autor în cauză.
   i18n:
     direction:
   language_names:
@@ -428,6 +408,12 @@ ro:
     next_page: Continuare
     previous_page: Înapoi
     print_entire_guide: Imprimați întreg ghidul
+  publication:
+    details: Detalii
+    documents:
+      few:
+      one: Document
+      other: Documente
   service_sign_in:
     continue: Continuați
     error:
@@ -440,15 +426,11 @@ ro:
       busy: Toți consultanții de pe webchat sunt ocupați în acest moment.
       closed: Webchatul este închis în acest moment.
       speak_to_adviser: Vorbiți cu un consultant acum
-      technical_problem: Webchatul este disponibil momentan din cauza problemelor
-        tehnice.
+      technical_problem: Webchatul este disponibil momentan din cauza problemelor tehnice.
   specialist_document:
-    pdo_alt_text: Logoul schemei este un timbru negru cu cuvintele Designated Origin
-      UK Protected
-    pgi_alt_text: Logoul schemei este un timbru negru cu cuvintele Geographic Origin
-      UK Protected
-    tsg_alt_text: Logoul schemei este un timbru negru cu cuvintele Traditional Speciality
-      UK Protected
+    pdo_alt_text: Logoul schemei este un timbru negru cu cuvintele Designated Origin UK Protected
+    pgi_alt_text: Logoul schemei este un timbru negru cu cuvintele Geographic Origin UK Protected
+    tsg_alt_text: Logoul schemei este un timbru negru cu cuvintele Traditional Speciality UK Protected
   speech:
     delivered_on: Livrat pe
     location: Locație
@@ -464,15 +446,10 @@ ro:
     release_date: Data publicării
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth
-        Office">FCO</abbr> nu recomandă călătoriile neesențiale în anumite părți ale
-        țării.
-      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth
-        Office">FCO</abbr> nu recomandă călătoriile neesențiale în întreaga țară.
-      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr>
-        nu recomandă călătoriile în anumite părți ale țării.
-      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr>
-        nu recomandă călătoriile în întreaga țară.
+      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile neesențiale în anumite părți ale țării.
+      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile neesențiale în întreaga țară.
+      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile în anumite părți ale țării.
+      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile în întreaga țară.
     context: Sfaturi pentru călătoriile în străinătate
     coronavirus_warning:
       content_html: |
@@ -495,8 +472,7 @@ ro:
     updated: Actualizat
   unpublishing:
     page_title: Nu mai este disponibil
-    summary: Informațiile de pe această pagină au fost șterse deoarece au fost publicate
-      din greșeală.
+    summary: Informațiile de pe această pagină au fost șterse deoarece au fost publicate din greșeală.
     title: Pagina pe care o căutați nu mai este disponibilă
   working_group:
     contact_details: Detalii de contact

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -310,8 +310,12 @@ ro:
       other: Documente
     details: Detalii
   brexit:
-    business_link: Îndrumări pentru companii privind Brexit
-    citizen_link: Îndrumări pentru persoane și familii privind Brexit
+    business_link:
+      path: "/guidance/brexit-guidance-for-businesses"
+      text: Îndrumări pentru companii privind Brexit
+    citizen_link:
+      path: "/guidance/brexit-guidance-for-individuals-and-families"
+      text: Îndrumări pentru persoane și familii privind Brexit
     heading_prefix: Diferit
   common:
     last_updated:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,581 +1,499 @@
----
 ro:
-  brexit:
-    business_link:
-      path:
-      text:
-    citizen_link:
-      path:
-      text:
-    heading_prefix:
-  common:
-    visit:
-  components:
-    figure:
-      image_credit:
-    published_dates:
-      hide_all_updates:
-      last_updated:
-      published:
-      see_all_updates:
-      show_all_updates:
-    publisher_metadata:
-      hide_all:
-      show_all:
-    share_links:
-      share_this_page:
-  consultation:
-    and:
-    another_website_html:
-    at:
-    closes:
-    closes_at:
-    complete_a:
-    description:
-    detail_of_feedback_received:
-    detail_of_outcome:
-    documents:
-    download_outcome:
-    either:
-    email_to:
-    feedback_received:
-    is_being:
-    not_open_yet:
-    'on':
-    opens:
-    original_consultation:
-    ran_from:
-    respond_online:
-    visit_soon:
-    was:
-    ways_to_respond:
-    write_to:
-  contact:
-    email:
-    find_call_charges:
-    online:
-    phone:
-    webchat:
   content_item:
-    coming_soon:
-    contents: Conținut
-    metadata:
-      published: Data publicării
-      updated: Actualizat
     schema_name:
       aaib_report:
+        one: Raportul agenției pentru investigații privind accidentele aviatice
         few:
-        one:
-        other:
+        other: Rapoartele agenției pentru investigații privind accidentele aviatice
       announcement:
+        one: Anunț
         few:
-        one: Știre
-        other: Știri
+        other: Anunțuri
       asylum_support_decision:
+        one: Decizia tribunalului cu privire la sprijinul pentru azil
         few:
-        one:
-        other:
+        other: Deciziile tribunalului cu privire la sprijinul pentru azil
       authored_article:
+        one: Articol publicat
         few:
-        one: 'Articol '
-        other: 'Articol '
+        other: Articole publicate
       business_finance_support_scheme:
+        one: Schema de sprijin pentru finanțarea întreprinderilor
         few:
-        one:
-        other:
+        other: Scheme de sprijin pentru finanțarea întreprinderilor
       case_study:
-        few:
         one: Studiu de caz
+        few:
         other: Studii de caz
       closed_consultation:
+        one: Consultație închisă
         few:
-        one: Dezbatere
-        other: Dezbateri
-        overview:
+        other: Consultații închise
       cma_case:
+        one: Caz Autoritatea pentru concurență și piețe
         few:
-        one:
-        other:
+        other: Cazuri Autoritatea pentru concurență și piețe
       coming_soon:
+        one: În curând
         few:
-        one:
-        other:
+        other: În curând
       consultation:
+        one: Consultație
         few:
-        one: Dezbatere
-        other: Dezbateri
+        other: Consultații
       consultation_outcome:
+        one: Rezultatul consultației
         few:
-        one: Concluzia dezbaterii
-        other: Concluziile dezbaterii
-        overview:
+        other: Rezultatele consultației
       corporate_information_page:
+        one: Pagina de informații
         few:
-        one:
-        other:
+        other: Pagini de informații
       corporate_report:
+        one: Raport de companie
         few:
-        one: Raport
-        other: Rapoarte
-        overview:
+        other: Rapoarte de companie
       correspondence:
+        one: Corespondență
         few:
-        one: Similaritate
-        other: Similarităţi
-        overview:
+        other: Corespondențe
       countryside_stewardship_grant:
+        one: Finanțare pentru gestionarea zonelor rurale
         few:
-        one:
-        other:
+        other: Finanțări pentru gestionarea zonelor rurale
       decision:
+        one: Decizie
         few:
-        one:
-        other:
-        overview:
+        other: Decizii
       detailed_guide:
+        one: Orientări
         few:
-        one: Mai multe detalii
-        other: Mai multe detalii
+        other: Orientări
       dfid_research_output:
+        one: Cercetare pentru rezultatul dezvoltării
         few:
-        one:
-        other:
+        other: Cercetare pentru rezultatele dezvoltării
       document_collection:
+        one: Colecție
         few:
-        one: Seria
-        other:
+        other: Colecții
       draft_text:
+        one: Proiect de text
         few:
-        one: Versiune preliminară
-        other: Versiuni preliminare
+        other: Proiecte de text
       drug_safety_update:
+        one: Actualizare cu privire la siguranța medicamentelor
         few:
-        one:
-        other:
+        other: Actualizări cu privire la siguranța medicamentelor
       employment_appeal_tribunal_decision:
+        one: Decizie a tribunalului de recurs cu privire la dreptul muncii
         few:
-        one:
-        other:
+        other: Decizii ale tribunalului de recurs cu privire la dreptul muncii
       employment_tribunal_decision:
+        one: Decizie a tribunalului pentru dreptul muncii
         few:
-        one:
-        other:
+        other: Decizii ale tribunalului pentru dreptul muncii
       esi_fund:
+        one: Fondul European Structural și de Investiții (ESIF)
         few:
-        one:
-        other:
+        other: Fonduri Europene Structurale și de Investiții (ESIF)
       fatality_notice:
+        one: Notificare accident mortal
         few:
-        one: Anunț privind decesul
-        other: Anunțuri privind decese
+        other: Notificări accident mortal
       foi_release:
+        one: Document eliberat privind libertatea informației
         few:
-        one: 'Acces la informații publice '
-        other: 'Acces la informații publice '
-        overview:
+        other: Documente eliberate privind libertatea informației
       form:
-        few:
         one: Formular
+        few:
         other: Formulare
-        overview:
       government_response:
+        one: Răspunsul guvernului
         few:
-        one: 'Document de poziție '
-        other: 'Documente de poziție '
+        other: Răspunsurile guvernului
       guidance:
+        one: Orientări
         few:
-        one: Mai multe detalii
-        other: Mai multe detalii
-        overview:
+        other: Orientări
       impact_assessment:
+        one: Evaluarea impactului
         few:
-        one: 'Evaluarea impactului '
-        other: 'Evaluarea impactului '
-        overview:
+        other: Evaluările impactului
       imported:
+        one: importat - se așteaptă tipul
         few:
-        one:
-        other:
+        other: importat - se așteaptă tipul
       independent_report:
-        few:
         one: Raport independent
+        few:
         other: Rapoarte independente
-        overview:
       international_development_fund:
+        one: Finanțare dezvoltare internațională
         few:
-        one:
-        other:
+        other: Finanțare dezvoltare internațională
       international_treaty:
+        one: Tratat internațional
         few:
-        one:
-        other:
-        overview:
+        other: Tratate internaționale
       maib_report:
+        one: Raportul agenției pentru investigații privind accidentele maritime
         few:
-        one:
-        other:
+        other: Rapoartele agenției pentru investigații privind accidentele maritime
       map:
-        few:
         one: Hartă
-        other: Hărţi
-        overview:
+        few:
+        other: Hărți
       medical_safety_alert:
+        one: Alerte și retragerea produselor pentru medicamente și dispozitive medicale
         few:
-        one:
-        other:
+        other: Alerte și retragerea produselor pentru medicamente și dispozitive medicale
       national:
+        one: Anunț de statistică națională
         few:
-        one:
-        other:
+        other: Anunțuri de statistică națională
       national_statistics:
+        one: Statistică națională
         few:
-        one: Statistici - statistici naționale
-        other: Statistici - statistici naționale
-        overview:
+        other: Statistică națională
       national_statistics_announcement:
+        one: Anunț de statistică națională
         few:
-        one:
-        other:
+        other: Anunțuri de statistică națională
       news_article:
+        one: Articol de știri
         few:
-        one: Știre
-        other: Știri
+        other: Articole de știri
       news_story:
+        one: Reportaj de știri
         few:
-        one: Știre
-        other: Știri
+        other: Reportaje de știri
       notice:
+        one: Notificare
         few:
-        one:
-        other:
-        overview:
+        other: Notificări
       official:
+        one: Anunț oficial de statistică
         few:
-        one:
-        other:
+        other: Anunțuri oficiale de statistică
       official_statistics:
+        one: Statistică oficială
         few:
-        one: Statistici
-        other: Statistici
-        overview:
+        other: Statistică oficială
       official_statistics_announcement:
+        one: Anunț oficial de statistică
         few:
-        one:
-        other:
+        other: Anunțuri oficiale de statistică
       open_consultation:
+        one: Consultație deschisă
         few:
-        one: Dezbatere
-        other: Dezbateri
-        overview:
+        other: Consultație deschise
       oral_statement:
+        one: Expunere orală către Parlament
         few:
-        one: 'Declarație verbală în fața Parlamentului '
-        other: 'Declarații verbale în fața Parlamentului '
+        other: Expuneri orale către Parlament
       policy:
+        one: Politică
         few:
-        one: Obiectiv strategic
-        other: Obiective strategic
+        other: Politici
       policy_paper:
+        one: Document de politică
         few:
-        one:
-        other:
-        overview:
+        other: Documente de politică
       press_release:
+        one: Comunicat de presă
         few:
-        one: Știre
-        other: Știri
+        other: Comunicate de presă
       promotional:
-        few:
         one: Material promoțional
-        other: Materiale promoționale
-        overview:
-      publication:
         few:
+        other: Material promoțional
+      publication:
         one: Publicație
+        few:
         other: Publicații
       raib_report:
+        one: Raportul agenției pentru investigații privind accidentele pe căile ferate
         few:
-        one:
-        other:
+        other: Rapoartele agenției pentru investigații privind accidentele pe căile
+          ferate
       regulation:
+        one: Reglementare
         few:
-        one:
-        other:
-        overview:
+        other: Reglementări
       research:
+        one: Cercetare și analiză
         few:
-        one: Analiză și cercetare
-        other: Analiză și cercetare
-        overview:
+        other: Cercetare și analiză
       residential_property_tribunal_decision:
+        one: Decizia tribunalului pentru proprietatea rezidențială
         few:
-        one:
-        other:
+        other: Deciziile tribunalului pentru proprietatea rezidențială
       service_sign_in:
+        one: Conectare la serviciu
         few:
-        one:
-        other:
+        other: Conectare la serviciu
       service_standard_report:
+        one: Raport standard pentru serviciu
         few:
-        one:
-        other:
+        other: Rapoarte standard pentru serviciu
       speaking_notes:
+        one: Note de discuție
         few:
-        one: 'Note '
-        other: 'Note '
+        other: Note de discuție
       speech:
-        few:
         one: Discurs
+        few:
         other: Discursuri
       standard:
+        one: Standard
         few:
-        one:
-        other:
-        overview:
+        other: Standarde
       statement_to_parliament:
+        one: Declarație către Parlament
         few:
-        one: Declarație în Parlament
-        other: Declarații în Parlament
+        other: Declarații către Parlament
       statistical_data_set:
+        one: Set de date statistice
         few:
-        one: Date statistice
-        other: Date statistice
+        other: Seturi de date statistice
       statistics_announcement:
+        one: Anunț eliberare documente statistice
         few:
-        one:
-        other:
+        other: Anunțuri eliberare documente statistice
       statutory_guidance:
+        one: Orientări privind dispozițiile legale
         few:
-        one:
-        other:
-        overview:
+        other: Orientări privind dispozițiile legale
       take_part:
+        one: Participă
         few:
-        one:
-        other:
+        other: Participă
       tax_tribunal_decision:
+        one: Decizia tribunalului pentru Tax and Chancery
         few:
-        one:
-        other:
+        other: Deciziile tribunalului pentru Tax and Chancery
       transcript:
-        few:
         one: Transcriere
+        few:
         other: Transcrieri
       transparency:
+        one: Date privind transparența
         few:
-        one:
-        other:
-        overview:
+        other: Date privind transparența
       utaac_decision:
+        one: Decizie a tribunalului de recurs cu privire dreptul administrativ
         few:
-        one:
-        other:
+        other: Decizii ale tribunalului de recurs cu privire la dreptul administrativ
       world_location_news_article:
+        one: Articol de știri
         few:
-        one: Știre
-        other: Știri
+        other: Articole de știri
       world_news_story:
+        one: Reportaj de știri global
         few:
-        one:
-        other:
+        other: Reportaje de știri globale
       written_statement:
+        one: Declarație scrisă către Parlament
         few:
-        one: 'Declarație scrisă către Parlament '
-        other: 'Declarații scrise către Parlament '
+        other: Declarații scrise către Parlament
+    coming_soon: Acest document va fi publicat pe
+    contents: Conținut
+    metadata:
+      published: Publicat
+      updated: Actualizat
+  publication:
+    documents:
+      one: Document
+      few:
+      other: Documente
+    details: Detalii
+  brexit:
+    business_link: Îndrumări pentru companii privind Brexit
+    citizen_link: Îndrumări pentru persoane și familii privind Brexit
+    heading_prefix: Diferit
+  common:
+    last_updated:
+    visit: 'Accesați:'
+  components:
+    figure:
+      image_credit: 'Autor imagine: %{credit}'
+    published_dates:
+      hide_all_updates: ascundeți toate actualizările
+      last_updated: Ultima actualizare %{date}
+      published: Publicat pe %{date}
+      see_all_updates: vedeți toate actualizările
+      show_all_updates: afișați toate actualizările
+    publisher_metadata:
+      collections:
+      from:
+      hide_all: ascundeți tot
+      show_all: afișați tot
+    save_this_page:
+      add_page_button: Adăugați la paginile salvate
+      confirmations:
+        page_removed:
+          message: Ați eliminat din paginile salvate
+        page_saved:
+          message: Ați adăugat la paginile salvate
+      page_not_saved_heading: Salvați această pagină pentru a reveni la ea mai târziu
+      page_was_saved_heading: Ați salvat această pagină
+      remove_page_button: Eliminați din paginile salvate
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Vedeți
+        paginile salvate</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Conectați-vă</a>
+        pentru a vedea paginile salvate.
+    share_links:
+      share_this_page: Distribuiți această pagină
+  consultation:
+    and: și
+    another_website_html: Această consultație %{closed} s-a ținut pe <a href="%{url}">un
+      alt website</a>
+    at: la
+    closes: Se închide la
+    closes_at: Această consultație se închide la
+    complete_a: Finalizați o
+    description: Descrierea consultației
+    detail_of_feedback_received: Detaliile feedbackului primit
+    detail_of_outcome: Detaliile rezultatului
+    documents: Documente
+    download_outcome: Descărcați rezultatul complet
+    either: sau
+    email_to: 'E-mail la:'
+    feedback_received: Feedback primit
+    is_being: este
+    not_open_yet: Această consultație nu este deschisă încă
+    'on':
+    opens: Această consultație se deschide
+    original_consultation: Consultație originală
+    ran_from: Această consultație a început la
+    respond_online: Răspundeți online
+    'true': adevărat
+    visit_soon: Accesați din această pagină în curând pentru a descărca rezultatul
+      acestui feedback&nbsp;public.
+    was: a fost
+    ways_to_respond: Modalități de a răspunde
+    write_to: 'Scrieți la:'
+  contact:
+    email: E-mail
+    find_call_charges: Aflați mai multe despre taxele apelurilor
+    online: Online
+    phone: Telefon
+    webchat: Webchat
   corporate_information_page:
-    about_our_services_html:
-    corporate_information: Informaţii despre ambasadă
-    personal_information_charter_html: Mai multe despre cum folosim informațiile cu caracter personal pe %{link}
-    publication_scheme_html: Citește mai multe despre informațiile pe care le publigăm în mod regulat pe  %{link}.
-    social_media_use_html: 'Citește mai multe despre strategia noastră pe '
-    welsh_language_scheme_html: Află mai multe despre angajamentul nostru față de accesul la informații publice pe %{link}.
-  email:
-    description_html:
-    subscribe_title:
-    unsubscribe_title:
+    about_our_services_html: Aflați %{link}.
+    corporate_information: Informații despre corporație
+    personal_information_charter_html: "%{link} explică cum tratăm informațiile dvs.
+      cu caracter personal."
+    publication_scheme_html: Citiți despre tipurile de informații pe care le publicăm
+      de obicei în %{link}.
+    social_media_use_html: Citiți politica noastră pe %{link}.
+    welsh_language_scheme_html: Aflați mai multe despre angajamentul nostru pentru
+      %{link}.
   fatality_notice:
-    alt_text:
-    field_of_operation:
-    operations_in:
-  get_involved:
-    active_blogs:
-    civil_service:
-    civil_service_quarterly:
-    closed:
-    closed_consultations:
-    closed_with_date:
-    closes:
-    closing_today:
-    closing_tomorrow:
-    days_left:
-    engage_with_gov:
-    fcdo_bloggers:
-    follow:
-    follow_paragraph:
-    gds_blog:
-    gov_past:
-    intro_paragraph:
-      body_html:
-      engage_with_government:
-      take_part:
-    join_ics:
-    make_donation:
-    more_ways:
-    neighbourhood_watch:
-    open_consultations:
-    page_heading:
-    page_title:
-    petition_paragraph:
-      body_html:
-      create_a_petition:
-    read_respond:
-    recent_outcomes:
-    recently_opened:
-    respond_to_consultations:
-    school_overseas:
-    search_all:
-    see_all_dept:
-    start_a_petition:
-    take_part:
-    take_part_suggestions:
-    your_views:
+    alt_text: Emblema Ministerului Apărării
+    field_of_operation: Domeniul de activitate
+    operations_in: Operațiuni în %{location}
   gone:
-    page_title:
-    published_in_error:
-    title:
+    page_title: Nu mai este disponibil
+    published_in_error: Informațiile de pe această pagină au fost șterse deoarece
+      au fost publicate din greșeală.
+    title: Pagina pe care o căutați nu mai este disponibilă.
   guide:
-    pages_in_guide:
-    skip_to_contents:
+    pages_in_guide: Paginile din acest ghid
+    skip_to_contents: Accesați direct conținutul ghidului
   html_publication:
     print_meta_data:
-      available_at:
-      copyright:
-      isbn:
-      licence_html:
-      third_party:
+      available_at: Această publicație este disponibilă la %{url}
+      copyright: "© Crown copyright %{year}"
+      isbn: 'ISBN:'
+      licence_html: 'Această publicație este licență conform condițiilor Open Government
+        Licence v3.0, cu excepția cazurilor în care se specifică contrariul. Pentru
+        a vedea licența, accesați <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
+        sau scrieți echipei Information Policy, The National Archives, Kew, Londra
+        TW9 4DU, sau trimiteți e-mail la: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: Acolo unde am identificat informații de terță parte cu drept de
+        autor, va trebui să obțineți permisiunea de la deținătorii drepturilor de
+        autor în cauză.
   i18n:
     direction:
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
     ro: Română
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
   multi_page:
-    next_page:
-    previous_page:
-    print_entire_guide:
-  publication:
-    details:
-    documents:
-      few:
-      one: Document
-      other: Documente
+    next_page: Continuare
+    previous_page: Înapoi
+    print_entire_guide: Imprimați întreg ghidul
   service_sign_in:
-    continue:
+    continue: Continuați
     error:
-      option:
-      title:
+      option: Selectați o opțiune
+      title: Nu ați selectat o opțiune
   shared:
-    historically_political:
+    historically_political: Acesta a fost publicat sub %{government}
     webchat:
-      available:
-      busy:
-      closed:
-      speak_to_adviser:
-      technical_problem:
+      available: Consultanții sunt disponibili pentru a discuta pe chat.
+      busy: Toți consultanții de pe webchat sunt ocupați în acest moment.
+      closed: Webchatul este închis în acest moment.
+      speak_to_adviser: Vorbiți cu un consultant acum
+      technical_problem: Webchatul este disponibil momentan din cauza problemelor
+        tehnice.
   specialist_document:
-    pdo_alt_text:
-    pgi_alt_text:
-    tsg_alt_text:
+    pdo_alt_text: Logoul schemei este un timbru negru cu cuvintele Designated Origin
+      UK Protected
+    pgi_alt_text: Logoul schemei este un timbru negru cu cuvintele Geographic Origin
+      UK Protected
+    tsg_alt_text: Logoul schemei este un timbru negru cu cuvintele Traditional Speciality
+      UK Protected
   speech:
-    delivered_on:
-    location:
-    written_on:
+    delivered_on: Livrat pe
+    location: Locație
+    written_on: Scris pe
   statistics_announcement:
-    cancellation_date:
-    cancelled:
-    changed_date:
-    forthcoming:
-    previous_date:
-    proposed_date:
-    reason_for_change:
-    release_date:
+    cancellation_date: Data anulării
+    cancelled: Eliberarea documentelor statistice a fost anulată
+    changed_date: Data eliberării a fost schimbată
+    forthcoming: Aceste statistici vor fi eliberate
+    previous_date: Data anterioară
+    proposed_date: Data propusă
+    reason_for_change: Motivul schimbării
+    release_date: Data publicării
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts_html:
-      avoid_all_but_essential_travel_to_whole_country_html:
-      avoid_all_travel_to_parts_html:
-      avoid_all_travel_to_whole_country_html:
-    context:
-    still_current_at:
-    summary:
-    updated:
+      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth
+        Office">FCO</abbr> nu recomandă călătoriile neesențiale în anumite părți ale
+        țării.
+      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth
+        Office">FCO</abbr> nu recomandă călătoriile neesențiale în întreaga țară.
+      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr>
+        nu recomandă călătoriile în anumite părți ale țării.
+      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr>
+        nu recomandă călătoriile în întreaga țară.
+    context: Sfaturi pentru călătoriile în străinătate
+    coronavirus_warning:
+      content_html: |
+        <p class="govuk-body">
+          Respectați reglementările actuale cu privire la COVID-19 acolo unde locuiți: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">Anglia</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scoția</a>, <a href="https://gov.wales/coronavirus-travel">Țara Galilor</a> și <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Irlanda de Nord</a>.
+        </p>
+        <p class="govuk-body">
+          Pentru a preveni noile variante de COVID să intre în Marea Britanie, nu trebuie să călătoriți <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">în țările de pe lista roșie sau portocalie</a>.
+        </p>
+        <p class="govuk-body">
+          Pentru a înțelege riscurile dintr-o țară, urmați <a href="/guidance/travel-advice-novel-coronavirus">sfaturile cu privire la călătorie ale FCDO</a>.
+        </p>
+        <p class="govuk-body">
+          Când reveniți, urmați regulile pentru a <a href="/uk-border-control">intra în Marea Britanie din străinătate</a> (cu excepția Irlandei).
+        </p>
+      text_assistive: Important
+      title: Călătoriile în pandemia cauzată de Coronavirus (COVID-19)
+    still_current_at: În acest moment la
+    summary: Rezumat
+    updated: Actualizat
   unpublishing:
-    page_title:
-    summary:
-    title:
+    page_title: Nu mai este disponibil
+    summary: Informațiile de pe această pagină au fost șterse deoarece au fost publicate
+      din greșeală.
+    title: Pagina pe care o căutați nu mai este disponibilă
   working_group:
-    contact_details:
-    policies:
+    contact_details: Detalii de contact
+    policies: Politici

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -446,10 +446,10 @@ ro:
     release_date: Data publicării
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile neesențiale în anumite părți ale țării.
-      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile neesențiale în întreaga țară.
-      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile în anumite părți ale țării.
-      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile în întreaga țară.
+      avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile neesențiale în anumite părți ale țării.
+      avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile neesențiale în întreaga țară.
+      avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile în anumite părți ale țării.
+      avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile în întreaga țară.
     context: Sfaturi pentru călătoriile în străinătate
     coronavirus_warning:
       content_html: |

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -366,10 +366,55 @@ ro:
     publication_scheme_html: Citiți despre tipurile de informații pe care le publicăm de obicei în %{link}.
     social_media_use_html: Citiți politica noastră pe %{link}.
     welsh_language_scheme_html: Aflați mai multe despre angajamentul nostru pentru %{link}.
+  email:
+    description_html:
+    subscribe_title:
+    unsubscribe_title:
   fatality_notice:
     alt_text: Emblema Ministerului Apărării
     field_of_operation: Domeniul de activitate
     operations_in: Operațiuni în %{location}
+  get_involved:
+    civil_service:
+    civil_service_quarterly:
+    closed:
+    closed_consultations:
+    closes:
+    closing_today:
+    closing_tomorrow:
+    days_left:
+    engage_with_gov:
+    fcdo_bloggers:
+    follow:
+    follow_links:
+    follow_paragraph:
+    gds_blog:
+    gov_past:
+    intro_paragraph:
+      body_html:
+      engage_with_government:
+      take_part:
+    join_ics:
+    make_donation:
+    more_ways:
+    neighbourhood_watch:
+    open_consultations:
+    page_heading:
+    page_title:
+    petition_paragraph:
+      body_html:
+      create_a_petition:
+    read_respond:
+    recent_outcomes:
+    recently_opened:
+    respond_to_consultations:
+    school_overseas:
+    search_all:
+    see_all_dept:
+    start_a_petition:
+    take_part:
+    take_part_suggestions:
+    your_views:
   gone:
     page_title: Nu mai este disponibil
     published_in_error: Informațiile de pe această pagină au fost șterse deoarece au fost publicate din greșeală.
@@ -387,7 +432,72 @@ ro:
   i18n:
     direction:
   language_names:
+    ar:
+    az:
+    be:
+    bg:
+    bn:
+    cs:
+    cy:
+    da:
+    de:
+    dr:
+    el:
+    en:
+    es:
+    es-419:
+    et:
+    fa:
+    fi:
+    fr:
+    gd:
+    gu:
+    he:
+    hi:
+    hr:
+    hu:
+    hy:
+    id:
+    is:
+    it:
+    ja:
+    ka:
+    kk:
+    ko:
+    lt:
+    lv:
+    ms:
+    mt:
+    ne:
+    nl:
+    'no':
+    pa:
+    pa-pk:
+    pl:
+    ps:
+    pt:
     ro: Română
+    ru:
+    si:
+    sk:
+    sl:
+    so:
+    sq:
+    sr:
+    sv:
+    sw:
+    ta:
+    th:
+    tk:
+    tr:
+    uk:
+    ur:
+    uz:
+    vi:
+    yi:
+    zh:
+    zh-hk:
+    zh-tw:
   multi_page:
     next_page: Continuare
     previous_page: Înapoi

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -9,7 +9,6 @@ ro:
       text: Îndrumări pentru persoane și familii privind Brexit
     heading_prefix: Diferit
   common:
-    last_updated:
     visit: 'Accesați:'
   components:
     figure:
@@ -21,22 +20,8 @@ ro:
       see_all_updates: vedeți toate actualizările
       show_all_updates: afișați toate actualizările
     publisher_metadata:
-      collections:
-      from:
       hide_all: ascundeți tot
       show_all: afișați tot
-    save_this_page:
-      add_page_button: Adăugați la paginile salvate
-      confirmations:
-        page_removed:
-          message: Ați eliminat din paginile salvate
-        page_saved:
-          message: Ați adăugat la paginile salvate
-      page_not_saved_heading: Salvați această pagină pentru a reveni la ea mai târziu
-      page_was_saved_heading: Ați salvat această pagină
-      remove_page_button: Eliminați din paginile salvate
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Vedeți paginile salvate</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Conectați-vă</a> pentru a vedea paginile salvate.
     share_links:
       share_this_page: Distribuiți această pagină
   consultation:
@@ -61,7 +46,6 @@ ro:
     original_consultation: Consultație originală
     ran_from: Această consultație a început la
     respond_online: Răspundeți online
-    'true': adevărat
     visit_soon: Accesați din această pagină în curând pentru a descărca rezultatul acestui feedback&nbsp;public.
     was: a fost
     ways_to_respond: Modalități de a răspunde
@@ -451,22 +435,6 @@ ro:
       avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile în anumite părți ale țării.
       avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile în întreaga țară.
     context: Sfaturi pentru călătoriile în străinătate
-    coronavirus_warning:
-      content_html: |
-        <p class="govuk-body">
-          Respectați reglementările actuale cu privire la COVID-19 acolo unde locuiți: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">Anglia</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Scoția</a>, <a href="https://gov.wales/coronavirus-travel">Țara Galilor</a> și <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Irlanda de Nord</a>.
-        </p>
-        <p class="govuk-body">
-          Pentru a preveni noile variante de COVID să intre în Marea Britanie, nu trebuie să călătoriți <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">în țările de pe lista roșie sau portocalie</a>.
-        </p>
-        <p class="govuk-body">
-          Pentru a înțelege riscurile dintr-o țară, urmați <a href="/guidance/travel-advice-novel-coronavirus">sfaturile cu privire la călătorie ale FCDO</a>.
-        </p>
-        <p class="govuk-body">
-          Când reveniți, urmați regulile pentru a <a href="/uk-border-control">intra în Marea Britanie din străinătate</a> (cu excepția Irlandei).
-        </p>
-      text_assistive: Important
-      title: Călătoriile în pandemia cauzată de Coronavirus (COVID-19)
     still_current_at: În acest moment la
     summary: Rezumat
     updated: Actualizat

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -521,10 +521,10 @@ ru:
     release_date: Дата выпуска
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых в части страны.
-      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых по всей стране.
-      avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых в части страны.
-      avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых по всей стране.
+      avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых в части страны.
+      avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых по всей стране.
+      avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых в части страны.
+      avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых по всей стране.
     context: Консультации по зарубежным поездкам
     coronavirus_warning:
       content_html: |

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,389 +1,5 @@
+---
 ru:
-  content_item:
-    schema_name:
-      aaib_report:
-        one: Отчет Отдела по Расследованию Авиационных Происшествий
-        few:
-        many:
-        other: Отчеты Отдела по Расследованию Авиационных Происшествий
-      announcement:
-        one: Объявление
-        few:
-        many:
-        other: Объявления
-      asylum_support_decision:
-        one: Решение суда по вопросам предоставления убежища
-        few:
-        many:
-        other: Решения суда по вопросам предоставления убежища
-      authored_article:
-        one: Авторская статья
-        few:
-        many:
-        other: Авторские статьи
-      business_finance_support_scheme:
-        one: План поддержки финансирования бизнеса
-        few:
-        many:
-        other: Планы поддержки финансирования бизнеса
-      case_study:
-        one: Причинный анализ
-        few:
-        many:
-        other: Причинные анализы
-      closed_consultation:
-        one: Закрытая консультация
-        few:
-        many:
-        other: Закрытые консультации
-      cma_case:
-        one: Дело Управления по Защите Конкуренции и Рынкам
-        few:
-        many:
-        other: Дела Управления по Защите Конкуренции и Рынкам
-      coming_soon:
-        one: Скоро на Экранах
-        few:
-        many:
-        other: Скоро на Экранах
-      consultation:
-        one: Консультация
-        few:
-        many:
-        other: Консультации
-      consultation_outcome:
-        one: Результат консультации
-        few:
-        many:
-        other: Результаты консультаций
-      corporate_information_page:
-        one: Информационная страница
-        few:
-        many:
-        other: Информационные страницы
-      corporate_report:
-        one: Корпоративный отчет
-        few:
-        many:
-        other: Корпоративные отчеты
-      correspondence:
-        one: Корреспонденция
-        few:
-        many:
-        other: Корреспонденция
-      countryside_stewardship_grant:
-        one: Грант Управлений Сельской местности
-        few:
-        many:
-        other: Гранты Управлений Сельской местности
-      decision:
-        one: Решение
-        few:
-        many:
-        other: Решения
-      detailed_guide:
-        one: Подробное руководство
-        few:
-        many:
-        other: Руководство
-      dfid_research_output:
-        one: Результат Исследования по развитию
-        few:
-        many:
-        other: Результаты Исследования по развитию
-      document_collection:
-        one: Коллекция
-        few:
-        many:
-        other: Коллекции
-      draft_text:
-        one: Проект текста
-        few:
-        many:
-        other: Проект текстов
-      drug_safety_update:
-        one: Обновлённые данные по Безопасности Лекарственного Средства
-        few:
-        many:
-        other: Обновлённые данные по Безопасности Лекарственного Средства
-      employment_appeal_tribunal_decision:
-        one: Решение Апелляционного Суда по Трудовым Делам
-        few:
-        many:
-        other: Решения Апелляционного Суда по Трудовым Делам
-      employment_tribunal_decision:
-        one: Решение органа по рассмотрению индивидуальных трудовых споров
-        few:
-        many:
-        other: Решения органа по рассмотрению индивидуальных трудовых споров
-      esi_fund:
-        one: Европейский Структурный и Инвестиционный Фонд (ЕСИФ)
-        few:
-        many:
-        other: Европейские Структурные и Инвестиционные Фонды (ЕСИФ)
-      fatality_notice:
-        one: Уведомление о несчастном случае
-        few:
-        many:
-        other: Уведомления о несчастных случаях
-      foi_release:
-        one: Новая редакция Закона о Свободе Распространения Информации
-        few:
-        many:
-        other: Новые редакции Закона о Свободе Распространения Информации
-      form:
-        one: Форма
-        few:
-        many:
-        other: Формы
-      government_response:
-        one: Ответ правительства
-        few:
-        many:
-        other: Ответы правительства
-      guidance:
-        one: Руководство
-        few:
-        many:
-        other: Руководство
-      impact_assessment:
-        one: Оценка воздействия
-        few:
-        many:
-        other: Оценки воздействия
-      imported:
-        one: импортировано - тип ожидания
-        few:
-        many:
-        other: импортировано - тип ожидания
-      independent_report:
-        one: Независимый отчет
-        few:
-        many:
-        other: Независимые отчеты
-      international_development_fund:
-        one: Международное финансирование развития
-        few:
-        many:
-        other: Международное финансирование развития
-      international_treaty:
-        one: Международное соглашение
-        few:
-        many:
-        other: Международные соглашения
-      maib_report:
-        one: Отчет Отдела по Расследованию Несчастных Случаев на Море
-        few:
-        many:
-        other: Отчеты Отдела по Расследованию Несчастных Случаев на Море
-      map:
-        one: Карта
-        few:
-        many:
-        other: Карты
-      medical_safety_alert:
-        one: Уведомления и отзывы о лекарственных препаратах и медицинских устройствах
-        few:
-        many:
-        other: Уведомления и отзывы о лекарственных препаратах и медицинских устройствах
-      national:
-        one: Объявление национального статистического комитета
-        few:
-        many:
-        other: Объявления национального статистического комитета
-      national_statistics:
-        one: Национальная статистика
-        few:
-        many:
-        other: Национальная статистика
-      national_statistics_announcement:
-        one: Объявление национального статистического комитета
-        few:
-        many:
-        other: Объявления национального статистического комитета
-      news_article:
-        one: Новостная статья
-        few:
-        many:
-        other: Новостные статьи
-      news_story:
-        one: Новостной сюжет
-        few:
-        many:
-        other: Новостные сюжеты
-      notice:
-        one: Заметка
-        few:
-        many:
-        other: Заметки
-      official:
-        one: Доклад по официальным статистическим данным
-        few:
-        many:
-        other: Доклады по официальным статистическим данным
-      official_statistics:
-        one: Официальная Статистика
-        few:
-        many:
-        other: Официальная Статистика
-      official_statistics_announcement:
-        one: Доклад по официальным статистическим данным
-        few:
-        many:
-        other: Доклады по официальным статистическим данным
-      open_consultation:
-        one: Открытая консультация
-        few:
-        many:
-        other: Открытые консультации
-      oral_statement:
-        one: Устное заявление парламенту
-        few:
-        many:
-        other: Устные заявления парламенту
-      policy:
-        one: Политика
-        few:
-        many:
-        other: Политика
-      policy_paper:
-        one: Директивный документ
-        few:
-        many:
-        other: Директивные документы
-      press_release:
-        one: Пресс-релиз
-        few:
-        many:
-        other: Пресс-релизы
-      promotional:
-        one: Рекламный материал
-        few:
-        many:
-        other: Рекламные материалы
-      publication:
-        one: Публикация
-        few:
-        many:
-        other: Публикации
-      raib_report:
-        one: Отчет Отдела по Расследованию Несчастных Случаев на Железнодорожном Транспорте
-        few:
-        many:
-        other: Отчеты Отдела по Расследованию Несчастных Случаев на Железнодорожном
-          Транспорте
-      regulation:
-        one: Требование
-        few:
-        many:
-        other: Требования
-      research:
-        one: Исследования и аналитика
-        few:
-        many:
-        other: Исследования и аналитика
-      residential_property_tribunal_decision:
-        one: Решение арбитражного суда по жилищной собственности
-        few:
-        many:
-        other: Решения арбитражного суда по жилищной собственности
-      service_sign_in:
-        one: Сервис по регистрации
-        few:
-        many:
-        other: Сервис по регистрации
-      service_standard_report:
-        one: Отчет оп Стандарту Обслуживания
-        few:
-        many:
-        other: Отчеты оп Стандарту Обслуживания
-      speaking_notes:
-        one: Тезисы выступления
-        few:
-        many:
-        other: Тезисы выступления
-      speech:
-        one: Текст выступления
-        few:
-        many:
-        other: Тексты выступлений
-      standard:
-        one: Стандарт
-        few:
-        many:
-        other: Стандарты
-      statement_to_parliament:
-        one: Заявление парламенту
-        few:
-        many:
-        other: Заявления парламенту
-      statistical_data_set:
-        one: Совокупность статистических данных
-        few:
-        many:
-        other: Совокупность статистических данных
-      statistics_announcement:
-        one: Объявление о публикации статистических данных
-        few:
-        many:
-        other: Объявления о публикации статистических данных
-      statutory_guidance:
-        one: Официальные рекомендации
-        few:
-        many:
-        other: Официальные рекомендации
-      take_part:
-        one: Принять участие
-        few:
-        many:
-        other: Принять участие
-      tax_tribunal_decision:
-        one: Решение суда по Налоговым и Канцелярским вопросам
-        few:
-        many:
-        other: Решения суда по Налоговым и Канцелярским вопросам
-      transcript:
-        one: Транскрипт
-        few:
-        many:
-        other: Транскрипты
-      transparency:
-        one: Прозрачность данных
-        few:
-        many:
-        other: Прозрачность данных
-      utaac_decision:
-        one: Решение суда по апелляции на решение административного органа
-        few:
-        many:
-        other: Решения суда по апелляции на решение административного органа
-      world_location_news_article:
-        one: Новостная статья
-        few:
-        many:
-        other: Новостные статьи
-      world_news_story:
-        one: Международные новости
-        few:
-        many:
-        other: Международные новости
-      written_statement:
-        one: Письменное заявление парламенту
-        few:
-        many:
-        other: Письменные заявления парламенту
-    coming_soon: Данный документ будет опубликован на
-    contents: Содержание
-    metadata:
-      published: Опубликовано
-      updated: обновлено
-  publication:
-    documents:
-      one: Документ
-      few:
-      many:
-      other: Документы
-    details: Детали
   brexit:
     business_link:
       path: "/guidance/brexit-guidance-for-businesses"
@@ -419,16 +35,13 @@ ru:
       page_not_saved_heading: Сохраните данную страницу, чтобы вернуться к ней позже
       page_was_saved_heading: Вы сохранили данную страницу
       remove_page_button: Удалите из сохранённых страниц
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Посмотрите
-        свои сохранённые страницы</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Зарегистрироваться</a>
-        чтобы посмотреть сохранённые страницы.
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Посмотрите свои сохранённые страницы</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Зарегистрироваться</a> чтобы посмотреть сохранённые страницы.
     share_links:
       share_this_page: 'Поделиться данной страницей '
   consultation:
     and: и
-    another_website_html: Консультация %{closed} проведенная на <a href="%{url}">другой
-      Веб-сайт</a>
+    another_website_html: Консультация %{closed} проведенная на <a href="%{url}">другой Веб-сайт</a>
     at: на
     closes: Она закрывается на
     closes_at: Данная консультация закрывается на
@@ -449,8 +62,7 @@ ru:
     ran_from: Обычная консультация
     respond_online: Он-лайн ответ
     'true': правда
-    visit_soon: Посетите эту страницу снова, чтобы скачать результат данного общественного
-      &nbsp;отзыв.
+    visit_soon: Посетите эту страницу снова, чтобы скачать результат данного общественного &nbsp;отзыв.
     was: был
     ways_to_respond: Как получить ответ
     write_to: 'Пишите на:'
@@ -460,13 +72,388 @@ ru:
     online: Он-лайн
     phone: Телефон
     webchat: Веб-чат
+  content_item:
+    coming_soon: Данный документ будет опубликован на
+    contents: Содержание
+    metadata:
+      published: Опубликовано
+      updated: обновлено
+    schema_name:
+      aaib_report:
+        few:
+        many:
+        one: Отчет Отдела по Расследованию Авиационных Происшествий
+        other: Отчеты Отдела по Расследованию Авиационных Происшествий
+      announcement:
+        few:
+        many:
+        one: Объявление
+        other: Объявления
+      asylum_support_decision:
+        few:
+        many:
+        one: Решение суда по вопросам предоставления убежища
+        other: Решения суда по вопросам предоставления убежища
+      authored_article:
+        few:
+        many:
+        one: Авторская статья
+        other: Авторские статьи
+      business_finance_support_scheme:
+        few:
+        many:
+        one: План поддержки финансирования бизнеса
+        other: Планы поддержки финансирования бизнеса
+      case_study:
+        few:
+        many:
+        one: Причинный анализ
+        other: Причинные анализы
+      closed_consultation:
+        few:
+        many:
+        one: Закрытая консультация
+        other: Закрытые консультации
+      cma_case:
+        few:
+        many:
+        one: Дело Управления по Защите Конкуренции и Рынкам
+        other: Дела Управления по Защите Конкуренции и Рынкам
+      coming_soon:
+        few:
+        many:
+        one: Скоро на Экранах
+        other: Скоро на Экранах
+      consultation:
+        few:
+        many:
+        one: Консультация
+        other: Консультации
+      consultation_outcome:
+        few:
+        many:
+        one: Результат консультации
+        other: Результаты консультаций
+      corporate_information_page:
+        few:
+        many:
+        one: Информационная страница
+        other: Информационные страницы
+      corporate_report:
+        few:
+        many:
+        one: Корпоративный отчет
+        other: Корпоративные отчеты
+      correspondence:
+        few:
+        many:
+        one: Корреспонденция
+        other: Корреспонденция
+      countryside_stewardship_grant:
+        few:
+        many:
+        one: Грант Управлений Сельской местности
+        other: Гранты Управлений Сельской местности
+      decision:
+        few:
+        many:
+        one: Решение
+        other: Решения
+      detailed_guide:
+        few:
+        many:
+        one: Подробное руководство
+        other: Руководство
+      dfid_research_output:
+        few:
+        many:
+        one: Результат Исследования по развитию
+        other: Результаты Исследования по развитию
+      document_collection:
+        few:
+        many:
+        one: Коллекция
+        other: Коллекции
+      draft_text:
+        few:
+        many:
+        one: Проект текста
+        other: Проект текстов
+      drug_safety_update:
+        few:
+        many:
+        one: Обновлённые данные по Безопасности Лекарственного Средства
+        other: Обновлённые данные по Безопасности Лекарственного Средства
+      employment_appeal_tribunal_decision:
+        few:
+        many:
+        one: Решение Апелляционного Суда по Трудовым Делам
+        other: Решения Апелляционного Суда по Трудовым Делам
+      employment_tribunal_decision:
+        few:
+        many:
+        one: Решение органа по рассмотрению индивидуальных трудовых споров
+        other: Решения органа по рассмотрению индивидуальных трудовых споров
+      esi_fund:
+        few:
+        many:
+        one: Европейский Структурный и Инвестиционный Фонд (ЕСИФ)
+        other: Европейские Структурные и Инвестиционные Фонды (ЕСИФ)
+      fatality_notice:
+        few:
+        many:
+        one: Уведомление о несчастном случае
+        other: Уведомления о несчастных случаях
+      foi_release:
+        few:
+        many:
+        one: Новая редакция Закона о Свободе Распространения Информации
+        other: Новые редакции Закона о Свободе Распространения Информации
+      form:
+        few:
+        many:
+        one: Форма
+        other: Формы
+      government_response:
+        few:
+        many:
+        one: Ответ правительства
+        other: Ответы правительства
+      guidance:
+        few:
+        many:
+        one: Руководство
+        other: Руководство
+      impact_assessment:
+        few:
+        many:
+        one: Оценка воздействия
+        other: Оценки воздействия
+      imported:
+        few:
+        many:
+        one: импортировано - тип ожидания
+        other: импортировано - тип ожидания
+      independent_report:
+        few:
+        many:
+        one: Независимый отчет
+        other: Независимые отчеты
+      international_development_fund:
+        few:
+        many:
+        one: Международное финансирование развития
+        other: Международное финансирование развития
+      international_treaty:
+        few:
+        many:
+        one: Международное соглашение
+        other: Международные соглашения
+      maib_report:
+        few:
+        many:
+        one: Отчет Отдела по Расследованию Несчастных Случаев на Море
+        other: Отчеты Отдела по Расследованию Несчастных Случаев на Море
+      map:
+        few:
+        many:
+        one: Карта
+        other: Карты
+      medical_safety_alert:
+        few:
+        many:
+        one: Уведомления и отзывы о лекарственных препаратах и медицинских устройствах
+        other: Уведомления и отзывы о лекарственных препаратах и медицинских устройствах
+      national:
+        few:
+        many:
+        one: Объявление национального статистического комитета
+        other: Объявления национального статистического комитета
+      national_statistics:
+        few:
+        many:
+        one: Национальная статистика
+        other: Национальная статистика
+      national_statistics_announcement:
+        few:
+        many:
+        one: Объявление национального статистического комитета
+        other: Объявления национального статистического комитета
+      news_article:
+        few:
+        many:
+        one: Новостная статья
+        other: Новостные статьи
+      news_story:
+        few:
+        many:
+        one: Новостной сюжет
+        other: Новостные сюжеты
+      notice:
+        few:
+        many:
+        one: Заметка
+        other: Заметки
+      official:
+        few:
+        many:
+        one: Доклад по официальным статистическим данным
+        other: Доклады по официальным статистическим данным
+      official_statistics:
+        few:
+        many:
+        one: Официальная Статистика
+        other: Официальная Статистика
+      official_statistics_announcement:
+        few:
+        many:
+        one: Доклад по официальным статистическим данным
+        other: Доклады по официальным статистическим данным
+      open_consultation:
+        few:
+        many:
+        one: Открытая консультация
+        other: Открытые консультации
+      oral_statement:
+        few:
+        many:
+        one: Устное заявление парламенту
+        other: Устные заявления парламенту
+      policy:
+        few:
+        many:
+        one: Политика
+        other: Политика
+      policy_paper:
+        few:
+        many:
+        one: Директивный документ
+        other: Директивные документы
+      press_release:
+        few:
+        many:
+        one: Пресс-релиз
+        other: Пресс-релизы
+      promotional:
+        few:
+        many:
+        one: Рекламный материал
+        other: Рекламные материалы
+      publication:
+        few:
+        many:
+        one: Публикация
+        other: Публикации
+      raib_report:
+        few:
+        many:
+        one: Отчет Отдела по Расследованию Несчастных Случаев на Железнодорожном Транспорте
+        other: Отчеты Отдела по Расследованию Несчастных Случаев на Железнодорожном Транспорте
+      regulation:
+        few:
+        many:
+        one: Требование
+        other: Требования
+      research:
+        few:
+        many:
+        one: Исследования и аналитика
+        other: Исследования и аналитика
+      residential_property_tribunal_decision:
+        few:
+        many:
+        one: Решение арбитражного суда по жилищной собственности
+        other: Решения арбитражного суда по жилищной собственности
+      service_sign_in:
+        few:
+        many:
+        one: Сервис по регистрации
+        other: Сервис по регистрации
+      service_standard_report:
+        few:
+        many:
+        one: Отчет оп Стандарту Обслуживания
+        other: Отчеты оп Стандарту Обслуживания
+      speaking_notes:
+        few:
+        many:
+        one: Тезисы выступления
+        other: Тезисы выступления
+      speech:
+        few:
+        many:
+        one: Текст выступления
+        other: Тексты выступлений
+      standard:
+        few:
+        many:
+        one: Стандарт
+        other: Стандарты
+      statement_to_parliament:
+        few:
+        many:
+        one: Заявление парламенту
+        other: Заявления парламенту
+      statistical_data_set:
+        few:
+        many:
+        one: Совокупность статистических данных
+        other: Совокупность статистических данных
+      statistics_announcement:
+        few:
+        many:
+        one: Объявление о публикации статистических данных
+        other: Объявления о публикации статистических данных
+      statutory_guidance:
+        few:
+        many:
+        one: Официальные рекомендации
+        other: Официальные рекомендации
+      take_part:
+        few:
+        many:
+        one: Принять участие
+        other: Принять участие
+      tax_tribunal_decision:
+        few:
+        many:
+        one: Решение суда по Налоговым и Канцелярским вопросам
+        other: Решения суда по Налоговым и Канцелярским вопросам
+      transcript:
+        few:
+        many:
+        one: Транскрипт
+        other: Транскрипты
+      transparency:
+        few:
+        many:
+        one: Прозрачность данных
+        other: Прозрачность данных
+      utaac_decision:
+        few:
+        many:
+        one: Решение суда по апелляции на решение административного органа
+        other: Решения суда по апелляции на решение административного органа
+      world_location_news_article:
+        few:
+        many:
+        one: Новостная статья
+        other: Новостные статьи
+      world_news_story:
+        few:
+        many:
+        one: Международные новости
+        other: Международные новости
+      written_statement:
+        few:
+        many:
+        one: Письменное заявление парламенту
+        other: Письменные заявления парламенту
   corporate_information_page:
     about_our_services_html: Узнайте %{link}.
     corporate_information: Корпоративная информация
-    personal_information_charter_html: Наше %{link} с объяснением о том, как мы обращаемся
-      с вашей личной информацией
-    publication_scheme_html: Прочитайте о информации, которая обычно публикуется нами
-      на %{link}.
+    personal_information_charter_html: Наше %{link} с объяснением о том, как мы обращаемся с вашей личной информацией
+    publication_scheme_html: Прочитайте о информации, которая обычно публикуется нами на %{link}.
     social_media_use_html: Ознакомьтесь с нашей политикой по %{link}.
     welsh_language_scheme_html: Узнайте о наших обязательствах по %{link}.
   fatality_notice:
@@ -475,8 +462,7 @@ ru:
     operations_in: Деятельность в  %{location}
   gone:
     page_title: Более не доступен
-    published_in_error: Информация на данной странице была удалена так как была опубликована
-      по ошибке.
+    published_in_error: Информация на данной странице была удалена так как была опубликована по ошибке.
     title: Страница, которую Вы ищите более не доступна
   guide:
     pages_in_guide: Страница в руководстве
@@ -486,14 +472,8 @@ ru:
       available_at: Данная публикация доступна на %{url}
       copyright: "© Авторское право короны %{year}"
       isbn: 'Международный Стандартный Книжный Номер:'
-      licence_html: 'Данная публикация лицензирована по условиям Открытой государственной
-        лицензии  v3.0, за исключением тех случаев, где указано иное. для просмотра
-        лицензии, посетите <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
-        либо обратитесь к Команде по Информационной политике, в Национальный Архив,
-        по адресу Кью, Лондон   TW9 4DU, либо по электронной почте: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
-      third_party: 'В случае обнаружения нами информации авторского права третьей
-        стороны, Вам будет необходимо получить разрешение владельцев авторского права,
-        имеющих к ней отношение. '
+      licence_html: 'Данная публикация лицензирована по условиям Открытой государственной лицензии  v3.0, за исключением тех случаев, где указано иное. для просмотра лицензии, посетите <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a> либо обратитесь к Команде по Информационной политике, в Национальный Архив, по адресу Кью, Лондон   TW9 4DU, либо по электронной почте: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: 'В случае обнаружения нами информации авторского права третьей стороны, Вам будет необходимо получить разрешение владельцев авторского права, имеющих к ней отношение. '
   i18n:
     direction:
   language_names:
@@ -502,6 +482,13 @@ ru:
     next_page: Следующий
     previous_page: Предыдущий
     print_entire_guide: Распечатать всё руководство
+  publication:
+    details: Детали
+    documents:
+      few:
+      many:
+      one: Документ
+      other: Документы
   service_sign_in:
     continue: Продолжить
     error:
@@ -516,12 +503,9 @@ ru:
       speak_to_adviser: Поговорите с консультантом
       technical_problem: В настоящий момент Веб-чат не доступен по техническим причинам.
   specialist_document:
-    pdo_alt_text: Схема логотипа это черная печать со словами - Защищённое Соединённым
-      Королевством Обозначение Происхождения
-    pgi_alt_text: Схема логотипа это черная печать со словами - Защищённое Соединённым
-      Королевством Обозначение Географического Происхождения
-    tsg_alt_text: Схема логотипа это черная печать со словами - Защищённая Соединённым
-      Королевством Традиционная особенность
+    pdo_alt_text: Схема логотипа это черная печать со словами - Защищённое Соединённым Королевством Обозначение Происхождения
+    pgi_alt_text: Схема логотипа это черная печать со словами - Защищённое Соединённым Королевством Обозначение Географического Происхождения
+    tsg_alt_text: Схема логотипа это черная печать со словами - Защищённая Соединённым Королевством Традиционная особенность
   speech:
     delivered_on: Доставлено на
     location: Место
@@ -537,17 +521,10 @@ ru:
     release_date: Дата выпуска
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth
-        Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых
-        в части страны.
-      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and
-        Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением
-        необходимых по всей стране.
-      avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr>
-        Все поездки не реккомендуются, за исключением необходимых в части страны.
-      avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth
-        Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых
-        по всей стране.
+      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых в части страны.
+      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых по всей стране.
+      avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых в части страны.
+      avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых по всей стране.
     context: Консультации по зарубежным поездкам
     coronavirus_warning:
       content_html: |
@@ -570,8 +547,7 @@ ru:
     updated: Обновлено
   unpublishing:
     page_title: Более не доступен
-    summary: Информация на данной странице была удалена так как была опубликована
-      по ошибке.
+    summary: Информация на данной странице была удалена так как была опубликована по ошибке.
     title: Страница, которую Вы ищите более не доступна
   working_group:
     contact_details: Контактная информация

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -9,7 +9,6 @@ ru:
       text: Руководство Брексит для физических лиц и семей
     heading_prefix: Здесь не так
   common:
-    last_updated:
     visit: 'Посетите:'
   components:
     figure:
@@ -21,22 +20,8 @@ ru:
       see_all_updates: Посмотреть всю поледнюю информацию
       show_all_updates: Показать всю поледнюю информацию
     publisher_metadata:
-      collections:
-      from:
       hide_all: Скрыть всё
       show_all: Показать всё
-    save_this_page:
-      add_page_button: Добавить к сохранённым страницам
-      confirmations:
-        page_removed:
-          message: Вы удалили это из сохранённых страниц
-        page_saved:
-          message: Вы добавили это к сохранённым страницам
-      page_not_saved_heading: Сохраните данную страницу, чтобы вернуться к ней позже
-      page_was_saved_heading: Вы сохранили данную страницу
-      remove_page_button: Удалите из сохранённых страниц
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Посмотрите свои сохранённые страницы</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Зарегистрироваться</a> чтобы посмотреть сохранённые страницы.
     share_links:
       share_this_page: 'Поделиться данной страницей '
   consultation:
@@ -61,7 +46,6 @@ ru:
     original_consultation: Оригинальная консультация
     ran_from: Обычная консультация
     respond_online: Он-лайн ответ
-    'true': правда
     visit_soon: Посетите эту страницу снова, чтобы скачать результат данного общественного &nbsp;отзыв.
     was: был
     ways_to_respond: Как получить ответ
@@ -526,22 +510,6 @@ ru:
       avoid_all_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых в части страны.
       avoid_all_travel_to_whole_country_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых по всей стране.
     context: Консультации по зарубежным поездкам
-    coronavirus_warning:
-      content_html: |
-        <p class="govuk-body">
-         Следите за актуальными правилами по COVID-19 вашего населенного пункта: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">Англия</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Шотландия</a>, <a href="https://gov.wales/coronavirus-travel">Уэльс</a> и <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Северная Ирландия</a>.
-        </p>
-        <p class="govuk-body">
-          Для предотвращения попадания в Соединённое Королевство новых вариантов COVID, Вам не следует путешествовать в <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">страны в находящиеся в желтом либо красном списке</a>.
-        </p>
-        <p class="govuk-body">
-          Для понимания рисков в стране пройдите на <a href="/guidance/travel-advice-novel-coronavirus">FCDO совет путешествия</a>.
-        </p>
-        <p class="govuk-body">
-          По возвращении, следуйте правилам  <a href="/uk-border-control">возвращения в Соединённое Королевство из за границы</a> (за исключением из Ирландии).
-        </p>
-      text_assistive: Важное
-      title: Поездки в период Короновируса  (COVID-19)
     still_current_at: Все еще на
     summary: Резюме
     updated: Обновлено

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -440,10 +440,55 @@ ru:
     publication_scheme_html: Прочитайте о информации, которая обычно публикуется нами на %{link}.
     social_media_use_html: Ознакомьтесь с нашей политикой по %{link}.
     welsh_language_scheme_html: Узнайте о наших обязательствах по %{link}.
+  email:
+    description_html:
+    subscribe_title:
+    unsubscribe_title:
   fatality_notice:
     alt_text: Герб Министерства Обороны
     field_of_operation: Сфера деятельности
     operations_in: Деятельность в  %{location}
+  get_involved:
+    civil_service:
+    civil_service_quarterly:
+    closed:
+    closed_consultations:
+    closes:
+    closing_today:
+    closing_tomorrow:
+    days_left:
+    engage_with_gov:
+    fcdo_bloggers:
+    follow:
+    follow_links:
+    follow_paragraph:
+    gds_blog:
+    gov_past:
+    intro_paragraph:
+      body_html:
+      engage_with_government:
+      take_part:
+    join_ics:
+    make_donation:
+    more_ways:
+    neighbourhood_watch:
+    open_consultations:
+    page_heading:
+    page_title:
+    petition_paragraph:
+      body_html:
+      create_a_petition:
+    read_respond:
+    recent_outcomes:
+    recently_opened:
+    respond_to_consultations:
+    school_overseas:
+    search_all:
+    see_all_dept:
+    start_a_petition:
+    take_part:
+    take_part_suggestions:
+    your_views:
   gone:
     page_title: Более не доступен
     published_in_error: Информация на данной странице была удалена так как была опубликована по ошибке.
@@ -461,7 +506,72 @@ ru:
   i18n:
     direction:
   language_names:
+    ar:
+    az:
+    be:
+    bg:
+    bn:
+    cs:
+    cy:
+    da:
+    de:
+    dr:
+    el:
+    en:
+    es:
+    es-419:
+    et:
+    fa:
+    fi:
+    fr:
+    gd:
+    gu:
+    he:
+    hi:
+    hr:
+    hu:
+    hy:
+    id:
+    is:
+    it:
+    ja:
+    ka:
+    kk:
+    ko:
+    lt:
+    lv:
+    ms:
+    mt:
+    ne:
+    nl:
+    'no':
+    pa:
+    pa-pk:
+    pl:
+    ps:
+    pt:
+    ro:
     ru: Русский язык
+    si:
+    sk:
+    sl:
+    so:
+    sq:
+    sr:
+    sv:
+    sw:
+    ta:
+    th:
+    tk:
+    tr:
+    uk:
+    ur:
+    uz:
+    vi:
+    yi:
+    zh:
+    zh-hk:
+    zh-tw:
   multi_page:
     next_page: Следующий
     previous_page: Предыдущий

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -385,8 +385,12 @@ ru:
       other: Документы
     details: Детали
   brexit:
-    business_link: Руководство Брексит для бизнеса
-    citizen_link: Руководство Брексит для физических лиц и семей
+    business_link:
+      path: "/guidance/brexit-guidance-for-businesses"
+      text: Руководство Брексит для бизнеса
+    citizen_link:
+      path: "/guidance/brexit-guidance-for-individuals-and-families"
+      text: Руководство Брексит для физических лиц и семей
     heading_prefix: Здесь не так
   common:
     last_updated:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,656 +1,574 @@
----
 ru:
-  brexit:
-    business_link:
-      path:
-      text:
-    citizen_link:
-      path:
-      text:
-    heading_prefix:
-  common:
-    visit:
-  components:
-    figure:
-      image_credit:
-    published_dates:
-      hide_all_updates:
-      last_updated:
-      published:
-      see_all_updates:
-      show_all_updates:
-    publisher_metadata:
-      hide_all:
-      show_all:
-    share_links:
-      share_this_page:
-  consultation:
-    and:
-    another_website_html:
-    at:
-    closes:
-    closes_at:
-    complete_a:
-    description:
-    detail_of_feedback_received:
-    detail_of_outcome:
-    documents:
-    download_outcome:
-    either:
-    email_to:
-    feedback_received:
-    is_being:
-    not_open_yet:
-    'on':
-    opens:
-    original_consultation:
-    ran_from:
-    respond_online:
-    visit_soon:
-    was:
-    ways_to_respond:
-    write_to:
-  contact:
-    email:
-    find_call_charges:
-    online:
-    phone:
-    webchat:
   content_item:
-    coming_soon:
-    contents:
+    schema_name:
+      aaib_report:
+        one: Отчет Отдела по Расследованию Авиационных Происшествий
+        few:
+        many:
+        other: Отчеты Отдела по Расследованию Авиационных Происшествий
+      announcement:
+        one: Объявление
+        few:
+        many:
+        other: Объявления
+      asylum_support_decision:
+        one: Решение суда по вопросам предоставления убежища
+        few:
+        many:
+        other: Решения суда по вопросам предоставления убежища
+      authored_article:
+        one: Авторская статья
+        few:
+        many:
+        other: Авторские статьи
+      business_finance_support_scheme:
+        one: План поддержки финансирования бизнеса
+        few:
+        many:
+        other: Планы поддержки финансирования бизнеса
+      case_study:
+        one: Причинный анализ
+        few:
+        many:
+        other: Причинные анализы
+      closed_consultation:
+        one: Закрытая консультация
+        few:
+        many:
+        other: Закрытые консультации
+      cma_case:
+        one: Дело Управления по Защите Конкуренции и Рынкам
+        few:
+        many:
+        other: Дела Управления по Защите Конкуренции и Рынкам
+      coming_soon:
+        one: Скоро на Экранах
+        few:
+        many:
+        other: Скоро на Экранах
+      consultation:
+        one: Консультация
+        few:
+        many:
+        other: Консультации
+      consultation_outcome:
+        one: Результат консультации
+        few:
+        many:
+        other: Результаты консультаций
+      corporate_information_page:
+        one: Информационная страница
+        few:
+        many:
+        other: Информационные страницы
+      corporate_report:
+        one: Корпоративный отчет
+        few:
+        many:
+        other: Корпоративные отчеты
+      correspondence:
+        one: Корреспонденция
+        few:
+        many:
+        other: Корреспонденция
+      countryside_stewardship_grant:
+        one: Грант Управлений Сельской местности
+        few:
+        many:
+        other: Гранты Управлений Сельской местности
+      decision:
+        one: Решение
+        few:
+        many:
+        other: Решения
+      detailed_guide:
+        one: Подробное руководство
+        few:
+        many:
+        other: Руководство
+      dfid_research_output:
+        one: Результат Исследования по развитию
+        few:
+        many:
+        other: Результаты Исследования по развитию
+      document_collection:
+        one: Коллекция
+        few:
+        many:
+        other: Коллекции
+      draft_text:
+        one: Проект текста
+        few:
+        many:
+        other: Проект текстов
+      drug_safety_update:
+        one: Обновлённые данные по Безопасности Лекарственного Средства
+        few:
+        many:
+        other: Обновлённые данные по Безопасности Лекарственного Средства
+      employment_appeal_tribunal_decision:
+        one: Решение Апелляционного Суда по Трудовым Делам
+        few:
+        many:
+        other: Решения Апелляционного Суда по Трудовым Делам
+      employment_tribunal_decision:
+        one: Решение органа по рассмотрению индивидуальных трудовых споров
+        few:
+        many:
+        other: Решения органа по рассмотрению индивидуальных трудовых споров
+      esi_fund:
+        one: Европейский Структурный и Инвестиционный Фонд (ЕСИФ)
+        few:
+        many:
+        other: Европейские Структурные и Инвестиционные Фонды (ЕСИФ)
+      fatality_notice:
+        one: Уведомление о несчастном случае
+        few:
+        many:
+        other: Уведомления о несчастных случаях
+      foi_release:
+        one: Новая редакция Закона о Свободе Распространения Информации
+        few:
+        many:
+        other: Новые редакции Закона о Свободе Распространения Информации
+      form:
+        one: Форма
+        few:
+        many:
+        other: Формы
+      government_response:
+        one: Ответ правительства
+        few:
+        many:
+        other: Ответы правительства
+      guidance:
+        one: Руководство
+        few:
+        many:
+        other: Руководство
+      impact_assessment:
+        one: Оценка воздействия
+        few:
+        many:
+        other: Оценки воздействия
+      imported:
+        one: импортировано - тип ожидания
+        few:
+        many:
+        other: импортировано - тип ожидания
+      independent_report:
+        one: Независимый отчет
+        few:
+        many:
+        other: Независимые отчеты
+      international_development_fund:
+        one: Международное финансирование развития
+        few:
+        many:
+        other: Международное финансирование развития
+      international_treaty:
+        one: Международное соглашение
+        few:
+        many:
+        other: Международные соглашения
+      maib_report:
+        one: Отчет Отдела по Расследованию Несчастных Случаев на Море
+        few:
+        many:
+        other: Отчеты Отдела по Расследованию Несчастных Случаев на Море
+      map:
+        one: Карта
+        few:
+        many:
+        other: Карты
+      medical_safety_alert:
+        one: Уведомления и отзывы о лекарственных препаратах и медицинских устройствах
+        few:
+        many:
+        other: Уведомления и отзывы о лекарственных препаратах и медицинских устройствах
+      national:
+        one: Объявление национального статистического комитета
+        few:
+        many:
+        other: Объявления национального статистического комитета
+      national_statistics:
+        one: Национальная статистика
+        few:
+        many:
+        other: Национальная статистика
+      national_statistics_announcement:
+        one: Объявление национального статистического комитета
+        few:
+        many:
+        other: Объявления национального статистического комитета
+      news_article:
+        one: Новостная статья
+        few:
+        many:
+        other: Новостные статьи
+      news_story:
+        one: Новостной сюжет
+        few:
+        many:
+        other: Новостные сюжеты
+      notice:
+        one: Заметка
+        few:
+        many:
+        other: Заметки
+      official:
+        one: Доклад по официальным статистическим данным
+        few:
+        many:
+        other: Доклады по официальным статистическим данным
+      official_statistics:
+        one: Официальная Статистика
+        few:
+        many:
+        other: Официальная Статистика
+      official_statistics_announcement:
+        one: Доклад по официальным статистическим данным
+        few:
+        many:
+        other: Доклады по официальным статистическим данным
+      open_consultation:
+        one: Открытая консультация
+        few:
+        many:
+        other: Открытые консультации
+      oral_statement:
+        one: Устное заявление парламенту
+        few:
+        many:
+        other: Устные заявления парламенту
+      policy:
+        one: Политика
+        few:
+        many:
+        other: Политика
+      policy_paper:
+        one: Директивный документ
+        few:
+        many:
+        other: Директивные документы
+      press_release:
+        one: Пресс-релиз
+        few:
+        many:
+        other: Пресс-релизы
+      promotional:
+        one: Рекламный материал
+        few:
+        many:
+        other: Рекламные материалы
+      publication:
+        one: Публикация
+        few:
+        many:
+        other: Публикации
+      raib_report:
+        one: Отчет Отдела по Расследованию Несчастных Случаев на Железнодорожном Транспорте
+        few:
+        many:
+        other: Отчеты Отдела по Расследованию Несчастных Случаев на Железнодорожном
+          Транспорте
+      regulation:
+        one: Требование
+        few:
+        many:
+        other: Требования
+      research:
+        one: Исследования и аналитика
+        few:
+        many:
+        other: Исследования и аналитика
+      residential_property_tribunal_decision:
+        one: Решение арбитражного суда по жилищной собственности
+        few:
+        many:
+        other: Решения арбитражного суда по жилищной собственности
+      service_sign_in:
+        one: Сервис по регистрации
+        few:
+        many:
+        other: Сервис по регистрации
+      service_standard_report:
+        one: Отчет оп Стандарту Обслуживания
+        few:
+        many:
+        other: Отчеты оп Стандарту Обслуживания
+      speaking_notes:
+        one: Тезисы выступления
+        few:
+        many:
+        other: Тезисы выступления
+      speech:
+        one: Текст выступления
+        few:
+        many:
+        other: Тексты выступлений
+      standard:
+        one: Стандарт
+        few:
+        many:
+        other: Стандарты
+      statement_to_parliament:
+        one: Заявление парламенту
+        few:
+        many:
+        other: Заявления парламенту
+      statistical_data_set:
+        one: Совокупность статистических данных
+        few:
+        many:
+        other: Совокупность статистических данных
+      statistics_announcement:
+        one: Объявление о публикации статистических данных
+        few:
+        many:
+        other: Объявления о публикации статистических данных
+      statutory_guidance:
+        one: Официальные рекомендации
+        few:
+        many:
+        other: Официальные рекомендации
+      take_part:
+        one: Принять участие
+        few:
+        many:
+        other: Принять участие
+      tax_tribunal_decision:
+        one: Решение суда по Налоговым и Канцелярским вопросам
+        few:
+        many:
+        other: Решения суда по Налоговым и Канцелярским вопросам
+      transcript:
+        one: Транскрипт
+        few:
+        many:
+        other: Транскрипты
+      transparency:
+        one: Прозрачность данных
+        few:
+        many:
+        other: Прозрачность данных
+      utaac_decision:
+        one: Решение суда по апелляции на решение административного органа
+        few:
+        many:
+        other: Решения суда по апелляции на решение административного органа
+      world_location_news_article:
+        one: Новостная статья
+        few:
+        many:
+        other: Новостные статьи
+      world_news_story:
+        one: Международные новости
+        few:
+        many:
+        other: Международные новости
+      written_statement:
+        one: Письменное заявление парламенту
+        few:
+        many:
+        other: Письменные заявления парламенту
+    coming_soon: Данный документ будет опубликован на
+    contents: Содержание
     metadata:
       published: Опубликовано
       updated: обновлено
-    schema_name:
-      aaib_report:
-        few:
-        many:
-        one:
-        other:
-      announcement:
-        few:
-        many:
-        one: Объявление
-        other: Объявления
-      asylum_support_decision:
-        few:
-        many:
-        one:
-        other:
-      authored_article:
-        few:
-        many:
-        one: Авторская статья
-        other: Авторские статьи
-      business_finance_support_scheme:
-        few:
-        many:
-        one:
-        other:
-      case_study:
-        few:
-        many:
-        one: Ситуационный анализ
-        other: Ситуационные анализы
-      closed_consultation:
-        few:
-        many:
-        one: Закрытая консультация
-        other: Закрытые консультации
-        overview:
-      cma_case:
-        few:
-        many:
-        one:
-        other:
-      coming_soon:
-        few:
-        many:
-        one:
-        other:
-      consultation:
-        few:
-        many:
-        one: Консультация
-        other: Консультации
-      consultation_outcome:
-        few:
-        many:
-        one: Результат консультации
-        other: Результаты консультаций
-        overview:
-      corporate_information_page:
-        few:
-        many:
-        one:
-        other:
-      corporate_report:
-        few:
-        many:
-        one: Корпоративный отчет
-        other: Корпоративные отчеты
-        overview:
-      correspondence:
-        few:
-        many:
-        one: Корреспонденция
-        other: Корреспонденция
-        overview:
-      countryside_stewardship_grant:
-        few:
-        many:
-        one:
-        other:
-      decision:
-        few:
-        many:
-        one:
-        other:
-        overview:
-      detailed_guide:
-        few:
-        many:
-        one: Подробное руководство
-        other: Подробное руководство
-      dfid_research_output:
-        few:
-        many:
-        one:
-        other:
-      document_collection:
-        few:
-        many:
-        one: Серии
-        other:
-      draft_text:
-        few:
-        many:
-        one: Проект текста
-        other: Проект текстов
-      drug_safety_update:
-        few:
-        many:
-        one:
-        other:
-      employment_appeal_tribunal_decision:
-        few:
-        many:
-        one:
-        other:
-      employment_tribunal_decision:
-        few:
-        many:
-        one:
-        other:
-      esi_fund:
-        few:
-        many:
-        one:
-        other:
-      fatality_notice:
-        few:
-        many:
-        one: Уведомление о несчастном случае
-        other: Уведомления о несчастных случаях
-      foi_release:
-        few:
-        many:
-        one: 'Свобода распространения информации '
-        other: 'Свобода распространения информации '
-        overview:
-      form:
-        few:
-        many:
-        one: Форма
-        other: Формы
-        overview:
-      government_response:
-        few:
-        many:
-        one: Ответ правительства
-        other: Ответы правительства
-      guidance:
-        few:
-        many:
-        one: Руководство
-        other: Руководство
-        overview:
-      impact_assessment:
-        few:
-        many:
-        one: Оценка воздействия
-        other: Оценки воздействия
-        overview:
-      imported:
-        few:
-        many:
-        one: импортировано - тип ожидания
-        other: импортировано - тип ожидания
-      independent_report:
-        few:
-        many:
-        one: Независимый отчет
-        other: Независимые отчеты
-        overview:
-      international_development_fund:
-        few:
-        many:
-        one:
-        other:
-      international_treaty:
-        few:
-        many:
-        one:
-        other:
-        overview:
-      maib_report:
-        few:
-        many:
-        one:
-        other:
-      map:
-        few:
-        many:
-        one: Карта
-        other: Карты
-        overview:
-      medical_safety_alert:
-        few:
-        many:
-        one:
-        other:
-      national:
-        few:
-        many:
-        one:
-        other:
-      national_statistics:
-        few:
-        many:
-        one: Статистика - национальная статистика
-        other: Статистика - национальная статистика
-        overview:
-      national_statistics_announcement:
-        few:
-        many:
-        one:
-        other:
-      news_article:
-        few:
-        many:
-        one: Новостная статья
-        other: Новостные статьи
-      news_story:
-        few:
-        many:
-        one: Новостная заметка
-        other: Новостные заметки
-      notice:
-        few:
-        many:
-        one:
-        other:
-        overview:
-      official:
-        few:
-        many:
-        one:
-        other:
-      official_statistics:
-        few:
-        many:
-        one: Статистика
-        other: Статистика
-        overview:
-      official_statistics_announcement:
-        few:
-        many:
-        one:
-        other:
-      open_consultation:
-        few:
-        many:
-        one: Открытая консультация
-        other: Открытые консультации
-        overview:
-      oral_statement:
-        few:
-        many:
-        one: Устное заявление парламенту
-        other: Устные заявления парламенту
-      policy:
-        few:
-        many:
-        one: Политика
-        other: Политика
-      policy_paper:
-        few:
-        many:
-        one: Директивный документ
-        other: Директивные документы
-        overview:
-      press_release:
-        few:
-        many:
-        one: Пресс-релиз
-        other: Пресс-релизы
-      promotional:
-        few:
-        many:
-        one: Рекламный материал
-        other: Рекламные материалы
-        overview:
-      publication:
-        few:
-        many:
-        one: Публикация
-        other: Публикации
-      raib_report:
-        few:
-        many:
-        one:
-        other:
-      regulation:
-        few:
-        many:
-        one:
-        other:
-        overview:
-      research:
-        few:
-        many:
-        one: Исследования и аналитика
-        other: Исследования и аналитика
-        overview:
-      residential_property_tribunal_decision:
-        few:
-        many:
-        one:
-        other:
-      service_sign_in:
-        few:
-        many:
-        one:
-        other:
-      service_standard_report:
-        few:
-        many:
-        one:
-        other:
-      speaking_notes:
-        few:
-        many:
-        one: Тезисы выступления
-        other: Тезисы выступления
-      speech:
-        few:
-        many:
-        one: Текст выступления
-        other: Тексты выступлений
-      standard:
-        few:
-        many:
-        one:
-        other:
-        overview:
-      statement_to_parliament:
-        few:
-        many:
-        one: Заявление парламенту
-        other: Заявления парламенту
-      statistical_data_set:
-        few:
-        many:
-        one: Статистика
-        other: Статистические данные
-      statistics_announcement:
-        few:
-        many:
-        one:
-        other:
-      statutory_guidance:
-        few:
-        many:
-        one:
-        other:
-        overview:
-      take_part:
-        few:
-        many:
-        one:
-        other:
-      tax_tribunal_decision:
-        few:
-        many:
-        one:
-        other:
-      transcript:
-        few:
-        many:
-        one: Текст
-        other: Тексты
-      transparency:
-        few:
-        many:
-        one: Прозрачность данных
-        other: Прозрачность данных
-        overview:
-      utaac_decision:
-        few:
-        many:
-        one:
-        other:
-      world_location_news_article:
-        few:
-        many:
-        one: Новостная статья
-        other: Новостные статьи
-      world_news_story:
-        few:
-        many:
-        one:
-        other:
-      written_statement:
-        few:
-        many:
-        one: Письменное заявление парламенту
-        other: Письменные заявления парламенту
+  publication:
+    documents:
+      one: Документ
+      few:
+      many:
+      other: Документы
+    details: Детали
+  brexit:
+    business_link: Руководство Брексит для бизнеса
+    citizen_link: Руководство Брексит для физических лиц и семей
+    heading_prefix: Здесь не так
+  common:
+    last_updated:
+    visit: 'Посетите:'
+  components:
+    figure:
+      image_credit: 'Графические материалы предоставлены: %{credit}'
+    published_dates:
+      hide_all_updates: Скрыть всю последнюю информацию
+      last_updated: Последние изменения %{date}
+      published: Опубликовано %{date}
+      see_all_updates: Посмотреть всю поледнюю информацию
+      show_all_updates: Показать всю поледнюю информацию
+    publisher_metadata:
+      collections:
+      from:
+      hide_all: Скрыть всё
+      show_all: Показать всё
+    save_this_page:
+      add_page_button: Добавить к сохранённым страницам
+      confirmations:
+        page_removed:
+          message: Вы удалили это из сохранённых страниц
+        page_saved:
+          message: Вы добавили это к сохранённым страницам
+      page_not_saved_heading: Сохраните данную страницу, чтобы вернуться к ней позже
+      page_was_saved_heading: Вы сохранили данную страницу
+      remove_page_button: Удалите из сохранённых страниц
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Посмотрите
+        свои сохранённые страницы</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Зарегистрироваться</a>
+        чтобы посмотреть сохранённые страницы.
+    share_links:
+      share_this_page: 'Поделиться данной страницей '
+  consultation:
+    and: и
+    another_website_html: Консультация %{closed} проведенная на <a href="%{url}">другой
+      Веб-сайт</a>
+    at: на
+    closes: Она закрывается на
+    closes_at: Данная консультация закрывается на
+    complete_a: Заполните
+    description: Описание консультации
+    detail_of_feedback_received: Детали, полученного отзыва
+    detail_of_outcome: Детали результата
+    documents: Документы
+    download_outcome: Скачать результат полностью
+    either: другое
+    email_to: 'Напишите на:'
+    feedback_received: Отзыв получен
+    is_being: сейчас
+    not_open_yet: Консультация еще не открыта
+    'on':
+    opens: Консультация открывается
+    original_consultation: Оригинальная консультация
+    ran_from: Обычная консультация
+    respond_online: Он-лайн ответ
+    'true': правда
+    visit_soon: Посетите эту страницу снова, чтобы скачать результат данного общественного
+      &nbsp;отзыв.
+    was: был
+    ways_to_respond: Как получить ответ
+    write_to: 'Пишите на:'
+  contact:
+    email: Электронная почта
+    find_call_charges: Узнайте о стоимости звонков
+    online: Он-лайн
+    phone: Телефон
+    webchat: Веб-чат
   corporate_information_page:
-    about_our_services_html:
+    about_our_services_html: Узнайте %{link}.
     corporate_information: Корпоративная информация
-    personal_information_charter_html: По %{link} объяснение о том, как мы обращаемся с вашей личной информацией
-    publication_scheme_html: Прочитать информацию, которая обычно публикуется,  по указанной %{link}.
-    social_media_use_html: Ознакомиться с нашей политикой по %{link}.
-    welsh_language_scheme_html: Выяснить о наших обязательствах по публикации можно по %{link}.
-  email:
-    description_html:
-    subscribe_title:
-    unsubscribe_title:
+    personal_information_charter_html: Наше %{link} с объяснением о том, как мы обращаемся
+      с вашей личной информацией
+    publication_scheme_html: Прочитайте о информации, которая обычно публикуется нами
+      на %{link}.
+    social_media_use_html: Ознакомьтесь с нашей политикой по %{link}.
+    welsh_language_scheme_html: Узнайте о наших обязательствах по %{link}.
   fatality_notice:
-    alt_text:
-    field_of_operation:
-    operations_in:
-  get_involved:
-    active_blogs:
-    civil_service:
-    civil_service_quarterly:
-    closed:
-    closed_consultations:
-    closed_with_date:
-    closes:
-    closing_today:
-    closing_tomorrow:
-    days_left:
-    engage_with_gov:
-    fcdo_bloggers:
-    follow:
-    follow_paragraph:
-    gds_blog:
-    gov_past:
-    intro_paragraph:
-      body_html:
-      engage_with_government:
-      take_part:
-    join_ics:
-    make_donation:
-    more_ways:
-    neighbourhood_watch:
-    open_consultations:
-    page_heading:
-    page_title:
-    petition_paragraph:
-      body_html:
-      create_a_petition:
-    read_respond:
-    recent_outcomes:
-    recently_opened:
-    respond_to_consultations:
-    school_overseas:
-    search_all:
-    see_all_dept:
-    start_a_petition:
-    take_part:
-    take_part_suggestions:
-    your_views:
+    alt_text: Герб Министерства Обороны
+    field_of_operation: Сфера деятельности
+    operations_in: Деятельность в  %{location}
   gone:
-    page_title:
-    published_in_error:
-    title:
+    page_title: Более не доступен
+    published_in_error: Информация на данной странице была удалена так как была опубликована
+      по ошибке.
+    title: Страница, которую Вы ищите более не доступна
   guide:
-    pages_in_guide:
-    skip_to_contents:
+    pages_in_guide: Страница в руководстве
+    skip_to_contents: Перейти к содержанию руководства
   html_publication:
     print_meta_data:
-      available_at:
-      copyright:
-      isbn:
-      licence_html:
-      third_party:
+      available_at: Данная публикация доступна на %{url}
+      copyright: "© Авторское право короны %{year}"
+      isbn: 'Международный Стандартный Книжный Номер:'
+      licence_html: 'Данная публикация лицензирована по условиям Открытой государственной
+        лицензии  v3.0, за исключением тех случаев, где указано иное. для просмотра
+        лицензии, посетите <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
+        либо обратитесь к Команде по Информационной политике, в Национальный Архив,
+        по адресу Кью, Лондон   TW9 4DU, либо по электронной почте: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: 'В случае обнаружения нами информации авторского права третьей
+        стороны, Вам будет необходимо получить разрешение владельцев авторского права,
+        имеющих к ней отношение. '
   i18n:
     direction:
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru: Русский
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    ru: Русский язык
   multi_page:
-    next_page:
-    previous_page:
-    print_entire_guide:
-  publication:
-    details:
-    documents:
-      few:
-      many:
-      one: Документ
-      other: Документы
+    next_page: Следующий
+    previous_page: Предыдущий
+    print_entire_guide: Распечатать всё руководство
   service_sign_in:
-    continue:
+    continue: Продолжить
     error:
-      option:
-      title:
+      option: Поджалуйста, выберите вариант
+      title: Вы не выбрали вариант
   shared:
-    historically_political:
+    historically_political: Данный документ был опубликован в соответствии %{government}
     webchat:
-      available:
-      busy:
-      closed:
-      speak_to_adviser:
-      technical_problem:
+      available: Консультанты доступны в чате.
+      busy: В настоящий момент все консультанты заняты.
+      closed: В настоящий момент Веб-чат не работает.
+      speak_to_adviser: Поговорите с консультантом
+      technical_problem: В настоящий момент Веб-чат не доступен по техническим причинам.
   specialist_document:
-    pdo_alt_text:
-    pgi_alt_text:
-    tsg_alt_text:
+    pdo_alt_text: Схема логотипа это черная печать со словами - Защищённое Соединённым
+      Королевством Обозначение Происхождения
+    pgi_alt_text: Схема логотипа это черная печать со словами - Защищённое Соединённым
+      Королевством Обозначение Географического Происхождения
+    tsg_alt_text: Схема логотипа это черная печать со словами - Защищённая Соединённым
+      Королевством Традиционная особенность
   speech:
-    delivered_on:
-    location:
-    written_on:
+    delivered_on: Доставлено на
+    location: Место
+    written_on: Написано на
   statistics_announcement:
-    cancellation_date:
-    cancelled:
-    changed_date:
-    forthcoming:
-    previous_date:
-    proposed_date:
-    reason_for_change:
-    release_date:
+    cancellation_date: Дата отмены
+    cancelled: Выпуск статистических данных отменен
+    changed_date: Дата выпуска была изменена
+    forthcoming: Данные статистические данные будут опубликованы
+    previous_date: Предыдущая дата
+    proposed_date: Предложенный выпуск
+    reason_for_change: Причина изменения
+    release_date: Дата выпуска
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts_html:
-      avoid_all_but_essential_travel_to_whole_country_html:
-      avoid_all_travel_to_parts_html:
-      avoid_all_travel_to_whole_country_html:
-    context:
-    still_current_at:
-    summary:
-    updated:
+      avoid_all_but_essential_travel_to_parts: The <abbr title="Foreign and Commonwealth
+        Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых
+        в части страны.
+      avoid_all_but_essential_travel_to_whole_country: The <abbr title="Foreign and
+        Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением
+        необходимых по всей стране.
+      avoid_all_travel_to_parts: The <abbr title="Foreign and Commonwealth Office">FCO</abbr>
+        Все поездки не реккомендуются, за исключением необходимых в части страны.
+      avoid_all_travel_to_whole_country: The <abbr title="Foreign and Commonwealth
+        Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых
+        по всей стране.
+    context: Консультации по зарубежным поездкам
+    coronavirus_warning:
+      content_html: |
+        <p class="govuk-body">
+         Следите за актуальными правилами по COVID-19 вашего населенного пункта: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">Англия</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Шотландия</a>, <a href="https://gov.wales/coronavirus-travel">Уэльс</a> и <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Северная Ирландия</a>.
+        </p>
+        <p class="govuk-body">
+          Для предотвращения попадания в Соединённое Королевство новых вариантов COVID, Вам не следует путешествовать в <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">страны в находящиеся в желтом либо красном списке</a>.
+        </p>
+        <p class="govuk-body">
+          Для понимания рисков в стране пройдите на <a href="/guidance/travel-advice-novel-coronavirus">FCDO совет путешествия</a>.
+        </p>
+        <p class="govuk-body">
+          По возвращении, следуйте правилам  <a href="/uk-border-control">возвращения в Соединённое Королевство из за границы</a> (за исключением из Ирландии).
+        </p>
+      text_assistive: Важное
+      title: Поездки в период Короновируса  (COVID-19)
+    still_current_at: Все еще на
+    summary: Резюме
+    updated: Обновлено
   unpublishing:
-    page_title:
-    summary:
-    title:
+    page_title: Более не доступен
+    summary: Информация на данной странице была удалена так как была опубликована
+      по ошибке.
+    title: Страница, которую Вы ищите более не доступна
   working_group:
-    contact_details:
-    policies:
+    contact_details: Контактная информация
+    policies: Политика

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -335,6 +335,7 @@ si:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -324,12 +324,10 @@ si:
     field_of_operation: මෙහෙයුම් ක්ෂේත්රය
     operations_in: "%{location} තුළ මෙහෙයුම්"
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -366,10 +366,55 @@ sk:
     publication_scheme_html: Prečítajte si o typoch informácií, ktoré bežne zverejňujeme v našom %{link}.
     social_media_use_html: Prečítajte si naše zásady na %{link}.
     welsh_language_scheme_html: Prečítajte si o našom záväzku voči %{link}.
+  email:
+    description_html:
+    subscribe_title:
+    unsubscribe_title:
   fatality_notice:
     alt_text: Erb ministerstva obrany
     field_of_operation: Oblasť činnosti
     operations_in: Operácie v %{location}
+  get_involved:
+    civil_service:
+    civil_service_quarterly:
+    closed:
+    closed_consultations:
+    closes:
+    closing_today:
+    closing_tomorrow:
+    days_left:
+    engage_with_gov:
+    fcdo_bloggers:
+    follow:
+    follow_links:
+    follow_paragraph:
+    gds_blog:
+    gov_past:
+    intro_paragraph:
+      body_html:
+      engage_with_government:
+      take_part:
+    join_ics:
+    make_donation:
+    more_ways:
+    neighbourhood_watch:
+    open_consultations:
+    page_heading:
+    page_title:
+    petition_paragraph:
+      body_html:
+      create_a_petition:
+    read_respond:
+    recent_outcomes:
+    recently_opened:
+    respond_to_consultations:
+    school_overseas:
+    search_all:
+    see_all_dept:
+    start_a_petition:
+    take_part:
+    take_part_suggestions:
+    your_views:
   gone:
     page_title: Už nie je k dispozícii
     published_in_error: Informácie na tejto stránke boli odstránené, pretože boli uverejnené omylom.
@@ -387,7 +432,72 @@ sk:
   i18n:
     direction:
   language_names:
+    ar:
+    az:
+    be:
+    bg:
+    bn:
+    cs:
+    cy:
+    da:
+    de:
+    dr:
+    el:
+    en:
+    es:
+    es-419:
+    et:
+    fa:
+    fi:
+    fr:
+    gd:
+    gu:
+    he:
+    hi:
+    hr:
+    hu:
+    hy:
+    id:
+    is:
+    it:
+    ja:
+    ka:
+    kk:
+    ko:
+    lt:
+    lv:
+    ms:
+    mt:
+    ne:
+    nl:
+    'no':
+    pa:
+    pa-pk:
+    pl:
+    ps:
+    pt:
+    ro:
+    ru:
+    si:
     sk: Slovensky
+    sl:
+    so:
+    sq:
+    sr:
+    sv:
+    sw:
+    ta:
+    th:
+    tk:
+    tr:
+    uk:
+    ur:
+    uz:
+    vi:
+    yi:
+    zh:
+    zh-hk:
+    zh-tw:
   multi_page:
     next_page: Ďalšie
     previous_page: Predchádzajúce

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,581 +1,498 @@
----
 sk:
-  brexit:
-    business_link:
-      path:
-      text:
-    citizen_link:
-      path:
-      text:
-    heading_prefix:
-  common:
-    visit:
-  components:
-    figure:
-      image_credit:
-    published_dates:
-      hide_all_updates:
-      last_updated:
-      published:
-      see_all_updates:
-      show_all_updates:
-    publisher_metadata:
-      hide_all:
-      show_all:
-    share_links:
-      share_this_page:
-  consultation:
-    and:
-    another_website_html:
-    at:
-    closes:
-    closes_at:
-    complete_a:
-    description:
-    detail_of_feedback_received:
-    detail_of_outcome:
-    documents:
-    download_outcome:
-    either:
-    email_to:
-    feedback_received:
-    is_being:
-    not_open_yet:
-    'on':
-    opens:
-    original_consultation:
-    ran_from:
-    respond_online:
-    visit_soon:
-    was:
-    ways_to_respond:
-    write_to:
-  contact:
-    email:
-    find_call_charges:
-    online:
-    phone:
-    webchat:
   content_item:
-    coming_soon:
-    contents:
-    metadata:
-      published:
-      updated:
     schema_name:
       aaib_report:
+        one: Správa Oddelenia pre vyšetrovanie leteckých nehôd
         few:
-        one:
-        other:
+        other: Správy Oddelenia pre vyšetrovanie leteckých nehôd
       announcement:
+        one: Oznámenie
         few:
-        one:
-        other:
+        other: Oznámenia
       asylum_support_decision:
+        one: Rozhodnutie tribunálu pre azylovú podporu
         few:
-        one:
-        other:
+        other: Rozhodnutia tribunálu pre azylovú podporu
       authored_article:
+        one: Autor článku
         few:
-        one:
-        other:
+        other: Autorské články
       business_finance_support_scheme:
+        one: Schéma podpory financovania podnikov
         few:
-        one:
-        other:
+        other: Systémy podpory financovania podnikov
       case_study:
+        one: Prípadová štúdia
         few:
-        one:
-        other:
+        other: Prípadové štúdie
       closed_consultation:
+        one: Uzavretá konzultácia
         few:
-        one:
-        other:
-        overview:
+        other: Uzavreté konzultácie
       cma_case:
+        one: Prípad Úradu pre hospodársku súťaž a trhy
         few:
-        one:
-        other:
+        other: Prípady Úradu pre hospodársku súťaž a trhy
       coming_soon:
+        one: Už čoskoro
         few:
-        one:
-        other:
+        other: Už čoskoro
       consultation:
+        one: Konzultácia
         few:
-        one:
-        other:
+        other: Konzultácie
       consultation_outcome:
+        one: Výsledok konzultácie
         few:
-        one:
-        other:
-        overview:
+        other: Výsledky konzultácie
       corporate_information_page:
+        one: Informačná stránka
         few:
-        one:
-        other:
+        other: Informačné stránky
       corporate_report:
+        one: Podniková správa
         few:
-        one:
-        other:
-        overview:
+        other: Podnikové správy
       correspondence:
+        one: Korešpondencia
         few:
-        one:
-        other:
-        overview:
+        other: Korešpondencie
       countryside_stewardship_grant:
+        one: Grant na správu krajiny
         few:
-        one:
-        other:
+        other: Granty na správu vidieka
       decision:
+        one: Rozhodnutie
         few:
-        one:
-        other:
-        overview:
+        other: Rozhodnutia
       detailed_guide:
+        one: Poradenstvo
         few:
-        one:
-        other:
+        other: Poradenstvo
       dfid_research_output:
+        one: Výstupy výskumu pre rozvoj
         few:
-        one:
-        other:
+        other: Výstupy výskumu pre rozvoj
       document_collection:
+        one: Zbierka
         few:
-        one:
-        other:
+        other: Zbierky
       draft_text:
+        one: Návrh textu
         few:
-        one:
-        other:
+        other: Návrhy textov
       drug_safety_update:
+        one: Aktualizácia bezpečnosti liekov
         few:
-        one:
-        other:
+        other: Aktualizácie bezpečnosti liekov
       employment_appeal_tribunal_decision:
+        one: Rozhodnutie odvolacieho pracovného súdu
         few:
-        one:
-        other:
+        other: Rozhodnutia odvolacieho pracovného súdu
       employment_tribunal_decision:
+        one: Rozhodnutie pracovného súdu
         few:
-        one:
-        other:
+        other: Rozhodnutia pracovného súdu
       esi_fund:
+        one: Európsky štrukturálny a investičný fond (EŠIF)
         few:
-        one:
-        other:
+        other: Európske štrukturálne a investičné fondy (EŠIF)
       fatality_notice:
+        one: Oznámenie o úmrtí
         few:
-        one:
-        other:
+        other: Oznámenia o úmrtí
       foi_release:
+        one: Zverejnenie slobody informácií
         few:
-        one:
-        other:
-        overview:
+        other: Zverejnenia slobody informácií
       form:
+        one: Formulár
         few:
-        one:
-        other:
-        overview:
+        other: Formuláre
       government_response:
+        one: Odpoveď vlády
         few:
-        one:
-        other:
+        other: Odpovede vlády
       guidance:
+        one: Poradenstvo
         few:
-        one:
-        other:
-        overview:
+        other: Poradenstvo
       impact_assessment:
+        one: Posúdenie vplyvu
         few:
-        one:
-        other:
-        overview:
+        other: Posúdenia vplyvu
       imported:
+        one: importované - čaká sa na typ
         few:
-        one:
-        other:
+        other: importované - čaká sa na typ
       independent_report:
+        one: Nezávislá správa
         few:
-        one:
-        other:
-        overview:
+        other: Nezávislé správy
       international_development_fund:
+        one: Medzinárodné financovanie rozvoja
         few:
-        one:
-        other:
+        other: Medzinárodné financovanie rozvoja
       international_treaty:
+        one: Medzinárodná zmluva
         few:
-        one:
-        other:
-        overview:
+        other: Medzinárodné zmluvy
       maib_report:
+        one: Správa oddelenia pre vyšetrovanie námorných nehôd
         few:
-        one:
-        other:
+        other: Správy oddelenia pre vyšetrovanie námorných nehôd
       map:
+        one: Mapa
         few:
-        one:
-        other:
-        overview:
+        other: Mapy
       medical_safety_alert:
+        one: Upozornenia a stiahnutia liekov a zdravotníckych pomôcok
         few:
-        one:
-        other:
+        other: Upozornenia a stiahnutia liekov a zdravotníckych pomôcok
       national:
+        one: Oznámenie o národných štatistikách
         few:
-        one:
-        other:
+        other: Oznámenia o národných štatistikách
       national_statistics:
+        one: Národné štatistiky
         few:
-        one:
-        other:
-        overview:
+        other: Národné štatistiky
       national_statistics_announcement:
+        one: Oznámenie o národných štatistikách
         few:
-        one:
-        other:
+        other: Oznámenia o národných štatistikách
       news_article:
+        one: Spravodajský článok
         few:
-        one:
-        other:
+        other: Spravodajské články
       news_story:
+        one: Spravodajský príbeh
         few:
-        one:
-        other:
+        other: Spravodajské príbehy
       notice:
+        one: Oznámenie
         few:
-        one:
-        other:
-        overview:
+        other: Oznámenia
       official:
+        one: Oficiálne štatistické oznámenie
         few:
-        one:
-        other:
+        other: Oficiálne štatistické oznámenia
       official_statistics:
+        one: Oficiálne štatistiky
         few:
-        one:
-        other:
-        overview:
+        other: Oficiálne štatistiky
       official_statistics_announcement:
+        one: Oficiálne štatistické oznámenie
         few:
-        one:
-        other:
+        other: Oficiálne štatistické oznámenia
       open_consultation:
+        one: Otvorená konzultácia
         few:
-        one:
-        other:
-        overview:
+        other: Otvorené konzultácie
       oral_statement:
+        one: Ústne vyhlásenie pred Parlamentom
         few:
-        one:
-        other:
+        other: Ústne vyhlásenia pred Parlamentom
       policy:
+        one: Politika
         few:
-        one:
-        other:
+        other: Politiky
       policy_paper:
+        one: Strategický dokument
         few:
-        one:
-        other:
-        overview:
+        other: Strategické dokumenty
       press_release:
+        one: Tlačová správa
         few:
-        one:
-        other:
+        other: Tlačové správy
       promotional:
+        one: Propagačné materiály
         few:
-        one:
-        other:
-        overview:
+        other: Propagačné materiály
       publication:
+        one: Publikácia
         few:
-        one:
-        other:
+        other: Publikácie
       raib_report:
+        one: Správa Oddelenia vyšetrovania železničných nehôd
         few:
-        one:
-        other:
+        other: Správa Oddelenia pre vyšetrovanie železničných nehôd
       regulation:
+        one: Nariadenie
         few:
-        one:
-        other:
-        overview:
+        other: Nariadenia
       research:
+        one: Výskum a analýza
         few:
-        one:
-        other:
-        overview:
+        other: Výskum a analýza
       residential_property_tribunal_decision:
+        one: Rozhodnutie tribunálu pre obytné nehnuteľnosti
         few:
-        one:
-        other:
+        other: Rozhodnutia tribunálu pre obytné nehnuteľnosti
       service_sign_in:
+        one: Prihlásiť sa do služby
         few:
-        one:
-        other:
+        other: Prihlásiť sa do služby
       service_standard_report:
+        one: Správa o štandardných službách
         few:
-        one:
-        other:
+        other: Správy o štandardných službách
       speaking_notes:
+        one: Poznámky k prejavu
         few:
-        one:
-        other:
+        other: Poznámky k prejavu
       speech:
+        one: Prejav
         few:
-        one:
-        other:
+        other: Prejay
       standard:
+        one: Štandard
         few:
-        one:
-        other:
-        overview:
+        other: Štandardy
       statement_to_parliament:
+        one: Vyhlásenie pre Parlament
         few:
-        one:
-        other:
+        other: Vyhlásenia pre Parlament
       statistical_data_set:
+        one: Súbor štatistických údajov
         few:
-        one:
-        other:
+        other: Súbory štatistických údajov
       statistics_announcement:
+        one: Oznámenie o vydaní štatistík
         few:
-        one:
-        other:
+        other: Oznámenia o vydaní štatistík
       statutory_guidance:
+        one: Zákonné usmernenia
         few:
-        one:
-        other:
-        overview:
+        other: Zákonné usmernenia
       take_part:
+        one: Zúčastniť sa
         few:
-        one:
-        other:
+        other: Zúčastniť sa
       tax_tribunal_decision:
+        one: Rozhodnutie daňového a kancelárskeho súdu
         few:
-        one:
-        other:
+        other: Rozhodnutia daňového a kancelárskeho súdu
       transcript:
+        one: Prepis
         few:
-        one:
-        other:
+        other: Prepisy
       transparency:
+        one: Údaje o transparentnosti
         few:
-        one:
-        other:
-        overview:
+        other: Údaje o transparentnosti
       utaac_decision:
+        one: Rozhodnutie správneho odvolacieho súdu
         few:
-        one:
-        other:
+        other: Rozhodnutia správneho odvolacieho súdu
       world_location_news_article:
+        one: Spravodajský článok
         few:
-        one:
-        other:
+        other: Spravodajské články
       world_news_story:
+        one: Svetové spravodajstvo
         few:
-        one:
-        other:
+        other: Svetové spravodajstvá
       written_statement:
+        one: Písomné vyhlásenie pre Parlament
         few:
-        one:
-        other:
+        other: Písomné vyhlásenia pre Parlament
+    coming_soon: Tento dokument bude uverejnený na
+    contents: Obsah
+    metadata:
+      published: Zverejnené na
+      updated: Aktualizované
+  publication:
+    documents:
+      one: Dokument
+      few:
+      other: Dokumenty
+    details: Podrobnosti na
+  brexit:
+    business_link: Usmernenia pre podniky týkajúce sa brexitu
+    citizen_link: Usmernenie k brexitu pre jednotlivcov a rodiny
+    heading_prefix: Existujú rôzne
+  common:
+    last_updated:
+    visit: 'Navštívte:'
+  components:
+    figure:
+      image_credit: 'Obrázok: %{credit}'
+    published_dates:
+      hide_all_updates: skryť všetky aktualizácie
+      last_updated: Posledná aktualizácia %{date}
+      published: Zverejnené %{date}
+      see_all_updates: pozrite si všetky aktualizácie
+      show_all_updates: zobraziť všetky aktualizácie
+    publisher_metadata:
+      collections:
+      from:
+      hide_all: skryť všetko
+      show_all: zobraziť všetko
+    save_this_page:
+      add_page_button: Pridanie do uložených stránok
+      confirmations:
+        page_removed:
+          message: Odstránili ste ju z uložených stránok
+        page_saved:
+          message: Toto ste pridali do svojich uložených stránok
+      page_not_saved_heading: Uložte si túto stránku, aby ste sa k nej mohli neskôr
+        vrátiť
+      page_was_saved_heading: Uložili ste túto stránku
+      remove_page_button: Odstrániť z uložených stránok
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Pozrite
+        si svoje uložené stránky</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Prihláste
+        sa</a>, aby ste videli svoje uložené stránky.
+    share_links:
+      share_this_page: Zdieľať túto stránku
+  consultation:
+    and: a
+    another_website_html: Táto konzultácia %{closed} sa konala na <a href="%{url}">inej
+      webovej stránke</a>
+    at: na
+    closes: Zatvára sa o
+    closes_at: Táto konzultácia sa končí o
+    complete_a: Dokončite
+    description: Popis konzultácie
+    detail_of_feedback_received: Podrobnosti o prijatej spätnej väzbe
+    detail_of_outcome: Podrobnosti o výsledku
+    documents: Dokumenty
+    download_outcome: Stiahnite si celý výsledok
+    either: buď
+    email_to: 'E-mailom na adresu:'
+    feedback_received: Prijatá spätná väzba
+    is_being: sa
+    not_open_yet: Táto konzultácia ešte nie je otvorená
+    'on':
+    opens: Táto konzultácia sa začína
+    original_consultation: Pôvodná konzultácia
+    ran_from: Táto konzultácia prebiehala od
+    respond_online: Odpovedať online
+    'true': pravda
+    visit_soon: Čoskoro opäť navštívte túto stránku a stiahnite si výsledok tejto
+      verejnej spätnej väzby.
+    was: bola
+    ways_to_respond: Spôsoby reakcie
+    write_to: 'Napíšte na adresu:'
+  contact:
+    email: E-mail
+    find_call_charges: Zistite informácie o poplatkoch za hovory
+    online: Online
+    phone: Telefón
+    webchat: Webový chat
   corporate_information_page:
-    about_our_services_html:
-    corporate_information:
-    personal_information_charter_html:
-    publication_scheme_html:
-    social_media_use_html:
-    welsh_language_scheme_html:
-  email:
-    description_html:
-    subscribe_title:
-    unsubscribe_title:
+    about_our_services_html: Zistite %{link}.
+    corporate_information: Firemné informácie
+    personal_information_charter_html: Náš %{link} vysvetľuje, ako zaobchádzame s
+      vašimi osobnými údajmi.
+    publication_scheme_html: Prečítajte si o typoch informácií, ktoré bežne zverejňujeme
+      v našom %{link}.
+    social_media_use_html: Prečítajte si naše zásady na %{link}.
+    welsh_language_scheme_html: Prečítajte si o našom záväzku voči %{link}.
   fatality_notice:
-    alt_text:
-    field_of_operation:
-    operations_in:
-  get_involved:
-    active_blogs:
-    civil_service:
-    civil_service_quarterly:
-    closed:
-    closed_consultations:
-    closed_with_date:
-    closes:
-    closing_today:
-    closing_tomorrow:
-    days_left:
-    engage_with_gov:
-    fcdo_bloggers:
-    follow:
-    follow_paragraph:
-    gds_blog:
-    gov_past:
-    intro_paragraph:
-      body_html:
-      engage_with_government:
-      take_part:
-    join_ics:
-    make_donation:
-    more_ways:
-    neighbourhood_watch:
-    open_consultations:
-    page_heading:
-    page_title:
-    petition_paragraph:
-      body_html:
-      create_a_petition:
-    read_respond:
-    recent_outcomes:
-    recently_opened:
-    respond_to_consultations:
-    school_overseas:
-    search_all:
-    see_all_dept:
-    start_a_petition:
-    take_part:
-    take_part_suggestions:
-    your_views:
+    alt_text: Erb ministerstva obrany
+    field_of_operation: Oblasť činnosti
+    operations_in: Operácie v %{location}
   gone:
-    page_title:
-    published_in_error:
-    title:
+    page_title: Už nie je k dispozícii
+    published_in_error: Informácie na tejto stránke boli odstránené, pretože boli
+      uverejnené omylom.
+    title: Stránka, ktorú hľadáte, už nie je k dispozícii
   guide:
-    pages_in_guide:
-    skip_to_contents:
+    pages_in_guide: Stránky v tejto príručke
+    skip_to_contents: Prejsť na obsah príručky
   html_publication:
     print_meta_data:
-      available_at:
-      copyright:
-      isbn:
-      licence_html:
-      third_party:
+      available_at: Táto publikácia je k dispozícii na %{url}
+      copyright: Korunné autorské právo %{year}
+      isbn: 'ISBN:'
+      licence_html: 'Táto publikácia je licencovaná podľa podmienok Open Government
+        Licence v3.0, pokiaľ nie je uvedené inak. Ak si chcete pozrieť túto licenciu,
+        navštívte <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
+        alebo napíšte na adresu: Information Policy Team, The National Archives, Kew,
+        London TW9 4DU, alebo pošlite e-mail: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: Ak sme identifikovali akékoľvek informácie o autorských právach
+        tretích strán, budete musieť získať povolenie od príslušných držiteľov autorských
+        práv.
   i18n:
     direction:
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk: Slovenčina
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    sk: Slovensky
   multi_page:
-    next_page:
-    previous_page:
-    print_entire_guide:
-  publication:
-    details:
-    documents:
-      few:
-      one:
-      other:
+    next_page: Ďalšie
+    previous_page: Predchádzajúce
+    print_entire_guide: Vytlačiť celú príručku
   service_sign_in:
-    continue:
+    continue: Pokračovať
     error:
-      option:
-      title:
+      option: Vyberte možnosť
+      title: Nevybrali ste žiadnu možnosť
   shared:
-    historically_political:
+    historically_political: Táto správa bola uverejnená pod hlavičkou %{government}
     webchat:
-      available:
-      busy:
-      closed:
-      speak_to_adviser:
-      technical_problem:
+      available: Poradcovia sú k dispozícii na rozhovor.
+      busy: Všetci poradcovia na webovom chate sú momentálne zaneprázdnení.
+      closed: Webový chat je momentálne zatvorený.
+      speak_to_adviser: Obráťte sa na poradcu
+      technical_problem: Webchat je momentálne nedostupný z dôvodu technických problémov.
   specialist_document:
-    pdo_alt_text:
-    pgi_alt_text:
-    tsg_alt_text:
+    pdo_alt_text: Logo schémy je čierna pečiatka s nápisom Designated Origin UK Protected
+    pgi_alt_text: Logo schémy je čierna pečiatka s nápisom Geographic Origin UK Protected
+    tsg_alt_text: Logo schémy je čierna pečiatka s nápisom Traditional Speciality
+      UK Protected
   speech:
-    delivered_on:
-    location:
-    written_on:
+    delivered_on: Doručené dňa
+    location: Umiestnenie
+    written_on: Napísané dňa
   statistics_announcement:
-    cancellation_date:
-    cancelled:
-    changed_date:
-    forthcoming:
-    previous_date:
-    proposed_date:
-    reason_for_change:
-    release_date:
+    cancellation_date: Dátum zrušenia
+    cancelled: Zrušené vydávanie štatistík
+    changed_date: Dátum vydania bol zmenený
+    forthcoming: Tieto štatistiky budú zverejnené
+    previous_date: Predchádzajúci dátum
+    proposed_date: Navrhované vydanie
+    reason_for_change: Dôvod zmeny
+    release_date: Dátum vydania
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts_html:
-      avoid_all_but_essential_travel_to_whole_country_html:
-      avoid_all_travel_to_parts_html:
-      avoid_all_travel_to_whole_country_html:
-    context:
-    still_current_at:
-    summary:
-    updated:
+      avoid_all_but_essential_travel_to_parts: Ministerstvo zahraničných vecí a Commonwealthu
+        <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať
+        do niektorých častí krajiny okrem nevyhnutných prípadov.
+      avoid_all_but_essential_travel_to_whole_country: Ministerstvo zahraničných vecí
+        a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča
+        cestovať do všetkých častí krajiny okrem nevyhnutných prípadov.
+      avoid_all_travel_to_parts: Ministerstvo zahraničných vecí a Commonwealthu <abbr
+        title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do
+        niektorých častí krajiny.
+      avoid_all_travel_to_whole_country: Ministerstvo zahraničných vecí a Commonwealthu
+        <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať
+        do všetkých častí krajiny.
+    context: Poradenstvo pri cestovaní do zahraničia
+    coronavirus_warning:
+      content_html: |
+        <p class="govuk-body">
+          Dodržiavajte platné pravidlá COVID-19 v mieste svojho bydliska: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">Anglicko</a>, <a href="https://www.gov.scot/coronavirus-covid-19/" >Škótsko</a>, <a href="https://gov.wales/coronavirus-travel">Wales</a> a <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Severné Írsko</a>.
+        </p>
+        <p class="govuk-body">
+          Aby ste zabránili preniknutiu nových variantov COVID do Spojeného kráľovstva, nemali by ste cestovať do krajín <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">z oranžového alebo červeného zoznamu</a>.
+        </p>
+        <p class="govuk-body">
+          Ak chcete pochopiť riziká v danej krajine, <a href="/guidance/travel-advice-novel-coronavirus">postupujte podľa cestovných odporúčaní FCDO</a>.
+        </p>
+        <p class="govuk-body">
+          Po návrate postupujte podľa pravidiel pre <a href="/uk-border-control">vstup do Spojeného kráľovstva zo zahraničia</a> (okrem Írska).
+        </p>
+      text_assistive: Dôležité
+      title: Cestovanie počas koronavírusu (COVID-19)
+    still_current_at: Stále aktuálne na
+    summary: Zhrnutie
+    updated: Aktualizované
   unpublishing:
-    page_title:
-    summary:
-    title:
+    page_title: Už nie je k dispozícii
+    summary: Informácie na tejto stránke boli odstránené, pretože boli uverejnené
+      omylom.
+    title: Stránka, ktorú hľadáte, už nie je k dispozícii
   working_group:
-    contact_details:
-    policies:
+    contact_details: Kontaktné údaje
+    policies: Politiky

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -446,10 +446,10 @@ sk:
     release_date: Dátum vydania
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do niektorých častí krajiny okrem nevyhnutných prípadov.
-      avoid_all_but_essential_travel_to_whole_country: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do všetkých častí krajiny okrem nevyhnutných prípadov.
-      avoid_all_travel_to_parts: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do niektorých častí krajiny.
-      avoid_all_travel_to_whole_country: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do všetkých častí krajiny.
+      avoid_all_but_essential_travel_to_parts_html: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do niektorých častí krajiny okrem nevyhnutných prípadov.
+      avoid_all_but_essential_travel_to_whole_country_html: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do všetkých častí krajiny okrem nevyhnutných prípadov.
+      avoid_all_travel_to_parts_html: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do niektorých častí krajiny.
+      avoid_all_travel_to_whole_country_html: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do všetkých častí krajiny.
     context: Poradenstvo pri cestovaní do zahraničia
     coronavirus_warning:
       content_html: |

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -309,8 +309,12 @@ sk:
       other: Dokumenty
     details: Podrobnosti na
   brexit:
-    business_link: Usmernenia pre podniky týkajúce sa brexitu
-    citizen_link: Usmernenie k brexitu pre jednotlivcov a rodiny
+    business_link:
+      path: "/guidance/brexit-guidance-for-businesses"
+      text: Usmernenia pre podniky týkajúce sa brexitu
+    citizen_link:
+      path: "/guidance/brexit-guidance-for-individuals-and-families"
+      text: Usmernenie k brexitu pre jednotlivcov a rodiny
     heading_prefix: Existujú rôzne
   common:
     last_updated:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,313 +1,5 @@
+---
 sk:
-  content_item:
-    schema_name:
-      aaib_report:
-        one: Správa Oddelenia pre vyšetrovanie leteckých nehôd
-        few:
-        other: Správy Oddelenia pre vyšetrovanie leteckých nehôd
-      announcement:
-        one: Oznámenie
-        few:
-        other: Oznámenia
-      asylum_support_decision:
-        one: Rozhodnutie tribunálu pre azylovú podporu
-        few:
-        other: Rozhodnutia tribunálu pre azylovú podporu
-      authored_article:
-        one: Autor článku
-        few:
-        other: Autorské články
-      business_finance_support_scheme:
-        one: Schéma podpory financovania podnikov
-        few:
-        other: Systémy podpory financovania podnikov
-      case_study:
-        one: Prípadová štúdia
-        few:
-        other: Prípadové štúdie
-      closed_consultation:
-        one: Uzavretá konzultácia
-        few:
-        other: Uzavreté konzultácie
-      cma_case:
-        one: Prípad Úradu pre hospodársku súťaž a trhy
-        few:
-        other: Prípady Úradu pre hospodársku súťaž a trhy
-      coming_soon:
-        one: Už čoskoro
-        few:
-        other: Už čoskoro
-      consultation:
-        one: Konzultácia
-        few:
-        other: Konzultácie
-      consultation_outcome:
-        one: Výsledok konzultácie
-        few:
-        other: Výsledky konzultácie
-      corporate_information_page:
-        one: Informačná stránka
-        few:
-        other: Informačné stránky
-      corporate_report:
-        one: Podniková správa
-        few:
-        other: Podnikové správy
-      correspondence:
-        one: Korešpondencia
-        few:
-        other: Korešpondencie
-      countryside_stewardship_grant:
-        one: Grant na správu krajiny
-        few:
-        other: Granty na správu vidieka
-      decision:
-        one: Rozhodnutie
-        few:
-        other: Rozhodnutia
-      detailed_guide:
-        one: Poradenstvo
-        few:
-        other: Poradenstvo
-      dfid_research_output:
-        one: Výstupy výskumu pre rozvoj
-        few:
-        other: Výstupy výskumu pre rozvoj
-      document_collection:
-        one: Zbierka
-        few:
-        other: Zbierky
-      draft_text:
-        one: Návrh textu
-        few:
-        other: Návrhy textov
-      drug_safety_update:
-        one: Aktualizácia bezpečnosti liekov
-        few:
-        other: Aktualizácie bezpečnosti liekov
-      employment_appeal_tribunal_decision:
-        one: Rozhodnutie odvolacieho pracovného súdu
-        few:
-        other: Rozhodnutia odvolacieho pracovného súdu
-      employment_tribunal_decision:
-        one: Rozhodnutie pracovného súdu
-        few:
-        other: Rozhodnutia pracovného súdu
-      esi_fund:
-        one: Európsky štrukturálny a investičný fond (EŠIF)
-        few:
-        other: Európske štrukturálne a investičné fondy (EŠIF)
-      fatality_notice:
-        one: Oznámenie o úmrtí
-        few:
-        other: Oznámenia o úmrtí
-      foi_release:
-        one: Zverejnenie slobody informácií
-        few:
-        other: Zverejnenia slobody informácií
-      form:
-        one: Formulár
-        few:
-        other: Formuláre
-      government_response:
-        one: Odpoveď vlády
-        few:
-        other: Odpovede vlády
-      guidance:
-        one: Poradenstvo
-        few:
-        other: Poradenstvo
-      impact_assessment:
-        one: Posúdenie vplyvu
-        few:
-        other: Posúdenia vplyvu
-      imported:
-        one: importované - čaká sa na typ
-        few:
-        other: importované - čaká sa na typ
-      independent_report:
-        one: Nezávislá správa
-        few:
-        other: Nezávislé správy
-      international_development_fund:
-        one: Medzinárodné financovanie rozvoja
-        few:
-        other: Medzinárodné financovanie rozvoja
-      international_treaty:
-        one: Medzinárodná zmluva
-        few:
-        other: Medzinárodné zmluvy
-      maib_report:
-        one: Správa oddelenia pre vyšetrovanie námorných nehôd
-        few:
-        other: Správy oddelenia pre vyšetrovanie námorných nehôd
-      map:
-        one: Mapa
-        few:
-        other: Mapy
-      medical_safety_alert:
-        one: Upozornenia a stiahnutia liekov a zdravotníckych pomôcok
-        few:
-        other: Upozornenia a stiahnutia liekov a zdravotníckych pomôcok
-      national:
-        one: Oznámenie o národných štatistikách
-        few:
-        other: Oznámenia o národných štatistikách
-      national_statistics:
-        one: Národné štatistiky
-        few:
-        other: Národné štatistiky
-      national_statistics_announcement:
-        one: Oznámenie o národných štatistikách
-        few:
-        other: Oznámenia o národných štatistikách
-      news_article:
-        one: Spravodajský článok
-        few:
-        other: Spravodajské články
-      news_story:
-        one: Spravodajský príbeh
-        few:
-        other: Spravodajské príbehy
-      notice:
-        one: Oznámenie
-        few:
-        other: Oznámenia
-      official:
-        one: Oficiálne štatistické oznámenie
-        few:
-        other: Oficiálne štatistické oznámenia
-      official_statistics:
-        one: Oficiálne štatistiky
-        few:
-        other: Oficiálne štatistiky
-      official_statistics_announcement:
-        one: Oficiálne štatistické oznámenie
-        few:
-        other: Oficiálne štatistické oznámenia
-      open_consultation:
-        one: Otvorená konzultácia
-        few:
-        other: Otvorené konzultácie
-      oral_statement:
-        one: Ústne vyhlásenie pred Parlamentom
-        few:
-        other: Ústne vyhlásenia pred Parlamentom
-      policy:
-        one: Politika
-        few:
-        other: Politiky
-      policy_paper:
-        one: Strategický dokument
-        few:
-        other: Strategické dokumenty
-      press_release:
-        one: Tlačová správa
-        few:
-        other: Tlačové správy
-      promotional:
-        one: Propagačné materiály
-        few:
-        other: Propagačné materiály
-      publication:
-        one: Publikácia
-        few:
-        other: Publikácie
-      raib_report:
-        one: Správa Oddelenia vyšetrovania železničných nehôd
-        few:
-        other: Správa Oddelenia pre vyšetrovanie železničných nehôd
-      regulation:
-        one: Nariadenie
-        few:
-        other: Nariadenia
-      research:
-        one: Výskum a analýza
-        few:
-        other: Výskum a analýza
-      residential_property_tribunal_decision:
-        one: Rozhodnutie tribunálu pre obytné nehnuteľnosti
-        few:
-        other: Rozhodnutia tribunálu pre obytné nehnuteľnosti
-      service_sign_in:
-        one: Prihlásiť sa do služby
-        few:
-        other: Prihlásiť sa do služby
-      service_standard_report:
-        one: Správa o štandardných službách
-        few:
-        other: Správy o štandardných službách
-      speaking_notes:
-        one: Poznámky k prejavu
-        few:
-        other: Poznámky k prejavu
-      speech:
-        one: Prejav
-        few:
-        other: Prejay
-      standard:
-        one: Štandard
-        few:
-        other: Štandardy
-      statement_to_parliament:
-        one: Vyhlásenie pre Parlament
-        few:
-        other: Vyhlásenia pre Parlament
-      statistical_data_set:
-        one: Súbor štatistických údajov
-        few:
-        other: Súbory štatistických údajov
-      statistics_announcement:
-        one: Oznámenie o vydaní štatistík
-        few:
-        other: Oznámenia o vydaní štatistík
-      statutory_guidance:
-        one: Zákonné usmernenia
-        few:
-        other: Zákonné usmernenia
-      take_part:
-        one: Zúčastniť sa
-        few:
-        other: Zúčastniť sa
-      tax_tribunal_decision:
-        one: Rozhodnutie daňového a kancelárskeho súdu
-        few:
-        other: Rozhodnutia daňového a kancelárskeho súdu
-      transcript:
-        one: Prepis
-        few:
-        other: Prepisy
-      transparency:
-        one: Údaje o transparentnosti
-        few:
-        other: Údaje o transparentnosti
-      utaac_decision:
-        one: Rozhodnutie správneho odvolacieho súdu
-        few:
-        other: Rozhodnutia správneho odvolacieho súdu
-      world_location_news_article:
-        one: Spravodajský článok
-        few:
-        other: Spravodajské články
-      world_news_story:
-        one: Svetové spravodajstvo
-        few:
-        other: Svetové spravodajstvá
-      written_statement:
-        one: Písomné vyhlásenie pre Parlament
-        few:
-        other: Písomné vyhlásenia pre Parlament
-    coming_soon: Tento dokument bude uverejnený na
-    contents: Obsah
-    metadata:
-      published: Zverejnené na
-      updated: Aktualizované
-  publication:
-    documents:
-      one: Dokument
-      few:
-      other: Dokumenty
-    details: Podrobnosti na
   brexit:
     business_link:
       path: "/guidance/brexit-guidance-for-businesses"
@@ -340,20 +32,16 @@ sk:
           message: Odstránili ste ju z uložených stránok
         page_saved:
           message: Toto ste pridali do svojich uložených stránok
-      page_not_saved_heading: Uložte si túto stránku, aby ste sa k nej mohli neskôr
-        vrátiť
+      page_not_saved_heading: Uložte si túto stránku, aby ste sa k nej mohli neskôr vrátiť
       page_was_saved_heading: Uložili ste túto stránku
       remove_page_button: Odstrániť z uložených stránok
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Pozrite
-        si svoje uložené stránky</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Prihláste
-        sa</a>, aby ste videli svoje uložené stránky.
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Pozrite si svoje uložené stránky</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Prihláste sa</a>, aby ste videli svoje uložené stránky.
     share_links:
       share_this_page: Zdieľať túto stránku
   consultation:
     and: a
-    another_website_html: Táto konzultácia %{closed} sa konala na <a href="%{url}">inej
-      webovej stránke</a>
+    another_website_html: Táto konzultácia %{closed} sa konala na <a href="%{url}">inej webovej stránke</a>
     at: na
     closes: Zatvára sa o
     closes_at: Táto konzultácia sa končí o
@@ -374,8 +62,7 @@ sk:
     ran_from: Táto konzultácia prebiehala od
     respond_online: Odpovedať online
     'true': pravda
-    visit_soon: Čoskoro opäť navštívte túto stránku a stiahnite si výsledok tejto
-      verejnej spätnej väzby.
+    visit_soon: Čoskoro opäť navštívte túto stránku a stiahnite si výsledok tejto verejnej spätnej väzby.
     was: bola
     ways_to_respond: Spôsoby reakcie
     write_to: 'Napíšte na adresu:'
@@ -385,13 +72,314 @@ sk:
     online: Online
     phone: Telefón
     webchat: Webový chat
+  content_item:
+    coming_soon: Tento dokument bude uverejnený na
+    contents: Obsah
+    metadata:
+      published: Zverejnené na
+      updated: Aktualizované
+    schema_name:
+      aaib_report:
+        few:
+        one: Správa Oddelenia pre vyšetrovanie leteckých nehôd
+        other: Správy Oddelenia pre vyšetrovanie leteckých nehôd
+      announcement:
+        few:
+        one: Oznámenie
+        other: Oznámenia
+      asylum_support_decision:
+        few:
+        one: Rozhodnutie tribunálu pre azylovú podporu
+        other: Rozhodnutia tribunálu pre azylovú podporu
+      authored_article:
+        few:
+        one: Autor článku
+        other: Autorské články
+      business_finance_support_scheme:
+        few:
+        one: Schéma podpory financovania podnikov
+        other: Systémy podpory financovania podnikov
+      case_study:
+        few:
+        one: Prípadová štúdia
+        other: Prípadové štúdie
+      closed_consultation:
+        few:
+        one: Uzavretá konzultácia
+        other: Uzavreté konzultácie
+      cma_case:
+        few:
+        one: Prípad Úradu pre hospodársku súťaž a trhy
+        other: Prípady Úradu pre hospodársku súťaž a trhy
+      coming_soon:
+        few:
+        one: Už čoskoro
+        other: Už čoskoro
+      consultation:
+        few:
+        one: Konzultácia
+        other: Konzultácie
+      consultation_outcome:
+        few:
+        one: Výsledok konzultácie
+        other: Výsledky konzultácie
+      corporate_information_page:
+        few:
+        one: Informačná stránka
+        other: Informačné stránky
+      corporate_report:
+        few:
+        one: Podniková správa
+        other: Podnikové správy
+      correspondence:
+        few:
+        one: Korešpondencia
+        other: Korešpondencie
+      countryside_stewardship_grant:
+        few:
+        one: Grant na správu krajiny
+        other: Granty na správu vidieka
+      decision:
+        few:
+        one: Rozhodnutie
+        other: Rozhodnutia
+      detailed_guide:
+        few:
+        one: Poradenstvo
+        other: Poradenstvo
+      dfid_research_output:
+        few:
+        one: Výstupy výskumu pre rozvoj
+        other: Výstupy výskumu pre rozvoj
+      document_collection:
+        few:
+        one: Zbierka
+        other: Zbierky
+      draft_text:
+        few:
+        one: Návrh textu
+        other: Návrhy textov
+      drug_safety_update:
+        few:
+        one: Aktualizácia bezpečnosti liekov
+        other: Aktualizácie bezpečnosti liekov
+      employment_appeal_tribunal_decision:
+        few:
+        one: Rozhodnutie odvolacieho pracovného súdu
+        other: Rozhodnutia odvolacieho pracovného súdu
+      employment_tribunal_decision:
+        few:
+        one: Rozhodnutie pracovného súdu
+        other: Rozhodnutia pracovného súdu
+      esi_fund:
+        few:
+        one: Európsky štrukturálny a investičný fond (EŠIF)
+        other: Európske štrukturálne a investičné fondy (EŠIF)
+      fatality_notice:
+        few:
+        one: Oznámenie o úmrtí
+        other: Oznámenia o úmrtí
+      foi_release:
+        few:
+        one: Zverejnenie slobody informácií
+        other: Zverejnenia slobody informácií
+      form:
+        few:
+        one: Formulár
+        other: Formuláre
+      government_response:
+        few:
+        one: Odpoveď vlády
+        other: Odpovede vlády
+      guidance:
+        few:
+        one: Poradenstvo
+        other: Poradenstvo
+      impact_assessment:
+        few:
+        one: Posúdenie vplyvu
+        other: Posúdenia vplyvu
+      imported:
+        few:
+        one: importované - čaká sa na typ
+        other: importované - čaká sa na typ
+      independent_report:
+        few:
+        one: Nezávislá správa
+        other: Nezávislé správy
+      international_development_fund:
+        few:
+        one: Medzinárodné financovanie rozvoja
+        other: Medzinárodné financovanie rozvoja
+      international_treaty:
+        few:
+        one: Medzinárodná zmluva
+        other: Medzinárodné zmluvy
+      maib_report:
+        few:
+        one: Správa oddelenia pre vyšetrovanie námorných nehôd
+        other: Správy oddelenia pre vyšetrovanie námorných nehôd
+      map:
+        few:
+        one: Mapa
+        other: Mapy
+      medical_safety_alert:
+        few:
+        one: Upozornenia a stiahnutia liekov a zdravotníckych pomôcok
+        other: Upozornenia a stiahnutia liekov a zdravotníckych pomôcok
+      national:
+        few:
+        one: Oznámenie o národných štatistikách
+        other: Oznámenia o národných štatistikách
+      national_statistics:
+        few:
+        one: Národné štatistiky
+        other: Národné štatistiky
+      national_statistics_announcement:
+        few:
+        one: Oznámenie o národných štatistikách
+        other: Oznámenia o národných štatistikách
+      news_article:
+        few:
+        one: Spravodajský článok
+        other: Spravodajské články
+      news_story:
+        few:
+        one: Spravodajský príbeh
+        other: Spravodajské príbehy
+      notice:
+        few:
+        one: Oznámenie
+        other: Oznámenia
+      official:
+        few:
+        one: Oficiálne štatistické oznámenie
+        other: Oficiálne štatistické oznámenia
+      official_statistics:
+        few:
+        one: Oficiálne štatistiky
+        other: Oficiálne štatistiky
+      official_statistics_announcement:
+        few:
+        one: Oficiálne štatistické oznámenie
+        other: Oficiálne štatistické oznámenia
+      open_consultation:
+        few:
+        one: Otvorená konzultácia
+        other: Otvorené konzultácie
+      oral_statement:
+        few:
+        one: Ústne vyhlásenie pred Parlamentom
+        other: Ústne vyhlásenia pred Parlamentom
+      policy:
+        few:
+        one: Politika
+        other: Politiky
+      policy_paper:
+        few:
+        one: Strategický dokument
+        other: Strategické dokumenty
+      press_release:
+        few:
+        one: Tlačová správa
+        other: Tlačové správy
+      promotional:
+        few:
+        one: Propagačné materiály
+        other: Propagačné materiály
+      publication:
+        few:
+        one: Publikácia
+        other: Publikácie
+      raib_report:
+        few:
+        one: Správa Oddelenia vyšetrovania železničných nehôd
+        other: Správa Oddelenia pre vyšetrovanie železničných nehôd
+      regulation:
+        few:
+        one: Nariadenie
+        other: Nariadenia
+      research:
+        few:
+        one: Výskum a analýza
+        other: Výskum a analýza
+      residential_property_tribunal_decision:
+        few:
+        one: Rozhodnutie tribunálu pre obytné nehnuteľnosti
+        other: Rozhodnutia tribunálu pre obytné nehnuteľnosti
+      service_sign_in:
+        few:
+        one: Prihlásiť sa do služby
+        other: Prihlásiť sa do služby
+      service_standard_report:
+        few:
+        one: Správa o štandardných službách
+        other: Správy o štandardných službách
+      speaking_notes:
+        few:
+        one: Poznámky k prejavu
+        other: Poznámky k prejavu
+      speech:
+        few:
+        one: Prejav
+        other: Prejay
+      standard:
+        few:
+        one: Štandard
+        other: Štandardy
+      statement_to_parliament:
+        few:
+        one: Vyhlásenie pre Parlament
+        other: Vyhlásenia pre Parlament
+      statistical_data_set:
+        few:
+        one: Súbor štatistických údajov
+        other: Súbory štatistických údajov
+      statistics_announcement:
+        few:
+        one: Oznámenie o vydaní štatistík
+        other: Oznámenia o vydaní štatistík
+      statutory_guidance:
+        few:
+        one: Zákonné usmernenia
+        other: Zákonné usmernenia
+      take_part:
+        few:
+        one: Zúčastniť sa
+        other: Zúčastniť sa
+      tax_tribunal_decision:
+        few:
+        one: Rozhodnutie daňového a kancelárskeho súdu
+        other: Rozhodnutia daňového a kancelárskeho súdu
+      transcript:
+        few:
+        one: Prepis
+        other: Prepisy
+      transparency:
+        few:
+        one: Údaje o transparentnosti
+        other: Údaje o transparentnosti
+      utaac_decision:
+        few:
+        one: Rozhodnutie správneho odvolacieho súdu
+        other: Rozhodnutia správneho odvolacieho súdu
+      world_location_news_article:
+        few:
+        one: Spravodajský článok
+        other: Spravodajské články
+      world_news_story:
+        few:
+        one: Svetové spravodajstvo
+        other: Svetové spravodajstvá
+      written_statement:
+        few:
+        one: Písomné vyhlásenie pre Parlament
+        other: Písomné vyhlásenia pre Parlament
   corporate_information_page:
     about_our_services_html: Zistite %{link}.
     corporate_information: Firemné informácie
-    personal_information_charter_html: Náš %{link} vysvetľuje, ako zaobchádzame s
-      vašimi osobnými údajmi.
-    publication_scheme_html: Prečítajte si o typoch informácií, ktoré bežne zverejňujeme
-      v našom %{link}.
+    personal_information_charter_html: Náš %{link} vysvetľuje, ako zaobchádzame s vašimi osobnými údajmi.
+    publication_scheme_html: Prečítajte si o typoch informácií, ktoré bežne zverejňujeme v našom %{link}.
     social_media_use_html: Prečítajte si naše zásady na %{link}.
     welsh_language_scheme_html: Prečítajte si o našom záväzku voči %{link}.
   fatality_notice:
@@ -400,8 +388,7 @@ sk:
     operations_in: Operácie v %{location}
   gone:
     page_title: Už nie je k dispozícii
-    published_in_error: Informácie na tejto stránke boli odstránené, pretože boli
-      uverejnené omylom.
+    published_in_error: Informácie na tejto stránke boli odstránené, pretože boli uverejnené omylom.
     title: Stránka, ktorú hľadáte, už nie je k dispozícii
   guide:
     pages_in_guide: Stránky v tejto príručke
@@ -411,14 +398,8 @@ sk:
       available_at: Táto publikácia je k dispozícii na %{url}
       copyright: Korunné autorské právo %{year}
       isbn: 'ISBN:'
-      licence_html: 'Táto publikácia je licencovaná podľa podmienok Open Government
-        Licence v3.0, pokiaľ nie je uvedené inak. Ak si chcete pozrieť túto licenciu,
-        navštívte <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
-        alebo napíšte na adresu: Information Policy Team, The National Archives, Kew,
-        London TW9 4DU, alebo pošlite e-mail: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
-      third_party: Ak sme identifikovali akékoľvek informácie o autorských právach
-        tretích strán, budete musieť získať povolenie od príslušných držiteľov autorských
-        práv.
+      licence_html: 'Táto publikácia je licencovaná podľa podmienok Open Government Licence v3.0, pokiaľ nie je uvedené inak. Ak si chcete pozrieť túto licenciu, navštívte <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a> alebo napíšte na adresu: Information Policy Team, The National Archives, Kew, London TW9 4DU, alebo pošlite e-mail: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: Ak sme identifikovali akékoľvek informácie o autorských právach tretích strán, budete musieť získať povolenie od príslušných držiteľov autorských práv.
   i18n:
     direction:
   language_names:
@@ -427,6 +408,12 @@ sk:
     next_page: Ďalšie
     previous_page: Predchádzajúce
     print_entire_guide: Vytlačiť celú príručku
+  publication:
+    details: Podrobnosti na
+    documents:
+      few:
+      one: Dokument
+      other: Dokumenty
   service_sign_in:
     continue: Pokračovať
     error:
@@ -443,8 +430,7 @@ sk:
   specialist_document:
     pdo_alt_text: Logo schémy je čierna pečiatka s nápisom Designated Origin UK Protected
     pgi_alt_text: Logo schémy je čierna pečiatka s nápisom Geographic Origin UK Protected
-    tsg_alt_text: Logo schémy je čierna pečiatka s nápisom Traditional Speciality
-      UK Protected
+    tsg_alt_text: Logo schémy je čierna pečiatka s nápisom Traditional Speciality UK Protected
   speech:
     delivered_on: Doručené dňa
     location: Umiestnenie
@@ -460,18 +446,10 @@ sk:
     release_date: Dátum vydania
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: Ministerstvo zahraničných vecí a Commonwealthu
-        <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať
-        do niektorých častí krajiny okrem nevyhnutných prípadov.
-      avoid_all_but_essential_travel_to_whole_country: Ministerstvo zahraničných vecí
-        a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča
-        cestovať do všetkých častí krajiny okrem nevyhnutných prípadov.
-      avoid_all_travel_to_parts: Ministerstvo zahraničných vecí a Commonwealthu <abbr
-        title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do
-        niektorých častí krajiny.
-      avoid_all_travel_to_whole_country: Ministerstvo zahraničných vecí a Commonwealthu
-        <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať
-        do všetkých častí krajiny.
+      avoid_all_but_essential_travel_to_parts: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do niektorých častí krajiny okrem nevyhnutných prípadov.
+      avoid_all_but_essential_travel_to_whole_country: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do všetkých častí krajiny okrem nevyhnutných prípadov.
+      avoid_all_travel_to_parts: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do niektorých častí krajiny.
+      avoid_all_travel_to_whole_country: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do všetkých častí krajiny.
     context: Poradenstvo pri cestovaní do zahraničia
     coronavirus_warning:
       content_html: |
@@ -494,8 +472,7 @@ sk:
     updated: Aktualizované
   unpublishing:
     page_title: Už nie je k dispozícii
-    summary: Informácie na tejto stránke boli odstránené, pretože boli uverejnené
-      omylom.
+    summary: Informácie na tejto stránke boli odstránené, pretože boli uverejnené omylom.
     title: Stránka, ktorú hľadáte, už nie je k dispozícii
   working_group:
     contact_details: Kontaktné údaje

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -9,7 +9,6 @@ sk:
       text: Usmernenie k brexitu pre jednotlivcov a rodiny
     heading_prefix: Existujú rôzne
   common:
-    last_updated:
     visit: 'Navštívte:'
   components:
     figure:
@@ -21,22 +20,8 @@ sk:
       see_all_updates: pozrite si všetky aktualizácie
       show_all_updates: zobraziť všetky aktualizácie
     publisher_metadata:
-      collections:
-      from:
       hide_all: skryť všetko
       show_all: zobraziť všetko
-    save_this_page:
-      add_page_button: Pridanie do uložených stránok
-      confirmations:
-        page_removed:
-          message: Odstránili ste ju z uložených stránok
-        page_saved:
-          message: Toto ste pridali do svojich uložených stránok
-      page_not_saved_heading: Uložte si túto stránku, aby ste sa k nej mohli neskôr vrátiť
-      page_was_saved_heading: Uložili ste túto stránku
-      remove_page_button: Odstrániť z uložených stránok
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Pozrite si svoje uložené stránky</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Prihláste sa</a>, aby ste videli svoje uložené stránky.
     share_links:
       share_this_page: Zdieľať túto stránku
   consultation:
@@ -61,7 +46,6 @@ sk:
     original_consultation: Pôvodná konzultácia
     ran_from: Táto konzultácia prebiehala od
     respond_online: Odpovedať online
-    'true': pravda
     visit_soon: Čoskoro opäť navštívte túto stránku a stiahnite si výsledok tejto verejnej spätnej väzby.
     was: bola
     ways_to_respond: Spôsoby reakcie
@@ -451,22 +435,6 @@ sk:
       avoid_all_travel_to_parts_html: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do niektorých častí krajiny.
       avoid_all_travel_to_whole_country_html: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do všetkých častí krajiny.
     context: Poradenstvo pri cestovaní do zahraničia
-    coronavirus_warning:
-      content_html: |
-        <p class="govuk-body">
-          Dodržiavajte platné pravidlá COVID-19 v mieste svojho bydliska: <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">Anglicko</a>, <a href="https://www.gov.scot/coronavirus-covid-19/" >Škótsko</a>, <a href="https://gov.wales/coronavirus-travel">Wales</a> a <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Severné Írsko</a>.
-        </p>
-        <p class="govuk-body">
-          Aby ste zabránili preniknutiu nových variantov COVID do Spojeného kráľovstva, nemali by ste cestovať do krajín <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">z oranžového alebo červeného zoznamu</a>.
-        </p>
-        <p class="govuk-body">
-          Ak chcete pochopiť riziká v danej krajine, <a href="/guidance/travel-advice-novel-coronavirus">postupujte podľa cestovných odporúčaní FCDO</a>.
-        </p>
-        <p class="govuk-body">
-          Po návrate postupujte podľa pravidiel pre <a href="/uk-border-control">vstup do Spojeného kráľovstva zo zahraničia</a> (okrem Írska).
-        </p>
-      text_assistive: Dôležité
-      title: Cestovanie počas koronavírusu (COVID-19)
     still_current_at: Stále aktuálne na
     summary: Zhrnutie
     updated: Aktualizované

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -1,388 +1,5 @@
+---
 sl:
-  content_item:
-    schema_name:
-      aaib_report:
-        one: Poročilo podružnice za preiskave letalskih nesreč
-        two:
-        few:
-        other: Poročila podružnice za preiskovanje letalskih nesreč
-      announcement:
-        one: Razglas
-        two:
-        few:
-        other: Razglasi
-      asylum_support_decision:
-        one: Odločitev sodišča o podpori azilu
-        two:
-        few:
-        other: Odločitve sodišča o podpori azilu
-      authored_article:
-        one: Avtorski članek
-        two:
-        few:
-        other: Avtorski članki
-      business_finance_support_scheme:
-        one: Program podpore za poslovne finance
-        two:
-        few:
-        other: Programi podpore za poslovne finance
-      case_study:
-        one: Študija primera
-        two:
-        few:
-        other: Študije primera
-      closed_consultation:
-        one: Tesno posvetovanje
-        two:
-        few:
-        other: Tesna posvetovanja
-      cma_case:
-        one: Primer organa za konkurenco in trge
-        two:
-        few:
-        other: Primeri organa za konkurenco in trge
-      coming_soon:
-        one: Kmalu na voljo
-        two:
-        few:
-        other: Kmalu na voljo
-      consultation:
-        one: Posvetovanje
-        two:
-        few:
-        other: Posvetovanja
-      consultation_outcome:
-        one: Rezultat posvetovanja
-        two:
-        few:
-        other: Rezultati posvetovanja
-      corporate_information_page:
-        one: Stran z informacijami
-        two:
-        few:
-        other: Strani z informacijami
-      corporate_report:
-        one: Poročilo podjetja
-        two:
-        few:
-        other: Poročila podjetja
-      correspondence:
-        one: Korespondenca
-        two:
-        few:
-        other: Korespondenca
-      countryside_stewardship_grant:
-        one: Nepovratna sredstva za ohranjanje podeželja
-        two:
-        few:
-        other: Nepovratna sredstva za ohranjanje podeželja
-      decision:
-        one: Odločitev
-        two:
-        few:
-        other: Odločitve
-      detailed_guide:
-        one: Smernice
-        two:
-        few:
-        other: Smernice
-      dfid_research_output:
-        one: Raziskave za razvojni rezultat
-        two:
-        few:
-        other: Raziskave za razvojne rezultate
-      document_collection:
-        one: Zbirka
-        two:
-        few:
-        other: Zbirke
-      draft_text:
-        one: Osnutek besedila
-        two:
-        few:
-        other: Osnutki besedila
-      drug_safety_update:
-        one: Posodobitev o varnosti zdravil
-        two:
-        few:
-        other: Posodobitve o varnosti zdravil
-      employment_appeal_tribunal_decision:
-        one: Odločitev pritožbenega delovnega sodišča
-        two:
-        few:
-        other: Odločitve pritožbenega delovnega sodišča
-      employment_tribunal_decision:
-        one: Odločitev delovnega sodišča
-        two:
-        few:
-        other: Odločitve delovnega sodišča
-      esi_fund:
-        one: Evropski strukturni in investicijski sklad (ESI)
-        two:
-        few:
-        other: Evropski strukturni in investicijski skladi (ESI)
-      fatality_notice:
-        one: Obvestilo o smrti
-        two:
-        few:
-        other: Obvestila o smrti
-      foi_release:
-        one: Izjava o svobodi informacij
-        two:
-        few:
-        other: Izjave o svobodi informacij
-      form:
-        one: Oblika
-        two:
-        few:
-        other: Oblike
-      government_response:
-        one: Odziv vlade
-        two:
-        few:
-        other: Odzivi vlade
-      guidance:
-        one: Smernice
-        two:
-        few:
-        other: Smernice
-      impact_assessment:
-        one: Presoja vpliva
-        two:
-        few:
-        other: Presoje vpliva
-      imported:
-        one: uvoženo − vrsta čakanja
-        two:
-        few:
-        other: uvoženo − vrsta čakanja
-      independent_report:
-        one: neodvisno poročilo
-        two:
-        few:
-        other: neodvisna poročila
-      international_development_fund:
-        one: Financiranje mednarodnega razvoja
-        two:
-        few:
-        other: Financiranje mednarodnega razvoja
-      international_treaty:
-        one: Mednarodni sporazum
-        two:
-        few:
-        other: Mednarodni sporazumi
-      maib_report:
-        one: Poročilo podružnice za preiskave pomorskih nesreč
-        two:
-        few:
-        other: Poročila podružnice za preiskave pomorskih nesreč
-      map:
-        one: Zemljevid
-        two:
-        few:
-        other: Zemljevidi
-      medical_safety_alert:
-        one: Opozorila glede zdravil in medicinskih pripomočkih in odpoklici le-teh
-        two:
-        few:
-        other: Opozorila glede zdravil in medicinskih pripomočkih in odpoklici le-teh
-      national:
-        one: Objava državne statistike
-        two:
-        few:
-        other: Objave državne statistike
-      national_statistics:
-        one: Državna statistika
-        two:
-        few:
-        other: Državna statistika
-      national_statistics_announcement:
-        one: Objava državne statistike
-        two:
-        few:
-        other: Objave državne statistike
-      news_article:
-        one: Časopisni članek
-        two:
-        few:
-        other: Časopisni članki
-      news_story:
-        one: Časopisna zgodba
-        two:
-        few:
-        other: Časopisne zgodbe
-      notice:
-        one: Obvestilo
-        two:
-        few:
-        other: Obvestila
-      official:
-        one: Objava uradne statistike
-        two:
-        few:
-        other: Objave uradne statistike
-      official_statistics:
-        one: Uradna statistika
-        two:
-        few:
-        other: Uradna statistika
-      official_statistics_announcement:
-        one: Objava uradne statistike
-        two:
-        few:
-        other: Objave uradne statistike
-      open_consultation:
-        one: Odprto posvetovanje
-        two:
-        few:
-        other: Odprto posvetovanje
-      oral_statement:
-        one: Ustna izjava za parlament
-        two:
-        few:
-        other: Ustne izjave za parlament
-      policy:
-        one: Politika
-        two:
-        few:
-        other: Politike
-      policy_paper:
-        one: Politični dokument
-        two:
-        few:
-        other: Politični dokumenti
-      press_release:
-        one: Sporočilo za javnost
-        two:
-        few:
-        other: Sporočila za javnost
-      promotional:
-        one: Promocijski material
-        two:
-        few:
-        other: Promocijski material
-      publication:
-        one: Publikacija
-        two:
-        few:
-        other: Publikacije
-      raib_report:
-        one: Poročilo podružnice za preiskave železniških nesreč
-        two:
-        few:
-        other: Poročila podružnice za preiskave železniških nesreč
-      regulation:
-        one: Uredba
-        two:
-        few:
-        other: Uredbe
-      research:
-        one: Raziskovanje in analiza
-        two:
-        few:
-        other: Raziskovanje in analiza
-      residential_property_tribunal_decision:
-        one: Odločitev sodišča za stanovanjske nepremičnine
-        two:
-        few:
-        other: Odločitve sodišča za stanovanjske nepremičnine
-      service_sign_in:
-        one: Prijava v storitev
-        two:
-        few:
-        other: Prijava v storitev
-      service_standard_report:
-        one: Standardno poročilo o storitvah
-        two:
-        few:
-        other: Standardna poročila o storitvah
-      speaking_notes:
-        one: Točke za govor
-        two:
-        few:
-        other: Točke za govor
-      speech:
-        one: Govor
-        two:
-        few:
-        other: Govori
-      standard:
-        one: Standard
-        two:
-        few:
-        other: Standardi
-      statement_to_parliament:
-        one: Izjava parlamentu
-        two:
-        few:
-        other: Izjave parlamentu
-      statistical_data_set:
-        one: Statistični podatkovni niz
-        two:
-        few:
-        other: Statistični podatkovni nizi
-      statistics_announcement:
-        one: Statistična objava
-        two:
-        few:
-        other: Statistične objave
-      statutory_guidance:
-        one: Zakonski napotki
-        two:
-        few:
-        other: Zakonski napotki
-      take_part:
-        one: Sodelujte
-        two:
-        few:
-        other: Sodelujte
-      tax_tribunal_decision:
-        one: Odločitev Sodišča za davčne in gospodarske spore
-        two:
-        few:
-        other: Odločitve Sodišča za davčne in gospodarske spore
-      transcript:
-        one: Prepis
-        two:
-        few:
-        other: Prepisi
-      transparency:
-        one: Podatki o preglednosti
-        two:
-        few:
-        other: Podatki o preglednosti
-      utaac_decision:
-        one: Odločitev Pritožbenega delovnega sodišča
-        two:
-        few:
-        other: Odločitve Pritožbenega delovnega sodišča
-      world_location_news_article:
-        one: Časopisni članek
-        two:
-        few:
-        other: Časopisni članki
-      world_news_story:
-        one: Novica s sveta
-        two:
-        few:
-        other: Novice s celega sveta
-      written_statement:
-        one: Pisna izjava za parlament
-        two:
-        few:
-        other: Pisne izjave za parlament
-    coming_soon: Ta dokument bo objavljen
-    contents: Vsebina
-    metadata:
-      published: Objavljeno
-      updated: Posodobljeno
-  publication:
-    documents:
-      one: Dokument
-      two:
-      few:
-      other: Dokumenti
-    details: Podrobnosti
   brexit:
     business_link:
       path: "/guidance/brexit-guidance-for-businesses"
@@ -418,16 +35,13 @@ sl:
       page_not_saved_heading: Shranite stran, da si jo lahko ponovno ogledate pozneje
       page_was_saved_heading: Shranili ste to stran
       remove_page_button: Odstrani s shranjenih strani
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Oglejte
-        si strani, ki ste jih shranili</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Prijavite
-        se</a>, da si ogledate shranjene strani.
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Oglejte si strani, ki ste jih shranili</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Prijavite se</a>, da si ogledate shranjene strani.
     share_links:
       share_this_page: Deli to stran
   consultation:
     and: in
-    another_website_html: To posvetovanje %{closed} poteka na <a href="%{url}">drugi
-      spletni strani</a>
+    another_website_html: To posvetovanje %{closed} poteka na <a href="%{url}">drugi spletni strani</a>
     at: na
     closes: Zapre se ob
     closes_at: To posvetovanje se zapre ob
@@ -448,8 +62,7 @@ sl:
     ran_from: To posvetovanje je trajalo od
     respond_online: Odgovori na spletu
     'true': res
-    visit_soon: Kmalu znova obiščite to stran in naložite rezultat v te javne& nbsp;povratne
-      informacije.
+    visit_soon: Kmalu znova obiščite to stran in naložite rezultat v te javne& nbsp;povratne informacije.
     was: je bilo
     ways_to_respond: Načini odziva
     write_to: 'Pišite na:'
@@ -459,13 +72,388 @@ sl:
     online: Na spletu
     phone: Telefon
     webchat: Spletni klepet
+  content_item:
+    coming_soon: Ta dokument bo objavljen
+    contents: Vsebina
+    metadata:
+      published: Objavljeno
+      updated: Posodobljeno
+    schema_name:
+      aaib_report:
+        few:
+        one: Poročilo podružnice za preiskave letalskih nesreč
+        other: Poročila podružnice za preiskovanje letalskih nesreč
+        two:
+      announcement:
+        few:
+        one: Razglas
+        other: Razglasi
+        two:
+      asylum_support_decision:
+        few:
+        one: Odločitev sodišča o podpori azilu
+        other: Odločitve sodišča o podpori azilu
+        two:
+      authored_article:
+        few:
+        one: Avtorski članek
+        other: Avtorski članki
+        two:
+      business_finance_support_scheme:
+        few:
+        one: Program podpore za poslovne finance
+        other: Programi podpore za poslovne finance
+        two:
+      case_study:
+        few:
+        one: Študija primera
+        other: Študije primera
+        two:
+      closed_consultation:
+        few:
+        one: Tesno posvetovanje
+        other: Tesna posvetovanja
+        two:
+      cma_case:
+        few:
+        one: Primer organa za konkurenco in trge
+        other: Primeri organa za konkurenco in trge
+        two:
+      coming_soon:
+        few:
+        one: Kmalu na voljo
+        other: Kmalu na voljo
+        two:
+      consultation:
+        few:
+        one: Posvetovanje
+        other: Posvetovanja
+        two:
+      consultation_outcome:
+        few:
+        one: Rezultat posvetovanja
+        other: Rezultati posvetovanja
+        two:
+      corporate_information_page:
+        few:
+        one: Stran z informacijami
+        other: Strani z informacijami
+        two:
+      corporate_report:
+        few:
+        one: Poročilo podjetja
+        other: Poročila podjetja
+        two:
+      correspondence:
+        few:
+        one: Korespondenca
+        other: Korespondenca
+        two:
+      countryside_stewardship_grant:
+        few:
+        one: Nepovratna sredstva za ohranjanje podeželja
+        other: Nepovratna sredstva za ohranjanje podeželja
+        two:
+      decision:
+        few:
+        one: Odločitev
+        other: Odločitve
+        two:
+      detailed_guide:
+        few:
+        one: Smernice
+        other: Smernice
+        two:
+      dfid_research_output:
+        few:
+        one: Raziskave za razvojni rezultat
+        other: Raziskave za razvojne rezultate
+        two:
+      document_collection:
+        few:
+        one: Zbirka
+        other: Zbirke
+        two:
+      draft_text:
+        few:
+        one: Osnutek besedila
+        other: Osnutki besedila
+        two:
+      drug_safety_update:
+        few:
+        one: Posodobitev o varnosti zdravil
+        other: Posodobitve o varnosti zdravil
+        two:
+      employment_appeal_tribunal_decision:
+        few:
+        one: Odločitev pritožbenega delovnega sodišča
+        other: Odločitve pritožbenega delovnega sodišča
+        two:
+      employment_tribunal_decision:
+        few:
+        one: Odločitev delovnega sodišča
+        other: Odločitve delovnega sodišča
+        two:
+      esi_fund:
+        few:
+        one: Evropski strukturni in investicijski sklad (ESI)
+        other: Evropski strukturni in investicijski skladi (ESI)
+        two:
+      fatality_notice:
+        few:
+        one: Obvestilo o smrti
+        other: Obvestila o smrti
+        two:
+      foi_release:
+        few:
+        one: Izjava o svobodi informacij
+        other: Izjave o svobodi informacij
+        two:
+      form:
+        few:
+        one: Oblika
+        other: Oblike
+        two:
+      government_response:
+        few:
+        one: Odziv vlade
+        other: Odzivi vlade
+        two:
+      guidance:
+        few:
+        one: Smernice
+        other: Smernice
+        two:
+      impact_assessment:
+        few:
+        one: Presoja vpliva
+        other: Presoje vpliva
+        two:
+      imported:
+        few:
+        one: uvoženo − vrsta čakanja
+        other: uvoženo − vrsta čakanja
+        two:
+      independent_report:
+        few:
+        one: neodvisno poročilo
+        other: neodvisna poročila
+        two:
+      international_development_fund:
+        few:
+        one: Financiranje mednarodnega razvoja
+        other: Financiranje mednarodnega razvoja
+        two:
+      international_treaty:
+        few:
+        one: Mednarodni sporazum
+        other: Mednarodni sporazumi
+        two:
+      maib_report:
+        few:
+        one: Poročilo podružnice za preiskave pomorskih nesreč
+        other: Poročila podružnice za preiskave pomorskih nesreč
+        two:
+      map:
+        few:
+        one: Zemljevid
+        other: Zemljevidi
+        two:
+      medical_safety_alert:
+        few:
+        one: Opozorila glede zdravil in medicinskih pripomočkih in odpoklici le-teh
+        other: Opozorila glede zdravil in medicinskih pripomočkih in odpoklici le-teh
+        two:
+      national:
+        few:
+        one: Objava državne statistike
+        other: Objave državne statistike
+        two:
+      national_statistics:
+        few:
+        one: Državna statistika
+        other: Državna statistika
+        two:
+      national_statistics_announcement:
+        few:
+        one: Objava državne statistike
+        other: Objave državne statistike
+        two:
+      news_article:
+        few:
+        one: Časopisni članek
+        other: Časopisni članki
+        two:
+      news_story:
+        few:
+        one: Časopisna zgodba
+        other: Časopisne zgodbe
+        two:
+      notice:
+        few:
+        one: Obvestilo
+        other: Obvestila
+        two:
+      official:
+        few:
+        one: Objava uradne statistike
+        other: Objave uradne statistike
+        two:
+      official_statistics:
+        few:
+        one: Uradna statistika
+        other: Uradna statistika
+        two:
+      official_statistics_announcement:
+        few:
+        one: Objava uradne statistike
+        other: Objave uradne statistike
+        two:
+      open_consultation:
+        few:
+        one: Odprto posvetovanje
+        other: Odprto posvetovanje
+        two:
+      oral_statement:
+        few:
+        one: Ustna izjava za parlament
+        other: Ustne izjave za parlament
+        two:
+      policy:
+        few:
+        one: Politika
+        other: Politike
+        two:
+      policy_paper:
+        few:
+        one: Politični dokument
+        other: Politični dokumenti
+        two:
+      press_release:
+        few:
+        one: Sporočilo za javnost
+        other: Sporočila za javnost
+        two:
+      promotional:
+        few:
+        one: Promocijski material
+        other: Promocijski material
+        two:
+      publication:
+        few:
+        one: Publikacija
+        other: Publikacije
+        two:
+      raib_report:
+        few:
+        one: Poročilo podružnice za preiskave železniških nesreč
+        other: Poročila podružnice za preiskave železniških nesreč
+        two:
+      regulation:
+        few:
+        one: Uredba
+        other: Uredbe
+        two:
+      research:
+        few:
+        one: Raziskovanje in analiza
+        other: Raziskovanje in analiza
+        two:
+      residential_property_tribunal_decision:
+        few:
+        one: Odločitev sodišča za stanovanjske nepremičnine
+        other: Odločitve sodišča za stanovanjske nepremičnine
+        two:
+      service_sign_in:
+        few:
+        one: Prijava v storitev
+        other: Prijava v storitev
+        two:
+      service_standard_report:
+        few:
+        one: Standardno poročilo o storitvah
+        other: Standardna poročila o storitvah
+        two:
+      speaking_notes:
+        few:
+        one: Točke za govor
+        other: Točke za govor
+        two:
+      speech:
+        few:
+        one: Govor
+        other: Govori
+        two:
+      standard:
+        few:
+        one: Standard
+        other: Standardi
+        two:
+      statement_to_parliament:
+        few:
+        one: Izjava parlamentu
+        other: Izjave parlamentu
+        two:
+      statistical_data_set:
+        few:
+        one: Statistični podatkovni niz
+        other: Statistični podatkovni nizi
+        two:
+      statistics_announcement:
+        few:
+        one: Statistična objava
+        other: Statistične objave
+        two:
+      statutory_guidance:
+        few:
+        one: Zakonski napotki
+        other: Zakonski napotki
+        two:
+      take_part:
+        few:
+        one: Sodelujte
+        other: Sodelujte
+        two:
+      tax_tribunal_decision:
+        few:
+        one: Odločitev Sodišča za davčne in gospodarske spore
+        other: Odločitve Sodišča za davčne in gospodarske spore
+        two:
+      transcript:
+        few:
+        one: Prepis
+        other: Prepisi
+        two:
+      transparency:
+        few:
+        one: Podatki o preglednosti
+        other: Podatki o preglednosti
+        two:
+      utaac_decision:
+        few:
+        one: Odločitev Pritožbenega delovnega sodišča
+        other: Odločitve Pritožbenega delovnega sodišča
+        two:
+      world_location_news_article:
+        few:
+        one: Časopisni članek
+        other: Časopisni članki
+        two:
+      world_news_story:
+        few:
+        one: Novica s sveta
+        other: Novice s celega sveta
+        two:
+      written_statement:
+        few:
+        one: Pisna izjava za parlament
+        other: Pisne izjave za parlament
+        two:
   corporate_information_page:
     about_our_services_html: Izvedite več %{link}.
     corporate_information: Informacije o podjetju
-    personal_information_charter_html: Na povezavi %{link} je razloženo, kako ravnamo
-      z vašimi osebnimi podatki.
-    publication_scheme_html: Več o vrstah informacij, ki jih redno objavljamo, preberite
-      v naši %{link}.
+    personal_information_charter_html: Na povezavi %{link} je razloženo, kako ravnamo z vašimi osebnimi podatki.
+    publication_scheme_html: Več o vrstah informacij, ki jih redno objavljamo, preberite v naši %{link}.
     social_media_use_html: Preberite si našo politiko na %{link}.
     welsh_language_scheme_html: Izvedite več o naši zavezanosti %{link}.
   fatality_notice:
@@ -474,8 +462,7 @@ sl:
     operations_in: Dejavni v %{location}
   gone:
     page_title: Ni več na voljo
-    published_in_error: Informacije na tej strani so bile odstranjene, ker so bile
-      objavljene po pomoti.
+    published_in_error: Informacije na tej strani so bile odstranjene, ker so bile objavljene po pomoti.
     title: Stran, ki ste jo iskali, ni več na voljo
   guide:
     pages_in_guide: Strani v tem vodiču
@@ -485,13 +472,8 @@ sl:
       available_at: Ta publikacija je na voljo na %{url}
       copyright: Avtorske pravice © Crown %{year}
       isbn: 'ISBN:'
-      licence_html: 'Ta publikacija ima licenco pod pogoji licence Open Government
-        License v3.0, razen kjer je navedeno drugače. Za ogled licence obiščite <a
-        href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
-        ali pišite  skupini za informacijsko politiko Information Policy Team, The
-        National Archives, Kew, London TW9 4DU ali napišite e-sporočilo: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
-      third_party: Če ugotovimo kakršne koli podatke o avtorskih pravicah tretjih
-        oseb, boste morali pridobiti dovoljenje zadevnih imetnikov avtorskih pravic.
+      licence_html: 'Ta publikacija ima licenco pod pogoji licence Open Government License v3.0, razen kjer je navedeno drugače. Za ogled licence obiščite <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a> ali pišite  skupini za informacijsko politiko Information Policy Team, The National Archives, Kew, London TW9 4DU ali napišite e-sporočilo: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: Če ugotovimo kakršne koli podatke o avtorskih pravicah tretjih oseb, boste morali pridobiti dovoljenje zadevnih imetnikov avtorskih pravic.
   i18n:
     direction:
   language_names:
@@ -500,6 +482,13 @@ sl:
     next_page: Naslednji
     previous_page: Prejšnji
     print_entire_guide: Natisni cel vodič
+  publication:
+    details: Podrobnosti
+    documents:
+      few:
+      one: Dokument
+      other: Dokumenti
+      two:
   service_sign_in:
     continue: Nadaljuj
     error:
@@ -532,14 +521,10 @@ sl:
     release_date: Datum objave
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth
-        Office">FCO</abbr> odsvetuje vsa nenujna potovanja v dele države.
-      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth
-        Office">FCO</abbr> odsvetuje vsa nenujna potovanja v državo.
-      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr>
-        odsvetuje vsa potovanja v dele države.
-      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr>
-        odsvetuje vsa potovanja v državo.
+      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa nenujna potovanja v dele države.
+      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa nenujna potovanja v državo.
+      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa potovanja v dele države.
+      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa potovanja v državo.
     context: Nasveti za potovanja v tujino
     coronavirus_warning:
       content_html: |
@@ -562,8 +547,7 @@ sl:
     updated: Posodobljeno
   unpublishing:
     page_title: Ni več na voljo
-    summary: Informacije na tej strani so bile odstranjene, ker so bile objavljene
-      po pomoti.
+    summary: Informacije na tej strani so bile odstranjene, ker so bile objavljene po pomoti.
     title: Stran, ki ste jo iskali, ni več na voljo
   working_group:
     contact_details: Kontaktni podatki

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -521,10 +521,10 @@ sl:
     release_date: Datum objave
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa nenujna potovanja v dele države.
-      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa nenujna potovanja v državo.
-      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa potovanja v dele države.
-      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa potovanja v državo.
+      avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa nenujna potovanja v dele države.
+      avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa nenujna potovanja v državo.
+      avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa potovanja v dele države.
+      avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa potovanja v državo.
     context: Nasveti za potovanja v tujino
     coronavirus_warning:
       content_html: |

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -440,10 +440,55 @@ sl:
     publication_scheme_html: Več o vrstah informacij, ki jih redno objavljamo, preberite v naši %{link}.
     social_media_use_html: Preberite si našo politiko na %{link}.
     welsh_language_scheme_html: Izvedite več o naši zavezanosti %{link}.
+  email:
+    description_html:
+    subscribe_title:
+    unsubscribe_title:
   fatality_notice:
     alt_text: Grb Ministrstva za obrambo
     field_of_operation: Področje delovanja
     operations_in: Dejavni v %{location}
+  get_involved:
+    civil_service:
+    civil_service_quarterly:
+    closed:
+    closed_consultations:
+    closes:
+    closing_today:
+    closing_tomorrow:
+    days_left:
+    engage_with_gov:
+    fcdo_bloggers:
+    follow:
+    follow_links:
+    follow_paragraph:
+    gds_blog:
+    gov_past:
+    intro_paragraph:
+      body_html:
+      engage_with_government:
+      take_part:
+    join_ics:
+    make_donation:
+    more_ways:
+    neighbourhood_watch:
+    open_consultations:
+    page_heading:
+    page_title:
+    petition_paragraph:
+      body_html:
+      create_a_petition:
+    read_respond:
+    recent_outcomes:
+    recently_opened:
+    respond_to_consultations:
+    school_overseas:
+    search_all:
+    see_all_dept:
+    start_a_petition:
+    take_part:
+    take_part_suggestions:
+    your_views:
   gone:
     page_title: Ni več na voljo
     published_in_error: Informacije na tej strani so bile odstranjene, ker so bile objavljene po pomoti.
@@ -461,7 +506,72 @@ sl:
   i18n:
     direction:
   language_names:
+    ar:
+    az:
+    be:
+    bg:
+    bn:
+    cs:
+    cy:
+    da:
+    de:
+    dr:
+    el:
+    en:
+    es:
+    es-419:
+    et:
+    fa:
+    fi:
+    fr:
+    gd:
+    gu:
+    he:
+    hi:
+    hr:
+    hu:
+    hy:
+    id:
+    is:
+    it:
+    ja:
+    ka:
+    kk:
+    ko:
+    lt:
+    lv:
+    ms:
+    mt:
+    ne:
+    nl:
+    'no':
+    pa:
+    pa-pk:
+    pl:
+    ps:
+    pt:
+    ro:
+    ru:
+    si:
+    sk:
     sl: slovenščina
+    so:
+    sq:
+    sr:
+    sv:
+    sw:
+    ta:
+    th:
+    tk:
+    tr:
+    uk:
+    ur:
+    uz:
+    vi:
+    yi:
+    zh:
+    zh-hk:
+    zh-tw:
   multi_page:
     next_page: Naslednji
     previous_page: Prejšnji

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -1,656 +1,566 @@
----
 sl:
-  brexit:
-    business_link:
-      path:
-      text:
-    citizen_link:
-      path:
-      text:
-    heading_prefix:
-  common:
-    visit:
-  components:
-    figure:
-      image_credit:
-    published_dates:
-      hide_all_updates:
-      last_updated:
-      published:
-      see_all_updates:
-      show_all_updates:
-    publisher_metadata:
-      hide_all:
-      show_all:
-    share_links:
-      share_this_page:
-  consultation:
-    and:
-    another_website_html:
-    at:
-    closes:
-    closes_at:
-    complete_a:
-    description:
-    detail_of_feedback_received:
-    detail_of_outcome:
-    documents:
-    download_outcome:
-    either:
-    email_to:
-    feedback_received:
-    is_being:
-    not_open_yet:
-    'on':
-    opens:
-    original_consultation:
-    ran_from:
-    respond_online:
-    visit_soon:
-    was:
-    ways_to_respond:
-    write_to:
-  contact:
-    email:
-    find_call_charges:
-    online:
-    phone:
-    webchat:
   content_item:
-    coming_soon:
-    contents:
-    metadata:
-      published:
-      updated:
     schema_name:
       aaib_report:
-        few:
-        one:
-        other:
+        one: Poročilo podružnice za preiskave letalskih nesreč
         two:
+        few:
+        other: Poročila podružnice za preiskovanje letalskih nesreč
       announcement:
-        few:
-        one:
-        other:
+        one: Razglas
         two:
+        few:
+        other: Razglasi
       asylum_support_decision:
-        few:
-        one:
-        other:
+        one: Odločitev sodišča o podpori azilu
         two:
+        few:
+        other: Odločitve sodišča o podpori azilu
       authored_article:
-        few:
-        one:
-        other:
+        one: Avtorski članek
         two:
+        few:
+        other: Avtorski članki
       business_finance_support_scheme:
-        few:
-        one:
-        other:
+        one: Program podpore za poslovne finance
         two:
+        few:
+        other: Programi podpore za poslovne finance
       case_study:
-        few:
-        one:
-        other:
+        one: Študija primera
         two:
+        few:
+        other: Študije primera
       closed_consultation:
-        few:
-        one:
-        other:
-        overview:
+        one: Tesno posvetovanje
         two:
+        few:
+        other: Tesna posvetovanja
       cma_case:
-        few:
-        one:
-        other:
+        one: Primer organa za konkurenco in trge
         two:
+        few:
+        other: Primeri organa za konkurenco in trge
       coming_soon:
-        few:
-        one:
-        other:
+        one: Kmalu na voljo
         two:
+        few:
+        other: Kmalu na voljo
       consultation:
-        few:
-        one:
-        other:
+        one: Posvetovanje
         two:
+        few:
+        other: Posvetovanja
       consultation_outcome:
-        few:
-        one:
-        other:
-        overview:
+        one: Rezultat posvetovanja
         two:
+        few:
+        other: Rezultati posvetovanja
       corporate_information_page:
-        few:
-        one:
-        other:
+        one: Stran z informacijami
         two:
+        few:
+        other: Strani z informacijami
       corporate_report:
-        few:
-        one:
-        other:
-        overview:
+        one: Poročilo podjetja
         two:
+        few:
+        other: Poročila podjetja
       correspondence:
-        few:
-        one:
-        other:
-        overview:
+        one: Korespondenca
         two:
+        few:
+        other: Korespondenca
       countryside_stewardship_grant:
-        few:
-        one:
-        other:
+        one: Nepovratna sredstva za ohranjanje podeželja
         two:
+        few:
+        other: Nepovratna sredstva za ohranjanje podeželja
       decision:
-        few:
-        one:
-        other:
-        overview:
+        one: Odločitev
         two:
+        few:
+        other: Odločitve
       detailed_guide:
-        few:
-        one:
-        other:
+        one: Smernice
         two:
+        few:
+        other: Smernice
       dfid_research_output:
-        few:
-        one:
-        other:
+        one: Raziskave za razvojni rezultat
         two:
+        few:
+        other: Raziskave za razvojne rezultate
       document_collection:
-        few:
-        one:
-        other:
+        one: Zbirka
         two:
+        few:
+        other: Zbirke
       draft_text:
-        few:
-        one:
-        other:
+        one: Osnutek besedila
         two:
+        few:
+        other: Osnutki besedila
       drug_safety_update:
-        few:
-        one:
-        other:
+        one: Posodobitev o varnosti zdravil
         two:
+        few:
+        other: Posodobitve o varnosti zdravil
       employment_appeal_tribunal_decision:
-        few:
-        one:
-        other:
+        one: Odločitev pritožbenega delovnega sodišča
         two:
+        few:
+        other: Odločitve pritožbenega delovnega sodišča
       employment_tribunal_decision:
-        few:
-        one:
-        other:
+        one: Odločitev delovnega sodišča
         two:
+        few:
+        other: Odločitve delovnega sodišča
       esi_fund:
-        few:
-        one:
-        other:
+        one: Evropski strukturni in investicijski sklad (ESI)
         two:
+        few:
+        other: Evropski strukturni in investicijski skladi (ESI)
       fatality_notice:
-        few:
-        one:
-        other:
+        one: Obvestilo o smrti
         two:
+        few:
+        other: Obvestila o smrti
       foi_release:
-        few:
-        one:
-        other:
-        overview:
+        one: Izjava o svobodi informacij
         two:
+        few:
+        other: Izjave o svobodi informacij
       form:
-        few:
-        one:
-        other:
-        overview:
+        one: Oblika
         two:
+        few:
+        other: Oblike
       government_response:
-        few:
-        one:
-        other:
+        one: Odziv vlade
         two:
+        few:
+        other: Odzivi vlade
       guidance:
-        few:
-        one:
-        other:
-        overview:
+        one: Smernice
         two:
+        few:
+        other: Smernice
       impact_assessment:
-        few:
-        one:
-        other:
-        overview:
+        one: Presoja vpliva
         two:
+        few:
+        other: Presoje vpliva
       imported:
-        few:
-        one:
-        other:
+        one: uvoženo − vrsta čakanja
         two:
+        few:
+        other: uvoženo − vrsta čakanja
       independent_report:
-        few:
-        one:
-        other:
-        overview:
+        one: neodvisno poročilo
         two:
+        few:
+        other: neodvisna poročila
       international_development_fund:
-        few:
-        one:
-        other:
+        one: Financiranje mednarodnega razvoja
         two:
+        few:
+        other: Financiranje mednarodnega razvoja
       international_treaty:
-        few:
-        one:
-        other:
-        overview:
+        one: Mednarodni sporazum
         two:
+        few:
+        other: Mednarodni sporazumi
       maib_report:
-        few:
-        one:
-        other:
+        one: Poročilo podružnice za preiskave pomorskih nesreč
         two:
+        few:
+        other: Poročila podružnice za preiskave pomorskih nesreč
       map:
-        few:
-        one:
-        other:
-        overview:
+        one: Zemljevid
         two:
+        few:
+        other: Zemljevidi
       medical_safety_alert:
-        few:
-        one:
-        other:
+        one: Opozorila glede zdravil in medicinskih pripomočkih in odpoklici le-teh
         two:
+        few:
+        other: Opozorila glede zdravil in medicinskih pripomočkih in odpoklici le-teh
       national:
-        few:
-        one:
-        other:
+        one: Objava državne statistike
         two:
+        few:
+        other: Objave državne statistike
       national_statistics:
-        few:
-        one:
-        other:
-        overview:
+        one: Državna statistika
         two:
+        few:
+        other: Državna statistika
       national_statistics_announcement:
-        few:
-        one:
-        other:
+        one: Objava državne statistike
         two:
+        few:
+        other: Objave državne statistike
       news_article:
-        few:
-        one:
-        other:
+        one: Časopisni članek
         two:
+        few:
+        other: Časopisni članki
       news_story:
-        few:
-        one:
-        other:
+        one: Časopisna zgodba
         two:
+        few:
+        other: Časopisne zgodbe
       notice:
-        few:
-        one:
-        other:
-        overview:
+        one: Obvestilo
         two:
+        few:
+        other: Obvestila
       official:
-        few:
-        one:
-        other:
+        one: Objava uradne statistike
         two:
+        few:
+        other: Objave uradne statistike
       official_statistics:
-        few:
-        one:
-        other:
-        overview:
+        one: Uradna statistika
         two:
+        few:
+        other: Uradna statistika
       official_statistics_announcement:
-        few:
-        one:
-        other:
+        one: Objava uradne statistike
         two:
+        few:
+        other: Objave uradne statistike
       open_consultation:
-        few:
-        one:
-        other:
-        overview:
+        one: Odprto posvetovanje
         two:
+        few:
+        other: Odprto posvetovanje
       oral_statement:
-        few:
-        one:
-        other:
+        one: Ustna izjava za parlament
         two:
+        few:
+        other: Ustne izjave za parlament
       policy:
-        few:
-        one:
-        other:
+        one: Politika
         two:
+        few:
+        other: Politike
       policy_paper:
-        few:
-        one:
-        other:
-        overview:
+        one: Politični dokument
         two:
+        few:
+        other: Politični dokumenti
       press_release:
-        few:
-        one:
-        other:
+        one: Sporočilo za javnost
         two:
+        few:
+        other: Sporočila za javnost
       promotional:
-        few:
-        one:
-        other:
-        overview:
+        one: Promocijski material
         two:
+        few:
+        other: Promocijski material
       publication:
-        few:
-        one:
-        other:
+        one: Publikacija
         two:
+        few:
+        other: Publikacije
       raib_report:
-        few:
-        one:
-        other:
+        one: Poročilo podružnice za preiskave železniških nesreč
         two:
+        few:
+        other: Poročila podružnice za preiskave železniških nesreč
       regulation:
-        few:
-        one:
-        other:
-        overview:
+        one: Uredba
         two:
+        few:
+        other: Uredbe
       research:
-        few:
-        one:
-        other:
-        overview:
+        one: Raziskovanje in analiza
         two:
+        few:
+        other: Raziskovanje in analiza
       residential_property_tribunal_decision:
-        few:
-        one:
-        other:
+        one: Odločitev sodišča za stanovanjske nepremičnine
         two:
+        few:
+        other: Odločitve sodišča za stanovanjske nepremičnine
       service_sign_in:
-        few:
-        one:
-        other:
+        one: Prijava v storitev
         two:
+        few:
+        other: Prijava v storitev
       service_standard_report:
-        few:
-        one:
-        other:
+        one: Standardno poročilo o storitvah
         two:
+        few:
+        other: Standardna poročila o storitvah
       speaking_notes:
-        few:
-        one:
-        other:
+        one: Točke za govor
         two:
+        few:
+        other: Točke za govor
       speech:
-        few:
-        one:
-        other:
+        one: Govor
         two:
+        few:
+        other: Govori
       standard:
-        few:
-        one:
-        other:
-        overview:
+        one: Standard
         two:
+        few:
+        other: Standardi
       statement_to_parliament:
-        few:
-        one:
-        other:
+        one: Izjava parlamentu
         two:
+        few:
+        other: Izjave parlamentu
       statistical_data_set:
-        few:
-        one:
-        other:
+        one: Statistični podatkovni niz
         two:
+        few:
+        other: Statistični podatkovni nizi
       statistics_announcement:
-        few:
-        one:
-        other:
+        one: Statistična objava
         two:
+        few:
+        other: Statistične objave
       statutory_guidance:
-        few:
-        one:
-        other:
-        overview:
+        one: Zakonski napotki
         two:
+        few:
+        other: Zakonski napotki
       take_part:
-        few:
-        one:
-        other:
+        one: Sodelujte
         two:
+        few:
+        other: Sodelujte
       tax_tribunal_decision:
-        few:
-        one:
-        other:
+        one: Odločitev Sodišča za davčne in gospodarske spore
         two:
+        few:
+        other: Odločitve Sodišča za davčne in gospodarske spore
       transcript:
-        few:
-        one:
-        other:
+        one: Prepis
         two:
+        few:
+        other: Prepisi
       transparency:
-        few:
-        one:
-        other:
-        overview:
+        one: Podatki o preglednosti
         two:
+        few:
+        other: Podatki o preglednosti
       utaac_decision:
-        few:
-        one:
-        other:
+        one: Odločitev Pritožbenega delovnega sodišča
         two:
+        few:
+        other: Odločitve Pritožbenega delovnega sodišča
       world_location_news_article:
-        few:
-        one:
-        other:
+        one: Časopisni članek
         two:
+        few:
+        other: Časopisni članki
       world_news_story:
-        few:
-        one:
-        other:
+        one: Novica s sveta
         two:
+        few:
+        other: Novice s celega sveta
       written_statement:
-        few:
-        one:
-        other:
+        one: Pisna izjava za parlament
         two:
+        few:
+        other: Pisne izjave za parlament
+    coming_soon: Ta dokument bo objavljen
+    contents: Vsebina
+    metadata:
+      published: Objavljeno
+      updated: Posodobljeno
+  publication:
+    documents:
+      one: Dokument
+      two:
+      few:
+      other: Dokumenti
+    details: Podrobnosti
+  brexit:
+    business_link: Vodnik po brexitu za podjetja
+    citizen_link: Vodnik po brexitu za posameznike in družine
+    heading_prefix: Drugače je
+  common:
+    last_updated:
+    visit: 'Obiščite:'
+  components:
+    figure:
+      image_credit: 'Avtor slike: %{credit}'
+    published_dates:
+      hide_all_updates: Skrij vse posodobitve
+      last_updated: Zadnjič posodobljeno %{date}
+      published: Objavljeno %{date}
+      see_all_updates: poglej vse posodobitve
+      show_all_updates: prikaži vse posodobitve
+    publisher_metadata:
+      collections:
+      from:
+      hide_all: skrij vse
+      show_all: prikaži vse
+    save_this_page:
+      add_page_button: Dodaj med shranjene strani
+      confirmations:
+        page_removed:
+          message: Zaznamek ste odstranili s shranjenih strani
+        page_saved:
+          message: Zaznamek ste dodali med shranjene strani
+      page_not_saved_heading: Shranite stran, da si jo lahko ponovno ogledate pozneje
+      page_was_saved_heading: Shranili ste to stran
+      remove_page_button: Odstrani s shranjenih strani
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Oglejte
+        si strani, ki ste jih shranili</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Prijavite
+        se</a>, da si ogledate shranjene strani.
+    share_links:
+      share_this_page: Deli to stran
+  consultation:
+    and: in
+    another_website_html: To posvetovanje %{closed} poteka na <a href="%{url}">drugi
+      spletni strani</a>
+    at: na
+    closes: Zapre se ob
+    closes_at: To posvetovanje se zapre ob
+    complete_a: 'Izpolnite '
+    description: Opis posvetovanja
+    detail_of_feedback_received: Podrobnosti o povratnih informacijah
+    detail_of_outcome: Podrobnosti o rezultatu
+    documents: Dokumenti
+    download_outcome: Prenesi končni rezultat
+    either: ali
+    email_to: 'Pošlji elektronsko sporočilo:'
+    feedback_received: Prejeli smo povratne informacije
+    is_being: se
+    not_open_yet: To posvetovanje še ni začeto
+    'on':
+    opens: Posvetovanje se začne
+    original_consultation: Izvirno posvetovanje
+    ran_from: To posvetovanje je trajalo od
+    respond_online: Odgovori na spletu
+    'true': res
+    visit_soon: Kmalu znova obiščite to stran in naložite rezultat v te javne& nbsp;povratne
+      informacije.
+    was: je bilo
+    ways_to_respond: Načini odziva
+    write_to: 'Pišite na:'
+  contact:
+    email: E-pošta
+    find_call_charges: Izvedite več o cenah klicev
+    online: Na spletu
+    phone: Telefon
+    webchat: Spletni klepet
   corporate_information_page:
-    about_our_services_html:
-    corporate_information:
-    personal_information_charter_html:
-    publication_scheme_html:
-    social_media_use_html:
-    welsh_language_scheme_html:
-  email:
-    description_html:
-    subscribe_title:
-    unsubscribe_title:
+    about_our_services_html: Izvedite več %{link}.
+    corporate_information: Informacije o podjetju
+    personal_information_charter_html: Na povezavi %{link} je razloženo, kako ravnamo
+      z vašimi osebnimi podatki.
+    publication_scheme_html: Več o vrstah informacij, ki jih redno objavljamo, preberite
+      v naši %{link}.
+    social_media_use_html: Preberite si našo politiko na %{link}.
+    welsh_language_scheme_html: Izvedite več o naši zavezanosti %{link}.
   fatality_notice:
-    alt_text:
-    field_of_operation:
-    operations_in:
-  get_involved:
-    active_blogs:
-    civil_service:
-    civil_service_quarterly:
-    closed:
-    closed_consultations:
-    closed_with_date:
-    closes:
-    closing_today:
-    closing_tomorrow:
-    days_left:
-    engage_with_gov:
-    fcdo_bloggers:
-    follow:
-    follow_paragraph:
-    gds_blog:
-    gov_past:
-    intro_paragraph:
-      body_html:
-      engage_with_government:
-      take_part:
-    join_ics:
-    make_donation:
-    more_ways:
-    neighbourhood_watch:
-    open_consultations:
-    page_heading:
-    page_title:
-    petition_paragraph:
-      body_html:
-      create_a_petition:
-    read_respond:
-    recent_outcomes:
-    recently_opened:
-    respond_to_consultations:
-    school_overseas:
-    search_all:
-    see_all_dept:
-    start_a_petition:
-    take_part:
-    take_part_suggestions:
-    your_views:
+    alt_text: Grb Ministrstva za obrambo
+    field_of_operation: Področje delovanja
+    operations_in: Dejavni v %{location}
   gone:
-    page_title:
-    published_in_error:
-    title:
+    page_title: Ni več na voljo
+    published_in_error: Informacije na tej strani so bile odstranjene, ker so bile
+      objavljene po pomoti.
+    title: Stran, ki ste jo iskali, ni več na voljo
   guide:
-    pages_in_guide:
-    skip_to_contents:
+    pages_in_guide: Strani v tem vodiču
+    skip_to_contents: Skočite na vsebino vodiča
   html_publication:
     print_meta_data:
-      available_at:
-      copyright:
-      isbn:
-      licence_html:
-      third_party:
+      available_at: Ta publikacija je na voljo na %{url}
+      copyright: Avtorske pravice © Crown %{year}
+      isbn: 'ISBN:'
+      licence_html: 'Ta publikacija ima licenco pod pogoji licence Open Government
+        License v3.0, razen kjer je navedeno drugače. Za ogled licence obiščite <a
+        href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
+        ali pišite  skupini za informacijsko politiko Information Policy Team, The
+        National Archives, Kew, London TW9 4DU ali napišite e-sporočilo: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: Če ugotovimo kakršne koli podatke o avtorskih pravicah tretjih
+        oseb, boste morali pridobiti dovoljenje zadevnih imetnikov avtorskih pravic.
   i18n:
     direction:
   language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl: Slovenščina
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur:
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
+    sl: slovenščina
   multi_page:
-    next_page:
-    previous_page:
-    print_entire_guide:
-  publication:
-    details:
-    documents:
-      few:
-      one:
-      other:
-      two:
+    next_page: Naslednji
+    previous_page: Prejšnji
+    print_entire_guide: Natisni cel vodič
   service_sign_in:
-    continue:
+    continue: Nadaljuj
     error:
-      option:
-      title:
+      option: Prosimo, izberite možnost
+      title: Niste izbrali možnosti
   shared:
-    historically_political:
+    historically_political: To je bilo objavljeno pod %{government}
     webchat:
-      available:
-      busy:
-      closed:
-      speak_to_adviser:
-      technical_problem:
+      available: Svetovalci so na voljo za klepet.
+      busy: Trenutno so vsi svetovalci spletnega klepeta zasedeni.
+      closed: Spletni klepet trenutno ne deluje.
+      speak_to_adviser: Govorite s svetovalcem zdaj
+      technical_problem: Spletni klepet trenutno ni na voljo zaradi tehničnih težav.
   specialist_document:
-    pdo_alt_text:
-    pgi_alt_text:
-    tsg_alt_text:
+    pdo_alt_text: Logotip sheme je črni žig z besedami Designated Origin UK Protected
+    pgi_alt_text: Logotip sheme je črni žig z besedami Geographic Origin UK Protected
+    tsg_alt_text: Logotip sheme je črni žig z besedami Traditional Speciality UK Protected
   speech:
-    delivered_on:
-    location:
-    written_on:
+    delivered_on: 'Podano dne:'
+    location: Lokacija
+    written_on: Napisano dne
   statistics_announcement:
-    cancellation_date:
-    cancelled:
-    changed_date:
-    forthcoming:
-    previous_date:
-    proposed_date:
-    reason_for_change:
-    release_date:
+    cancellation_date: Datum preklica
+    cancelled: Statistična objava je bila preklicana
+    changed_date: Datum objave seje spremenil
+    forthcoming: Ta statistika bo objavljena
+    previous_date: Prejšnji datum
+    proposed_date: Predlagana objava
+    reason_for_change: Razlog za spremembo
+    release_date: Datum objave
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts_html:
-      avoid_all_but_essential_travel_to_whole_country_html:
-      avoid_all_travel_to_parts_html:
-      avoid_all_travel_to_whole_country_html:
-    context:
-    still_current_at:
-    summary:
-    updated:
+      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth
+        Office">FCO</abbr> odsvetuje vsa nenujna potovanja v dele države.
+      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth
+        Office">FCO</abbr> odsvetuje vsa nenujna potovanja v državo.
+      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr>
+        odsvetuje vsa potovanja v dele države.
+      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr>
+        odsvetuje vsa potovanja v državo.
+    context: Nasveti za potovanja v tujino
+    coronavirus_warning:
+      content_html: |
+        <p class="govuk-body">
+          Upoštevajte trenutna pravila glede virusa COVID-19, kjer živite. <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Škotska</a>, <a href="https://gov.wales/coronavirus-travel">Wales</a> in <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Severna Irska</a>.
+        ​<p class="govuk-body">​
+        Da preprečite vnos novih različic virusa COVID v Združeno kraljestvo, ne smete potovati ​v  <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">države z oranžnega ali rdečega seznama​</a>​.
+
+        </p>
+        <p class="govuk-body">
+          Če želite izvedeti več o tveganjih v državi, pojdite na <a href="/guidance/travel-advice-novel-coronavirus"> Pisarna za zunanje zadeve, zadeve Commonwealtha in razvoj Nasveti za potovanja</a>.
+        </p>
+        <p class="govuk-body">
+          Ob vrnitvi upoštevate pravila na <a href="/uk-border-control">vstop v Združeno kraljestvo iz tujine</a> (z izjemo Irske).
+        </p>
+      text_assistive: Pomembno
+      title: Potovanje v času koronavirusa (COVID-19)
+    still_current_at: Še vedno aktualno ob
+    summary: Povzetek
+    updated: Posodobljeno
   unpublishing:
-    page_title:
-    summary:
-    title:
+    page_title: Ni več na voljo
+    summary: Informacije na tej strani so bile odstranjene, ker so bile objavljene
+      po pomoti.
+    title: Stran, ki ste jo iskali, ni več na voljo
   working_group:
-    contact_details:
-    policies:
+    contact_details: Kontaktni podatki
+    policies: Politike

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -384,8 +384,12 @@ sl:
       other: Dokumenti
     details: Podrobnosti
   brexit:
-    business_link: Vodnik po brexitu za podjetja
-    citizen_link: Vodnik po brexitu za posameznike in družine
+    business_link:
+      path: "/guidance/brexit-guidance-for-businesses"
+      text: Vodnik po brexitu za podjetja
+    citizen_link:
+      path: "/guidance/brexit-guidance-for-individuals-and-families"
+      text: Vodnik po brexitu za posameznike in družine
     heading_prefix: Drugače je
   common:
     last_updated:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -9,7 +9,6 @@ sl:
       text: Vodnik po brexitu za posameznike in družine
     heading_prefix: Drugače je
   common:
-    last_updated:
     visit: 'Obiščite:'
   components:
     figure:
@@ -21,22 +20,8 @@ sl:
       see_all_updates: poglej vse posodobitve
       show_all_updates: prikaži vse posodobitve
     publisher_metadata:
-      collections:
-      from:
       hide_all: skrij vse
       show_all: prikaži vse
-    save_this_page:
-      add_page_button: Dodaj med shranjene strani
-      confirmations:
-        page_removed:
-          message: Zaznamek ste odstranili s shranjenih strani
-        page_saved:
-          message: Zaznamek ste dodali med shranjene strani
-      page_not_saved_heading: Shranite stran, da si jo lahko ponovno ogledate pozneje
-      page_was_saved_heading: Shranili ste to stran
-      remove_page_button: Odstrani s shranjenih strani
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">Oglejte si strani, ki ste jih shranili</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">Prijavite se</a>, da si ogledate shranjene strani.
     share_links:
       share_this_page: Deli to stran
   consultation:
@@ -61,7 +46,6 @@ sl:
     original_consultation: Izvirno posvetovanje
     ran_from: To posvetovanje je trajalo od
     respond_online: Odgovori na spletu
-    'true': res
     visit_soon: Kmalu znova obiščite to stran in naložite rezultat v te javne& nbsp;povratne informacije.
     was: je bilo
     ways_to_respond: Načini odziva
@@ -526,22 +510,6 @@ sl:
       avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa potovanja v dele države.
       avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa potovanja v državo.
     context: Nasveti za potovanja v tujino
-    coronavirus_warning:
-      content_html: |
-        <p class="govuk-body">
-          Upoštevajte trenutna pravila glede virusa COVID-19, kjer živite. <a href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do">England</a>, <a href="https://www.gov.scot/coronavirus-covid-19/">Škotska</a>, <a href="https://gov.wales/coronavirus-travel">Wales</a> in <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you">Severna Irska</a>.
-        ​<p class="govuk-body">​
-        Da preprečite vnos novih različic virusa COVID v Združeno kraljestvo, ne smete potovati ​v  <a href="/guidance/red-amber-and-green-list-rules-for-entering-england">države z oranžnega ali rdečega seznama​</a>​.
-
-        </p>
-        <p class="govuk-body">
-          Če želite izvedeti več o tveganjih v državi, pojdite na <a href="/guidance/travel-advice-novel-coronavirus"> Pisarna za zunanje zadeve, zadeve Commonwealtha in razvoj Nasveti za potovanja</a>.
-        </p>
-        <p class="govuk-body">
-          Ob vrnitvi upoštevate pravila na <a href="/uk-border-control">vstop v Združeno kraljestvo iz tujine</a> (z izjemo Irske).
-        </p>
-      text_assistive: Pomembno
-      title: Potovanje v času koronavirusa (COVID-19)
     still_current_at: Še vedno aktualno ob
     summary: Povzetek
     updated: Posodobljeno

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -324,12 +324,10 @@ so:
     field_of_operation: Hawalaha dibadaa
     operations_in: Hawalaha %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -335,6 +335,7 @@ so:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -324,12 +324,10 @@ sq:
     field_of_operation: Fusha e operimit
     operations_in: Operacione në %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -335,6 +335,7 @@ sq:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -472,12 +472,10 @@ sr:
     field_of_operation: Oblast delovanja
     operations_in: Delovanje na lokaciji %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -483,6 +483,7 @@ sr:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -324,12 +324,10 @@ sv:
     field_of_operation: Verksamhetsområde
     operations_in: Verksamhet på %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -335,6 +335,7 @@ sv:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -335,6 +335,7 @@ sw:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -324,12 +324,10 @@ sw:
     field_of_operation: Sehemu ya kazi
     operations_in: Shughuli zinazofanywa katika %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -335,6 +335,7 @@ ta:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -324,12 +324,10 @@ ta:
     field_of_operation: இயங்குதளம்
     operations_in: "%{location}-ல் செயல்பாடுகள்"
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -335,6 +335,7 @@ th:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -324,12 +324,10 @@ th:
     field_of_operation: พื้นที่ปฏิบัติการ
     operations_in: การดำเนินงานใน %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -335,6 +335,7 @@ tk:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -324,12 +324,10 @@ tk:
     field_of_operation: Iş meýdany
     operations_in: "%{location} ýerindäki işler"
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -324,12 +324,10 @@ tr:
     field_of_operation: Faaliyet alanı
     operations_in: "%{location} konumundaki faaliyetler"
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -335,6 +335,7 @@ tr:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -483,6 +483,7 @@ uk:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -472,12 +472,10 @@ uk:
     field_of_operation: Сфера діяльності
     operations_in: Операції в %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -9,7 +9,6 @@ ur:
       text: افراد اور اہل خانہ کے لیے Brexit کی رہنمائی
     heading_prefix: یہاں فرق ہے
   common:
-    last_updated:
     visit: 'ملاحظہ کریں:'
   components:
     figure:
@@ -21,22 +20,8 @@ ur:
       see_all_updates: تمام اپ ڈیٹس دیکھیں
       show_all_updates: تمام اپ ڈیٹس دکھائیں
     publisher_metadata:
-      collections:
-      from:
       hide_all: تمام کو پوشیدہ کریں
       show_all: تمام دکھائیں
-    save_this_page:
-      add_page_button: اپنے محفوظ کردہ صفحات پر شامل کریں
-      confirmations:
-        page_removed:
-          message: آپ کو اپنے محفوظ کردہ صفحات سے ہٹا دیا گیا ہے
-        page_saved:
-          message: آپ نے اپنے محفوظ کردہ صفحات شامل کر لیے ہیں
-      page_not_saved_heading: اس صفحے کو محفوظ کر لیں تاکہ بعد میں آپ اس پر واپس آ سکیں
-      page_was_saved_heading: آپ نے یہ صفحہ محفوظ کر لیا ہے
-      remove_page_button: اپنے محفوظ کردہ صفحات سے ہٹائیں
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">اپنے محفوظ کردہ صفحات دیکھیں۔</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">سائن ان</a> اپنے محفوظ کردہ صفحات دیکھنے کے لیے.
     share_links:
       share_this_page: اس صفحے کو شیئر کریں
   consultation:
@@ -61,7 +46,6 @@ ur:
     original_consultation: اصل مشاورت
     ran_from: اس مشاورت میں درج ذیل ختم ہو گیا
     respond_online: آن لائن جواب دیں
-    'true': درست
     visit_soon: اس عوامی&nbsp;فیڈ بیک کا نتیجہ ڈاؤن لوڈ کرنے کے لیے اس صفحے کا دوبارہ جلد دورہ کریں۔
     was: تھا
     ways_to_respond: جواب دینے کے طریقے
@@ -376,10 +360,6 @@ ur:
       avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ملک کے کچھ حصوں میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
       avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> پورے ملک میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
     context: غیر ملکی سفر کی مشاورت
-    coronavirus_warning:
-      content_html: "<p class=\"govuk-body\">\n اپنے رہائشی علاقے کے موجودہ COVID-19 اصولوں پر عمل کریں: <a href=\"/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do\">England</a>, <a href=\"https://www.gov.scot/coronavirus-covid-19/\">Scotland</a>, <a href=\"https://gov.wales/coronavirus-travel\">Wales</a> اور <a href=\"https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you\">Northern Ireland</a>.\n</p>\n<p class=\"govuk-body\">/\n    COVID کی نئے تغیرات کے برطانیہ میں داخلے کو روکنے کے لیے، آپ کو <a href=\"/guidance/red-amber-and-green-list-rules-for-entering-england\">زرد یا سرخ فہرست میں شامل کردہ ممالک</a> کا سفر نہیں کرنا چاہیئے \n</p>\n<p class=\"govuk-body\">\n  کاؤنٹی میں خطرات کو سمجھنے کے لیے <a href=\"/guidance/travel-advice-novel-coronavirus\">ایف سی کی ڈگری۔ کی سروس مشاورت</a> پر عمل کریں۔\n</p>\n<p class=\"govuk-body\">\nجب آپ واپس آئیں، <a href=\"/uk-border-control\">بیرون ملک سے UK میں داخل ہوں</a> کے اصولوں پر عمال کریں (سوائے آئرلینڈ کے)\n</p>\n"
-      text_assistive: اہم
-      title: کورونا وائرس (COVID-19) سفر
     still_current_at: ابھی تک حالیہ ہے از
     summary: خلاصہ
     updated: اپ ڈیٹ کردہ

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -371,10 +371,10 @@ ur:
     release_date: اجراء کی تاریخ
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr> سوائے ملک کے کچھ حصوں میں ضروری سفر کرنے کے ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
-      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr> سوائے پورے ملک میں ضروری سفر کرنے کے ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
-      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ملک کے کچھ حصوں میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
-      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr> پورے ملک میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+      avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> سوائے ملک کے کچھ حصوں میں ضروری سفر کرنے کے ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+      avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> سوائے پورے ملک میں ضروری سفر کرنے کے ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+      avoid_all_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ملک کے کچھ حصوں میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+      avoid_all_travel_to_whole_country_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> پورے ملک میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
     context: غیر ملکی سفر کی مشاورت
     coronavirus_warning:
       content_html: "<p class=\"govuk-body\">\n اپنے رہائشی علاقے کے موجودہ COVID-19 اصولوں پر عمل کریں: <a href=\"/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do\">England</a>, <a href=\"https://www.gov.scot/coronavirus-covid-19/\">Scotland</a>, <a href=\"https://gov.wales/coronavirus-travel\">Wales</a> اور <a href=\"https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you\">Northern Ireland</a>.\n</p>\n<p class=\"govuk-body\">/\n    COVID کی نئے تغیرات کے برطانیہ میں داخلے کو روکنے کے لیے، آپ کو <a href=\"/guidance/red-amber-and-green-list-rules-for-entering-england\">زرد یا سرخ فہرست میں شامل کردہ ممالک</a> کا سفر نہیں کرنا چاہیئے \n</p>\n<p class=\"govuk-body\">\n  کاؤنٹی میں خطرات کو سمجھنے کے لیے <a href=\"/guidance/travel-advice-novel-coronavirus\">ایف سی کی ڈگری۔ کی سروس مشاورت</a> پر عمل کریں۔\n</p>\n<p class=\"govuk-body\">\nجب آپ واپس آئیں، <a href=\"/uk-border-control\">بیرون ملک سے UK میں داخل ہوں</a> کے اصولوں پر عمال کریں (سوائے آئرلینڈ کے)\n</p>\n"

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -292,10 +292,55 @@ ur:
     publication_scheme_html: ہماری %{link} میں ہماری جانب سے معمول کے حساب سے شائع کی جانے والی معلومات کی اقسام کے بارے میں پڑھیں۔
     social_media_use_html: "%{link} پر ہماری پالیسی کو پڑھیں۔"
     welsh_language_scheme_html: "%{link} کے ساتھ ہماری وابستگی کے بارے میں جانیں۔"
+  email:
+    description_html:
+    subscribe_title:
+    unsubscribe_title:
   fatality_notice:
     alt_text: وزارت دفاع کا کریسنٹ
     field_of_operation: کارروائی کی فیلڈ
     operations_in: "%{location} میں کارروائیاں"
+  get_involved:
+    civil_service:
+    civil_service_quarterly:
+    closed:
+    closed_consultations:
+    closes:
+    closing_today:
+    closing_tomorrow:
+    days_left:
+    engage_with_gov:
+    fcdo_bloggers:
+    follow:
+    follow_links:
+    follow_paragraph:
+    gds_blog:
+    gov_past:
+    intro_paragraph:
+      body_html:
+      engage_with_government:
+      take_part:
+    join_ics:
+    make_donation:
+    more_ways:
+    neighbourhood_watch:
+    open_consultations:
+    page_heading:
+    page_title:
+    petition_paragraph:
+      body_html:
+      create_a_petition:
+    read_respond:
+    recent_outcomes:
+    recently_opened:
+    respond_to_consultations:
+    school_overseas:
+    search_all:
+    see_all_dept:
+    start_a_petition:
+    take_part:
+    take_part_suggestions:
+    your_views:
   gone:
     page_title: مزید دستیاب نہیں
     published_in_error: اس صفحے سے معلومات ہٹا دی گئی ہیں کیونکہ اسے نقص کے ساتھ شائع کیا گیا تھا۔
@@ -313,7 +358,72 @@ ur:
   i18n:
     direction:
   language_names:
+    ar:
+    az:
+    be:
+    bg:
+    bn:
+    cs:
+    cy:
+    da:
+    de:
+    dr:
+    el:
+    en:
+    es:
+    es-419:
+    et:
+    fa:
+    fi:
+    fr:
+    gd:
+    gu:
+    he:
+    hi:
+    hr:
+    hu:
+    hy:
+    id:
+    is:
+    it:
+    ja:
+    ka:
+    kk:
+    ko:
+    lt:
+    lv:
+    ms:
+    mt:
+    ne:
+    nl:
+    'no':
+    pa:
+    pa-pk:
+    pl:
+    ps:
+    pt:
+    ro:
+    ru:
+    si:
+    sk:
+    sl:
+    so:
+    sq:
+    sr:
+    sv:
+    sw:
+    ta:
+    th:
+    tk:
+    tr:
+    uk:
     ur: اردو
+    uz:
+    vi:
+    yi:
+    zh:
+    zh-hk:
+    zh-tw:
   multi_page:
     next_page: اگلا
     previous_page: گزشتہ

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -1,506 +1,419 @@
----
 ur:
-  brexit:
-    business_link:
-      path:
-      text:
-    citizen_link:
-      path:
-      text:
-    heading_prefix:
-  common:
-    visit:
-  components:
-    figure:
-      image_credit:
-    published_dates:
-      hide_all_updates:
-      last_updated:
-      published:
-      see_all_updates:
-      show_all_updates:
-    publisher_metadata:
-      hide_all:
-      show_all:
-    share_links:
-      share_this_page:
-  consultation:
-    and:
-    another_website_html:
-    at:
-    closes:
-    closes_at:
-    complete_a:
-    description:
-    detail_of_feedback_received:
-    detail_of_outcome:
-    documents:
-    download_outcome:
-    either:
-    email_to:
-    feedback_received:
-    is_being:
-    not_open_yet:
-    'on':
-    opens:
-    original_consultation:
-    ran_from:
-    respond_online:
-    visit_soon:
-    was:
-    ways_to_respond:
-    write_to:
-  contact:
-    email:
-    find_call_charges:
-    online:
-    phone:
-    webchat:
   content_item:
-    coming_soon:
-    contents:
-    metadata:
-      published: شائع شدہ
-      updated: تجدید شدہ
     schema_name:
       aaib_report:
-        one:
-        other:
+        one: فضائی حادثات کی تفتیشی برانچ رپورٹ
+        other: فضائی حادثات کی تفتیشی برانچ رپورٹس
       announcement:
         one: اعلان
         other: اعلانات
       asylum_support_decision:
-        one:
-        other:
+        one: پناہ گزین کی معاونتی عدالت کا فیصلہ
+        other: پناہ گزین کی معاونتی عدالت کے فیصلے
       authored_article:
-        one: تحریر کردہ مضمون
-        other: تحریر کردہ مضامین
+        one: مصنف کے نام کے ساتھ لکھا مضمون
+        other: مصنف کے نام کے ساتھ لکھے مضامین
       business_finance_support_scheme:
-        one:
-        other:
+        one: بزنس فائنانس معاونتی اسکیم
+        other: بزنس فائنانس معاونتی اسکیمز
       case_study:
         one: کیس اسٹڈی
         other: کیس اسٹڈیز
       closed_consultation:
-        one: مشاورت ختم
-        other: " مشاورت ختم"
-        overview:
+        one: محدود مشاورت
+        other: محدود مشاورتیں
       cma_case:
-        one:
-        other:
+        one: مقابلے اور مارکیٹس کی اتھارٹی کا کیس
+        other: مقابلے اور مارکیٹس کی اتھارٹی کے کیسز
       coming_soon:
-        one:
-        other:
+        one: جلد آ رہا ہے
+        other: جلد آ رہا ہے
       consultation:
         one: مشاورت
-        other: مشاورت
+        other: مشاورتیں
       consultation_outcome:
         one: مشاورت کا نتیجہ
         other: مشاورت کے نتائج
-        overview:
       corporate_information_page:
-        one:
-        other:
+        one: معلومات کا صفحہ
+        other: معلومات کے صفحات
       corporate_report:
         one: کارپوریٹ رپورٹ
         other: کارپوریٹ رپورٹس
-        overview:
       correspondence:
-        one: مراسلت
-        other: مراسلات
-        overview:
+        one: خط و کتابت
+        other: خط و کتابت
       countryside_stewardship_grant:
-        one:
-        other:
+        one: Countryside Stewardship گرانٹ
+        other: Countryside Stewardship گرانٹس
       decision:
-        one:
-        other:
-        overview:
+        one: فیصلہ
+        other: فیصلے
       detailed_guide:
-        one: مفصل رہنمائی
-        other: مفصل رہنمائی
+        one: رہنمائی
+        other: رہنمائی
       dfid_research_output:
-        one:
-        other:
+        one: ترقی کے نتیجے پر تحقیق
+        other: ترقی کے نتائج پر تحقیق
       document_collection:
-        one: سلسلہ
-        other:
+        one: مجموعہ
+        other: مجموعے
       draft_text:
-        one: ڈرافٹ متن
-        other: ڈرافٹ متن
+        one: ڈرافٹ کا متن
+        other: ڈرافٹ کے متن
       drug_safety_update:
-        one:
-        other:
+        one: دوا کی حفاظتی اپ ڈیٹ
+        other: دوا کی حفاظتی اپ ڈیٹس
       employment_appeal_tribunal_decision:
-        one:
-        other:
+        one: ملازمت کی اپیل کا عدالتی فیصلہ
+        other: ملازمت کی اپیل کے عدالتی فیصلے
       employment_tribunal_decision:
-        one:
-        other:
+        one: ملازمت کی اپیل کا فیصلہ
+        other: ملازمت کی اپیل کے فیصلے
       esi_fund:
-        one:
-        other:
+        one: یورپی بناوٹی اور سرمایہ کاری کا فنڈ (ESIF)
+        other: یورپی بناوٹی اور سرمایہ کاری کے فنڈز (ESIF)
       fatality_notice:
-        one: وفات کی اطلاع
-        other: وفات کی اطلاعات
+        one: موت کا نوٹس
+        other: موت کے نوٹسز
       foi_release:
-        one: آزادئی معلومات کی اشاعت
-        other: آزادئی معلومات کی اشاعت
-        overview:
+        one: رہائی تھی۔
+        other: رہائی تھی۔
       form:
         one: فارم
         other: فارمز
-        overview:
       government_response:
-        one: حکومتی جوابی اقدام
-        other: حکومتی جوابی اقدامات
+        one: حکومت کا جواب
+        other: حکومت کے جوابات
       guidance:
         one: رہنمائی
         other: رہنمائی
-        overview:
       impact_assessment:
-        one: اثرات کا تجزیہ
-        other: اثرات کے تجزیے
-        overview:
+        one: اثر کی جانچ
+        other: اثر کی جانچیں
       imported:
-        one: امپورٹڈ- نوع کا انتظار
-        other: امپورٹڈ- نوع کا انتظار
+        one: درآمد شدہ - قسم کا انتظار
+        other: درآمد شدہ - قسم کا انتظار
       independent_report:
-        one: غیر جانبدار رپورٹ
-        other: غیر جانبداررپورٹس
-        overview:
+        one: خودمختار رپورٹ
+        other: خودمختار رپورٹس
       international_development_fund:
-        one:
-        other:
+        one: عالمی ترقیاتی فنڈنگ
+        other: عالمی ترقیاتی فنڈنگ
       international_treaty:
-        one:
-        other:
-        overview:
+        one: عالمی معاہدہ
+        other: عالمی معاہدے
       maib_report:
-        one:
-        other:
+        one: میرین حادثے کی تفتیشی برانچ رپورٹ
+        other: میرین حادثے کی تفتیشی برانچ رپورٹس
       map:
         one: نقشہ
         other: نقشے
-        overview:
       medical_safety_alert:
-        one:
-        other:
+        one: ادویات اور طبی ڈیوائسز کے لیے انتباہات اور ری کالز
+        other: ادویات اور طبی ڈیوائسز کے لیے انتباہات اور ری کالز
       national:
-        one:
-        other:
+        one: قومی شماریاتی اعلان
+        other: قومی شماریاتی اعلانات
       national_statistics:
-        one: شماریات- قومی اعدادوشمار
-        other: شماریات- قومی اعدادوشمار
-        overview:
+        one: قومی شماریات
+        other: قومی شماریات
       national_statistics_announcement:
-        one:
-        other:
+        one: قومی شماریاتی اعلان
+        other: قومی شماریاتی اعلانات
       news_article:
-        one: نیوزآرٹیکل
-        other: نیوزآرٹیکلز
+        one: خبروں کا مضمون
+        other: خبروں کے مضامین
       news_story:
-        one: نیوز اسٹوری
-        other: نیوزاسٹوریز
+        one: خبروں کی کہانی
+        other: خبروں کی کہانیاں
       notice:
-        one:
-        other:
-        overview:
+        one: نوٹس
+        other: نوٹسز
       official:
-        one:
-        other:
+        one: سرکاری شماریات کا اعلان
+        other: سرکاری شماریات کے اعلانات
       official_statistics:
-        one: اعدادوشمار
-        other: اعدادو شمار
-        overview:
+        one: سرکاری شماریات
+        other: سرکاری شماریات
       official_statistics_announcement:
-        one:
-        other:
+        one: سرکاری شماریات کا اعلان
+        other: سرکاری شماریات کے اعلانات
       open_consultation:
-        one: جاری مشاورت
-        other: جاری مشاورت
-        overview:
+        one: آزاد مشاورت
+        other: آزاد مشاورت
       oral_statement:
-        one: پارلیمنٹ میں زبانی بیان
-        other: پارلیمنٹ میں زبانی بیانات
+        one: پارلیمان کے لیے زبانی بیان
+        other: پارلیمان کے لیے زبانی بیانات
       policy:
         one: پالیسی
         other: پالیسیاں
       policy_paper:
-        one: پالیسی پیپر
-        other: پالیسی پیپرز
-        overview:
+        one: پالیسی کا کاغذ
+        other: پالیسی کے کاغذات
       press_release:
         one: پریس ریلیز
         other: پریس ریلیزز
       promotional:
         one: تشہیری مواد
         other: تشہیری مواد
-        overview:
       publication:
-        one: مطبوعہ
-        other: مطبوعات
+        one: پبلیکیشن
+        other: پبلیکیشنز
       raib_report:
-        one:
-        other:
+        one: ریل حادثے کی تفتیشی برانچ رپورٹ
+        other: ریل حادثے کی تفتیشی برانچ رپورٹس
       regulation:
-        one:
-        other:
-        overview:
+        one: ضابطہ
+        other: ضابطے
       research:
-        one: تحقیق وتجزیہ
-        other: تحقیق وتجزیہ
-        overview:
+        one: تحقیق اور تجزیہ
+        other: تحقیق اور تجزیہ
       residential_property_tribunal_decision:
-        one:
-        other:
+        one: رہائشی پراپرٹی کے لیے عدالتی فیصلہ
+        other: رہائشی پراپرٹی کے لیے عدالتی فیصلے
       service_sign_in:
-        one:
-        other:
+        one: سروس سائن ان
+        other: سروس سائن ان
       service_standard_report:
-        one:
-        other:
+        one: سروس کے معیار کی رپورٹ
+        other: سروس کے معیار کی رپورٹس
       speaking_notes:
-        one: تقریری نوٹ
-        other: تقریری نوٹ
+        one: صوتی نوٹس
+        other: صوتی نوٹس
       speech:
         one: تقریر
         other: تقاریر
       standard:
-        one:
-        other:
-        overview:
+        one: معیار
+        other: معیارات
       statement_to_parliament:
-        one: پارلیمنٹ میں بیان
-        other: پارلیمنٹ میں بیانات
+        one: پارلیمان میں دیا گیا بیان
+        other: پارلیمان میں دیے گئے بیانات
       statistical_data_set:
         one: شماریاتی ڈیٹا سیٹ
-        other: " شماریاتی ڈیٹا سیٹس"
+        other: شماریاتی ڈیٹا سیٹس
       statistics_announcement:
-        one:
-        other:
+        one: شماریات کے اجراء کا اعلان
+        other: شماریات کے اجراء کا اعلانات
       statutory_guidance:
-        one:
-        other:
-        overview:
+        one: قانونی رہنمائی
+        other: قانونی رہنمائی
       take_part:
-        one:
-        other:
+        one: شرکت کریں
+        other: شرکت کریں
       tax_tribunal_decision:
-        one:
-        other:
+        one: ٹیکس اینڈ چانسری عدالتی فیصلہ
+        other: ٹیکس اینڈ چانسری عدالتی فیصلے
       transcript:
         one: ٹرانسکرپٹ
-        other: ٹرانسکرپٹس
+        other: ٹرنسکرپٹس
       transparency:
-        one: ٹرانسپیرنسی ڈیٹا
-        other: ٹرانسپیرنسی ڈیٹا
-        overview:
+        one: شفافیت کا ڈیٹا
+        other: شفافیت کا ڈیٹا
       utaac_decision:
-        one:
-        other:
+        one: انتظامی اپیلز کا عدالتی فیصلہ
+        other: انتظامی اپیلز کے عدالتی فیصلے
       world_location_news_article:
-        one: نیوزآرٹیکل
-        other: نیوزآرٹیکلز
+        one: خبروں کا مضمون
+        other: خبروں کے مضامین
       world_news_story:
-        one:
-        other:
+        one: دنیا کی خبروں کی کہانی
+        other: دنیا کی خبروں کی کہانیاں
       written_statement:
-        one: پارلیمنٹ میں تحریری بیان
-        other: پارلیمنٹ میں تحریری بیانات
-  corporate_information_page:
-    about_our_services_html:
-    corporate_information: کارپوریٹ معلومات
-    personal_information_charter_html: ہمارے %{link} واضح کرتے ہیں کہ ہم آپکی ذاتی معلومات کو کیسے استعمال کرتے ہیں
-    publication_scheme_html: 'ہماری معمول کے مطابق  شائع کردہ معلومات کی نوعیت  %{link} پرملاحظہ کیجئیے '
-    social_media_use_html: ہماری پالیسی  %{link} پر ملاحظہ کیجئیے
-    welsh_language_scheme_html: اشاعت کے باب میں ہمارے کمٹ منٹ %{link} میں ملاحظہ کیجئیے
-  email:
-    description_html:
-    subscribe_title:
-    unsubscribe_title:
-  fatality_notice:
-    alt_text:
-    field_of_operation:
-    operations_in:
-  get_involved:
-    active_blogs:
-    civil_service:
-    civil_service_quarterly:
-    closed:
-    closed_consultations:
-    closed_with_date:
-    closes:
-    closing_today:
-    closing_tomorrow:
-    days_left:
-    engage_with_gov:
-    fcdo_bloggers:
-    follow:
-    follow_paragraph:
-    gds_blog:
-    gov_past:
-    intro_paragraph:
-      body_html:
-      engage_with_government:
-      take_part:
-    join_ics:
-    make_donation:
-    more_ways:
-    neighbourhood_watch:
-    open_consultations:
-    page_heading:
-    page_title:
-    petition_paragraph:
-      body_html:
-      create_a_petition:
-    read_respond:
-    recent_outcomes:
-    recently_opened:
-    respond_to_consultations:
-    school_overseas:
-    search_all:
-    see_all_dept:
-    start_a_petition:
-    take_part:
-    take_part_suggestions:
-    your_views:
-  gone:
-    page_title:
-    published_in_error:
-    title:
-  guide:
-    pages_in_guide:
-    skip_to_contents:
-  html_publication:
-    print_meta_data:
-      available_at:
-      copyright:
-      isbn:
-      licence_html:
-      third_party:
-  i18n:
-    direction: rtl
-  language_names:
-    ar:
-    az:
-    be:
-    bg:
-    bn:
-    cs:
-    cy:
-    da:
-    de:
-    dr:
-    el:
-    en:
-    es:
-    es-419:
-    et:
-    fa:
-    fi:
-    fr:
-    gd:
-    gu:
-    he:
-    hi:
-    hr:
-    hu:
-    hy:
-    id:
-    is:
-    it:
-    ja:
-    ka:
-    kk:
-    ko:
-    lt:
-    lv:
-    ms:
-    mt:
-    ne:
-    nl:
-    'no':
-    pa:
-    pa-pk:
-    pl:
-    ps:
-    pt:
-    ro:
-    ru:
-    si:
-    sk:
-    sl:
-    so:
-    sq:
-    sr:
-    sv:
-    sw:
-    ta:
-    th:
-    tk:
-    tr:
-    uk:
-    ur: اردو
-    uz:
-    vi:
-    yi:
-    zh:
-    zh-hk:
-    zh-tw:
-  multi_page:
-    next_page:
-    previous_page:
-    print_entire_guide:
+        one: پالیمان کے لیے تحریری بیان
+        other: پالیمان کے لیے تحریری بیانات
+    coming_soon: یہ دستاویز درج ذیل کو شائع کی جائے گی
+    contents: مشمولات
+    metadata:
+      published: شائع کردہ
+      updated: اپ ڈیٹ کردہ
   publication:
-    details:
     documents:
       one: دستاویز
       other: دستاویزات
+    details: تفصیلات
+  brexit:
+    business_link: بزنسز کے لیے Brexit کی رہنمائی
+    citizen_link: افراد اور اہل خانہ کے لیے Brexit کی رہنمائی
+    heading_prefix: یہاں فرق ہے
+  common:
+    last_updated:
+    visit: 'ملاحظہ کریں:'
+  components:
+    figure:
+      image_credit: 'تصویری کریڈٹ: %{credit}'
+    published_dates:
+      hide_all_updates: تمام اپ ڈیٹس کو پوشیدہ کریں
+      last_updated: آخری اپ ڈیٹ کردہ %{date}
+      published: شائع کردہ %{date}
+      see_all_updates: تمام اپ ڈیٹس دیکھیں
+      show_all_updates: تمام اپ ڈیٹس دکھائیں
+    publisher_metadata:
+      collections:
+      from:
+      hide_all: تمام کو پوشیدہ کریں
+      show_all: تمام دکھائیں
+    save_this_page:
+      add_page_button: اپنے محفوظ کردہ صفحات پر شامل کریں
+      confirmations:
+        page_removed:
+          message: آپ کو اپنے محفوظ کردہ صفحات سے ہٹا دیا گیا ہے
+        page_saved:
+          message: آپ نے اپنے محفوظ کردہ صفحات شامل کر لیے ہیں
+      page_not_saved_heading: اس صفحے کو محفوظ کر لیں تاکہ بعد میں آپ اس پر واپس آ
+        سکیں
+      page_was_saved_heading: آپ نے یہ صفحہ محفوظ کر لیا ہے
+      remove_page_button: اپنے محفوظ کردہ صفحات سے ہٹائیں
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">اپنے
+        محفوظ کردہ صفحات دیکھیں۔</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">سائن
+        ان</a> اپنے محفوظ کردہ صفحات دیکھنے کے لیے.
+    share_links:
+      share_this_page: اس صفحے کو شیئر کریں
+  consultation:
+    and: اور
+    another_website_html: یہ مشاورت %{closed} <a href="%{url}">ایک اور ویب سائٹ پر
+      ہوئی تھی</a>
+    at: پر
+    closes: یہ درج ذیل پر بند ہوتی ہے
+    closes_at: یہ مشاورت درج ذیل پر بند ہوتی ہے
+    complete_a: مکمل کریں
+    description: مشاورت کی تفصیل
+    detail_of_feedback_received: وصول کردہ فیڈ بیک کی تفصیل
+    detail_of_outcome: نتیجے کی تفصیل
+    documents: دستاویزات
+    download_outcome: مکمل نتیجہ ڈاؤن لوڈ کریں
+    either: کوئی بھی ایک
+    email_to: 'ای میل کریں از:'
+    feedback_received: فیڈ بیک موصول ہو گیا
+    is_being: ہو رہا ہے
+    not_open_yet: یہ مشاورت ابھی تک کھلی نہیں ہے
+    'on':
+    opens: یہ مشاورت درج ذیل پر کھلتی ہے
+    original_consultation: اصل مشاورت
+    ran_from: اس مشاورت میں درج ذیل ختم ہو گیا
+    respond_online: آن لائن جواب دیں
+    'true': درست
+    visit_soon: اس عوامی&nbsp;فیڈ بیک کا نتیجہ ڈاؤن لوڈ کرنے کے لیے اس صفحے کا دوبارہ
+      جلد دورہ کریں۔
+    was: تھا
+    ways_to_respond: جواب دینے کے طریقے
+    write_to: 'لکھیں بنام:'
+  contact:
+    email: ای میل
+    find_call_charges: کال کے چارجز کے بارے میں جانیں
+    online: آن لائن
+    phone: فون
+    webchat: Webchat
+  corporate_information_page:
+    about_our_services_html: "%{link} کو جانیے۔"
+    corporate_information: کارپوریٹ معلومات
+    personal_information_charter_html: ہماری %{link} بیان کرتی ہے کہ ہم آپ کی ذاتی
+      معلومات سے کیسے نمٹتے ہیں۔
+    publication_scheme_html: ہماری %{link} میں ہماری جانب سے معمول کے حساب سے شائع
+      کی جانے والی معلومات کی اقسام کے بارے میں پڑھیں۔
+    social_media_use_html: "%{link} پر ہماری پالیسی کو پڑھیں۔"
+    welsh_language_scheme_html: "%{link} کے ساتھ ہماری وابستگی کے بارے میں جانیں۔"
+  fatality_notice:
+    alt_text: وزارت دفاع کا کریسنٹ
+    field_of_operation: کارروائی کی فیلڈ
+    operations_in: "%{location} میں کارروائیاں"
+  gone:
+    page_title: مزید دستیاب نہیں
+    published_in_error: اس صفحے سے معلومات ہٹا دی گئی ہیں کیونکہ اسے نقص کے ساتھ شائع
+      کیا گیا تھا۔
+    title: جس صفحے کی آپ کو تلاش ہے وہ مزید دستیاب نہیں ہے
+  guide:
+    pages_in_guide: اس رہنما میں موجود صفحات
+    skip_to_contents: چھوڑ کر رہنما کے مشمولات پر جائیں
+  html_publication:
+    print_meta_data:
+      available_at: یہ پبلیکیشن %{url} پر دستیاب ہے
+      copyright: "© Crown copyright %{year}"
+      isbn: 'ISBN:'
+      licence_html: 'یہ پبلیکیشن اوپن گورنمنٹ لائسنس v3.0 کے تحت لائسنس یافتہ ہے سوائے
+        اس کے جو بصورت دیگر بیان کردہ ہے۔ لائسنس دیکھنے کے لیے، <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
+        کو ملاحظہ کریں یا معلوماتی پالیسی کی ٹیم، قومی آرکائیوز، کیو، لندن TW9 4DUپر
+        پیغام بھیجیں، یا یہاں ای میل کریں: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: جہاں ہم کسی فریق ثالث کی کاپی رائٹ معلومات کی شناخت کی ہو آپ کو
+        متعلقہ کاپی رائٹ ہولڈرز سے اجازت لینے کی ضرورت ہو گی۔
+  i18n:
+    direction:
+  language_names:
+    ur: اردو
+  multi_page:
+    next_page: اگلا
+    previous_page: گزشتہ
+    print_entire_guide: پوری رہنمائی کا پرنٹ لیں
   service_sign_in:
-    continue:
+    continue: جاری رکھیں
     error:
-      option:
-      title:
+      option: براہ کرم کوئی اختیار منتخب کریں
+      title: آپ نے کوئی اختیار منتخب نہیں کیا
   shared:
-    historically_political:
+    historically_political: اسے %{government} کے تحت شائع کیا گیا تھا
     webchat:
-      available:
-      busy:
-      closed:
-      speak_to_adviser:
-      technical_problem:
+      available: مشاورت کار چیٹ کے لیے دستیاب ہیں۔
+      busy: webchat کے تمام مشاورت کار فی الوقت مصروف ہیں۔
+      closed: Webchat فی الوقت بند ہے۔
+      speak_to_adviser: ابھی کسی مشاورت کار سے بات کریں
+      technical_problem: تکنیکی مسائل کی وجہ سے Webchat فی الوقت دستیاب نہیں ہے۔
   specialist_document:
-    pdo_alt_text:
-    pgi_alt_text:
-    tsg_alt_text:
+    pdo_alt_text: سکیم کا لوگو متعین کردہ اصل UK سے محفوظ شدہ (Designated Origin UK
+      Protected) کے ساتھ سیاہ اسٹام پر مشتمل ہے
+    pgi_alt_text: سکیم کا لوگو جغرافیائی اصل UK سے محفوظ شدہ (Geographic Origin UK
+      Protected) کے ساتھ سیاہ اسٹام پر مشتمل ہے
+    tsg_alt_text: سکیم کا لوگو روایتی خصوصیت UK سے محفوظ شدہ (Traditional Speciality
+      UK Protected) کے ساتھ سیاہ اسٹام پر مشتمل ہے
   speech:
-    delivered_on:
-    location:
-    written_on:
+    delivered_on: ترسیل کردہ بتاریخ
+    location: مقام
+    written_on: تحریر کردہ بتاریخ
   statistics_announcement:
-    cancellation_date:
-    cancelled:
-    changed_date:
-    forthcoming:
-    previous_date:
-    proposed_date:
-    reason_for_change:
-    release_date:
+    cancellation_date: منسوخی کی تاریخ
+    cancelled: شماریات کے اجراء کو منسوخ کر دیا گیا
+    changed_date: اجراء کی تاریخ تبدیل ہو گئی ہے
+    forthcoming: یہ شماریات جاری کی جائیں گے
+    previous_date: گزشتہ تاریخ
+    proposed_date: تجویز کردہ اجراء
+    reason_for_change: تبدیلی کی وجہ
+    release_date: اجراء کی تاریخ
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts_html:
-      avoid_all_but_essential_travel_to_whole_country_html:
-      avoid_all_travel_to_parts_html:
-      avoid_all_travel_to_whole_country_html:
-    context:
-    still_current_at:
-    summary:
-    updated:
+      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth
+        Office">FCO</abbr> سوائے ملک کے کچھ حصوں میں ضروری سفر کرنے کے ہر قسم کے سفر
+        کے خلاف مشاورت فراہم کرتا ہے۔
+      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth
+        Office">FCO</abbr> سوائے پورے ملک میں ضروری سفر کرنے کے ہر قسم کے سفر کے خلاف
+        مشاورت فراہم کرتا ہے۔
+      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr>
+        ملک کے کچھ حصوں میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr>
+        پورے ملک میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+    context: غیر ملکی سفر کی مشاورت
+    coronavirus_warning:
+      content_html: "<p class=\"govuk-body\">\n اپنے رہائشی علاقے کے موجودہ COVID-19
+        اصولوں پر عمل کریں: <a href=\"/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do\">England</a>,
+        <a href=\"https://www.gov.scot/coronavirus-covid-19/\">Scotland</a>, <a href=\"https://gov.wales/coronavirus-travel\">Wales</a>
+        اور <a href=\"https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you\">Northern
+        Ireland</a>.\n</p>\n<p class=\"govuk-body\">/\n    COVID کی نئے تغیرات کے
+        برطانیہ میں داخلے کو روکنے کے لیے، آپ کو <a href=\"/guidance/red-amber-and-green-list-rules-for-entering-england\">زرد
+        یا سرخ فہرست میں شامل کردہ ممالک</a> کا سفر نہیں کرنا چاہیئے \n</p>\n<p class=\"govuk-body\">\n
+        \ کاؤنٹی میں خطرات کو سمجھنے کے لیے <a href=\"/guidance/travel-advice-novel-coronavirus\">ایف
+        سی کی ڈگری۔ کی سروس مشاورت</a> پر عمل کریں۔\n</p>\n<p class=\"govuk-body\">\nجب
+        آپ واپس آئیں، <a href=\"/uk-border-control\">بیرون ملک سے UK میں داخل ہوں</a>
+        کے اصولوں پر عمال کریں (سوائے آئرلینڈ کے)\n</p>\n"
+      text_assistive: اہم
+      title: کورونا وائرس (COVID-19) سفر
+    still_current_at: ابھی تک حالیہ ہے از
+    summary: خلاصہ
+    updated: اپ ڈیٹ کردہ
   unpublishing:
-    page_title:
-    summary:
-    title:
+    page_title: مزید دستیاب نہیں
+    summary: اس صفحے سے معلومات ہٹا دی گئی ہیں کیونکہ اسے نقص کے ساتھ شائع کیا گیا
+      تھا۔
+    title: جس صفحے کی آپ کو تلاش ہے وہ مزید دستیاب نہیں ہے
   working_group:
-    contact_details:
-    policies:
+    contact_details: رابطے کی تفصیلات
+    policies: پالیسیاں

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -234,8 +234,12 @@ ur:
       other: دستاویزات
     details: تفصیلات
   brexit:
-    business_link: بزنسز کے لیے Brexit کی رہنمائی
-    citizen_link: افراد اور اہل خانہ کے لیے Brexit کی رہنمائی
+    business_link:
+      path: "/guidance/brexit-guidance-for-businesses"
+      text: بزنسز کے لیے Brexit کی رہنمائی
+    citizen_link:
+      path: "/guidance/brexit-guidance-for-individuals-and-families"
+      text: افراد اور اہل خانہ کے لیے Brexit کی رہنمائی
     heading_prefix: یہاں فرق ہے
   common:
     last_updated:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -1,5 +1,83 @@
+---
 ur:
+  brexit:
+    business_link:
+      path: "/guidance/brexit-guidance-for-businesses"
+      text: بزنسز کے لیے Brexit کی رہنمائی
+    citizen_link:
+      path: "/guidance/brexit-guidance-for-individuals-and-families"
+      text: افراد اور اہل خانہ کے لیے Brexit کی رہنمائی
+    heading_prefix: یہاں فرق ہے
+  common:
+    last_updated:
+    visit: 'ملاحظہ کریں:'
+  components:
+    figure:
+      image_credit: 'تصویری کریڈٹ: %{credit}'
+    published_dates:
+      hide_all_updates: تمام اپ ڈیٹس کو پوشیدہ کریں
+      last_updated: آخری اپ ڈیٹ کردہ %{date}
+      published: شائع کردہ %{date}
+      see_all_updates: تمام اپ ڈیٹس دیکھیں
+      show_all_updates: تمام اپ ڈیٹس دکھائیں
+    publisher_metadata:
+      collections:
+      from:
+      hide_all: تمام کو پوشیدہ کریں
+      show_all: تمام دکھائیں
+    save_this_page:
+      add_page_button: اپنے محفوظ کردہ صفحات پر شامل کریں
+      confirmations:
+        page_removed:
+          message: آپ کو اپنے محفوظ کردہ صفحات سے ہٹا دیا گیا ہے
+        page_saved:
+          message: آپ نے اپنے محفوظ کردہ صفحات شامل کر لیے ہیں
+      page_not_saved_heading: اس صفحے کو محفوظ کر لیں تاکہ بعد میں آپ اس پر واپس آ سکیں
+      page_was_saved_heading: آپ نے یہ صفحہ محفوظ کر لیا ہے
+      remove_page_button: اپنے محفوظ کردہ صفحات سے ہٹائیں
+      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">اپنے محفوظ کردہ صفحات دیکھیں۔</a>
+      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">سائن ان</a> اپنے محفوظ کردہ صفحات دیکھنے کے لیے.
+    share_links:
+      share_this_page: اس صفحے کو شیئر کریں
+  consultation:
+    and: اور
+    another_website_html: یہ مشاورت %{closed} <a href="%{url}">ایک اور ویب سائٹ پر ہوئی تھی</a>
+    at: پر
+    closes: یہ درج ذیل پر بند ہوتی ہے
+    closes_at: یہ مشاورت درج ذیل پر بند ہوتی ہے
+    complete_a: مکمل کریں
+    description: مشاورت کی تفصیل
+    detail_of_feedback_received: وصول کردہ فیڈ بیک کی تفصیل
+    detail_of_outcome: نتیجے کی تفصیل
+    documents: دستاویزات
+    download_outcome: مکمل نتیجہ ڈاؤن لوڈ کریں
+    either: کوئی بھی ایک
+    email_to: 'ای میل کریں از:'
+    feedback_received: فیڈ بیک موصول ہو گیا
+    is_being: ہو رہا ہے
+    not_open_yet: یہ مشاورت ابھی تک کھلی نہیں ہے
+    'on':
+    opens: یہ مشاورت درج ذیل پر کھلتی ہے
+    original_consultation: اصل مشاورت
+    ran_from: اس مشاورت میں درج ذیل ختم ہو گیا
+    respond_online: آن لائن جواب دیں
+    'true': درست
+    visit_soon: اس عوامی&nbsp;فیڈ بیک کا نتیجہ ڈاؤن لوڈ کرنے کے لیے اس صفحے کا دوبارہ جلد دورہ کریں۔
+    was: تھا
+    ways_to_respond: جواب دینے کے طریقے
+    write_to: 'لکھیں بنام:'
+  contact:
+    email: ای میل
+    find_call_charges: کال کے چارجز کے بارے میں جانیں
+    online: آن لائن
+    phone: فون
+    webchat: Webchat
   content_item:
+    coming_soon: یہ دستاویز درج ذیل کو شائع کی جائے گی
+    contents: مشمولات
+    metadata:
+      published: شائع کردہ
+      updated: اپ ڈیٹ کردہ
     schema_name:
       aaib_report:
         one: فضائی حادثات کی تفتیشی برانچ رپورٹ
@@ -223,100 +301,11 @@ ur:
       written_statement:
         one: پالیمان کے لیے تحریری بیان
         other: پالیمان کے لیے تحریری بیانات
-    coming_soon: یہ دستاویز درج ذیل کو شائع کی جائے گی
-    contents: مشمولات
-    metadata:
-      published: شائع کردہ
-      updated: اپ ڈیٹ کردہ
-  publication:
-    documents:
-      one: دستاویز
-      other: دستاویزات
-    details: تفصیلات
-  brexit:
-    business_link:
-      path: "/guidance/brexit-guidance-for-businesses"
-      text: بزنسز کے لیے Brexit کی رہنمائی
-    citizen_link:
-      path: "/guidance/brexit-guidance-for-individuals-and-families"
-      text: افراد اور اہل خانہ کے لیے Brexit کی رہنمائی
-    heading_prefix: یہاں فرق ہے
-  common:
-    last_updated:
-    visit: 'ملاحظہ کریں:'
-  components:
-    figure:
-      image_credit: 'تصویری کریڈٹ: %{credit}'
-    published_dates:
-      hide_all_updates: تمام اپ ڈیٹس کو پوشیدہ کریں
-      last_updated: آخری اپ ڈیٹ کردہ %{date}
-      published: شائع کردہ %{date}
-      see_all_updates: تمام اپ ڈیٹس دیکھیں
-      show_all_updates: تمام اپ ڈیٹس دکھائیں
-    publisher_metadata:
-      collections:
-      from:
-      hide_all: تمام کو پوشیدہ کریں
-      show_all: تمام دکھائیں
-    save_this_page:
-      add_page_button: اپنے محفوظ کردہ صفحات پر شامل کریں
-      confirmations:
-        page_removed:
-          message: آپ کو اپنے محفوظ کردہ صفحات سے ہٹا دیا گیا ہے
-        page_saved:
-          message: آپ نے اپنے محفوظ کردہ صفحات شامل کر لیے ہیں
-      page_not_saved_heading: اس صفحے کو محفوظ کر لیں تاکہ بعد میں آپ اس پر واپس آ
-        سکیں
-      page_was_saved_heading: آپ نے یہ صفحہ محفوظ کر لیا ہے
-      remove_page_button: اپنے محفوظ کردہ صفحات سے ہٹائیں
-      see_saved_pages_signed_in: <a href="%{link}" class="govuk-link %{additional_class}">اپنے
-        محفوظ کردہ صفحات دیکھیں۔</a>
-      see_saved_pages_signed_out: <a href="%{link}" class="govuk-link %{additional_class}">سائن
-        ان</a> اپنے محفوظ کردہ صفحات دیکھنے کے لیے.
-    share_links:
-      share_this_page: اس صفحے کو شیئر کریں
-  consultation:
-    and: اور
-    another_website_html: یہ مشاورت %{closed} <a href="%{url}">ایک اور ویب سائٹ پر
-      ہوئی تھی</a>
-    at: پر
-    closes: یہ درج ذیل پر بند ہوتی ہے
-    closes_at: یہ مشاورت درج ذیل پر بند ہوتی ہے
-    complete_a: مکمل کریں
-    description: مشاورت کی تفصیل
-    detail_of_feedback_received: وصول کردہ فیڈ بیک کی تفصیل
-    detail_of_outcome: نتیجے کی تفصیل
-    documents: دستاویزات
-    download_outcome: مکمل نتیجہ ڈاؤن لوڈ کریں
-    either: کوئی بھی ایک
-    email_to: 'ای میل کریں از:'
-    feedback_received: فیڈ بیک موصول ہو گیا
-    is_being: ہو رہا ہے
-    not_open_yet: یہ مشاورت ابھی تک کھلی نہیں ہے
-    'on':
-    opens: یہ مشاورت درج ذیل پر کھلتی ہے
-    original_consultation: اصل مشاورت
-    ran_from: اس مشاورت میں درج ذیل ختم ہو گیا
-    respond_online: آن لائن جواب دیں
-    'true': درست
-    visit_soon: اس عوامی&nbsp;فیڈ بیک کا نتیجہ ڈاؤن لوڈ کرنے کے لیے اس صفحے کا دوبارہ
-      جلد دورہ کریں۔
-    was: تھا
-    ways_to_respond: جواب دینے کے طریقے
-    write_to: 'لکھیں بنام:'
-  contact:
-    email: ای میل
-    find_call_charges: کال کے چارجز کے بارے میں جانیں
-    online: آن لائن
-    phone: فون
-    webchat: Webchat
   corporate_information_page:
     about_our_services_html: "%{link} کو جانیے۔"
     corporate_information: کارپوریٹ معلومات
-    personal_information_charter_html: ہماری %{link} بیان کرتی ہے کہ ہم آپ کی ذاتی
-      معلومات سے کیسے نمٹتے ہیں۔
-    publication_scheme_html: ہماری %{link} میں ہماری جانب سے معمول کے حساب سے شائع
-      کی جانے والی معلومات کی اقسام کے بارے میں پڑھیں۔
+    personal_information_charter_html: ہماری %{link} بیان کرتی ہے کہ ہم آپ کی ذاتی معلومات سے کیسے نمٹتے ہیں۔
+    publication_scheme_html: ہماری %{link} میں ہماری جانب سے معمول کے حساب سے شائع کی جانے والی معلومات کی اقسام کے بارے میں پڑھیں۔
     social_media_use_html: "%{link} پر ہماری پالیسی کو پڑھیں۔"
     welsh_language_scheme_html: "%{link} کے ساتھ ہماری وابستگی کے بارے میں جانیں۔"
   fatality_notice:
@@ -325,8 +314,7 @@ ur:
     operations_in: "%{location} میں کارروائیاں"
   gone:
     page_title: مزید دستیاب نہیں
-    published_in_error: اس صفحے سے معلومات ہٹا دی گئی ہیں کیونکہ اسے نقص کے ساتھ شائع
-      کیا گیا تھا۔
+    published_in_error: اس صفحے سے معلومات ہٹا دی گئی ہیں کیونکہ اسے نقص کے ساتھ شائع کیا گیا تھا۔
     title: جس صفحے کی آپ کو تلاش ہے وہ مزید دستیاب نہیں ہے
   guide:
     pages_in_guide: اس رہنما میں موجود صفحات
@@ -336,12 +324,8 @@ ur:
       available_at: یہ پبلیکیشن %{url} پر دستیاب ہے
       copyright: "© Crown copyright %{year}"
       isbn: 'ISBN:'
-      licence_html: 'یہ پبلیکیشن اوپن گورنمنٹ لائسنس v3.0 کے تحت لائسنس یافتہ ہے سوائے
-        اس کے جو بصورت دیگر بیان کردہ ہے۔ لائسنس دیکھنے کے لیے، <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a>
-        کو ملاحظہ کریں یا معلوماتی پالیسی کی ٹیم، قومی آرکائیوز، کیو، لندن TW9 4DUپر
-        پیغام بھیجیں، یا یہاں ای میل کریں: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
-      third_party: جہاں ہم کسی فریق ثالث کی کاپی رائٹ معلومات کی شناخت کی ہو آپ کو
-        متعلقہ کاپی رائٹ ہولڈرز سے اجازت لینے کی ضرورت ہو گی۔
+      licence_html: 'یہ پبلیکیشن اوپن گورنمنٹ لائسنس v3.0 کے تحت لائسنس یافتہ ہے سوائے اس کے جو بصورت دیگر بیان کردہ ہے۔ لائسنس دیکھنے کے لیے، <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a> کو ملاحظہ کریں یا معلوماتی پالیسی کی ٹیم، قومی آرکائیوز، کیو، لندن TW9 4DUپر پیغام بھیجیں، یا یہاں ای میل کریں: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
+      third_party: جہاں ہم کسی فریق ثالث کی کاپی رائٹ معلومات کی شناخت کی ہو آپ کو متعلقہ کاپی رائٹ ہولڈرز سے اجازت لینے کی ضرورت ہو گی۔
   i18n:
     direction:
   language_names:
@@ -350,6 +334,11 @@ ur:
     next_page: اگلا
     previous_page: گزشتہ
     print_entire_guide: پوری رہنمائی کا پرنٹ لیں
+  publication:
+    details: تفصیلات
+    documents:
+      one: دستاویز
+      other: دستاویزات
   service_sign_in:
     continue: جاری رکھیں
     error:
@@ -364,12 +353,9 @@ ur:
       speak_to_adviser: ابھی کسی مشاورت کار سے بات کریں
       technical_problem: تکنیکی مسائل کی وجہ سے Webchat فی الوقت دستیاب نہیں ہے۔
   specialist_document:
-    pdo_alt_text: سکیم کا لوگو متعین کردہ اصل UK سے محفوظ شدہ (Designated Origin UK
-      Protected) کے ساتھ سیاہ اسٹام پر مشتمل ہے
-    pgi_alt_text: سکیم کا لوگو جغرافیائی اصل UK سے محفوظ شدہ (Geographic Origin UK
-      Protected) کے ساتھ سیاہ اسٹام پر مشتمل ہے
-    tsg_alt_text: سکیم کا لوگو روایتی خصوصیت UK سے محفوظ شدہ (Traditional Speciality
-      UK Protected) کے ساتھ سیاہ اسٹام پر مشتمل ہے
+    pdo_alt_text: سکیم کا لوگو متعین کردہ اصل UK سے محفوظ شدہ (Designated Origin UK Protected) کے ساتھ سیاہ اسٹام پر مشتمل ہے
+    pgi_alt_text: سکیم کا لوگو جغرافیائی اصل UK سے محفوظ شدہ (Geographic Origin UK Protected) کے ساتھ سیاہ اسٹام پر مشتمل ہے
+    tsg_alt_text: سکیم کا لوگو روایتی خصوصیت UK سے محفوظ شدہ (Traditional Speciality UK Protected) کے ساتھ سیاہ اسٹام پر مشتمل ہے
   speech:
     delivered_on: ترسیل کردہ بتاریخ
     location: مقام
@@ -385,29 +371,13 @@ ur:
     release_date: اجراء کی تاریخ
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth
-        Office">FCO</abbr> سوائے ملک کے کچھ حصوں میں ضروری سفر کرنے کے ہر قسم کے سفر
-        کے خلاف مشاورت فراہم کرتا ہے۔
-      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth
-        Office">FCO</abbr> سوائے پورے ملک میں ضروری سفر کرنے کے ہر قسم کے سفر کے خلاف
-        مشاورت فراہم کرتا ہے۔
-      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr>
-        ملک کے کچھ حصوں میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
-      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr>
-        پورے ملک میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+      avoid_all_but_essential_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr> سوائے ملک کے کچھ حصوں میں ضروری سفر کرنے کے ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+      avoid_all_but_essential_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr> سوائے پورے ملک میں ضروری سفر کرنے کے ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+      avoid_all_travel_to_parts: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ملک کے کچھ حصوں میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
+      avoid_all_travel_to_whole_country: <abbr title="Foreign and Commonwealth Office">FCO</abbr> پورے ملک میں ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔
     context: غیر ملکی سفر کی مشاورت
     coronavirus_warning:
-      content_html: "<p class=\"govuk-body\">\n اپنے رہائشی علاقے کے موجودہ COVID-19
-        اصولوں پر عمل کریں: <a href=\"/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do\">England</a>,
-        <a href=\"https://www.gov.scot/coronavirus-covid-19/\">Scotland</a>, <a href=\"https://gov.wales/coronavirus-travel\">Wales</a>
-        اور <a href=\"https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you\">Northern
-        Ireland</a>.\n</p>\n<p class=\"govuk-body\">/\n    COVID کی نئے تغیرات کے
-        برطانیہ میں داخلے کو روکنے کے لیے، آپ کو <a href=\"/guidance/red-amber-and-green-list-rules-for-entering-england\">زرد
-        یا سرخ فہرست میں شامل کردہ ممالک</a> کا سفر نہیں کرنا چاہیئے \n</p>\n<p class=\"govuk-body\">\n
-        \ کاؤنٹی میں خطرات کو سمجھنے کے لیے <a href=\"/guidance/travel-advice-novel-coronavirus\">ایف
-        سی کی ڈگری۔ کی سروس مشاورت</a> پر عمل کریں۔\n</p>\n<p class=\"govuk-body\">\nجب
-        آپ واپس آئیں، <a href=\"/uk-border-control\">بیرون ملک سے UK میں داخل ہوں</a>
-        کے اصولوں پر عمال کریں (سوائے آئرلینڈ کے)\n</p>\n"
+      content_html: "<p class=\"govuk-body\">\n اپنے رہائشی علاقے کے موجودہ COVID-19 اصولوں پر عمل کریں: <a href=\"/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do\">England</a>, <a href=\"https://www.gov.scot/coronavirus-covid-19/\">Scotland</a>, <a href=\"https://gov.wales/coronavirus-travel\">Wales</a> اور <a href=\"https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-guidance-what-restrictions-mean-you\">Northern Ireland</a>.\n</p>\n<p class=\"govuk-body\">/\n    COVID کی نئے تغیرات کے برطانیہ میں داخلے کو روکنے کے لیے، آپ کو <a href=\"/guidance/red-amber-and-green-list-rules-for-entering-england\">زرد یا سرخ فہرست میں شامل کردہ ممالک</a> کا سفر نہیں کرنا چاہیئے \n</p>\n<p class=\"govuk-body\">\n  کاؤنٹی میں خطرات کو سمجھنے کے لیے <a href=\"/guidance/travel-advice-novel-coronavirus\">ایف سی کی ڈگری۔ کی سروس مشاورت</a> پر عمل کریں۔\n</p>\n<p class=\"govuk-body\">\nجب آپ واپس آئیں، <a href=\"/uk-border-control\">بیرون ملک سے UK میں داخل ہوں</a> کے اصولوں پر عمال کریں (سوائے آئرلینڈ کے)\n</p>\n"
       text_assistive: اہم
       title: کورونا وائرس (COVID-19) سفر
     still_current_at: ابھی تک حالیہ ہے از
@@ -415,8 +385,7 @@ ur:
     updated: اپ ڈیٹ کردہ
   unpublishing:
     page_title: مزید دستیاب نہیں
-    summary: اس صفحے سے معلومات ہٹا دی گئی ہیں کیونکہ اسے نقص کے ساتھ شائع کیا گیا
-      تھا۔
+    summary: اس صفحے سے معلومات ہٹا دی گئی ہیں کیونکہ اسے نقص کے ساتھ شائع کیا گیا تھا۔
     title: جس صفحے کی آپ کو تلاش ہے وہ مزید دستیاب نہیں ہے
   working_group:
     contact_details: رابطے کی تفصیلات

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -324,12 +324,10 @@ uz:
     field_of_operation: Фаолият соҳаси
     operations_in: "%{location} да ишлаш"
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -335,6 +335,7 @@ uz:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -335,6 +335,7 @@ vi:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -324,12 +324,10 @@ vi:
     field_of_operation: Lĩnh vực hoạt động
     operations_in: Hoạt động ở %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -335,6 +335,7 @@ yi:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -324,12 +324,10 @@ yi:
     field_of_operation:
     operations_in:
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -335,6 +335,7 @@ zh-hk:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -324,12 +324,10 @@ zh-hk:
     field_of_operation: 行動領域
     operations_in: 行動位置 %{location}
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -324,12 +324,10 @@ zh-tw:
     field_of_operation: 經營領域
     operations_in: 在 %{location} 的領域
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -335,6 +335,7 @@ zh-tw:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -335,6 +335,7 @@ zh:
     engage_with_gov:
     fcdo_bloggers:
     follow:
+    follow_links:
     follow_paragraph:
     gds_blog:
     gov_past:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -324,12 +324,10 @@ zh:
     field_of_operation: 经营领域
     operations_in: 在 %{location} 经营
   get_involved:
-    active_blogs:
     civil_service:
     civil_service_quarterly:
     closed:
     closed_consultations:
-    closed_with_date:
     closes:
     closing_today:
     closing_tomorrow:


### PR DESCRIPTION
These languages were originally missed out from the supplier (ASP) and so this PR imports them.

Original import PR: https://github.com/alphagov/government-frontend/pull/2285

More info in the commits ->

Trello:
https://trello.com/c/Xz78vNR4/2757-import-newly-sourced-translations-into-locale-files-5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
