### PR TITLE
Add custom pluralisation for the new Product Safety Alerts, Reports and Recalls

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -224,6 +224,9 @@ en:
       publication:
         one: Publication
         other: Publications
+      product-safety-alert-report-recall:
+        one: Product Safety Alerts, Reports and Recalls
+        other: Product Safety Alerts, Reports and Recalls
       raib_report:
         one: Rail Accident Investigation Branch report
         other: Rail Accident Investigation Branch reports


### PR DESCRIPTION
Add custom pluralisation for the new Product Safety Alerts, Reports and Recalls
specialist finder.

Trello: https://trello.com/c/ojsFViiX/2746-create-new-specialist-document-and-finder-product-safety-alerts-unsafe-products-and-recalls-3-5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
