### PR TITLE
Require metadata script for skiplink fix

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,6 +4,7 @@
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/single-page-notification-button


### PR DESCRIPTION
`require` the script which was introduced in https://github.com/alphagov/govuk_publishing_components/pull/2552 

https://trello.com/c/XwSjaTET

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
