### PR TITLE
Undo temporary workaround in pull request #2330

### DIFF
--- a/app/views/components/_published-dates.html.erb
+++ b/app/views/components/_published-dates.html.erb
@@ -10,7 +10,7 @@
   classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
 %>
 <% if published || last_updated %>
-<div id="full-publication-update-history"><div class="<%= classes.join(' ') %>" <% if history.any? %>id="history" data-module="gem-toggle"<% end %> lang="en">
+<div class="<%= classes.join(' ') %>" <% if history.any? %>id="full-publication-update-history" data-module="gem-toggle"<% end %> lang="en">
   <% if published %>
     <%= t('components.published_dates.published', date: published) %>
   <% end %>
@@ -36,5 +36,5 @@
       </div>
     <% end %>
   <% end %>
-</div></div>
+</div>
 <% end %>

--- a/test/components/published_dates_test.rb
+++ b/test/components/published_dates_test.rb
@@ -48,14 +48,14 @@ class PublishedDatesTest < ComponentTestCase
 
   test "only adds history id when passed page history" do
     render_component(published: "1st November 2000")
-    assert_select "#history", false, "should only render history id if passed history item"
+    assert_select "#full-publication-update-history", false, "should only render history id if passed history item"
 
     render_component(
       published: "1st November 2000",
       last_updated: "15th July 2015",
       history: [display_time: "23 August 2013", note: "Updated with new data"],
     )
-    assert_select "#history"
+    assert_select "#full-publication-update-history"
   end
 
   test "full page history is hidden on page load" do


### PR DESCRIPTION
PR #2330 added an additional div around `published-dates` to prevent this
change in `govuk_publishing_components` being a breaking one:
https://github.com/alphagov/govuk_publishing_components/pull/2558

This additional div is now safe to remove and the id of the wrapper for
`published-dates` can be updated to the new one.

Fixes https://github.com/alphagov/govuk_publishing_components/issues/600

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
