### PR TITLE
Change single page notification button allow list to an exemption list

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -135,7 +135,7 @@ private
     end
 
     # use these and `@content_item.base_path` in the template
-    @notification_button_visible = in_single_page_notifications_trial? && !@content_item.brexit_child_taxon
+    @notification_button_visible = @content_item.has_single_page_notifications? && !@content_item.brexit_child_taxon
     @include_single_page_notification_button_js = account_session_header.present?
 
     request.variant = :print if params[:variant] == "print"
@@ -210,37 +210,5 @@ private
     # Override the default from GovukPersonalisation::ControllerConcern so pages are cached on each flash message
     # variation, rather than caching pages per user
     response.headers["Vary"] = [response.headers["Vary"], "GOVUK-Account-Session-Exists", "GOVUK-Account-Session-Flash"].compact.join(", ")
-  end
-
-  def in_single_page_notifications_trial?
-    %w[
-      /government/publications/open-standards-for-government
-      /government/publications/identity-proofing-and-verification-of-an-individual
-      /guidance/travel-to-england-from-another-country-during-coronavirus-covid-19
-      /guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do
-      /government/publications/face-coverings-when-to-wear-one-and-how-to-make-your-own
-      /guidance/commercial-court-hearing-and-trial-dates
-      /guidance/london-circuit-commercial-court-hearing-and-trial-dates
-      /guidance/united-kingdom-single-issuing-authority-uksia
-      /government/publications/current-catch-limits-over-10-metre-non-sector-pool
-      /government/publications/current-catch-limits-10-metres-and-under-pool
-      /government/publications/fishing-vessel-licence-variations
-      /guidance/check-if-youre-eligible-for-making-tax-digital-for-income-tax
-      /guidance/check-when-to-sign-up-for-making-tax-digital-for-income-tax
-      /guidance/find-software-thats-compatible-with-making-tax-digital-for-income-tax
-      /guidance/using-making-tax-digital-for-income-tax
-      /guidance/sign-up-your-business-for-making-tax-digital-for-income-tax
-      /guidance/list-of-customs-agents-and-fast-parcel-operators
-      /guidance/check-if-you-need-to-register-for-plastic-packaging-tax
-      /guidance/work-out-which-packaging-is-subject-to-plastic-packaging-tax
-      /guidance/check-which-plastic-packaging-is-exempt-from-plastic-packaging-tax
-      /guidance/examples-of-tests-and-calculations-for-plastic-packaging-tax
-      /guidance/register-for-plastic-packaging-tax
-      /guidance/claim-a-credit-or-defer-paying-plastic-packaging-tax
-      /guidance/completing-your-plastic-packaging-tax-return
-      /guidance/register-a-group-of-companies-for-plastic-packaging-tax
-      /guidance/decide-if-you-need-to-register-for-plastic-packaging-tax
-      /guidance/uk-trade-agreements-with-non-eu-countries
-    ].include? @content_item.base_path
   end
 end

--- a/app/presenters/content_item/single_page_notification_button.rb
+++ b/app/presenters/content_item/single_page_notification_button.rb
@@ -1,0 +1,21 @@
+module ContentItem
+  module SinglePageNotificationButton
+    # Add the content id of the publication, detailed_guide or consultation that should be exempt from having the single page notification button
+    EXEMPTION_LIST = %w[
+      c5c8d3cd-0dc2-4ca3-8672-8ca0a6e92165
+      70bd3a76-6606-45dd-9fb5-2b95f8667b4d
+      a457220c-915c-4cb1-8e41-9191fba42540
+      5f9c6c15-7631-11e4-a3cb-005056011aef
+    ].freeze
+
+    ALLOWED_DOCUMENT_TYPES = %w[
+      publication
+      detailed_guide
+      consultation
+    ].freeze
+
+    def has_single_page_notifications?
+      (!EXEMPTION_LIST.include? content_item["content_id"]) && (ALLOWED_DOCUMENT_TYPES.include? content_item["schema_name"])
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,6 +1,7 @@
 class ContentItemPresenter
   include ContentItem::Withdrawable
   include ContentItem::BrexitTaxons
