### PR TITLE
Fix `email-subscription-already-subscribed` flash inconsistency

### DIFF
--- a/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
+++ b/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
@@ -18,7 +18,7 @@
       } %>
     </div>
   </div>
-<% elsif @account_flash.include?("email-subscribe-already-subscribed") %>
+<% elsif @account_flash.include?("email-subscription-already-subscribed") %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-top-3">
       <%= render "govuk_publishing_components/components/success_alert", {

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -392,7 +392,7 @@ class ContentItemsControllerTest < ActionController::TestCase
   test "displays the already subscribed success banner when the 'email-subscribe-already-subscribed' flash is present" do
     content_item = content_store_has_schema_example("publication", "publication")
 
-    request.headers["GOVUK-Account-Session"] = GovukPersonalisation::Flash.encode_session("session-id", %w[email-subscribe-already-subscribed])
+    request.headers["GOVUK-Account-Session"] = GovukPersonalisation::Flash.encode_session("session-id", %w[email-subscription-already-subscribed])
     get :show, params: { path: path_for(content_item) }
     assert response.body.include?("already getting emails about this page")
   end


### PR DESCRIPTION
In email-alert-frontend we set this flash message in the
AccountSubscriptionsController[1][2], but the name of the key used in
this app was inconsistent with what was being set - so the banner was
never being shown.

[1] https://github.com/alphagov/email-alert-frontend/blob/22a0a2048dc09243a386a214bb507c52f51bc8f1/app/controllers/account_subscriptions_controller.rb#L86
[2] https://github.com/alphagov/email-alert-frontend/blob/22a0a2048dc09243a386a214bb507c52f51bc8f1/app/services/create_account_subscription_service.rb#L5

---

[Trello card](https://trello.com/c/PkNG9Ecl/1190-journey-when-clicking-on-get-email-updates-when-i-have-a-subscription-already-but-am-not-signed-in)
