### PR TITLE
Move single page notification button to `government-frontend`

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,7 +7,7 @@
 //= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/radio
-//= require govuk_publishing_components/components/single-page-notification-button
 //= require govuk_publishing_components/components/step-by-step-nav
 
 //= require_tree ./modules
+//= require_tree ./components

--- a/app/assets/javascripts/components/single-page-notification-button.js
+++ b/app/assets/javascripts/components/single-page-notification-button.js
@@ -1,0 +1,62 @@
+/* global XMLHttpRequest */
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function SinglePageNotificationButton ($module) {
+    this.$module = $module
+    this.basePath = this.$module.querySelector('input[name="base_path"]').value
+    this.buttonLocation = this.$module.getAttribute('data-button-location')
+    this.buttonVisibleClass = 'app-c-single-page-notification-button--visible'
+
+    this.personalisationEndpoint = '/api/personalisation/check-email-subscription?base_path=' + this.basePath
+    // This attribute is passed through to the personalisation API to ensure the updated button has the same button_location for analytics
+    if (this.buttonLocation) this.personalisationEndpoint += '&button_location=' + this.buttonLocation
+  }
+
+  SinglePageNotificationButton.prototype.init = function () {
+    var xhr = new XMLHttpRequest()
+    xhr.open('GET', this.personalisationEndpoint, true)
+    // if XHR to the personalisation endpoint is taking an incredibly long time to complete, we are better off leaving the button in its default unpersonalised state. Content changing before the user's eyes while they are browsing can be jarring and should be avoided.
+    xhr.timeout = 10000
+
+    xhr.ontimeout = function () {
+      this.makeVisible(this.$module)
+    }.bind(this)
+
+    xhr.onreadystatechange = function () {
+      if (xhr.readyState === 4) {
+        if (xhr.status === 200) {
+          var responseText = xhr.responseText
+          // if response text exists and is JSON parse-able, parse the response and get the button html
+          if (responseText && this.responseIsJSON(responseText)) {
+            var newButton = JSON.parse(responseText).button_html
+            var html = document.createElement('div')
+            html.innerHTML = newButton
+            // test that the html returned contains the button component; if yes, swap the button for the updated version
+            var responseButtonContainer = html.querySelector('form.app-c-single-page-notification-button')
+            if (responseButtonContainer) {
+              this.$module.parentNode.replaceChild(responseButtonContainer, this.$module)
+            }
+          }
+        }
+        this.makeVisible(this.$module)
+      }
+    }.bind(this)
+    xhr.send()
+  }
+
+  SinglePageNotificationButton.prototype.responseIsJSON = function (string) {
+    try {
+      JSON.parse(string)
+    } catch (e) {
+      return false
+    }
+    return true
+  }
+
+  SinglePageNotificationButton.prototype.makeVisible = function (target) {
+    target.classList.add(this.buttonVisibleClass)
+  }
+  Modules.SinglePageNotificationButton = SinglePageNotificationButton
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -42,7 +42,6 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/radio';
 @import 'govuk_publishing_components/components/related-navigation';
 @import 'govuk_publishing_components/components/share-links';
-@import 'govuk_publishing_components/components/single-page-notification-button';
 @import 'govuk_publishing_components/components/step-by-step-nav';
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/step-by-step-nav-related';

--- a/app/assets/stylesheets/components/_single-page-notification-button.scss
+++ b/app/assets/stylesheets/components/_single-page-notification-button.scss
@@ -1,0 +1,38 @@
+.app-c-single-page-notification-button__submit {
+  padding: govuk-spacing(2);
+  margin: govuk-spacing(0);
+  border: 1px solid $govuk-border-colour;
+  color: $govuk-link-colour;
+  cursor: pointer;
+  background: none;
+
+  &:focus {
+    @include govuk-focused-text;
+    background-color: $govuk-focus-colour;
+    border-color: transparent;
+    box-shadow: 0 $govuk-focus-width $govuk-text-colour;
+  }
+
+  &:hover {
+    background-color: govuk-colour("light-grey");
+    color: $govuk-link-hover-colour;
+
+    &:focus {
+      color: $govuk-text-colour;
+    }
+  }
+}
+
+.app-c-single-page-notification-button__icon {
+  color: govuk-colour("black");
+  vertical-align: top;
+  margin-right: govuk-spacing(1);
+}
+
+.js-enabled .app-c-single-page-notification-button.js-personalisation-enhancement {
+  opacity: 0;
+
+  &.app-c-single-page-notification-button--visible {
+    opacity: 1;
+  }
+}

--- a/app/helpers/single_page_notification_button_helper.rb
+++ b/app/helpers/single_page_notification_button_helper.rb
@@ -1,0 +1,26 @@
+module SinglePageNotificationButtonHelper
+  def single_page_notification_button_data(local_assigns)
+    button_location = button_location_is_valid?(local_assigns[:button_location]) ? local_assigns[:button_location] : nil
+    data_attributes = local_assigns[:data_attributes] || {}
+    button_type = local_assigns[:already_subscribed] ? "Unsubscribe" : "Subscribe"
+    data_attributes[:track_label] = local_assigns[:base_path]
+    # data-action for tracking should have the format of e.g. "Unsubscribe-button-top", or "Subscribe-button-bottom"
+    # when button_location is not present data-action will fall back to "Unsubscribe-button"/"Subscribe-button"
+    data_attributes[:track_action] = [button_type, "button", button_location].compact.join("-")
+    data_attributes[:module] = "single-page-notification-button" if local_assigns[:js_enhancement]
+    data_attributes[:track_category] = "Single-page-notification-button"
+    # This attribute is passed through to the personalisation API to ensure when a new button is returned from the API, it has the same button_location
+    data_attributes[:button_location] = button_location
+    data_attributes
+  end
+
+  def single_page_notification_button_text(already_subscribed)
+    already_subscribed ? I18n.t("components.single_page_notification_button.unsubscribe_text") : I18n.t("components.single_page_notification_button.subscribe_text")
+  end
+
+private
+
+  def button_location_is_valid?(button_location)
+    %w[bottom top].include? button_location
+  end
+end

--- a/app/views/components/_single_page_notification_button.html.erb
+++ b/app/views/components/_single_page_notification_button.html.erb
@@ -1,0 +1,21 @@
+<%
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+
+  wrapper_classes = %w(govuk-!-display-none-print)
+  wrapper_classes << shared_helper.get_margin_bottom
+  component_classes = %w[app-c-single-page-notification-button]
+  component_classes << "js-personalisation-enhancement" if local_assigns[:js_enhancement]
+  base_path = local_assigns[:base_path] || nil
+%>
+<% button_text = capture do %>
+  <svg class="app-c-single-page-notification-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334"><path fill="currentColor" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"/></svg><%= single_page_notification_button_text(local_assigns[:already_subscribed]) %>
+<% end %>
+<%= tag.div class: wrapper_classes, data: { module: "gem-track-click"} do %>
+  <%= tag.form class: component_classes, action: "/email/subscriptions/single-page/new", method: "POST", data: single_page_notification_button_data(local_assigns) do %>
+    <input type="hidden" name="base_path" value="<%= base_path %>">
+    <%= content_tag(:button, button_text, {
+      class: "govuk-body-s app-c-single-page-notification-button__submit",
+      type: "submit",
+    }) %>
+  <% end %>
+<% end if base_path %>