+  include ContentItem::SinglePageNotificationButton
 
   attr_reader :content_item,
               :requested_path,

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -4,6 +4,8 @@
   ) %>
 <% end %>
 
+<%= render 'shared/email_subscribe_unsubscribe_flash' %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -373,28 +373,33 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert response.headers["Vary"].include?("GOVUK-Account-Session-Flash")
   end
 
-  test "displays the subscription success banner when the 'email-subscription-success' flash is present" do
-    content_item = content_store_has_schema_example("publication", "publication")
+  %w[publication consultation detailed_guide].each do |schema_name|
+    test "#{schema_name} displays the subscription success banner when the 'email-subscription-success' flash is present" do
+      example_name = schema_name == "consultation" ? "open_consultation" : schema_name
+      content_item = content_store_has_schema_example(schema_name, example_name)
 
-    request.headers["GOVUK-Account-Session"] = GovukPersonalisation::Flash.encode_session("session-id", %w[email-subscription-success])
-    get :show, params: { path: path_for(content_item) }
-    assert response.body.include?("subscribed to emails about this page")
-  end
+      request.headers["GOVUK-Account-Session"] = GovukPersonalisation::Flash.encode_session("session-id", %w[email-subscription-success])
+      get :show, params: { path: path_for(content_item) }
+      assert response.body.include?("subscribed to emails about this page")
+    end
 
-  test "displays the unsubscribe success banner when the 'email-unsubscribe-success' flash is present" do
-    content_item = content_store_has_schema_example("publication", "publication")
+    test "#{schema_name} displays the unsubscribe success banner when the 'email-unsubscribe-success' flash is present" do
+      example_name = schema_name == "consultation" ? "open_consultation" : schema_name
+      content_item = content_store_has_schema_example(schema_name, example_name)
 
-    request.headers["GOVUK-Account-Session"] = GovukPersonalisation::Flash.encode_session("session-id", %w[email-unsubscribe-success])
-    get :show, params: { path: path_for(content_item) }
-    assert response.body.include?("unsubscribed from emails about this page")
-  end
+      request.headers["GOVUK-Account-Session"] = GovukPersonalisation::Flash.encode_session("session-id", %w[email-unsubscribe-success])
+      get :show, params: { path: path_for(content_item) }
+      assert response.body.include?("unsubscribed from emails about this page")
+    end
 
-  test "displays the already subscribed success banner when the 'email-subscribe-already-subscribed' flash is present" do
-    content_item = content_store_has_schema_example("publication", "publication")
+    test "#{schema_name} displays the already subscribed success banner when the 'email-subscribe-already-subscribed' flash is present" do
+      example_name = schema_name == "consultation" ? "open_consultation" : schema_name
+      content_item = content_store_has_schema_example(schema_name, example_name)
 
-    request.headers["GOVUK-Account-Session"] = GovukPersonalisation::Flash.encode_session("session-id", %w[email-subscription-already-subscribed])
-    get :show, params: { path: path_for(content_item) }
-    assert response.body.include?("already getting emails about this page")
+      request.headers["GOVUK-Account-Session"] = GovukPersonalisation::Flash.encode_session("session-id", %w[email-subscription-already-subscribed])
+      get :show, params: { path: path_for(content_item) }
+      assert response.body.include?("already getting emails about this page")
+    end
   end
 
   def path_for(content_item, locale = nil)

--- a/test/integration/answer_test.rb
+++ b/test/integration/answer_test.rb
@@ -28,4 +28,9 @@ class AnswerTest < ActionDispatch::IntegrationTest
     assert_equal faq_schema["name"], @content_item["title"]
     assert_not_equal faq_schema["mainEntity"], []
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("answer")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/case_study_test.rb
+++ b/test/integration/case_study_test.rb
@@ -26,4 +26,9 @@ class CaseStudyTest < ActionDispatch::IntegrationTest
       assert page.has_css?("time[datetime='#{@content_item['withdrawn_notice']['withdrawn_at']}']")
     end
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("translated")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -154,4 +154,14 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     assert page.has_css?("a", text: "Facebook")
     assert page.has_css?("a", text: "Twitter")
   end
