### PR TITLE
Change heading on foreign-travel-advice

### DIFF
--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -20,15 +20,4 @@
       margin-left: govuk-spacing(1);
     }
   }
-
-  .part-title {
-    @include govuk-font(27, $weight: bold);
-    margin-bottom: govuk-spacing(3);
-    margin-top: govuk-spacing(3);
-
-    @include govuk-media-query($from: tablet) {
-      margin-bottom: govuk-spacing(4);
-      margin-top: govuk-spacing(4);
-    }
-  }
 }

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -47,9 +47,10 @@
   <div class="govuk-grid-column-two-thirds" id="guide-contents">
     <% if @content_item.has_parts? %>
       <% if @content_item.show_guide_navigation? %>
-        <h1 class="part-title">
-          <%= @content_item.current_part_title %>
-        </h1>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: @content_item.current_part_title,
+          margin_bottom: 3
+        } %>
       <% end %>
 
       <%= render "govuk_publishing_components/components/govspeak", {

--- a/app/views/content_items/travel_advice.html+print.erb
+++ b/app/views/content_items/travel_advice.html+print.erb
@@ -31,10 +31,10 @@
 
     <% @content_item.parts.each_with_index do |part, i| %>
       <section>
-        <h1 class="part-title">
-          <%= part['title'] %>
-        </h1>
-
+        <%= render "govuk_publishing_components/components/heading", {
+          text: part['title'],
+          margin_bottom: 3
+        } %>
         <%= render 'shared/travel_advice_summary', content_item: @content_item if i == 0 %>
 
         <%= render 'govuk_publishing_components/components/govspeak',

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -27,10 +27,11 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="part-title">
-      <%= @content_item.current_part_title %>
-    </h1>
+  <div class="govuk-grid-column-two-thirds govuk-!-padding-top-4">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: @content_item.current_part_title,
+      margin_bottom: 3
+    } %>
 
     <% if @content_item.is_summary? %>
       <%= render 'shared/travel_advice_summary', content_item: @content_item %>


### PR DESCRIPTION
## What 

Change to component, alter from `h1` to `h2` on page: https://www.gov.uk/foreign-travel-advice/afghanistan

## Why

> The problem is that in part-separated content we have two `h1` headings, one for the guide name, then one for the part name, and then the content is displayed with `h2` headings.  Make the guide heading a `h2` even though it comes before the part heading. This is not ideal as it's a slightly confusing structure but does not violate any standards and it leaves the `h1` as the most relevant title on the page.

## Visual changes

None

## Anything else

Ideally the Content under the `h2` should now be updated to `h3` however this lives within `govspeak` controlled by Content teams. Been made aware there are 226 different guides to update.
https://www.gov.uk/foreign-travel-advice/afghanistan