--- a/app/views/components/docs/single_page_notification_button.yml
+++ b/app/views/components/docs/single_page_notification_button.yml
@@ -1,0 +1,50 @@
+name: Single page notification button
+description: A button that subscribes the user to email notifications to a page
+body: |
+  By default, the component displays with the "Get emails about this page" state.
+  If the `js-enhancement` flag is present, the component uses JavaScript to check if the user has already subscribed to email notifications on the current page. If yes, the state of the component updates accordingly.
+
+  The component does not render without the `base_path` parameter. The `base_path` is necessary for [checking if an email subscription is active on page load](https://github.com/alphagov/account-api/blob/main/docs/api.md#get-apipersonalisationcheck-email-subscriptiontopic_slug) and the creation/deletion of an email notification subscription.
+
+  When the button is clicked, the `base_path` is submitted to an endpoint which proceeds to check the user's authentication status and whether they are already subscribed to the page or not. Depending on these factors, they will be routed accordingly.
+accessibility_criteria: |
+  - The bell icon must be presentational and ignored by screen readers.
+examples:
+  default:
+    description: By default this component prompts the user to subscribe to email notifications to this page.
+    data:
+      base_path: '/current-page-path'
+  already_subscribed:
+    description: If the user has already subscribed to email notifications about the current page, display the "Stop getting emails about this page" state.
+    data:
+      base_path: '/current-page-path'
+      already_subscribed: true
+  with_data_attributes:
+    description: The component accepts data attributes (for example, for analytics)
+    data:
+      base_path: '/current-page-path'
+      data_attributes:
+        test_attribute: "testing"
+  with_margin_bottom:
+    description: |
+      The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a margin bottom of 15px.
+    data:
+      base_path: '/current-page-path'
+      margin_bottom: 5
+  with_js_enhancement:
+    description: |
+      If the `js-enhancement` flag is present, the component uses JavaScript to check if the user has already subscribed to email notifications on the current page. If yes, the state of the component updates accordingly.
+    data:
+      base_path: '/current-page-path'
+      js_enhancement: true
+  with_button_location:
+    description: |
+      When there is more than one button on a page, we should specify their location so that Analytics can differentiate between them.
+
+      The location should have one of two values: "top" or "bottom".
+
+      When this parameter is passed, its value is reflected in the `data-action` attribute (i.e "Unsubscribe-button-top"). When the flag is not present, `data-action` defaults to "Subscribe-button" or "Unsubscribe-button", depending on the state of the button.
+    data:
+      base_path: '/current-page-path'
+      js_enhancement: true
+      button_location: 'top'

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -1,4 +1,7 @@
-<% brexit_child_taxon ||= nil %>
+<%
+  brexit_child_taxon ||= nil
+  history = @content_item.history || nil
+%>
 
 <%= render 'components/published-dates', {
     published: @content_item.published,
@@ -6,7 +9,7 @@
     history: @content_item.history,
     margin_bottom: 3,
   } unless brexit_child_taxon %>
-<%= render 'govuk_publishing_components/components/single_page_notification_button', {
+<%= render 'components/single_page_notification_button', {
     base_path: @content_item.base_path,
     js_enhancement: @include_single_page_notification_button_js,
     button_location: "bottom",

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -17,7 +17,7 @@
   </div>
 </div>
 
-<%= render 'govuk_publishing_components/components/single_page_notification_button', {
+<%= render 'components/single_page_notification_button', {
   base_path: @content_item.base_path,
   js_enhancement: @include_single_page_notification_button_js,
   margin_bottom: 6,

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -26,6 +26,9 @@ ar:
       show_all: إظهار الكل
     share_links:
       share_this_page: شارك هذه الصفحة
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: و
     another_website_html: عُقدت هذه الاستشارة %{closed} على <a href="%{url}">موقع ويب آخر</a>

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -26,6 +26,9 @@ az:
       show_all: hamısını göstər
     share_links:
       share_this_page: Bu səhifəni paylaşın
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: və
     another_website_html: Bu məsləhətləşmə %{closed} başqa <a href="%{url}">vebsaytda həyata keçirilir</a>

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -26,6 +26,9 @@ be:
       show_all: 'паказаць усе '
     share_links:
       share_this_page: Падзяліцца гэтай старонкай
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: і
     another_website_html: Гэта кансультацыя %{closed}  праводзілася на <a href="%{url}">іншым сайце</a>

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -26,6 +26,9 @@ bg:
       show_all: показване на всички
     share_links:
       share_this_page: Споделяне на тази страница
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: и
     another_website_html: Тази консултация %{closed} се намира на <a href="%{url}">друг уебсайт</a>

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -26,6 +26,9 @@ bn:
       show_all: সবগুলো দেখান
     share_links:
       share_this_page: এই পেজটি শেয়ার করুন
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: এবং
     another_website_html: এই পরামর্শটি %{closed} <a href="%{url}">আরেকটি ওয়েবসাইটে</a> অনুষ্ঠিত হয়

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -26,6 +26,9 @@ cs:
       show_all: zobrazit vše
     share_links:
       share_this_page: Sdílet tuto stránku
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: a
     another_website_html: Tato konzultace %{closed} se konala na <a href="%{url}">jiné webové stránce</a>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -26,6 +26,9 @@ cy:
       show_all: dangos popeth
     share_links:
       share_this_page: Rhannu'r dudalen hon
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: a
     another_website_html: Cynhaliwyd yr ymgynghoriad hwn %{closed} ar <a href="%{url}">wefan arall</a>

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -26,6 +26,9 @@ da:
       show_all: se alle
     share_links:
       share_this_page: Del denne side
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: og
     another_website_html: Denne konsultation %{closed} blev afholdt på <a href="%{url}">en anden hjemmeside</a>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -26,6 +26,9 @@ de:
       show_all: alle anzeigen
     share_links:
       share_this_page: Diese Seite teilen
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: und
     another_website_html: Diese Anhörung %{closed} fand auf einer <a href="%{url}">anderen Website</a> statt

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -26,6 +26,9 @@ dr:
       show_all: همه را نمایش دهید
     share_links:
       share_this_page: این صفحه را به اشتراک بگذارید
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: و
     another_website_html: این مشاوره%{closed}برگزار میشود در<a href="%{url}">ویبسایت دیگر</a>

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -26,6 +26,9 @@ el:
       show_all: εμφάνιση όλων
     share_links:
       share_this_page: Κοινοποιήστε αυτή τη σελίδα
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: και
     another_website_html: Αυτή η διαβούλευση %{closed} πραγματοποιήθηκε σε <a href="%{url}">άλλο ιστότοπο</a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,9 @@ en:
       show_all: show all
     share_links:
       share_this_page: Share this page
+    single_page_notification_button:
+      subscribe_text: Get emails about this page
+      unsubscribe_text: Stop getting emails about this page
   consultation:
     and: and
     another_website_html: This consultation %{closed} held on <a href="%{url}">another website</a>

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -26,6 +26,9 @@ es-419:
       show_all: mostrar todo
     share_links:
       share_this_page: Compartir esta página
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: y
     another_website_html: Esta consulta %{closed} realizada en <a href="%{url}">otro sitio web</a>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -26,6 +26,9 @@ es:
       show_all: mostrar todo
     share_links:
       share_this_page: Compartir esta página
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: y
     another_website_html: Esta consulta %{closed} se realizó en <a href='%{url}'>otro sitio web</a>

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -26,6 +26,9 @@ et:
       show_all: kuva kõik
     share_links:
       share_this_page: Jaga seda lehte
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: ja
     another_website_html: See konsultatsioon %{closed} toimus <a href="%{url}">teisel veebisaidil</a>

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -26,6 +26,9 @@ fa:
       show_all: نمایش همه
     share_links:
       share_this_page: اشتراک‌گذاری این صفحه
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: و
     another_website_html: این مشاوره %{closed} در <a href="%{url}">وب‌سات دیگر برگزار شد</a>

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -26,6 +26,9 @@ fi:
       show_all: näytä kaikki
     share_links:
       share_this_page: Jaa tämä sivu
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: ja
     another_website_html: Tämä kuuleminen %{closed} järjestettiin toisella <a href="%{url}">averkkosivustolla</a>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -26,6 +26,9 @@ fr:
       show_all: afficher tout
     share_links:
       share_this_page: Partagez cette page
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: et
     another_website_html: Cette consultation %{closed} s'est tenue sur <a href="%{url}">un autre site Web</a>

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -26,6 +26,9 @@ gd:
       show_all: Taispeáin go léir
     share_links:
       share_this_page: Comhroinn an leathanach seo
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: agus
     another_website_html: Tionóladh an comhairliúchán %{closed} seo ar <a href="%{url}">suíomh Gréasáin eile</a>

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -26,6 +26,9 @@ gu:
       show_all: બધા બતાવો
     share_links:
       share_this_page: આ પેજ શેર કરો
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: અને
     another_website_html: આ પરામર્શ %{closed} ના રોજ <a href="%{url}">અન્ય વેબસાઇટ</a> પર આયોજિત કરેલ છે

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -26,6 +26,9 @@ he:
       show_all: הצג הכל
     share_links:
       share_this_page: שתף דף זה
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: ו
     another_website_html: דיון זה %{closed} התקיים ב <a href="%{url}">אתר אחר</a>

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -26,6 +26,9 @@ hi:
       show_all: सब दिखाएं
     share_links:
       share_this_page: यह पेज शेयर करें
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: और
     another_website_html: यह परामर्श %{closed} <a href="%{url}">एक अन्य वेबसाइट</a>पर आयोजित किया गया

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -26,6 +26,9 @@ hr:
       show_all: prikaži sve
     share_links:
       share_this_page: Podijelite ovu stranicu
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: i
     another_website_html: Ovo savjetovanje %{closed} održano je na <ahref="%{url}">drugoj web stranici</a>

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -26,6 +26,9 @@ hu:
       show_all: összes megjelenítése
     share_links:
       share_this_page: Oldal megosztása
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: és
     another_website_html: A konzultáció %{closed} egy <a href="%{url}">másik weboldalon kerül megrendezésre</a>

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -26,6 +26,9 @@ hy:
       show_all: ցույց տալ բոլորը
     share_links:
       share_this_page: Կիսվել այս էջով
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: և
     another_website_html: Այս խորհրդակցությունը %{closed} անցկացվել է <a href="%{url}">մեկ այլ</a>

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -26,6 +26,9 @@ id:
       show_all: tampilkan semua
     share_links:
       share_this_page: Bagikan halaman ini
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: dan
     another_website_html: Konsultasi ini %{closed} diadakan di <a href="%{url}">situs web lain</a>

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -26,6 +26,9 @@ is:
       show_all: sýna allt
     share_links:
       share_this_page: Deila þessari síðu
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: og
     another_website_html: Þessi ráðgjöf %{closed} var haldin á <a href="%{url}">annarri vefsíðu</a>

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -26,6 +26,9 @@ it:
       show_all: mostra tutto
     share_links:
       share_this_page: Condividi questa pagina
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: e
     another_website_html: Questa consultazione %{closed} tenuta su <a href=”%{url}”>un altro sito web</a>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -26,6 +26,9 @@ ja:
       show_all: すべて表示
     share_links:
       share_this_page: このページを共有
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: および
     another_website_html: この審議％{closed}は、<ahref = "％{url}">別のウェブサイト</a>で行われました

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -26,6 +26,9 @@ ka:
       show_all: ყველას ჩვენება
     share_links:
       share_this_page: ამ გვერდის გაზიარება
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: და
     another_website_html: ეს კონსულტაცია %{closed} ჩატარდა <a href="%{url}">სხვა ვებგვერდზე</a>

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -26,6 +26,9 @@ kk:
       show_all: барлығын көрсету
     share_links:
       share_this_page: Осы бетпен бөлісу
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: және
     another_website_html: Бұл кеңес %{closed} <a href="%{url}">басқа веб-сайтта өтті</a>

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -26,6 +26,9 @@ ko:
       show_all: 모두 보기
     share_links:
       share_this_page: 이 페이지 공유하기
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: 그리고
     another_website_html: 이 상담 %{closed} 은 <a href="%{url}">다른 웹사이트</a>에서 진행되었습니다

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -26,6 +26,9 @@ lt:
       show_all: rodyti visus
     share_links:
       share_this_page: Bendrinti šį puslapį
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: ir
     another_website_html: Ši konsultacija %{closed} teikiama <a href="%{url}">kitoje interneto svetainėje</a>

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -26,6 +26,9 @@ lv:
       show_all: rādīt visu
     share_links:
       share_this_page: Kopīgot šo lapu
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: un
     another_website_html: Šī konsultācija %{closed} notika <a href="%{url}">citā tīmekļa vietnē</a>

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -26,6 +26,9 @@ ms:
       show_all: tunjuk semua
     share_links:
       share_this_page: Kongsi laman ini
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: dan
     another_website_html: Perundingan ini %{closed} telah diadakan di <a href="%{url}">laman web lain</a>

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -26,6 +26,9 @@ mt:
       show_all: uri kollox
     share_links:
       share_this_page: Aqsam din il-paġna ma'
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: u
     another_website_html: Din il-konsultazzjoni %{closed} tinsab fuq  <a href="%{url}">websajt oħra</a>

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -26,6 +26,9 @@ ne:
       show_all: सबै देखाउनुहोस्
     share_links:
       share_this_page: यो पृष्ठ साझा गर्नुहोस्
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: र
     another_website_html: यो परामर्श %{बन्द} <a href="%{url}">अर्को वेबसाइट</a> मा आयोजित

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -26,6 +26,9 @@ nl:
       show_all: alles tonen
     share_links:
       share_this_page: Deel deze pagina
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: en
     another_website_html: Dit overleg %{closed} werd gehouden op <a href="%{url}">een andere website</a>

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -26,6 +26,9 @@
       show_all: Vis alt
     share_links:
       share_this_page: Del denne siden
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: og
     another_website_html: Denne konsultasjonen %{closed} ble avholdt på <a href="%{url}">et annet nettsted</a>

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -26,6 +26,9 @@ pa-pk:
       show_all: سارا وکھاؤ
     share_links:
       share_this_page: ایہ ورقہ تقسیم کرو
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: ہور
     another_website_html: ایہ مشورہ  {closed} %ایندے تے وقوعہ ہویا <a href="%{url}">دُوسری ویب سائٹ</a>

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -26,6 +26,9 @@ pa:
       show_all: ਸਾਰੇ ਦਿਖਾਓ
     share_links:
       share_this_page: ਇਸ ਪੇਜ ਨੂੰ ਸ਼ੇਅਰ ਕਰੋ
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: ਅਤੇ
     another_website_html: ਇਹ ਸਲਾਹ -ਮਸ਼ਵਰਾ %{close} <a href="%{url}"> ਹੋਰ ਵੈਬਸਾਈਟ </a> 'ਤੇ ਆਯੋਜਿਤ ਕੀਤਾ ਗਿਆ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -26,6 +26,9 @@ pl:
       show_all: pokaż wszystkie
     share_links:
       share_this_page: Udostępnij tę stronę
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: i
     another_website_html: Te konsultacje %{closed} odbyły się na <a href="%{url}">innej stronie internetowej</a>

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -26,6 +26,9 @@ ps:
       show_all: ټول ښکاره کړه
     share_links:
       share_this_page: دا پاه شریکه کړئ
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: او
     another_website_html: دا مشوره <a href="%{url}">په بله ویبپا ڼه  کې %{closed}ترسره شوه</a>

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -26,6 +26,9 @@ pt:
       show_all: mostrar tudo
     share_links:
       share_this_page: Partilhar esta página
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: e
     another_website_html: Esta consulta %{closed} foi realizada <a href="%{url}">noutro site</a>

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -26,6 +26,9 @@ ro:
       show_all: afișați tot
     share_links:
       share_this_page: Distribuiți această pagină
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: și
     another_website_html: Această consultație %{closed} s-a ținut pe <a href="%{url}">un alt website</a>

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -26,6 +26,9 @@ ru:
       show_all: Показать всё
     share_links:
       share_this_page: 'Поделиться данной страницей '
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: и
     another_website_html: Консультация %{closed} проведенная на <a href="%{url}">другой Веб-сайт</a>

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -26,6 +26,9 @@ si:
       show_all: සියල්ල පෙන්වන්න
     share_links:
       share_this_page: මෙම පිටුව බෙදාගන්න
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: සහ
     another_website_html: මෙම උපදේශනය %{closed} <a href="%{url}">වෙනත් වෙබ් අඩවියක</a> පවත් වනු ලැබේ

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -26,6 +26,9 @@ sk:
       show_all: zobraziť všetko
     share_links:
       share_this_page: Zdieľať túto stránku
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: a
     another_website_html: Táto konzultácia %{closed} sa konala na <a href="%{url}">inej webovej stránke</a>

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -26,6 +26,9 @@ sl:
       show_all: prikaži vse
     share_links:
       share_this_page: Deli to stran
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: in
     another_website_html: To posvetovanje %{closed} poteka na <a href="%{url}">drugi spletni strani</a>

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -26,6 +26,9 @@ so:
       show_all: Muuji dhamaan
     share_links:
       share_this_page: Lawadaag bogan
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: iyo
     another_website_html: Latalintan %{closed} held on <a href="%{url}">websaayt kale</a>

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -26,6 +26,9 @@ sq:
       show_all: shfaq të gjitha
     share_links:
       share_this_page: Shpërdaj këtë faqe
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: dhe
     another_website_html: Ky konsultim %{closed} u mbajt <a href="%{url}">uebfaqe tjetër</a>

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -26,6 +26,9 @@ sr:
       show_all: prikaži sve
     share_links:
       share_this_page: Podeli ovu stranicu
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: i
     another_website_html: Ove konsultacije %{closed} se održavaju na <a href="%{url}">drugom veb-sajtu</a>

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -26,6 +26,9 @@ sv:
       show_all: visa alla
     share_links:
       share_this_page: Dela den här sidan
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: och
     another_website_html: Detta samråd %{closed} hölls på <a href="%{url}">en annan webbplats</a>

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -26,6 +26,9 @@ sw:
       show_all: onyesha zote
     share_links:
       share_this_page: Shiriki ukurasa huu
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: na
     another_website_html: Mashauriano haya %{closed} yalifanywa kwenye <a href="%{url}">tovuti nyingine</a>

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -26,6 +26,9 @@ ta:
       show_all: அனைத்தையும் காட்டு
     share_links:
       share_this_page: இந்தப் பக்கத்தைப் பகிர்க
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: மற்றும்
     another_website_html: இந்தக் கலந்தாலோசனை %{closed} <a href="%{url}">வேறொரு இணையதளத்தில்</a>நடைபெற்றது

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -26,6 +26,9 @@ th:
       show_all: แสดงทั้งหมด
     share_links:
       share_this_page: แชร์หน้านี้
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: และ
     another_website_html: การให้คำปรึกษา %{closed} นี้จัดขึ้นใน <a href="%{url}">เว็บไซต์อื่น</a>

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -26,6 +26,9 @@ tk:
       show_all: ählisini görkez
     share_links:
       share_this_page: Bu sahypany paýlaşyň
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: we
     another_website_html: Bu maslahat %{closed} <a href="%{url}">başga websahypa</a> internet sahypasynda görkezilýär

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -26,6 +26,9 @@ tr:
       show_all: hepsini göster
     share_links:
       share_this_page: Bu sayfayı paylaş
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: ve
     another_website_html: Bu danışma %{closed} başka bir websitesinde<a href="%{url}">gerçekleşti</a>

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -26,6 +26,9 @@ uk:
       show_all: показати всі
     share_links:
       share_this_page: Поділіться цією сторінкою
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: та
     another_website_html: Ця консультація %{closed} проведена на <a href="%{url}">іншому вебсайті</a>

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -26,6 +26,9 @@ ur:
       show_all: تمام دکھائیں
     share_links:
       share_this_page: اس صفحے کو شیئر کریں
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: اور
     another_website_html: یہ مشاورت %{closed} <a href="%{url}">ایک اور ویب سائٹ پر ہوئی تھی</a>

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -26,6 +26,9 @@ uz:
       show_all: барчасини кўрсатиш
     share_links:
       share_this_page: Саҳифа билан бўлишиш
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: ва
     another_website_html: Ушбу маслаҳат %{closed} бошқа <a href="%{url}"> веб-сайтда ўтказилди</a>

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -26,6 +26,9 @@ vi:
       show_all: hiển thị tất cả
     share_links:
       share_this_page: Chia sẻ trang này
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: và
     another_website_html: Buổi tham vấn này %{closed} được tổ chức trên <a href="%{url}">một trang web khác</a>

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -26,6 +26,9 @@ yi:
       show_all:
     share_links:
       share_this_page:
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and:
     another_website_html:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -26,6 +26,9 @@ zh-hk:
       show_all: 全部顯示
     share_links:
       share_this_page: 轉載此一頁面
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: 及
     another_website_html: 本次諮詢 %{closed} 在 <a href="%{url}">另一網站舉行</a>

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -26,6 +26,9 @@ zh-tw:
       show_all: 展開全部
     share_links:
       share_this_page: 分享此頁面
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: 以及
     another_website_html: 此諮詢 %{closed} 在 <a href="%{url}">另一個網站進</a>

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -26,6 +26,9 @@ zh:
       show_all: 显示全部
     share_links:
       share_this_page: 分享本页面
+    single_page_notification_button:
+      subscribe_text:
+      unsubscribe_text:
   consultation:
     and: 和
     another_website_html: 本咨询 %{closed} 位于 <a href="%{url}">另一个网站</a>

--- a/spec/javascripts/components/single-page-notification-button-spec.js
+++ b/spec/javascripts/components/single-page-notification-button-spec.js
@@ -1,0 +1,112 @@
+/* eslint-env jasmine */
+/* global GOVUK */
+
+describe('Single page notification component', function () {
+  var FIXTURE
+
+  beforeEach(function () {
+    FIXTURE =
+      '<form class="app-c-single-page-notification-button old-button-for-test js-personalisation-enhancement" action="/email/subscriptions/single-page/new" method="POST" data-module="single-page-notification-button">' +
+        '<input type="hidden" name="base_path" value="/current-page-path">' +
+        '<button class="app-c-single-page-notification-button__submit" type="submit">Get emails about this page</button>' +
+    '</form>'
+    window.setFixtures(FIXTURE)
+    jasmine.Ajax.install()
+  })
+
+  afterEach(function () {
+    jasmine.Ajax.uninstall()
+  })
+
+  it('calls the personalisation API on load', function () {
+    initButton()
+    var request = jasmine.Ajax.requests.mostRecent()
+    expect(request.url).toBe('/api/personalisation/check-email-subscription?base_path=/current-page-path')
+    expect(request.method).toBe('GET')
+  })
+
+  it('includes button_location in the call to the personalisation API when button_location is specified', function () {
+    FIXTURE =
+      '<form class="app-c-single-page-notification-button old-button-for-test js-personalisation-enhancement" action="/email/subscriptions/single-page/new" method="POST" data-module="single-page-notification-button" data-button-location="top">' +
+        '<input type="hidden" name="base_path" value="/current-page-path">' +
+        '<button class="app-c-single-page-notification-button__submit" type="submit">Get emails about this page</button>' +
+      '</form>'
+    window.setFixtures(FIXTURE)
+
+    initButton()
+    var request = jasmine.Ajax.requests.mostRecent()
+    expect(request.url).toBe('/api/personalisation/check-email-subscription?base_path=/current-page-path&button_location=top')
+    expect(request.method).toBe('GET')
+  })
+
+  it('replaces the button when the API returns button html', function () {
+    initButton()
+
+    jasmine.Ajax.requests.mostRecent().respondWith({
+      status: 200,
+      contentType: 'application/json',
+      responseText: '{\n    "base_path": "/current-page-path",\n    "active": true,\n    "button_html": "<form class=\\"app-c-single-page-notification-button new-button-for-test\\" action=\\"/email/subscriptions/single-page/new\\" method=\\"POST\\">\\n  <input type=\\"hidden\\" name=\\"base_path\\" value=\\"/current-page-path\\">\\n  <button class=\\"app-c-single-page-notification-button__submit\\" type=\\"submit\\">Stop getting emails about this page\\n</button>\\n</form>"\n}'
+    })
+
+    var button = document.querySelector('form.app-c-single-page-notification-button.new-button-for-test button')
+    expect(button).toHaveText('Stop getting emails about this page')
+  })
+
+  it('should remain unchanged if the response is not JSON', function () {
+    var responseText = 'I am not JSON, actually'
+    initButton()
+
+    jasmine.Ajax.requests.mostRecent().respondWith({
+      status: 200,
+      contentType: 'application/json',
+      responseText: responseText
+    })
+
+    var button = document.querySelector('form.app-c-single-page-notification-button.old-button-for-test.app-c-single-page-notification-button--visible button')
+    expect(button).toHaveText('Get emails about this page')
+    expect(GOVUK.Modules.SinglePageNotificationButton.prototype.responseIsJSON(responseText)).toBe(false)
+  })
+
+  it('should remain unchanged if response text is empty', function () {
+    var responseText = ''
+    initButton()
+
+    jasmine.Ajax.requests.mostRecent().respondWith({
+      status: 200,
+      contentType: 'application/json',
+      responseText: responseText
+    })
+
+    var button = document.querySelector('form.app-c-single-page-notification-button.old-button-for-test.app-c-single-page-notification-button--visible button')
+    expect(button).toHaveText('Get emails about this page')
+    expect(GOVUK.Modules.SinglePageNotificationButton.prototype.responseIsJSON(responseText)).toBe(false)
+  })
+
+  it('should remain unchanged if the endpoint fails', function () {
+    initButton()
+
+    jasmine.Ajax.requests.mostRecent().respondWith({
+      status: 500,
+      contentType: 'text/plain',
+      responseText: ''
+    })
+
+    var button = document.querySelector('form.app-c-single-page-notification-button.old-button-for-test.app-c-single-page-notification-button--visible button')
+    expect(button).toHaveText('Get emails about this page')
+  })
+
+  it('should remain unchanged if xhr times out', function () {
+    jasmine.clock().install()
+    initButton()
+    jasmine.Ajax.requests.mostRecent().responseTimeout()
+
+    var button = document.querySelector('form.app-c-single-page-notification-button.old-button-for-test.app-c-single-page-notification-button--visible button')
+    expect(button).toHaveText('Get emails about this page')
+    jasmine.clock().uninstall()
+  })
+
+  function initButton () {
+    var element = document.querySelector('[data-module=single-page-notification-button]')
+    new GOVUK.Modules.SinglePageNotificationButton(element).init()
+  }
+})

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -14,6 +14,7 @@ src_files:
   - "spec/javascripts/vendor/jquery-1.12.4.js"
   - "spec/javascripts/vendor/jasmine-jquery-2.0.5.js"
   - "spec/javascripts/vendor/lolex.js"
+  - "spec/javascripts/vendor/mock-ajax.js"
   - "assets/application.js"
   - "assets/webchat.js"
 

--- a/spec/javascripts/vendor/mock-ajax.js
+++ b/spec/javascripts/vendor/mock-ajax.js
@@ -1,0 +1,774 @@
+/*
+
+Jasmine-Ajax - v3.2.0: a set of helpers for testing AJAX requests under the Jasmine
+BDD framework for JavaScript.
+
+http://github.com/jasmine/jasmine-ajax
+
+Jasmine Home page: http://jasmine.github.io/
+
+Copyright (c) 2008-2015 Pivotal Labs
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+//Module wrapper to support both browser and CommonJS environment
+(function (root, factory) {
+    if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
+        // CommonJS
+        var jasmineRequire = require('jasmine-core');
+        module.exports = factory(root, function() {
+            return jasmineRequire;
+        });
+    } else {
+        // Browser globals
+        window.MockAjax = factory(root, getJasmineRequireObj);
+    }
+}(typeof window !== 'undefined' ? window : global, function (global, getJasmineRequireObj) {
+
+//
+getJasmineRequireObj().ajax = function(jRequire) {
+  var $ajax = {};
+
+  $ajax.RequestStub = jRequire.AjaxRequestStub();
+  $ajax.RequestTracker = jRequire.AjaxRequestTracker();
+  $ajax.StubTracker = jRequire.AjaxStubTracker();
+  $ajax.ParamParser = jRequire.AjaxParamParser();
+  $ajax.event = jRequire.AjaxEvent();
+  $ajax.eventBus = jRequire.AjaxEventBus($ajax.event);
+  $ajax.fakeRequest = jRequire.AjaxFakeRequest($ajax.eventBus);
+  $ajax.MockAjax = jRequire.MockAjax($ajax);
+
+  return $ajax.MockAjax;
+};
+
+getJasmineRequireObj().AjaxEvent = function() {
+  function now() {
+    return new Date().getTime();
+  }
+
+  function noop() {
+  }
+
+  // Event object
+  // https://dom.spec.whatwg.org/#concept-event
+  function XMLHttpRequestEvent(xhr, type) {
+    this.type = type;
+    this.bubbles = false;
+    this.cancelable = false;
+    this.timeStamp = now();
+
+    this.isTrusted = false;
+    this.defaultPrevented = false;
+
+    // Event phase should be "AT_TARGET"
+    // https://dom.spec.whatwg.org/#dom-event-at_target
+    this.eventPhase = 2;
+
+    this.target = xhr;
+    this.currentTarget = xhr;
+  }
+
+  XMLHttpRequestEvent.prototype.preventDefault = noop;
+  XMLHttpRequestEvent.prototype.stopPropagation = noop;
+  XMLHttpRequestEvent.prototype.stopImmediatePropagation = noop;
+
+  function XMLHttpRequestProgressEvent() {
+    XMLHttpRequestEvent.apply(this, arguments);
+
+    this.lengthComputable = false;
+    this.loaded = 0;
+    this.total = 0;
+  }
+
+  // Extend prototype
+  XMLHttpRequestProgressEvent.prototype = XMLHttpRequestEvent.prototype;
+
+  return {
+    event: function(xhr, type) {
+      return new XMLHttpRequestEvent(xhr, type);
+    },
+
+    progressEvent: function(xhr, type) {
+      return new XMLHttpRequestProgressEvent(xhr, type);
+    }
+  };
+};
+getJasmineRequireObj().AjaxEventBus = function(eventFactory) {
+  function EventBus(source) {
+    this.eventList = {};
+    this.source = source;
+  }
+
+  function ensureEvent(eventList, name) {
+    eventList[name] = eventList[name] || [];
+    return eventList[name];
+  }
+
+  function findIndex(list, thing) {
+    if (list.indexOf) {
+      return list.indexOf(thing);
+    }
+
+    for(var i = 0; i < list.length; i++) {
+      if (thing === list[i]) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  EventBus.prototype.addEventListener = function(event, callback) {
+    ensureEvent(this.eventList, event).push(callback);
+  };
+
+  EventBus.prototype.removeEventListener = function(event, callback) {
+    var index = findIndex(this.eventList[event], callback);
+
+    if (index >= 0) {
+      this.eventList[event].splice(index, 1);
+    }
+  };
+
+  EventBus.prototype.trigger = function(event) {
+    var evt;
+
+    // Event 'readystatechange' is should be a simple event.
+    // Others are progress event.
+    // https://xhr.spec.whatwg.org/#events
+    if (event === 'readystatechange') {
+      evt = eventFactory.event(this.source, event);
+    } else {
+      evt = eventFactory.progressEvent(this.source, event);
+    }
+
+    var eventListeners = this.eventList[event];
+
+    if (eventListeners) {
+      for (var i = 0; i < eventListeners.length; i++) {
+        eventListeners[i].call(this.source, evt);
+      }
+    }
+  };
+
+  return function(source) {
+    return new EventBus(source);
+  };
+};
+
+getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
+  function extend(destination, source, propertiesToSkip) {
+    propertiesToSkip = propertiesToSkip || [];
+    for (var property in source) {
+      if (!arrayContains(propertiesToSkip, property)) {
+        destination[property] = source[property];
+      }
+    }
+    return destination;
+  }
+
+  function arrayContains(arr, item) {
+    for (var i = 0; i < arr.length; i++) {
+      if (arr[i] === item) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function wrapProgressEvent(xhr, eventName) {
+    return function() {
+      if (xhr[eventName]) {
+        xhr[eventName].apply(xhr, arguments);
+      }
+    };
+  }
+
+  function initializeEvents(xhr) {
+    xhr.eventBus.addEventListener('readystatechange', wrapProgressEvent(xhr, 'onreadystatechange'));
+    xhr.eventBus.addEventListener('loadstart', wrapProgressEvent(xhr, 'onloadstart'));
+    xhr.eventBus.addEventListener('load', wrapProgressEvent(xhr, 'onload'));
+    xhr.eventBus.addEventListener('loadend', wrapProgressEvent(xhr, 'onloadend'));
+    xhr.eventBus.addEventListener('progress', wrapProgressEvent(xhr, 'onprogress'));
+    xhr.eventBus.addEventListener('error', wrapProgressEvent(xhr, 'onerror'));
+    xhr.eventBus.addEventListener('abort', wrapProgressEvent(xhr, 'onabort'));
+    xhr.eventBus.addEventListener('timeout', wrapProgressEvent(xhr, 'ontimeout'));
+  }
+
+  function unconvertibleResponseTypeMessage(type) {
+    var msg = [
+      "Can't build XHR.response for XHR.responseType of '",
+      type,
+      "'.",
+      "XHR.response must be explicitly stubbed"
+    ];
+    return msg.join(' ');
+  }
+
+  function fakeRequest(global, requestTracker, stubTracker, paramParser) {
+    function FakeXMLHttpRequest() {
+      requestTracker.track(this);
+      this.eventBus = eventBusFactory(this);
+      initializeEvents(this);
+      this.requestHeaders = {};
+      this.overriddenMimeType = null;
+    }
+
+    function findHeader(name, headers) {
+      name = name.toLowerCase();
+      for (var header in headers) {
+        if (header.toLowerCase() === name) {
+          return headers[header];
+        }
+      }
+    }
+
+    function normalizeHeaders(rawHeaders, contentType) {
+      var headers = [];
+
+      if (rawHeaders) {
+        if (rawHeaders instanceof Array) {
+          headers = rawHeaders;
+        } else {
+          for (var headerName in rawHeaders) {
+            if (rawHeaders.hasOwnProperty(headerName)) {
+              headers.push({ name: headerName, value: rawHeaders[headerName] });
+            }
+          }
+        }
+      } else {
+        headers.push({ name: "Content-Type", value: contentType || "application/json" });
+      }
+
+      return headers;
+    }
+
+    function parseXml(xmlText, contentType) {
+      if (global.DOMParser) {
+        return (new global.DOMParser()).parseFromString(xmlText, 'text/xml');
+      } else {
+        var xml = new global.ActiveXObject("Microsoft.XMLDOM");
+        xml.async = "false";
+        xml.loadXML(xmlText);
+        return xml;
+      }
+    }
+
+    var xmlParsables = ['text/xml', 'application/xml'];
+
+    function getResponseXml(responseText, contentType) {
+      if (arrayContains(xmlParsables, contentType.toLowerCase())) {
+        return parseXml(responseText, contentType);
+      } else if (contentType.match(/\+xml$/)) {
+        return parseXml(responseText, 'text/xml');
+      }
+      return null;
+    }
+
+    var iePropertiesThatCannotBeCopied = ['responseBody', 'responseText', 'responseXML', 'status', 'statusText', 'responseTimeout', 'responseURL'];
+    extend(FakeXMLHttpRequest.prototype, new global.XMLHttpRequest(), iePropertiesThatCannotBeCopied);
+    extend(FakeXMLHttpRequest.prototype, {
+      open: function() {
+        this.method = arguments[0];
+        this.url = arguments[1];
+        this.username = arguments[3];
+        this.password = arguments[4];
+        this.readyState = 1;
+        this.requestHeaders = {};
+        this.eventBus.trigger('readystatechange');
+      },
+
+      setRequestHeader: function(header, value) {
+        if(this.requestHeaders.hasOwnProperty(header)) {
+          this.requestHeaders[header] = [this.requestHeaders[header], value].join(', ');
+        } else {
+          this.requestHeaders[header] = value;
+        }
+      },
+
+      overrideMimeType: function(mime) {
+        this.overriddenMimeType = mime;
+      },
+
+      abort: function() {
+        this.readyState = 0;
+        this.status = 0;
+        this.statusText = "abort";
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('abort');
+        this.eventBus.trigger('loadend');
+      },
+
+      readyState: 0,
+
+      onloadstart: null,
+      onprogress: null,
+      onabort: null,
+      onerror: null,
+      onload: null,
+      ontimeout: null,
+      onloadend: null,
+      onreadystatechange: null,
+
+      addEventListener: function() {
+        this.eventBus.addEventListener.apply(this.eventBus, arguments);
+      },
+
+      removeEventListener: function(event, callback) {
+        this.eventBus.removeEventListener.apply(this.eventBus, arguments);
+      },
+
+      status: null,
+
+      send: function(data) {
+        this.params = data;
+        this.eventBus.trigger('loadstart');
+
+        var stub = stubTracker.findStub(this.url, data, this.method);
+
+        this.dispatchStub(stub);
+      },
+
+      dispatchStub: function(stub) {
+        if (stub) {
+          if (stub.isReturn()) {
+            this.respondWith(stub);
+          } else if (stub.isError()) {
+            this.responseError();
+          } else if (stub.isTimeout()) {
+            this.responseTimeout();
+          } else if (stub.isCallFunction()) {
+            this.responseCallFunction(stub);
+          }
+        }
+      },
+
+      contentType: function() {
+        return findHeader('content-type', this.requestHeaders);
+      },
+
+      data: function() {
+        if (!this.params) {
+          return {};
+        }
+
+        return paramParser.findParser(this).parse(this.params);
+      },
+
+      getResponseHeader: function(name) {
+        name = name.toLowerCase();
+        var resultHeader;
+        for(var i = 0; i < this.responseHeaders.length; i++) {
+          var header = this.responseHeaders[i];
+          if (name === header.name.toLowerCase()) {
+            if (resultHeader) {
+              resultHeader = [resultHeader, header.value].join(', ');
+            } else {
+              resultHeader = header.value;
+            }
+          }
+        }
+        return resultHeader;
+      },
+
+      getAllResponseHeaders: function() {
+        var responseHeaders = [];
+        for (var i = 0; i < this.responseHeaders.length; i++) {
+          responseHeaders.push(this.responseHeaders[i].name + ': ' +
+            this.responseHeaders[i].value);
+        }
+        return responseHeaders.join('\r\n') + '\r\n';
+      },
+
+      responseText: null,
+      response: null,
+      responseType: null,
+      responseURL: null,
+
+      responseValue: function() {
+        switch(this.responseType) {
+          case null:
+          case "":
+          case "text":
+            return this.readyState >= 3 ? this.responseText : "";
+          case "json":
+            return JSON.parse(this.responseText);
+          case "arraybuffer":
+            throw unconvertibleResponseTypeMessage('arraybuffer');
+          case "blob":
+            throw unconvertibleResponseTypeMessage('blob');
+          case "document":
+            return this.responseXML;
+        }
+      },
+
+
+      respondWith: function(response) {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+
+        this.status = response.status;
+        this.statusText = response.statusText || "";
+        this.responseHeaders = normalizeHeaders(response.responseHeaders, response.contentType);
+        this.readyState = 2;
+        this.eventBus.trigger('readystatechange');
+
+        this.responseText = response.responseText || "";
+        this.responseType = response.responseType || "";
+        this.responseURL = response.responseURL || null;
+        this.readyState = 4;
+        this.responseXML = getResponseXml(response.responseText, this.getResponseHeader('content-type') || '');
+        if (this.responseXML) {
+          this.responseType = 'document';
+        }
+
+        if ('response' in response) {
+          this.response = response.response;
+        } else {
+          this.response = this.responseValue();
+        }
+
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('load');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseTimeout: function() {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+        this.readyState = 4;
+        jasmine.clock().tick(30000);
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('timeout');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseError: function() {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+        this.readyState = 4;
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('error');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseCallFunction: function(stub) {
+        stub.action = undefined;
+        stub.functionToCall(stub, this);
+        this.dispatchStub(stub);
+      }
+    });
+
+    return FakeXMLHttpRequest;
+  }
+
+  return fakeRequest;
+};
+
+getJasmineRequireObj().MockAjax = function($ajax) {
+  function MockAjax(global) {
+    var requestTracker = new $ajax.RequestTracker(),
+      stubTracker = new $ajax.StubTracker(),
+      paramParser = new $ajax.ParamParser(),
+      realAjaxFunction = global.XMLHttpRequest,
+      mockAjaxFunction = $ajax.fakeRequest(global, requestTracker, stubTracker, paramParser);
+
+    this.install = function() {
+      if (global.XMLHttpRequest === mockAjaxFunction) {
+        throw "MockAjax is already installed.";
+      }
+
+      global.XMLHttpRequest = mockAjaxFunction;
+    };
+
+    this.uninstall = function() {
+      if (global.XMLHttpRequest !== mockAjaxFunction) {
+        throw "MockAjax not installed.";
+      }
+      global.XMLHttpRequest = realAjaxFunction;
+
+      this.stubs.reset();
+      this.requests.reset();
+      paramParser.reset();
+    };
+
+    this.stubRequest = function(url, data, method) {
+      var stub = new $ajax.RequestStub(url, data, method);
+      stubTracker.addStub(stub);
+      return stub;
+    };
+
+    this.withMock = function(closure) {
+      this.install();
+      try {
+        closure();
+      } finally {
+        this.uninstall();
+      }
+    };
+
+    this.addCustomParamParser = function(parser) {
+      paramParser.add(parser);
+    };
+
+    this.requests = requestTracker;
+    this.stubs = stubTracker;
+  }
+
+  return MockAjax;
+};
+
+getJasmineRequireObj().AjaxParamParser = function() {
+  function ParamParser() {
+    var defaults = [
+      {
+        test: function(xhr) {
+          return (/^application\/json/).test(xhr.contentType());
+        },
+        parse: function jsonParser(paramString) {
+          return JSON.parse(paramString);
+        }
+      },
+      {
+        test: function(xhr) {
+          return true;
+        },
+        parse: function naiveParser(paramString) {
+          var data = {};
+          var params = paramString.split('&');
+
+          for (var i = 0; i < params.length; ++i) {
+            var kv = params[i].replace(/\+/g, ' ').split('=');
+            var key = decodeURIComponent(kv[0]);
+            data[key] = data[key] || [];
+            data[key].push(decodeURIComponent(kv[1]));
+          }
+          return data;
+        }
+      }
+    ];
+    var paramParsers = [];
+
+    this.add = function(parser) {
+      paramParsers.unshift(parser);
+    };
+
+    this.findParser = function(xhr) {
+        for(var i in paramParsers) {
+          var parser = paramParsers[i];
+          if (parser.test(xhr)) {
+            return parser;
+          }
+        }
+    };
+
+    this.reset = function() {
+      paramParsers = [];
+      for(var i in defaults) {
+        paramParsers.push(defaults[i]);
+      }
+    };
+
+    this.reset();
+  }
+
+  return ParamParser;
+};
+
+getJasmineRequireObj().AjaxRequestStub = function() {
+  var RETURN = 0,
+      ERROR = 1,
+      TIMEOUT = 2,
+      CALL = 3;
+
+  function RequestStub(url, stubData, method) {
+    var normalizeQuery = function(query) {
+      return query ? query.split('&').sort().join('&') : undefined;
+    };
+
+    if (url instanceof RegExp) {
+      this.url = url;
+      this.query = undefined;
+    } else {
+      var split = url.split('?');
+      this.url = split[0];
+      this.query = split.length > 1 ? normalizeQuery(split[1]) : undefined;
+    }
+
+    this.data = (stubData instanceof RegExp) ? stubData : normalizeQuery(stubData);
+    this.method = method;
+
+    this.andReturn = function(options) {
+      this.action = RETURN;
+      this.status = options.status || 200;
+
+      this.contentType = options.contentType;
+      this.response = options.response;
+      this.responseText = options.responseText;
+      this.responseHeaders = options.responseHeaders;
+      this.responseURL = options.responseURL;
+    };
+
+    this.isReturn = function() {
+      return this.action === RETURN;
+    };
+
+    this.andError = function() {
+      this.action = ERROR;
+    };
+
+    this.isError = function() {
+      return this.action === ERROR;
+    };
+
+    this.andTimeout = function() {
+      this.action = TIMEOUT;
+    };
+
+    this.isTimeout = function() {
+      return this.action === TIMEOUT;
+    };
+
+    this.andCallFunction = function(functionToCall) {
+      this.action = CALL;
+      this.functionToCall = functionToCall;
+    };
+
+    this.isCallFunction = function() {
+      return this.action === CALL;
+    };
+
+    this.matches = function(fullUrl, data, method) {
+      var urlMatches = false;
+      fullUrl = fullUrl.toString();
+      if (this.url instanceof RegExp) {
+        urlMatches = this.url.test(fullUrl);
+      } else {
+        var urlSplit = fullUrl.split('?'),
+            url = urlSplit[0],
+            query = urlSplit[1];
+        urlMatches = this.url === url && this.query === normalizeQuery(query);
+      }
+      var dataMatches = false;
+      if (this.data instanceof RegExp) {
+        dataMatches = this.data.test(data);
+      } else {
+        dataMatches = !this.data || this.data === normalizeQuery(data);
+      }
+      return urlMatches && dataMatches && (!this.method || this.method === method);
+    };
+  }
+
+  return RequestStub;
+};
+
+getJasmineRequireObj().AjaxRequestTracker = function() {
+  function RequestTracker() {
+    var requests = [];
+
+    this.track = function(request) {
+      requests.push(request);
+    };
+
+    this.first = function() {
+      return requests[0];
+    };
+
+    this.count = function() {
+      return requests.length;
+    };
+
+    this.reset = function() {
+      requests = [];
+    };
+
+    this.mostRecent = function() {
+      return requests[requests.length - 1];
+    };
+
+    this.at = function(index) {
+      return requests[index];
+    };
+
+    this.filter = function(url_to_match) {
+      var matching_requests = [];
+
+      for (var i = 0; i < requests.length; i++) {
+        if (url_to_match instanceof RegExp &&
+            url_to_match.test(requests[i].url)) {
+            matching_requests.push(requests[i]);
+        } else if (url_to_match instanceof Function &&
+            url_to_match(requests[i])) {
+            matching_requests.push(requests[i]);
+        } else {
+          if (requests[i].url === url_to_match) {
+            matching_requests.push(requests[i]);
+          }
+        }
+      }
+
+      return matching_requests;
+    };
+  }
+
+  return RequestTracker;
+};
+
+getJasmineRequireObj().AjaxStubTracker = function() {
+  function StubTracker() {
+    var stubs = [];
+
+    this.addStub = function(stub) {
+      stubs.push(stub);
+    };
+
+    this.reset = function() {
+      stubs = [];
+    };
+
+    this.findStub = function(url, data, method) {
+      for (var i = stubs.length - 1; i >= 0; i--) {
+        var stub = stubs[i];
+        if (stub.matches(url, data, method)) {
+          return stub;
+        }
+      }
+    };
+  }
+
+  return StubTracker;
+};
+
+
+    var jRequire = getJasmineRequireObj();
+    var MockAjax = jRequire.ajax(jRequire);
+    jasmine.Ajax = new MockAjax(global);
+
+    return MockAjax;
+}));

--- a/test/components/single_page_notification_button_test.rb
+++ b/test/components/single_page_notification_button_test.rb
@@ -1,0 +1,95 @@
+require "component_test_helper"
+
+class SinglePageNotificationButtonTest < ComponentTestCase
+  def component_name
+    "single_page_notification_button"
+  end
+
+  test "does not render without a base path" do
+    assert_empty render_component({})
+  end
+
+  test "renders with the correct markup if base path is present" do
+    render_component({ base_path: "/the-current-page" })
+    assert_select "form.app-c-single-page-notification-button"
+    assert_select "input[type='hidden']", value: "/the-current-page"
+    assert_select ".app-c-single-page-notification-button button.app-c-single-page-notification-button__submit[type='submit']"
+  end
+
+  test "shows 'Get emails about this page' by default" do
+    render_component({ base_path: "/the-current-page" })
+    assert_select ".app-c-single-page-notification-button", text: "Get emails about this page"
+  end
+
+  test "shows 'Stop getting emails about this page' if already_subscribed is true" do
+    render_component({ base_path: "/the-current-page", already_subscribed: true })
+    assert_select ".app-c-single-page-notification-button", text: "Stop getting emails about this page"
+  end
+
+  test "has data attributes if data_attributes is specified" do
+    render_component({ base_path: "/the-current-page", data_attributes: { custom_attribute: "kaboom!" } })
+    assert_select ".app-c-single-page-notification-button[data-custom-attribute='kaboom!']"
+  end
+
+  test "sets a default bottom margin to its wrapper" do
+    render_component({ base_path: "/the-current-page" })
+    assert_select 'div.govuk-\!-margin-bottom-3 .app-c-single-page-notification-button'
+  end
+
+  test "adds bottom margin to its wrapper if margin_bottom is specified" do
+    render_component({ base_path: "/the-current-page", margin_bottom: 9 })
+    assert_select 'div.govuk-\!-margin-bottom-9 .app-c-single-page-notification-button'
+  end
+
+  test "has a js-enhancement class and a data-module attribute if the js-enhancement flag is present" do
+    render_component({ base_path: "/the-current-page", js_enhancement: true })
+    assert_select ".app-c-single-page-notification-button.js-personalisation-enhancement[data-module='single-page-notification-button']"
+  end
+
+  test "does not have a js-enhancement class and a data-module attribute if the js-enhancement flag is not present" do
+    render_component({ base_path: "/the-current-page" })
+    assert_select ".app-c-single-page-notification-button.js-personalisation-enhancement", false
+    assert_select ".app-c-single-page-notification-button[data-module='single-page-notification-button']", false
+  end
+
+  test "has correct attributes for tracking by default" do
+    render_component({ base_path: "/the-current-page" })
+    assert_select ".app-c-single-page-notification-button[data-track-category='Single-page-notification-button'][data-track-action='Subscribe-button'][data-track-label='/the-current-page']"
+  end
+
+  test "has correct attributes for tracking when already_subscribed is true" do
+    render_component({ base_path: "/the-current-page", already_subscribed: true })
+
+    assert_select ".app-c-single-page-notification-button[data-track-category='Single-page-notification-button'][data-track-action='Unsubscribe-button'][data-track-label='/the-current-page']"
+  end
+
+  test "has the correct default data-track-action for tracking when button_location is top" do
+    render_component({ base_path: "/the-current-page", button_location: "top" })
+
+    assert_select ".app-c-single-page-notification-button[data-track-action='Subscribe-button-top']"
+  end
+
+  test "has the correct data-track-action for tracking when button_location is top and already_subscribed is true" do
+    render_component({ base_path: "/the-current-page", button_location: "top", already_subscribed: true })
+
+    assert_select ".app-c-single-page-notification-button[data-track-action='Unsubscribe-button-top']"
+  end
+
+  test "has the correct default data-track-action for tracking when button_location is bottom" do
+    render_component({ base_path: "/the-current-page", button_location: "bottom" })
+
+    assert_select ".app-c-single-page-notification-button[data-track-action='Subscribe-button-bottom']"
+  end
+
+  test "has the correct data-track-action for tracking when button_location is bottom and already_subscribed is true" do
+    render_component({ base_path: "/the-current-page", button_location: "bottom", already_subscribed: true })
+
+    assert_select ".app-c-single-page-notification-button[data-track-action='Unsubscribe-button-bottom']"
+  end
+
+  test "has the correct data-track-action for tracking when button_location has an invalid value" do
+    render_component({ base_path: "/the-current-page", button_location: "this is unacceptable" })
+
+    assert_select ".app-c-single-page-notification-button[data-track-action='Subscribe-button']"
+  end
+end


### PR DESCRIPTION
The single page notification button component was originally created in `govuk_publishing_components` as the initial understanding was that it might be used on different frontend apps.

However, the button is only being used on `government-frontend` currently and it is highly unlikely that there will be a purpose for this component outside of the scope of this application.

This commit copies over the `single_page_notification_button` from `govuk_publishing_components` into `government-frontend`'s app-level component library. 
Some notable adjustments have been made to the test file (`government-frontend` uses Minitest while `govuk_publishing_components` relies on Rspec) and also to the single page notification helper file as instance variables are not allowed in helpers in `government-frontend`.

The component's JS test file relies on Jasmine Ajax so support for that has also been added as part of this work.

The next step in this piece of work is to remove the component from `govuk_publishing_components`.

A few pages which use the component:
https://government-f-move-singl-nrz30x.herokuapp.com/government/publications/open-standards-for-government 
https://government-f-move-singl-nrz30x.herokuapp.com//guidance/check-which-plastic-packaging-is-exempt-from-plastic-packaging-tax
https://government-f-move-singl-nrz30x.herokuapp.com/guidance/uk-trade-agreements-with-non-eu-countries#full-publication-update-history


------

https://trello.com/c/HWDXgTdp

------

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