+
+  test "renders with the single page notification button" do
+    setup_and_visit_content_item("open_consultation")
+    assert page.has_css?(".gem-c-single-page-notification-button")
+  end
+
+  test "does not render the single page notification button on exempt pages" do
+    setup_and_visit_notification_exempt_page("open_consultation")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/contact_test.rb
+++ b/test/integration/contact_test.rb
@@ -48,4 +48,9 @@ class ContactTest < ActionDispatch::IntegrationTest
     assert page.has_css?("h2#post-title")
     assert page.has_css?(".street-address")
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("contact")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/corporate_information_page_test.rb
+++ b/test/integration/corporate_information_page_test.rb
@@ -86,4 +86,9 @@ class CorporateInformationPageTest < ActionDispatch::IntegrationTest
     assert page.has_css?(".gem-c-notice__title", text: "This information page was withdrawn on 9 August 2014")
     assert page.has_css?(".gem-c-notice", text: "This is out of date")
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("corporate_information_page")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -131,4 +131,14 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     assert_equal "brexit-citizen-page", track_category
     assert_equal "Guidance nav link", track_label
   end
+
+  test "renders with the single page notification button" do
+    setup_and_visit_content_item("detailed_guide")
+    assert page.has_css?(".gem-c-single-page-notification-button")
+  end
+
+  test "does not render the single page notification button on exempt pages" do
+    setup_and_visit_notification_exempt_page("detailed_guide")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -152,4 +152,9 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
       assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
     end
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("document_collection")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/fatality_notice_test.rb
+++ b/test/integration/fatality_notice_test.rb
@@ -78,4 +78,9 @@ class FatalityNoticeTest < ActionDispatch::IntegrationTest
       assert page.has_text?("This content is not factually correct. For current information please go to")
     end
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("fatality_notice")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -164,6 +164,11 @@ class GuideTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("guide")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
+
   def once_voting_has_closed
     Timecop.freeze(Time.zone.local(2021, 5, 6, 22, 0, 0))
     yield

--- a/test/integration/help_page_test.rb
+++ b/test/integration/help_page_test.rb
@@ -18,4 +18,9 @@ class HelpPageTest < ActionDispatch::IntegrationTest
 
     assert page.has_css?('meta[name="robots"][content="noindex"]', visible: false)
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("help_page")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -103,4 +103,9 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
 
     assert page.has_css?(".gem-c-notice__title", text: "This publication was withdrawn on 9 August 2014")
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_html_publication("published")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/news_article_test.rb
+++ b/test/integration/news_article_test.rb
@@ -42,4 +42,9 @@ class NewsArticleTest < ActionDispatch::IntegrationTest
       assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
     end
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("news_article")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -91,4 +91,14 @@ class PublicationTest < ActionDispatch::IntegrationTest
       },
     ])
   end
