### PR TITLE
Add 'already subscribed' email flash banner

### DIFF
--- a/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
+++ b/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
@@ -18,4 +18,14 @@
       } %>
     </div>
   </div>
+<% elsif @account_flash.include?("email-subscribe-already-subscribed") %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-3">
+      <%= render "govuk_publishing_components/components/success_alert", {
+        message: sanitize(t("email.already_subscribed_title")),
+        description: sanitize(t("email.description_html")),
+        margin_bottom: 0,
+      } %>
+    </div>
+  </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -296,6 +296,7 @@ en:
     description_html: <p class="govuk-body">Go to your GOV.UK account to <a class="govuk-link govuk-notification-banner__link" href="/email/manage">see and manage all your GOV.UK email subscriptions</a>.</p>
     subscribe_title: You’ve subscribed to emails about this page
     unsubscribe_title: You’ve unsubscribed from emails about this page
+    already_subscribed_title: You’re already getting emails about this page
   fatality_notice:
     alt_text: Ministry of Defence crest
     field_of_operation: Field of operation

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -389,6 +389,14 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert response.body.include?("unsubscribed from emails about this page")
   end
 
+  test "displays the already subscribed success banner when the 'email-subscribe-already-subscribed' flash is present" do
+    content_item = content_store_has_schema_example("publication", "publication")
+
+    request.headers["GOVUK-Account-Session"] = GovukPersonalisation::Flash.encode_session("session-id", %w[email-subscribe-already-subscribed])
+    get :show, params: { path: path_for(content_item) }
+    assert response.body.include?("already getting emails about this page")
+  end
+
   def path_for(content_item, locale = nil)
     base_path = content_item["base_path"].sub(/^\//, "")
     base_path.gsub!(/\.#{locale}$/, "") if locale


### PR DESCRIPTION
Handle the new flash message variation added in https://github.com/alphagov/email-alert-frontend/pull/1223
which should be shown when a user clicks the button to subscribe to
email alerts about a page, but is already subscribed.

[Trello](https://trello.com/c/PkNG9Ecl/1190-journey-when-clicking-on-get-email-updates-when-i-have-a-subscription-already-but-am-not-signed-in)

New banner:

![image](https://user-images.githubusercontent.com/6362602/147114909-df221171-da94-48d0-89d0-33302c8a664a.png)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
