### PR TITLE
Update email subscription banner content

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -13,6 +13,8 @@ class ContentItemsController < ApplicationController
 
   attr_accessor :content_item, :taxonomy_navigation
 
+  helper_method :show_email_subscription_success_banner?
+
   def show
     load_content_item
 
@@ -44,6 +46,10 @@ class ContentItemsController < ApplicationController
 
       redirect_to service_url(selected[:url])
     end
+  end
+
+  def show_email_subscription_success_banner?
+    @account_flash.include?("email-subscription-success") || @account_flash.include?("email-unsubscribe-success") || @account_flash.include?("email-subscription-already-subscribed")
   end
 
 private

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -13,8 +13,6 @@ class ContentItemsController < ApplicationController
 
   attr_accessor :content_item, :taxonomy_navigation
 
-  helper_method :show_email_subscription_success_banner?
-
   def show
     load_content_item
 
@@ -46,10 +44,6 @@ class ContentItemsController < ApplicationController
 
       redirect_to service_url(selected[:url])
     end
-  end
-
-  def show_email_subscription_success_banner?
-    @account_flash.include?("email-subscription-success") || @account_flash.include?("email-unsubscribe-success") || @account_flash.include?("email-subscription-already-subscribed")
   end
 
 private

--- a/app/helpers/content_items_helper.rb
+++ b/app/helpers/content_items_helper.rb
@@ -1,0 +1,15 @@
+module ContentItemsHelper
+  def email_subscription_success_banner_heading(account_flash)
+    if account_flash.include?("email-subscription-success")
+      sanitize(t("email.subscribe_title"))
+    elsif account_flash.include?("email-unsubscribe-success")
+      sanitize(t("email.unsubscribe_title"))
+    elsif account_flash.include?("email-subscription-already-subscribed")
+      sanitize(t("email.already_subscribed_title"))
+    end
+  end
+
+  def show_email_subscription_success_banner?(account_flash)
+    account_flash.include?("email-subscription-success") || account_flash.include?("email-unsubscribe-success") || account_flash.include?("email-subscription-already-subscribed")
+  end
+end

--- a/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
+++ b/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
@@ -1,24 +1,12 @@
-<% banner_heading = capture do %>
-  <%
-    if @account_flash.include?("email-subscription-success")
-      sanitize(t("email.subscribe_title"))
-    elsif @account_flash.include?("email-unsubscribe-success")
-      sanitize(t("email.unsubscribe_title"))
-    elsif @account_flash.include?("email-subscription-already-subscribed")
-      sanitize(t("email.already_subscribed_title"))
-    end
-  %>
-<% end %>
-
 <% banner_description = capture do %>
   <a class="govuk-link govuk-notification-banner__link" href="/email/manage"><%= t("email.description") %></a>
 <% end %>
 
-<% if show_email_subscription_success_banner? %>
+<% if show_email_subscription_success_banner?(@account_flash) %>
   <div class="govuk-grid-row govuk-!-margin-top-3">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/success_alert", {
-        message: banner_heading,
+        message: email_subscription_success_banner_heading(@account_flash),
         description: banner_description,
         margin_bottom: 0,
       } %>

--- a/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
+++ b/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
@@ -1,29 +1,25 @@
-<% if @account_flash.include?("email-subscription-success") %>
+<% banner_heading = capture do %>
+  <%
+    if @account_flash.include?("email-subscription-success")
+      sanitize(t("email.subscribe_title"))
+    elsif @account_flash.include?("email-unsubscribe-success")
+      sanitize(t("email.unsubscribe_title"))
+    elsif @account_flash.include?("email-subscription-already-subscribed")
+      sanitize(t("email.already_subscribed_title"))
+    end
+  %>
+<% end %>
+
+<% banner_description = capture do %>
+  <a class="govuk-link govuk-notification-banner__link" href="/email/manage"><%= t("email.description") %></a>
+<% end %>
+
+<% if show_email_subscription_success_banner? %>
   <div class="govuk-grid-row govuk-!-margin-top-3">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/success_alert", {
