### PR TITLE
Update HMPO live chat form to new URL

### DIFF
--- a/lib/webchat.yaml
+++ b/lib/webchat.yaml
@@ -1,12 +1,4 @@
-- base_path: /government/organisations/hm-passport-office/contact/passport-advice-and-complaints
-  open_url: https://hmpowebchat.klick2contact.com/v03/launcherV3.php?p=HMPO&d=717&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Chat&s=https://hmpowebchat.klick2contact.com/v03&u=&wo=&uh=&pid=2&iif=0
-  availability_url: https://hmpowebchat.klick2contact.com/v03/providers/HMPO/api/availability.php
-  open_url_redirect: false
-- base_path: /government/organisations/hm-passport-office/contact/webchat
-  open_url: https://hmpowebchat.klick2contact.com/v03/launcherV3.php?p=HMPO&d=717&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Chat&s=https://hmpowebchat.klick2contact.com/v03&u=&wo=&uh=&pid=2&iif=0
-  availability_url: https://hmpowebchat.klick2contact.com/v03/providers/HMPO/api/availability.php
-  open_url_redirect: false
 - base_path: /government/organisations/hm-passport-office/contact/hm-passport-office-webchat
-  open_url: https://hmpowebchat.klick2contact.com/v03/launcherV3.php?p=HMPO&d=717&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Chat&s=https://hmpowebchat.klick2contact.com/v03&u=&wo=&uh=&pid=2&iif=0
-  availability_url: https://hmpowebchat.klick2contact.com/v03/providers/HMPO/api/availability.php
+  open_url: https://omni.eckoh.uk/v03.5/launcherV3.php?p=HMPO&d=717&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Chat&s=https://omni.eckoh.uk/v03.5&u=&wo=&uh=&pid=2&iif=0
+  availability_url: https://omni.eckoh.uk/v03.5/providers/HMPO/api/availability.php
   open_url_redirect: false


### PR DESCRIPTION
As requested by HMPO, this commit changes the old provider URL to
the new provider, as well as the associated availability URL.

We need to decide how this can be tested correctly by HMPO.

https://trello.com/c/wg6cckR1/770-set-up-a-test-page-for-hmpo-to-check-new-webchat-update

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
