### PR TITLE
Add accessible form link

### DIFF
--- a/app/presenters/content_item/attachments.rb
+++ b/app/presenters/content_item/attachments.rb
@@ -1,9 +1,15 @@
 module ContentItem
   module Attachments
     def attachment_details(attachment_id)
-      content_item.dig("details", "attachments")&.find do |attachment|
+      found_attachment = content_item.dig("details", "attachments")&.find do |attachment|
         attachment["id"] == attachment_id
       end
+
+      return unless found_attachment
+
+      found_attachment["attachment_id"] = found_attachment.delete("id")
+      found_attachment["owning_document_content_id"] = content_item["content_id"]
+      found_attachment
     end
   end
 end

--- a/test/presenters/content_item/attachments_test.rb
+++ b/test/presenters/content_item/attachments_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class ContentItemAttachmentsTest < ActiveSupport::TestCase
+  class DummyContentItem
+    include ContentItem::Attachments
+    attr_reader :content_item, :attachment_id, :content_id
+
+    def initialize
+      @attachment_id = 1234
+      @content_id = SecureRandom.uuid
+      @content_item = {
+        "content_id" => content_id,
+        "details" => {
+          "attachments" => [
+            {
+              "id" => attachment_id,
+              "title" => "Some title",
+              "url" => "some/url",
+              "alternative_format_contact_email" => "alternative.formats@education.gov.uk",
+            },
+          ],
+        },
+      }
+    end
+  end
+
+  test "returns attachment details for found attachment" do
+    dummy = DummyContentItem.new
+
+    details = dummy.attachment_details(dummy.attachment_id)
+
+    assert_equal details, {
+      "title" => "Some title",
+      "url" => "some/url",
+      "alternative_format_contact_email" => "alternative.formats@education.gov.uk",
+      "attachment_id" => dummy.attachment_id,
+      "owning_document_content_id" => dummy.content_id,
+    }
+  end
+
+  test "returns nil if no attachment found" do
+    attachment_id = 4321
+    dummy = DummyContentItem.new
+
+    details = dummy.attachment_details(attachment_id)
+
+    assert_equal details, nil
+  end
+end

--- a/test/views/content_items/attachments.html.erb_test.rb
+++ b/test/views/content_items/attachments.html.erb_test.rb
@@ -14,9 +14,17 @@ class ContentItemsAttachmentsTest < ActionView::TestCase
 
   test "can render attachments using their metadata" do
     @content_item = PublicationPresenter.new(
-      { "details" => { "attachments" => [{ "id" => "attachment_id",
-                                           "title" => "Some title",
-                                           "url" => "some/url" }] } },
+      {
+        "content_id" => "doc_content_id",
+        "details" => {
+          "attachments" => [
+            { "id" => "attachment_id",
+              "title" => "Some title",
+              "url" => "some/url",
+              "alternative_format_contact_email" => "alternative.formats@education.gov.uk" },
+          ],
+        },
+      },
       "/publication",
       ApplicationController.new.view_context,
     )
@@ -30,6 +38,7 @@ class ContentItemsAttachmentsTest < ActionView::TestCase
 
     assert_includes rendered, "gem-c-attachment"
     assert_includes rendered, "Some title"
+    assert_includes rendered, "href=\"/contact/govuk/request-accessible-format?content_id=doc_content_id&amp;attachment_id=attachment_id"
   end
 
   test "it prioritises pre-rendered attachments" do


### PR DESCRIPTION
These are needed to render the new accessible form link from GOVUK
Publishing Components. This is dependant on the component being updated
first [1].

This change will apply to publications and consultations, which use the
attachments partial. Initially, the new flow of requesting accessible
formats will be a pilot and only available for documents, owned by a few
organisations. This code will not need to be changed when the change is
released to all orgs.

> App tests will not pass until [1] has been merged

### Running code locally against [1]
<img width="969" alt="Screenshot 2022-02-25 at 16 21 11" src="https://user-images.githubusercontent.com/24479188/155750293-ceb93529-ef79-4fdd-8e7e-0d02fec27c76.png">

[1]: https://github.com/alphagov/govuk_publishing_components/pull/2636

Trello: https://trello.com/c/FdQvPVhD/1094-accessible-format-request-government-frontend-add-parent-document-contentid-to-the-attachment-model

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
