### PR TITLE
Add notification button to detailed guide template

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -135,7 +135,7 @@ private
     end
 
     # use these and `@content_item.base_path` in the template
-    @notification_button_visible = in_single_page_notifications_trial?
+    @notification_button_visible = in_single_page_notifications_trial? && !@content_item.brexit_child_taxon
     @include_single_page_notification_button_js = account_session_header.present?
 
     request.variant = :print if params[:variant] == "print"
@@ -216,6 +216,9 @@ private
     %w[
       /government/publications/open-standards-for-government
       /government/publications/identity-proofing-and-verification-of-an-individual
+      /guidance/travel-to-england-from-another-country-during-coronavirus-covid-19
+      /guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do
+      /government/publications/face-coverings-when-to-wear-one-and-how-to-make-your-own
     ].include? @content_item.base_path
   end
 end

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -37,6 +37,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' unless brexit_child_taxon %>
+
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
@@ -65,8 +66,16 @@
         <%= render 'components/published-dates', {
             published: @content_item.published,
             last_updated: @content_item.updated,
-            history: @content_item.history
+            history: @content_item.history,
+            margin_bottom: 3,
           } unless brexit_child_taxon %>
+
+          <%= render 'govuk_publishing_components/components/single_page_notification_button', {
+            base_path: @content_item.base_path,
+            js_enhancement: @include_single_page_notification_button_js,
+            button_location: "bottom",
+            margin_bottom: 0,
+          } if @notification_button_visible %>
       </div>
     <% end %>
     <%= render "govuk_publishing_components/components/print_link", {

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -18,12 +18,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
-<%= render 'govuk_publishing_components/components/single_page_notification_button', {
-  base_path: @content_item.base_path,
-  js_enhancement: @include_single_page_notification_button_js,
-  margin_bottom: 6,
-  button_location: "top",
-} if @notification_button_visible %>
+
 <%= render 'shared/history_notice', content_item: @content_item %>
 
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -16,3 +16,10 @@
     </div>
   </div>
 </div>
+
+<%= render 'govuk_publishing_components/components/single_page_notification_button', {
+  base_path: @content_item.base_path,
+  js_enhancement: @include_single_page_notification_button_js,
+  margin_bottom: 6,
+  button_location: "top",
+} if @notification_button_visible %>


### PR DESCRIPTION
Based on feedback we received following our original rollout of the single page notification button to a couple of pages, the GOVUK Accounts team are moving forward with adding the single page notification button to a few additional pages. 

Some of these pages are `detailed_guide` pages rather than `publication`s. 
This adds the button to the `detailed_guide` template, and adds the paths of the new pages to the list in `content_items_controller.rb`.


https://trello.com/c/GHkbMziw/1172-enable-single-page-notifications-on-more-pages

https://trello.com/c/fGfa64jD


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
