### PR TITLE
Add single page notification button to `consultation` template

### DIFF
--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -196,11 +196,7 @@
         %>
       </div>
 
-    <%= render 'components/published-dates', {
-        published: @content_item.published,
-        last_updated: @content_item.updated,
-        history: @content_item.history
-      } %>
+      <%= render 'shared/published_dates_with_notification_button' %>
     </div>
   </div>
   <%= render 'shared/sidebar_navigation' %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -115,19 +115,7 @@
       <% end %>
 
       <div class="responsive-bottom-margin">
-        <%= render 'components/published-dates', {
-            published: @content_item.published,
-            last_updated: @content_item.updated,
-            history: @content_item.history,
-            margin_bottom: 3,
-          } unless brexit_child_taxon %>
-
-          <%= render 'govuk_publishing_components/components/single_page_notification_button', {
-            base_path: @content_item.base_path,
-            js_enhancement: @include_single_page_notification_button_js,
-            button_location: "bottom",
-            margin_bottom: 0,
-          } if @notification_button_visible %>
+        <%= render 'shared/published_dates_with_notification_button', { brexit_child_taxon: brexit_child_taxon } %>
       </div>
     <% end %>
     <%= render "govuk_publishing_components/components/print_link", {

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -54,19 +54,7 @@
           <% end %>
         </section>
       </div>
-
-      <%= render 'components/published-dates', {
-        published: @content_item.published,
-        last_updated: @content_item.updated,
-        history: @content_item.history,
-        margin_bottom: 3
-      } %>
-
-      <%= render 'govuk_publishing_components/components/single_page_notification_button', {
-        base_path: @content_item.base_path,
-        js_enhancement: @include_single_page_notification_button_js,
-        button_location: "bottom",
-      } if @notification_button_visible %>
+      <%= render 'shared/published_dates_with_notification_button' %>
     </div>
   </div>
   <%= render 'shared/sidebar_navigation' %>

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -1,0 +1,14 @@
+<% brexit_child_taxon ||= nil %>
+
+<%= render 'components/published-dates', {
+    published: @content_item.published,
+    last_updated: @content_item.updated,
+    history: @content_item.history,
+    margin_bottom: 3,
+  } unless brexit_child_taxon %>
+<%= render 'govuk_publishing_components/components/single_page_notification_button', {
+    base_path: @content_item.base_path,
+    js_enhancement: @include_single_page_notification_button_js,
+    button_location: "bottom",
+    margin_bottom: 0,
+} if @notification_button_visible %>


### PR DESCRIPTION
Add support for the single page notification button to the `consultation`
template. The button will not appear until the feature is enabled on
pages with this content type.

Seeing as the button is always grouped together with the published dates
component I created a new  `published_dates_with_notification_button`
partial to be shared between `publication`, `detailed_guide` and
`consultation`.


https://trello.com/c/iqhyMnMP

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
