### PR TITLE
Add recruitment banner to tax and business browse pages

### DIFF
--- a/app/lib/recruitment_helper.rb
+++ b/app/lib/recruitment_helper.rb
@@ -1,0 +1,7 @@
+module RecruitmentHelper
+  USER_RESEARCH_PAGES = %w[register-for-self-assessment self-employed-records income-tax-rates].freeze
+
+  def self.show_banner?(slug)
+    USER_RESEARCH_PAGES.include?(slug)
+  end
+end

--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,9 +1,23 @@
 module ContentItem
   module RecruitmentBanner
-    USER_RESEARCH_PAGES = %w[register-for-self-assessment self-employed-records income-tax-rates].freeze
+    SURVEY_URLS = { "/browse/tax" => "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1" }.freeze
 
-    def show_study_banner?
-      USER_RESEARCH_PAGES.include?(slug)
+    def recruitment_survey_url
+      key = SURVEY_URLS.keys.find{ |k| content_tagged_to(k).present? }
+      SURVEY_URLS[key]
+    end
+
+  private
+
+    def mainstream_browse_pages
+      content_item["links"]["mainstream_browse_pages"] if content_item["links"]
+    end
+
+    def content_tagged_to(browse_base_path)
+      return [] unless mainstream_browse_pages
+      mainstream_browse_pages.find do |mainstream_browse_page|
+        mainstream_browse_page["base_path"].starts_with? browse_base_path
+      end
     end
   end
 end

--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,0 +1,9 @@
+module ContentItem
+  module RecruitmentBanner
+    USER_RESEARCH_PAGES = %w[register-for-self-assessment self-employed-records income-tax-rates].freeze
+
+    def show_study_banner?
+      USER_RESEARCH_PAGES.include?(slug)
+    end
+  end
+end

--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,9 +1,13 @@
 module ContentItem
   module RecruitmentBanner
-    SURVEY_URLS = { "/browse/tax" => "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1" }.freeze
+    SURVEY_URL_ONE = "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1".freeze
+    SURVEY_URLS = {
+      "/browse/tax" => SURVEY_URL_ONE,
+      "/browse/business" => SURVEY_URL_ONE,
+    }.freeze
 
     def recruitment_survey_url
-      key = SURVEY_URLS.keys.find{ |k| content_tagged_to(k).present? }
+      key = SURVEY_URLS.keys.find { |k| content_tagged_to(k).present? }
       SURVEY_URLS[key]
     end
 
@@ -15,6 +19,7 @@ module ContentItem
 
     def content_tagged_to(browse_base_path)
       return [] unless mainstream_browse_pages
+
       mainstream_browse_pages.find do |mainstream_browse_page|
         mainstream_browse_page["base_path"].starts_with? browse_base_path
       end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -2,7 +2,7 @@ class ContentItemPresenter
   include ContentItem::Withdrawable
   include ContentItem::BrexitTaxons
   include ContentItem::SinglePageNotificationButton
-
+  include ContentItem::RecruitmentBanner
   attr_reader :content_item,
               :requested_path,
               :view_context,
@@ -19,8 +19,6 @@ class ContentItemPresenter
               :taxons
 
   attr_accessor :include_collections_in_other_publisher_metadata
-
-  USER_RESEARCH_PAGES = %w[register-for-self-assessment self-employed-records income-tax-rates].freeze
 
   def initialize(content_item, requested_path, view_context)
     @content_item = content_item
@@ -87,10 +85,6 @@ class ContentItemPresenter
 
   def show_phase_banner?
     phase.in?(%w[alpha beta])
-  end
-
-  def show_study_banner?
-    USER_RESEARCH_PAGES.include?(slug)
   end
 
   def render_guide_as_single_page?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,11 +31,11 @@
 </head>
 <body>
   <div id="wrapper" class="<%= wrapper_class %>">
-    <% if @content_item.show_study_banner? %>
+    <% if @content_item.recruitment_survey_url %>
       <%= render "govuk_publishing_components/components/intervention", {
         suggestion_text: "Help improve GOV.UK",
         suggestion_link_text: "Take part in user research",
-        suggestion_link_url: "https://GDSUserResearch.optimalworkshop.com/treejack/lb5eu75l",
+        suggestion_link_url: @content_item.recruitment_survey_url,
         new_tab: true,
       } %>
     <% elsif @content_item.show_phase_banner? %>

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -169,22 +169,6 @@ class GuideTest < ActionDispatch::IntegrationTest
     assert_not page.has_css?(".gem-c-single-page-notification-button")
   end
 
-  test "does not render intervention banner by default" do
-    setup_and_visit_content_item("guide")
-
-    assert_not page.has_css?(".gem-c-intervention")
-  end
-
-  test "renders intervention banner on specific page" do
-    user_research_pages = %w[register-for-self-assessment self-employed-records income-tax-rates]
-
-    user_research_pages.each do |banner_page|
-      setup_and_visit_a_page_with_specific_base_path("guide", "/#{banner_page}")
-    end
-
-    assert page.has_css?(".gem-c-intervention")
-  end
-
   def once_voting_has_closed
     Timecop.freeze(Time.zone.local(2021, 5, 6, 22, 0, 0))
     yield

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -19,8 +19,34 @@ class RecruitmentBannerTest < ActionDispatch::IntegrationTest
     assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1")
   end
 
-  test "Recruitment Banner is not displayed for pages not tagged to Money and Tax" do
+  test "Recruitment Banner is displayed for any page tagged to Business and Self-employed" do
+    @business_browse_page = {
+      "content_id" => "123",
+      "title" => "Self Assessment",
+      "base_path" => "/browse/business",
+    }
+
     guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    guide["links"]["mainstream_browse_pages"] = []
+    guide["links"]["mainstream_browse_pages"] << @business_browse_page
+
+    stub_content_store_has_item(guide["base_path"], guide.to_json)
+    visit guide["base_path"]
+
+    assert page.has_css?(".gem-c-intervention")
+    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1")
+  end
+
+  test "Recruitment Banner is not displayed unless page is tagged to a topic of interest" do
+    @not_of_interest = {
+      "content_id" => "123",
+      "title" => "I am not interesting",
+      "base_path" => "/browse/boring",
+    }
+
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    guide["links"]["mainstream_browse_pages"] = []
+    guide["links"]["mainstream_browse_pages"] << @not_of_interest
     stub_content_store_has_item(guide["base_path"], guide.to_json)
     visit_with_cachebust guide["base_path"]
 

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "Recruitment Banner is displayed for any page tagged to Money and Tax" do
+    @money_and_tax_browse_page = {
+      "content_id" => "123",
+      "title" => "Self Assessment",
+      "base_path" => "/browse/tax/self-assessment",
+    }
+
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    guide["links"]["mainstream_browse_pages"] = []
+    guide["links"]["mainstream_browse_pages"] << @money_and_tax_browse_page
+
+    stub_content_store_has_item(guide["base_path"], guide.to_json)
+    visit guide["base_path"]
+
+    assert page.has_css?(".gem-c-intervention")
+    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1")
+  end
+
+  test "Recruitment Banner is not displayed for pages not tagged to Money and Tax" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    stub_content_store_has_item(guide["base_path"], guide.to_json)
+    visit_with_cachebust guide["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1")
+  end
+end


### PR DESCRIPTION
Add banner to pages requested by UR colleagues as per [sheet](https://docs.google.com/spreadsheets/d/104ird2xevvcA77Lrhtrelkz4DpkoLJ30jdnDaq6bhpg/edit#gid=0)

Trello: https://trello.com/c/qPhlRiUx/779-launch-and-monitor-the-recruitment-banner-for-money-tax


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
