### PR TITLE
Remove 'Local Sponsorship Scheme for Ukraine' from exemptions

### DIFF
--- a/app/presenters/content_item/single_page_notification_button.rb
+++ b/app/presenters/content_item/single_page_notification_button.rb
@@ -6,7 +6,6 @@ module ContentItem
       70bd3a76-6606-45dd-9fb5-2b95f8667b4d
       a457220c-915c-4cb1-8e41-9191fba42540
       5f9c6c15-7631-11e4-a3cb-005056011aef
-      c72228d4-e277-4ad8-a7b3-e58c32a249d0
       0ea26b38-7858-46f3-8774-72aaffbdf9be
       912cb994-4ed6-448d-9632-af3910491fc0
       3aa39dfe-642c-47df-bb86-39a64f9c1d58


### PR DESCRIPTION
Remove the content id for 'Local Sponsorship Scheme for Ukraine' from
the single page notification exemption list.
The exemption was added here: https://github.com/alphagov/government-frontend/pull/2391

However, the original page has now been unpublished with a redirect.

So the original page was:
https://www.gov.uk/guidance/local-sponsorship-scheme-for-ukraine
But it is now redirecting to:
https://homesforukraine.campaign.gov.uk

----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
