### PR TITLE
Turn scroll tracking on for various pages

### DIFF
--- a/app/views/content_items/answer.html.erb
+++ b/app/views/content_items/answer.html.erb
@@ -2,6 +2,20 @@
   <%= machine_readable_metadata(
     schema: :faq
   ) %>
+
+  <%
+    scroll_track_headings_paths = [
+      "/wood-packaging-import-export",
+    ]
+    scroll_track_percent_paths = [
+      "/get-coronavirus-test",
+    ]
+  %>
+  <% if scroll_track_headings_paths.include?(@content_item.base_path) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker" data-track-type="headings"/>
+  <% elsif scroll_track_percent_paths.include?(@content_item.base_path) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker"/>
+  <% end %>
 <% end %>
 
 <%= render 'content_items/body_with_related_links' %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -2,6 +2,30 @@
   <%= machine_readable_metadata(
     schema: :faq
   ) %>
+
+  <%
+    scroll_track_headings_paths = [
+      "/guidance/universal-credit-how-it-helps-you-into-work",
+      "/guidance/returning-to-the-uk",
+      "/guidance/foreign-travel-insurance",
+      "/guidance/living-in-france",
+      "/guidance/healthcare-for-eu-and-efta-citizens-visiting-the-uk",
+      "/guidance/guidance-for-suppliers-of-cattle-sheep-and-goat-ear-tags",
+      "/guidance/ecmt-international-road-haulage-permits",
+      "/guidance/travel-abroad-from-england-during-coronavirus-covid-19",
+      "/guidance/travel-to-england-from-another-country-during-coronavirus-covid-19",
+    ]
+    scroll_track_percent_paths = [
+      "/guidance/brexit-guidance-for-businesses",
+      "/guidance/brexit-guidance-for-individuals-and-families",
+      "/guidance/import-and-export-goods-using-preference-agreements",
+    ]
+  %>
+  <% if scroll_track_headings_paths.include?(@content_item.base_path) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker" data-track-type="headings"/>
+  <% elsif scroll_track_percent_paths.include?(@content_item.base_path) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker"/>
+  <% end %>
 <% end %>
 
 <%= render 'shared/email_subscribe_unsubscribe_flash' %>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -4,6 +4,21 @@
     canonical_url: @content_item.canonical_url,
     body: @content_item.has_parts? ? @content_item.current_part_body : nil
   ) %>
+
+  <%
+    scroll_track_headings_paths = [
+      "/council-housing",
+      "/driving-abroad",
+      "/get-a-passport-urgently",
+      "/driving-abroad/international-driving-permit",
+      "/taking-goods-out-uk-temporarily/get-an-ata-carnet",
+    ]
+
+    full_url = [@content_item.base_path, @content_item.part_slug].compact.join('/')
+  %>
+  <% if scroll_track_headings_paths.include?(full_url) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker" data-track-type="headings"/>
+  <% end %>
 <% end %>
 
 <% unless @content_item.requesting_a_part? %>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -2,6 +2,16 @@
   <%= machine_readable_metadata(
     schema: :html_publication
   ) %>
+
+  <%
+    scroll_track_headings_paths = [
+      "/government/publications/the-essential-trustee-what-you-need-to-know-cc3/the-essential-trustee-what-you-need-to-know-what-you-need-to-do",
+      "/government/publications/spring-budget-2017-documents/spring-budget-2017",
+    ]
+  %>
+  <% if scroll_track_headings_paths.include?(@content_item.base_path) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker" data-track-type="headings"/>
+  <% end %>
 <% end %>
 
 <%


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Turn on scroll tracking for various pages.

**NOTE** this change depends on [this change](https://github.com/alphagov/govuk_publishing_components/pull/2548) in the components gem being deployed to `static` at the same time, otherwise duplicate or no scroll tracking events may occur.

## Why
We're retiring the old scroll tracker and migrating all pages that use it to the new one.

## Visual changes
None.

Trello card: https://trello.com/c/sdugtMbX/37-migrate-to-new-scroll-tracker