### PR TITLE
Bump the components gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,7 @@ GEM
     govuk_personalisation (0.11.0)
       plek (>= 1.9.0)
       rails (~> 6)
-    govuk_publishing_components (27.18.0)
+    govuk_publishing_components (27.19.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Dependabot hasn't spotted this yet and we need the change to the contextual sidebar rolled out.

what I did:

pulled main on government-frontend
ran bundle update govuk_publishing_components
pushed the changes