### PR TITLE
Set Urdu text direction to right-to-left

### DIFF
--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -356,7 +356,7 @@ ur:
       licence_html: 'یہ پبلیکیشن اوپن گورنمنٹ لائسنس v3.0 کے تحت لائسنس یافتہ ہے سوائے اس کے جو بصورت دیگر بیان کردہ ہے۔ لائسنس دیکھنے کے لیے، <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a> کو ملاحظہ کریں یا معلوماتی پالیسی کی ٹیم، قومی آرکائیوز، کیو، لندن TW9 4DUپر پیغام بھیجیں، یا یہاں ای میل کریں: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
       third_party: جہاں ہم کسی فریق ثالث کی کاپی رائٹ معلومات کی شناخت کی ہو آپ کو متعلقہ کاپی رائٹ ہولڈرز سے اجازت لینے کی ضرورت ہو گی۔
   i18n:
-    direction:
+    direction: rtl
   language_names:
     ar:
     az:


### PR DESCRIPTION
## What

Sets the `i18n.direction` key in the Urdu language file to right-to-left.

## Why

This key used by application to determine whether the direction that text should be displayed:

ttps://github.com/alphagov/government-frontend/blob/4fab76c1cc871f3da91592a88a1b06f94922d58d/app/helpers/application_helper.rb#L3

Urdu was missing this key, so was defaulting to displaying it left-to-right.

## Visual differences

Before:

![image](https://user-images.githubusercontent.com/1732331/150150688-38f948e9-0c26-4c7c-97aa-3930baf0b2cb.png)

After:
![image](https://user-images.githubusercontent.com/1732331/150150785-a1bbaca5-de2e-4c7b-bb89-14b3c598f2eb.png)

From https://www.gov.uk/government/news/innovative-afghan-businesses-receive-uk-aid-grants.ur

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