+
+  test "renders with the single page notification button" do
+    setup_and_visit_content_item("publication")
+    assert page.has_css?(".gem-c-single-page-notification-button")
+  end
+
+  test "does not render the single page notification button on exempt pages" do
+    setup_and_visit_notification_exempt_page("publication")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -178,4 +178,9 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
       text: "See all EU Withdrawal Act 2018 statutory instruments",
     )
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("aaib-reports")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/speech_test.rb
+++ b/test/integration/speech_test.rb
@@ -38,4 +38,9 @@ class SpeechTest < ActionDispatch::IntegrationTest
 
     assert_footer_has_published_dates("Published 8 March 2016")
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("speech")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -65,4 +65,9 @@ class StatisticalDataSetTest < ActionDispatch::IntegrationTest
 
     assert_not page.has_css?(".gem-c-contents-list")
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("statistical_data_set")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -67,4 +67,9 @@ class StatisticsAnnouncementTest < ActionDispatch::IntegrationTest
 
     assert_not page.has_text?(StatisticsAnnouncementPresenter::FORTHCOMING_NOTICE)
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("official_statistics")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/take_part_test.rb
+++ b/test/integration/take_part_test.rb
@@ -9,4 +9,9 @@ class TakePartTest < ActionDispatch::IntegrationTest
 
     assert page.has_text?("There are roughly 20,000 local councillors in England. Councillors are elected to the local council to represent their own local community, so they must either live or work in the area.")
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("take_part")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/topical_event_about_page_test.rb
+++ b/test/integration/topical_event_about_page_test.rb
@@ -42,6 +42,11 @@ class TopicalEventAboutPageTest < ActionDispatch::IntegrationTest
     assert page.has_css?(".gem-c-contents-list")
   end
 
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("topical_event_about_page")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
+
 private
 
   def topical_event_end_date

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -64,6 +64,11 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     assert page.has_css?("link[type*='atom'][href='#{@content_item['base_path']}.atom']", visible: false)
   end
 
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("full-country")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
+
   def setup_and_visit_travel_advice_part(name, part)
     @content_item = get_content_example(name).tap do |item|
       stub_content_store_has_item("#{item['base_path']}/#{part}", item.to_json)

--- a/test/integration/working_group_test.rb
+++ b/test/integration/working_group_test.rb
@@ -54,4 +54,9 @@ class WorkingGroupTest < ActionDispatch::IntegrationTest
 
     assert_not page.has_css?(".gem-c-contents-list")
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("long")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/integration/world_location_news_article_test.rb
+++ b/test/integration/world_location_news_article_test.rb
@@ -47,4 +47,9 @@ class WorldLocationNewsArticleTest < ActionDispatch::IntegrationTest
       assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
     end
   end
+
+  test "does not render with the single page notification button" do
+    setup_and_visit_content_item("world_location_news_article")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -193,6 +193,14 @@ class ActionDispatch::IntegrationTest
     end
   end
 
+  def setup_and_visit_notification_exempt_page(name)
+    @content_item = get_content_example(name).tap do |item|
+      item["content_id"] = ContentItem::SinglePageNotificationButton::EXEMPTION_LIST[0]
+      stub_content_store_has_item(item["base_path"], item.to_json)
+      visit_with_cachebust((item["base_path"]).to_s)
+    end
+  end
+
   def brexit_citizen_id
     ContentItem::BrexitTaxons::BREXIT_CITIZEN_PAGE_CONTENT_ID
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -85,7 +85,9 @@ class ActionDispatch::IntegrationTest
     text = []
     text << first_published if first_published
     text << last_updated if last_updated
-    within ".app-c-published-dates:last-of-type" do
+    last_published_dates_element = all(".app-c-published-dates").last
+
+    within last_published_dates_element do
       assert page.has_text?(text.join("\n")), "Published dates #{text.join("\n")} not found"
       if history_link
         assert page.has_link?("see all updates", href: "#history"), "Updates link not found"


### PR DESCRIPTION
The next stage for the single page notification rollout is to put the button on all pages with a `publication`, `detailed_guide` or `consultation` type. 
The exemption mechanism will be a denylist. Publishers can request that the button not be included on certain individual pages. The way the exemption is applied is by adding the `content_id` of the page to the single page notification button exclusion list.



### Implement notification button exemption list:
Change single page notification button allow list to an exemption list.

Switch from using `base_path`s to `content_id`s for long term stability (content ids persist, base paths can change)

Add some basic tests to verify that pages whose content item is on the exemption list do not display with the single page notification button.

### Put account flash message on `consultation`:
This was missed in the previous PR which added the button to the `consultation` template. The success message is necessary to indicate when subscribing/unsubscribing to notifications has been completed.

### Fix failing test:
`.app-c-published-dates:last-of-type` is failing because there is now another element after the published dates component. 
The `:last-of-type` selector doesn't work the way one might assume on first glance, as in it doesn't apply to classes the same way that it applies to element selectors. 
https://stackoverflow.com/questions/13211453/css-how-to-say-classlast-of-type-classes-not-elements 


-----

https://trello.com/c/4OWUb0no

-----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