-        message: sanitize(t("email.subscribe_title")),
-        description: sanitize(t("email.description_html")),
-        margin_bottom: 0,
-      } %>
-    </div>
-  </div>
-<% elsif @account_flash.include?("email-unsubscribe-success") %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-3">
-      <%= render "govuk_publishing_components/components/success_alert", {
-        message: sanitize(t("email.unsubscribe_title")),
-        description: sanitize(t("email.description_html")),
-        margin_bottom: 0,
-      } %>
-    </div>
-  </div>
-<% elsif @account_flash.include?("email-subscription-already-subscribed") %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-3">
-      <%= render "govuk_publishing_components/components/success_alert", {
-        message: sanitize(t("email.already_subscribed_title")),
-        description: sanitize(t("email.description_html")),
+        message: banner_heading,
+        description: banner_description,
         margin_bottom: 0,
       } %>
     </div>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -599,7 +599,7 @@ ar:
     welsh_language_scheme_html: تعرف على التزامنا بشأن %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -299,7 +299,7 @@ az:
     welsh_language_scheme_html: "%{link} ilə bağlı öhdəliyimiz barədə öyrənin."
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -449,7 +449,7 @@ be:
     welsh_language_scheme_html: Даведайцеся аб нашых абавязках да публікацыі ў %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -299,7 +299,7 @@ bg:
     welsh_language_scheme_html: Научете повече за нашия ангажимент към %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -299,7 +299,7 @@ bn:
     welsh_language_scheme_html: "%{link}-এ আপনার আমাদের অঙ্গীকার সম্পর্কে জানুন।"
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -374,7 +374,7 @@ cs:
     welsh_language_scheme_html: Přečtěte si o našem závazku k %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -599,7 +599,7 @@ cy:
     welsh_language_scheme_html: Dysgwch am ein hymrwymiad i %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -311,7 +311,7 @@ da:
     welsh_language_scheme_html: Learn more about our commitment to% {link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -299,7 +299,7 @@ de:
     welsh_language_scheme_html: Informieren Sie sich über unser Engagement für %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -299,7 +299,7 @@ dr:
     welsh_language_scheme_html: از تعهد ما به %{link} مطلع شوید.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -299,7 +299,7 @@ el:
     welsh_language_scheme_html: Μάθετε για τη δέσμευσή μας στο %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -299,7 +299,7 @@ en:
     welsh_language_scheme_html: Find out about our commitment to %{link}.
   email:
     already_subscribed_title: You’re already getting emails about this page
-    description_html: <p class="govuk-body">Go to your GOV.UK account to <a class="govuk-link govuk-notification-banner__link" href="/email/manage">see and manage all your GOV.UK email subscriptions</a>.</p>
+    description: See and manage all your GOV.UK email subscriptions
     subscribe_title: You’ve subscribed to emails about this page
     unsubscribe_title: You’ve unsubscribed from emails about this page
   fatality_notice:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -299,7 +299,7 @@ es-419:
     welsh_language_scheme_html: Conozca nuestro compromiso con %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -299,7 +299,7 @@ es:
     welsh_language_scheme_html: Encuentre más sobre nuestro compromiso de publicar en %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -299,7 +299,7 @@ et:
     welsh_language_scheme_html: Lisateave meie pühendumuse kohta %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -299,7 +299,7 @@ fa:
     welsh_language_scheme_html: درباره تعهد ما نسبت به %{link} اطلاعات کسب کنید.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -299,7 +299,7 @@ fi:
     welsh_language_scheme_html: Tutustu sitoumukseemme %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -299,7 +299,7 @@ fr:
     welsh_language_scheme_html: Découvrez comment nous nous engageons sur %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -449,7 +449,7 @@ gd:
     welsh_language_scheme_html: Faigh amach ár gcomhréiteach ar an %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -299,7 +299,7 @@ gu:
     welsh_language_scheme_html: "%{link} પ્રત્યે અમારી પ્રતિબદ્ધતા અંગે જાણો."
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -299,7 +299,7 @@ he:
     welsh_language_scheme_html: מידע נוסף על המחויבות שלנו לפרסום %{link}
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -299,7 +299,7 @@ hi:
     welsh_language_scheme_html: हमारी प्रकाशन के प्रति वचनबद्धता के बारे में जानें %(link)।
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -449,7 +449,7 @@ hr:
     welsh_language_scheme_html: Saznajte o našoj predanosti %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -299,7 +299,7 @@ hu:
     welsh_language_scheme_html: 'Tájékozódjon az információk közzétételével kapcsolatos elkötelezettségünkről: %{link}'
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -299,7 +299,7 @@ hy:
     welsh_language_scheme_html: 'Տեղեկանալ մեր աշխատանքի մասին %{link} հղումով:'
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -224,7 +224,7 @@ id:
     welsh_language_scheme_html: Cari tahu komitmen kami kepada %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -299,7 +299,7 @@ is:
     welsh_language_scheme_html: Kynntu þér skuldbindingu okkar við %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -299,7 +299,7 @@ it:
     welsh_language_scheme_html: Scopri il nostro impegno per %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -224,7 +224,7 @@ ja:
     welsh_language_scheme_html: 情報公開の詳細については %{link} をご覧下さい。
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -299,7 +299,7 @@ ka:
     welsh_language_scheme_html: გაეცანით ჩვენს ვალდებულებას %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -299,7 +299,7 @@ kk:
     welsh_language_scheme_html: "%{link} қосқан үлесіміз туралы оқыңыз."
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -224,7 +224,7 @@ ko:
     welsh_language_scheme_html: "%{link} 에서 정보 공개에 대한 내용."
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -374,7 +374,7 @@ lt:
     welsh_language_scheme_html: Sužinokite apie mūsų įsipareigojimą skelbti %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -299,7 +299,7 @@ lv:
     welsh_language_scheme_html: Vairāk par mūsu apņemšanos nodrošināt informācijas pieejamību %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -224,7 +224,7 @@ ms:
     welsh_language_scheme_html: Ketahui tentang komitmen kami kepada %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -449,7 +449,7 @@ mt:
     welsh_language_scheme_html: Kun af dwar l-impenn tagħna lejn %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -299,7 +299,7 @@ ne:
     welsh_language_scheme_html: "%{link} को हाम्रो प्रतिबद्धताको बारेमा जानकारी पाउनुहोस्।"
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -299,7 +299,7 @@ nl:
     welsh_language_scheme_html: Lees meer over onze inzet voor %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -299,7 +299,7 @@
     welsh_language_scheme_html: Finn ut mer om vårt engasjement for %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -299,7 +299,7 @@ pa-pk:
     welsh_language_scheme_html: ساڈی وابستگی دے بارے جانو {link}%.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -299,7 +299,7 @@ pa:
     welsh_language_scheme_html: "%{link} ਪ੍ਰਤੀ ਸਾਡੀ ਵਚਨਬੱਧਤਾ ਬਾਰੇ ਜਾਣੋ।"
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -449,7 +449,7 @@ pl:
     welsh_language_scheme_html: Poznaj nasze zobowiązania związane z publikowaniem w %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -299,7 +299,7 @@ ps:
     welsh_language_scheme_html: "%{link} ته زموږ د ژمنتیا په اړه معلومات ترلاسه کړئ."
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -299,7 +299,7 @@ pt:
     welsh_language_scheme_html: Saiba mais sobre o nosso compromisso para com %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -374,7 +374,7 @@ ro:
     welsh_language_scheme_html: Aflați mai multe despre angajamentul nostru pentru %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -449,7 +449,7 @@ ru:
     welsh_language_scheme_html: Узнайте о наших обязательствах по %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -299,7 +299,7 @@ si:
     welsh_language_scheme_html: "%{link} සඳහා අපේ කැපවීම ගැන සොයා බලන්න."
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -374,7 +374,7 @@ sk:
     welsh_language_scheme_html: Prečítajte si o našom záväzku voči %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -449,7 +449,7 @@ sl:
     welsh_language_scheme_html: Izvedite več o naši zavezanosti %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -299,7 +299,7 @@ so:
     welsh_language_scheme_html: Raadi waxyaabaha ku saabsan ka go'naanshahayaga %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -299,7 +299,7 @@ sq:
     welsh_language_scheme_html: Mësoni rreth angazhimit tonë ndaj %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -449,7 +449,7 @@ sr:
     welsh_language_scheme_html: Saznajte više o našoj posvećenosti %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -299,7 +299,7 @@ sv:
     welsh_language_scheme_html: Ta reda på vårt åtagande om %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -299,7 +299,7 @@ sw:
     welsh_language_scheme_html: Pata maelezo kuhusu wajibu wetu wa %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -299,7 +299,7 @@ ta:
     welsh_language_scheme_html: "%{link}-க்கு எங்கள் கடப்பாடு குறித்துக் கண்டறியுங்கள்."
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -224,7 +224,7 @@ th:
     welsh_language_scheme_html: ดูข้อมูลเพิ่มเติมเกี่ยวกับพันธกิจของเราสำหรับ %{link}
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -299,7 +299,7 @@ tk:
     welsh_language_scheme_html: Niýetimiz barada %{link}-da okaň.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -299,7 +299,7 @@ tr:
     welsh_language_scheme_html: "%{link} bağlantısına taahhüdümüzü okuyun."
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -449,7 +449,7 @@ uk:
     welsh_language_scheme_html: Дізнайтесь про дотримання нами %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -299,7 +299,7 @@ ur:
     welsh_language_scheme_html: "%{link} کے ساتھ ہماری وابستگی کے بارے میں جانیں۔"
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -299,7 +299,7 @@ uz:
     welsh_language_scheme_html: "%{link} да бизнинг содиқлилигимиз ҳақида билиб олинг ."
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -224,7 +224,7 @@ vi:
     welsh_language_scheme_html: Tìm hiểu về cam kết của chúng tôi đối với %{link}.
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -299,7 +299,7 @@ yi:
     welsh_language_scheme_html:
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -299,7 +299,7 @@ zh-hk:
     welsh_language_scheme_html: 查閱我們在 %{link} 的發佈承諾。
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -299,7 +299,7 @@ zh-tw:
     welsh_language_scheme_html: 了解我們對 %{link} 的承諾。
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -224,7 +224,7 @@ zh:
     welsh_language_scheme_html: 查看我们对 %{link} 的承诺。
   email:
     already_subscribed_title:
-    description_html:
+    description:
     subscribe_title:
     unsubscribe_title:
   fatality_notice:


### PR DESCRIPTION
Update the single page notification success banner content based on
input from our designers and reduce some repetition in the
`email_subscribe_unsubscribe_flash` partial

-----

https://trello.com/c/bPoMTXr0

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
