### PR TITLE
Add exception to single page notification button

### DIFF
--- a/app/presenters/content_item/single_page_notification_button.rb
+++ b/app/presenters/content_item/single_page_notification_button.rb
@@ -6,6 +6,7 @@ module ContentItem
       70bd3a76-6606-45dd-9fb5-2b95f8667b4d
       a457220c-915c-4cb1-8e41-9191fba42540
       5f9c6c15-7631-11e4-a3cb-005056011aef
+      c72228d4-e277-4ad8-a7b3-e58c32a249d0
     ].freeze
 
     ALLOWED_DOCUMENT_TYPES = %w[


### PR DESCRIPTION
### What
Add exception to single page notification button

### Why
Signing up for updates on '[Local Sponsorship Scheme for Ukraine](https://www.gov.uk/guidance/local-sponsorship-scheme-for-ukraine)' is currently only possible by setting up an Account, which requires a UK phone number to set up. This is currently causing issues to users, so we drop this in favour of adding [a sign-up link to the related topical event](https://www.gov.uk/email-signup?link=/government/topical-events/russian-invasion-of-ukraine-uk-government-response) as part of the content.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
