### PR TITLE
Add temporary container to published-dates

### DIFF
--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -10,7 +10,7 @@
   classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
 %>
 <% if published || last_updated %>
-<div class="<%= classes.join(' ') %>" <% if history.any? %>id="history" data-module="gem-toggle"<% end %> lang="en">
+<div id="full-publication-update-history"><div class="<%= classes.join(' ') %>" <% if history.any? %>id="history" data-module="gem-toggle"<% end %> lang="en">
   <% if published %>
     <%= t('components.published_dates.published', date: published) %>
   <% end %>
@@ -36,5 +36,5 @@
       </div>
     <% end %>
   <% end %>
-</div>
+</div></div>
 <% end %>


### PR DESCRIPTION
This is to prevent the change in this PR being a breaking one:
https://github.com/alphagov/govuk_publishing_components/pull/2558

Once the change above has been rolled out to `government-frontend`, the
additional container can be removed, and the id of the component wrapper updated
from "history" to "full-publication-update-history"

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
