### PR TITLE
Display intervention banner on specific pages for User Research

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,6 +4,7 @@
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/intervention
 //= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/radio

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -34,3 +34,7 @@
   max-width: 30em;
   padding-top: govuk-spacing(2);
 }
+
+.gem-c-intervention {
+  margin-top: govuk-spacing(4);
+}

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -20,6 +20,8 @@ class ContentItemPresenter
 
   attr_accessor :include_collections_in_other_publisher_metadata
 
+  USER_RESEARCH_PAGES = %w[register-for-self-assessment self-employed-records income-tax-rates].freeze
+
   def initialize(content_item, requested_path, view_context)
     @content_item = content_item
     @requested_path = requested_path
@@ -85,6 +87,10 @@ class ContentItemPresenter
 
   def show_phase_banner?
     phase.in?(%w[alpha beta])
+  end
+
+  def show_study_banner?
+    USER_RESEARCH_PAGES.include?(slug)
   end
 
   def render_guide_as_single_page?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,14 @@
 </head>
 <body>
   <div id="wrapper" class="<%= wrapper_class %>">
-    <% if @content_item.show_phase_banner? %>
+    <% if @content_item.show_study_banner? %>
+      <%= render "govuk_publishing_components/components/intervention", {
+        suggestion_text: "Help improve GOV.UK",
+        suggestion_link_text: "Take part in user research",
+        suggestion_link_url: "https://GDSUserResearch.optimalworkshop.com/treejack/lb5eu75l",
+        new_tab: true,
+      } %>
+    <% elsif @content_item.show_phase_banner? %>
       <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase %>
     <% end %>
 

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -169,6 +169,22 @@ class GuideTest < ActionDispatch::IntegrationTest
     assert_not page.has_css?(".gem-c-single-page-notification-button")
   end
 
+  test "does not render intervention banner by default" do
+    setup_and_visit_content_item("guide")
+
+    assert_not page.has_css?(".gem-c-intervention")
+  end
+
+  test "renders intervention banner on specific page" do
+    user_research_pages = %w[register-for-self-assessment self-employed-records income-tax-rates]
+
+    user_research_pages.each do |banner_page|
+      setup_and_visit_a_page_with_specific_base_path("guide", "/#{banner_page}")
+    end
+
+    assert page.has_css?(".gem-c-intervention")
+  end
+
   def once_voting_has_closed
     Timecop.freeze(Time.zone.local(2021, 5, 6, 22, 0, 0))
     yield

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -201,6 +201,15 @@ class ActionDispatch::IntegrationTest
     end
   end
 
+  def setup_and_visit_a_page_with_specific_base_path(name, base_path, content_id = nil)
+    @content_item = get_content_example(name).tap do |item|
+      item["content_id"] = content_id if content_id.present?
+      item["base_path"] = base_path
+      stub_content_store_has_item(item["base_path"], item.to_json)
+      visit_with_cachebust(item["base_path"])
+    end
+  end
+
   def brexit_citizen_id
     ContentItem::BrexitTaxons::BREXIT_CITIZEN_PAGE_CONTENT_ID
   end


### PR DESCRIPTION
## What / Why

Adds the intervention banner to specific pages that links to a tree test that User Research want to conduct.

[Trello card](https://trello.com/c/i6PqMLdp/842-add-banner-to-guidance-pages)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


## Screenshots

### Before 
![www gov uk_register-for-self-assessment(iPhone SE)](https://user-images.githubusercontent.com/424772/156803035-36e191dd-8128-41c5-9244-b233020e5953.png)

### After
![localhost_3090_register-for-self-assessment(iPhone SE)](https://user-images.githubusercontent.com/424772/156803060-f54d801f-9cff-4487-9af5-d6fd34c75d71.png)

