### PR TITLE
Add exceptions to single page notifications button

### DIFF
--- a/app/presenters/content_item/single_page_notification_button.rb
+++ b/app/presenters/content_item/single_page_notification_button.rb
@@ -7,6 +7,11 @@ module ContentItem
       a457220c-915c-4cb1-8e41-9191fba42540
       5f9c6c15-7631-11e4-a3cb-005056011aef
       c72228d4-e277-4ad8-a7b3-e58c32a249d0
+      0ea26b38-7858-46f3-8774-72aaffbdf9be
+      912cb994-4ed6-448d-9632-af3910491fc0
+      3aa39dfe-642c-47df-bb86-39a64f9c1d58
+      cd539d2b-aade-4495-bcad-7b8ab963270b
+      29d4e5c4-cc10-4e69-837a-2e2622acf074
     ].freeze
 
     ALLOWED_DOCUMENT_TYPES = %w[


### PR DESCRIPTION
### What
Add exceptions to single page notifications button

### Why
Signing up for updates on certain pages is currently only possible by setting up an Account, which requires a UK phone number to set up. This is currently causing issues to users, so we drop this in favour of adding a sign-up link to the related topical event as part of the content on the following pages:
 - https://www.gov.uk/guidance/taking-humanitarian-aid-out-of-great-britain-to-support-ukraine
 - https://www.gov.uk/government/publications/immigration-information-for-ukrainians-in-the-uk-british-nationals-and-their-family-members
 - https://www.gov.uk/guidance/ukrainian-nationals-in-the-uk-visa-support
 - https://www.gov.uk/guidance/support-for-family-members-of-british-nationals-in-ukraine-and-ukrainian-nationals-in-ukraine-and-the-uk
 - https://www.gov.uk/guidance/apply-for-a-ukraine-family-scheme-visa

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
