### PR TITLE
Fix incomplete page title for first page of mainstream guide

### DIFF
--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -4,7 +4,7 @@ class GuidePresenter < ContentItemPresenter
   attr_accessor :draft_access_token
 
   def page_title
-    if @part_slug
+    if parts.any?
       "#{super}: #{current_part_title}"
     else
       super

--- a/test/presenters/guide_presenter_test.rb
+++ b/test/presenters/guide_presenter_test.rb
@@ -11,7 +11,6 @@ class GuidePresenterTest
     end
 
     test "presents unique page titles for each part" do
-      assert_equal presented_item.page_title, schema_item["title"]
       schema_item["details"]["parts"].each do |part|
         assert_equal presented_item("guide", part["slug"]).page_title, "#{schema_item['title']}: #{part['title']}"
       end
@@ -19,7 +18,7 @@ class GuidePresenterTest
 
     test "presents withdrawn in the title for withdrawn content" do
       presented_item = presented_item(schema_name, nil, "withdrawn_notice" => { "explanation": "Withdrawn", "withdrawn_at": "2014-08-22T10:29:02+01:00" })
-      assert_equal "[Withdrawn] The national curriculum", presented_item.page_title
+      assert_equal "[Withdrawn] The national curriculum: Overview", presented_item.page_title
     end
 
     test "presents a print link" do


### PR DESCRIPTION
## What
https://trello.com/c/vG0AdGbb/40-incomplete-page-title-for-first-page-of-mainstream-guide-11

Update the first page of a guide to include both the page title and sub section title. So, for https://www.gov.uk/change-address-driving-licence, the page title should be change to

```
<title lang="en">
  Change the address on your driving licence: Apply online - GOV.UK
</title>
```

From

```
<title lang="en">
  Change the address on your driving licence - GOV.UK
</title>
```

## Why

WCAG failure

- WCAG SC: 2.4.2
- severity: 1
- complexity: 1

## Anything else