### PR TITLE
Correct language names for French and Dari

### DIFF
--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -376,7 +376,7 @@ dr:
     cy:
     da:
     de:
-    dr: بعدی
+    dr: دری
     el:
     en:
     es:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -381,7 +381,7 @@ fr:
     et:
     fa:
     fi:
-    fr: français
+    fr: Français
     gd:
     gu:
     he:


### PR DESCRIPTION
## What

 - Correct the language name for Dari from بعدی to دری
 - Capitalize "français" to match the convention in the other languages

## Why

In Dari "بعدی" means "the next one" or "future" rather than the language name, so needed to be corrected. 

And "français" was the only language name not to be capitalised, so looked out of place in the list of languages on a page.

## Visual differences


From https://www.gov.uk/government/publications/what-is-a-forced-marriage:
Before:

![image](https://user-images.githubusercontent.com/1732331/154038346-21420f0d-d984-453e-9061-56a8b3e73afc.png)


After:
![image](https://user-images.githubusercontent.com/1732331/154038115-80b142e5-b084-47bd-9490-c300bcc2c361.png)

From https://www.gov.uk/guidance/passenger-locator-form-how-to-guide.fr:

Before:
![image](https://user-images.githubusercontent.com/1732331/154038066-7cb7e7de-fba8-4cc1-930e-2057fe648265.png)

After:
![image](https://user-images.githubusercontent.com/1732331/154038033-c516089b-6b0e-4a29-867e-13a7873ff42b.png)


 ---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
