### PR TITLE
Revert "Force English for metadata"

### DIFF
--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -1,5 +1,4 @@
 .app-c-published-dates {
-  direction: ltr;
   line-height: 1.45em;
   color: govuk-colour("black");
 }

--- a/app/assets/stylesheets/components/_publisher-metadata.scss
+++ b/app/assets/stylesheets/components/_publisher-metadata.scss
@@ -1,6 +1,5 @@
 .app-c-publisher-metadata {
   @include responsive-bottom-margin;
-  direction: ltr;
   padding-top: govuk-spacing(3);
 }
 
@@ -13,6 +12,20 @@
 .app-c-publisher-metadata__term {
   float: left;
   padding-right: govuk-spacing(1);
+
+  .direction-rtl & {
+    float: none;
+    display: inline-block;
+    padding-right: 0;
+    padding-left: 5px;
+  }
+}
+
+.app-c-publisher-metadata__definition {
+  .direction-rtl & {
+    float: none;
+    display: inline-block;
+  }
 }
 
 .app-c-publisher-metadata__toggle,

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -99,7 +99,7 @@ private
   end
 
   def display_date(timestamp, format = "%-d %B %Y")
-    I18n.l(Time.zone.parse(timestamp), format: format, locale: "en") if timestamp
+    I18n.l(Time.zone.parse(timestamp), format: format) if timestamp
   end
 
   def sorted_locales(translations)

--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -10,20 +10,21 @@
   classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
 %>
 <% if published || last_updated %>
-<div id="full-publication-update-history"><div class="<%= classes.join(' ') %>" <% if history.any? %>id="history" data-module="gem-toggle"<% end %> lang="en">
+<div id="full-publication-update-history"><div class="<%= classes.join(' ') %>" <% if history.any? %>id="history" data-module="gem-toggle"<% end %>>
   <% if published %>
     <%= t('components.published_dates.published', date: published) %>
   <% end %>
   <% if last_updated %>
     <% if published %><br /><% end %><%= t('components.published_dates.last_updated', date: last_updated) %>
     <% if link_to_history && history.empty? %>
-      &mdash; <a href="#history" class="app-c-published-dates__history-link govuk-link"><%= t('components.published_dates.see_all_updates', locale: :en) %></a>
+      &mdash; <a href="#history" class="app-c-published-dates__history-link govuk-link"><%= t('components.published_dates.see_all_updates') %></a>
     <% elsif history.any? %>
       <a href="#full-history"
       class="app-c-published-dates__toggle govuk-link"
       data-controls="full-history"
       data-expanded="false"
-      data-toggled-text="&#45;&nbsp;<%= t('components.published_dates.hide_all_updates', locale: :en) %>">&#43;&nbsp;<%= t('components.published_dates.show_all_updates', locale: :en) %></a>
+      data-toggled-text="&#45;&nbsp;<%= t('components.published_dates.hide_all_updates') %>">&#43;&nbsp;<%= t('components.published_dates.show_all_updates')
+       %></a>
       <div class="app-c-published-dates__change-history js-hidden" id="full-history">
         <ol class="app-c-published-dates__list">
           <% history.each do |change| %>

--- a/app/views/components/_publisher-metadata.html.erb
+++ b/app/views/components/_publisher-metadata.html.erb
@@ -7,7 +7,7 @@
   metadata = [published, last_updated]
 %>
 <% if metadata.any? || other_has_values %>
-  <div class="app-c-publisher-metadata" lang="en">
+  <div class="app-c-publisher-metadata">
     <%= render 'components/published-dates', published: published, last_updated: last_updated, link_to_history: link_to_history %>
     <% if other_has_values %>
       <div class="app-c-publisher-metadata__other">
@@ -20,13 +20,15 @@
           %>
           <% if values.any? %>
             <dt class="app-c-publisher-metadata__term">
-              <%= title.to_s.humanize %>:
+              <%= t(title.to_s.parameterize(separator: '_'),
+                    scope: 'components.publisher_metadata',
+                    default: title.to_s.humanize) %>:
             </dt>
             <dd class="app-c-publisher-metadata__definition" data-module="gem-toggle">
               <% if title.to_sym == :collections %>
                 <% if values.size <= 2 %>
                   <span class="app-c-publisher-metadata__definition-sentence">
-                    <%= values.take(2).to_sentence(locale: :en).html_safe %>
+                    <%= values.take(2).to_sentence.html_safe %>
                   </span>
                 <% else %>
                   <% featured_value, *other_values = values %>
@@ -40,11 +42,11 @@
                     data-toggled-text="&minus; <%= t('components.publisher_metadata.hide_all') %>">
                     + <%= t('components.publisher_metadata.show_all') %>
                   </a>
-                  <span id="<%= toggle_id %>" class="js-hidden"><%= other_values.to_sentence(locale: :en).html_safe %></span>
+                  <span id="<%= toggle_id %>" class="js-hidden"><%= other_values.to_sentence.html_safe %></span>
                 <% end %>
               <% else %>
                 <span class="app-c-publisher-metadata__definition-sentence">
-                  <%= values.to_sentence(locale: :en).html_safe %>
+                  <%= values.to_sentence.html_safe %>
                 </span>
               <% end %>
             </dd>


### PR DESCRIPTION
This reverts commit 20171564e8e23470ad203021ecdf4ae87e13316a.

Relevant keys have now been translated to this change can be reverted.

Trello: https://trello.com/c/4rRSo056/2794-re-enable-translated-dates-3

![image](https://user-images.githubusercontent.com/24547183/148553965-e890fda8-4099-4988-8023-af5170e9e564.png)

![image](https://user-images.githubusercontent.com/24547183/148553997-5ae4521a-aa51-4bc9-8d02-974b1a03c858.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
