### PR TITLE
Migrate manuals from Manuals Frontend to Government Frontend

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 //= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/accordion
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/details
 //= require govuk_publishing_components/components/error-summary

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -96,3 +96,4 @@ $govuk-new-link-styles: true;
 @import 'views/answer';
 @import 'views/help-page';
 @import 'views/guide';
+@import 'views/manual';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';
 
+@import 'govuk_publishing_components/components/accordion';
 @import 'govuk_publishing_components/components/attachment';
 @import 'govuk_publishing_components/components/back-link';
 @import 'govuk_publishing_components/components/big-number';

--- a/app/assets/stylesheets/views/_manual.scss
+++ b/app/assets/stylesheets/views/_manual.scss
@@ -1,111 +1,112 @@
 .manuals-frontend-body {
   padding-bottom: govuk-spacing(6);
+}
 
-  header {
-    background: $govuk-brand-colour;
+.manuals-header {
+  @include govuk-font(16);
+  @include govuk-clearfix;
 
-    &.hmrc {
-      background: govuk-organisation-colour("hm-revenue-customs");
-    }
+  background: $govuk-brand-colour;
+  color: govuk-colour('white');
+  margin: 0;
+  padding-bottom: govuk-spacing(6);
+  padding-top: govuk-spacing(6);
 
-    padding-top: govuk-spacing(6);
-    padding-bottom: govuk-spacing(6);
-    color: govuk-colour("white");
-    margin: 0;
-    @include govuk-font(16);
-    @include govuk-clearfix;
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(6) govuk-spacing(3);
+  }
+
+  .manual-type {
+    @include govuk-font(24);
+  }
+
+  h1 {
+    @include govuk-font(36, $weight: bold);
+    padding: 0 0 govuk-spacing(3);
 
     @include govuk-media-query($from: tablet) {
-      padding: govuk-spacing(6) govuk-spacing(3);
-    }
-
-    .manual-type {
-      @include govuk-font(24);
-    }
-
-    h1 {
-      @include govuk-font(36, $weight: bold);
-      padding: 0 0 govuk-spacing(3) 0;
-
-      @include govuk-media-query($from: tablet) {
-        padding: 0 0 govuk-spacing(6) 0;
-      }
-    }
-
-    a {
-      color: govuk-colour("white");
-
-      &:focus {
-        @include govuk-focused-text;
-      }
+      padding: 0 0 govuk-spacing(6);
     }
   }
 
-  .section-list {
+  a {
+    color: govuk-colour('white');
+
+    &:focus {
+      @include govuk-focused-text;
+    }
+  }
+
+  &.hmrc {
+    background: govuk-organisation-colour('hm-revenue-customs');
+  }
+}
+
+.section-list {
+  margin-top: govuk-spacing(6);
+  padding: 0;
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(9);
+  }
+}
+
+.section-list-item {
+  @include govuk-font(19);
+
+  border-top: 1px solid $govuk-border-colour;
+  cursor: pointer;
+  list-style: none;
+
+  &:hover {
+    background-color: govuk-colour("light-grey", $legacy: 'grey-4');
+  }
+
+  &:last-child {
+    border-bottom: 1px solid $govuk-border-colour;
+  }
+}
+
+.section-link {
+  display: block;
+  padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
+  text-decoration: none;
+
+  @include govuk-media-query($from: tablet) {
+    padding-right: 33.3333%;
+  }
+
+  &:focus {
+    @include govuk-focused-text;
+  }
+
+  .subsection-title-text {
+    @include govuk-typography-weight-bold;
+    @include govuk-link-decoration;
+    display: block;
+  }
+
+  .subsection-summary {
+    color: $govuk-text-colour;
+    display: block;
+  }
+
+  &:hover {
+    .subsection-title-text {
+      @include govuk-link-hover-decoration;
+    }
+  }
+}
+
+.manual-body {
+  @include govuk-media-query($from: tablet) {
     margin-top: govuk-spacing(6);
-    padding: 0;
-
-    @include govuk-media-query($from: tablet) {
-      margin-top: govuk-spacing(9);
-    }
-
-    li {
-      @include govuk-font(19);
-      list-style: none;
-      cursor: pointer;
-      border-top: 1px solid $govuk-border-colour;
-
-      &:hover {
-        background-color: govuk-colour("light-grey", $legacy: "grey-4");
-      }
-
-      &:last-child {
-        border-bottom: 1px solid $govuk-border-colour;
-      }
-
-      a {
-        text-decoration: none;
-        display: block;
-        padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
-
-        &:focus {
-          @include govuk-focused-text;
-        }
-
-        @include govuk-media-query($from: tablet) {
-          padding-right: 33.3333%;
-        }
-
-        .subsection-title-text {
-          @include govuk-typography-weight-bold;
-          @include govuk-link-decoration;
-          display: block;
-        }
-
-        .subsection-summary {
-          color: $govuk-text-colour;
-          display: block;
-        }
-
-        &:hover {
-          .subsection-title-text {
-            @include govuk-link-hover-decoration;
-          }
-        }
-      }
-    }
   }
 
-  .manual-body {
-    @include govuk-media-query($from: tablet) {
-      margin-top: govuk-spacing(6);
-    }
-
-    .section-title {
-      @include govuk-text-colour;
-      @include govuk-font($size: 24, $weight: bold);
-      @include govuk-responsive-margin(4, "bottom");
-    }
+  .section-title {
+    @include govuk-text-colour;
+    @include govuk-font($size: 24, $weight: bold);
+    @include govuk-responsive-margin(4, 'bottom');
   }
 }
 
@@ -134,10 +135,10 @@
   a {
     padding-right: 0;
   }
-}
 
-.subsection-id {
-  color: $govuk-secondary-text-colour;
-  min-width: 135px;
-  padding-right: govuk-spacing(3);
+  .subsection-id {
+    color: $govuk-secondary-text-colour;
+    min-width: 135px;
+    padding-right: govuk-spacing(3);
+  }
 }

--- a/app/assets/stylesheets/views/_manual.scss
+++ b/app/assets/stylesheets/views/_manual.scss
@@ -1,0 +1,51 @@
+.manuals-frontend-body {
+  padding-bottom: govuk-spacing(6);
+
+  header {
+    background: $govuk-brand-colour;
+
+    padding-top: govuk-spacing(6);
+    padding-bottom: govuk-spacing(6);
+    color: govuk-colour("white");
+    margin: 0;
+    @include govuk-font(16);
+    @include govuk-clearfix;
+
+    @include govuk-media-query($from: tablet) {
+      padding: govuk-spacing(6) govuk-spacing(3);
+    }
+
+    .manual-type {
+      @include govuk-font(24);
+    }
+
+    h1 {
+      @include govuk-font(36, $weight: bold);
+      padding: 0 0 govuk-spacing(3) 0;
+
+      @include govuk-media-query($from: tablet) {
+        padding: 0 0 govuk-spacing(6) 0;
+      }
+    }
+
+    a {
+      color: govuk-colour("white");
+
+      &:focus {
+        @include govuk-focused-text;
+      }
+    }
+  }
+
+  .manual-body {
+    @include govuk-media-query($from: tablet) {
+      margin-top: govuk-spacing(6);
+    }
+
+    .section-title {
+      @include govuk-text-colour;
+      @include govuk-font($size: 24, $weight: bold);
+      @include govuk-responsive-margin(4, "bottom");
+    }
+  }
+}

--- a/app/assets/stylesheets/views/_manual.scss
+++ b/app/assets/stylesheets/views/_manual.scss
@@ -4,6 +4,10 @@
   header {
     background: $govuk-brand-colour;
 
+    &.hmrc {
+      background: govuk-organisation-colour("hm-revenue-customs");
+    }
+
     padding-top: govuk-spacing(6);
     padding-bottom: govuk-spacing(6);
     color: govuk-colour("white");
@@ -37,6 +41,61 @@
     }
   }
 
+  .section-list {
+    margin-top: govuk-spacing(6);
+    padding: 0;
+
+    @include govuk-media-query($from: tablet) {
+      margin-top: govuk-spacing(9);
+    }
+
+    li {
+      @include govuk-font(19);
+      list-style: none;
+      cursor: pointer;
+      border-top: 1px solid $govuk-border-colour;
+
+      &:hover {
+        background-color: govuk-colour("light-grey", $legacy: "grey-4");
+      }
+
+      &:last-child {
+        border-bottom: 1px solid $govuk-border-colour;
+      }
+
+      a {
+        text-decoration: none;
+        display: block;
+        padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
+
+        &:focus {
+          @include govuk-focused-text;
+        }
+
+        @include govuk-media-query($from: tablet) {
+          padding-right: 33.3333%;
+        }
+
+        .subsection-title-text {
+          @include govuk-typography-weight-bold;
+          @include govuk-link-decoration;
+          display: block;
+        }
+
+        .subsection-summary {
+          color: $govuk-text-colour;
+          display: block;
+        }
+
+        &:hover {
+          .subsection-title-text {
+            @include govuk-link-hover-decoration;
+          }
+        }
+      }
+    }
+  }
+
   .manual-body {
     @include govuk-media-query($from: tablet) {
       margin-top: govuk-spacing(6);
@@ -48,4 +107,37 @@
       @include govuk-responsive-margin(4, "bottom");
     }
   }
+}
+
+.subsection-collection {
+  margin-top: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(6);
+  }
+}
+
+.hmrc.section-list {
+  margin-top: govuk-spacing(6);
+  padding-bottom: govuk-spacing(6);
+
+  @include govuk-media-query($from: tablet) {
+    .title-wrap {
+      display: table-row;
+
+      div {
+        display: table-cell;
+      }
+    }
+  }
+
+  a {
+    padding-right: 0;
+  }
+}
+
+.subsection-id {
+  color: $govuk-secondary-text-colour;
+  min-width: 135px;
+  padding-right: govuk-spacing(3);
 }

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -119,6 +119,8 @@ private
 
   def content_item_template
     return "guide_single" if @content_item.render_guide_as_single_page?
+    return "manual_updates" if @content_item.manual_updates?
+    return "hmrc_manual_updates" if @content_item.hmrc_manual_updates?
 
     @content_item.schema_name
   end

--- a/app/presenters/content_item/manual.rb
+++ b/app/presenters/content_item/manual.rb
@@ -13,6 +13,7 @@ module ContentItem
         I18n.t("manuals.title", title: title)
       end
     end
+    alias_method :manual_page_title, :page_title
 
     def breadcrumbs
       crumbs = []

--- a/app/presenters/content_item/manual.rb
+++ b/app/presenters/content_item/manual.rb
@@ -29,6 +29,7 @@ module ContentItem
         })
       end
     end
+    alias_method :manual_breadcrumbs, :breadcrumbs
 
     def section_groups
       content_item.dig("details", "child_section_groups") || []

--- a/app/presenters/content_item/manual.rb
+++ b/app/presenters/content_item/manual.rb
@@ -1,0 +1,64 @@
+module ContentItem
+  module Manual
+    include Linkable
+    include Updatable
+
+    def page_title
+      title = content_item["title"] || ""
+      title += " - " if title.present?
+
+      if hmrc?
+        I18n.t("manuals.hmrc_title", title: title)
+      else
+        I18n.t("manuals.title", title: title)
+      end
+    end
+
+    def breadcrumbs
+      crumbs = []
+
+      if view_context.request.path == base_path
+        crumbs.push({
+          title: I18n.t("manuals.breadcrumb_contents"),
+        })
+      else
+        crumbs.push({
+          title: I18n.t("manuals.breadcrumb_contents"),
+          url: base_path,
+        })
+      end
+    end
+
+    def section_groups
+      content_item.dig("details", "child_section_groups") || []
+    end
+
+    def body
+      details["body"]
+    end
+
+    def manual_metadata
+      {
+        from: from,
+        first_published: published,
+        other: other_metadata,
+        inverse: true,
+      }
+    end
+
+  private
+
+    def other_metadata
+      updates_link = view_context.link_to(I18n.t("manuals.see_all_updates"), "#{base_path}/updates")
+      { I18n.t("manuals.updated") => "#{display_date(public_updated_at)}, #{updates_link}" }
+    end
+
+    def details
+      content_item["details"]
+    end
+
+    def hmrc?
+      %w[hmrc_manual hmrc_manual_section].include?(schema_name)
+    end
+  end
+end

--- a/app/presenters/content_item/manual_section.rb
+++ b/app/presenters/content_item/manual_section.rb
@@ -1,0 +1,28 @@
+module ContentItem
+  module ManualSection
+    def title
+      manual["title"]
+    end
+
+    def page_title
+      "#{breadcrumb} - #{manual_page_title}"
+    end
+
+    def document_heading
+      document_heading = []
+
+      document_heading << details["section_id"] if details["section_id"]
+      document_heading << content_item["title"] if content_item["title"]
+    end
+
+    def breadcrumb
+      details["section_id"] || title
+    end
+
+    def manual_content_item
+      # TODO: Add the same tagging to a normal section as a manual for contextual breadcrumbs
+      # TODO: Add the manual title to the HMRC section content item and then we can remove this request (manual_content_item)
+      @manual_content_item ||= Services.content_store.content_item(base_path)
+    end
+  end
+end

--- a/app/presenters/content_item/manual_updates.rb
+++ b/app/presenters/content_item/manual_updates.rb
@@ -1,0 +1,51 @@
+module ContentItem
+  module ManualUpdates
+    def page_title
+      I18n.t("manuals.updates_page_title", title: manual_page_title)
+    end
+
+    def description
+      I18n.t("manuals.updates_description", title: manual_page_title)
+    end
+
+    def presented_change_notes
+      group_updates_by_year(change_notes)
+    end
+
+  private
+
+    def change_notes
+      details.fetch("change_notes", [])
+    end
+
+    def updated_at(published_at)
+      Date.parse(published_at)
+    end
+
+    def group_updates_by_year(updates)
+      updates.group_by { |update| updated_at(update["published_at"]).year }
+             .sort_by { |year, _| year }
+             .map { |year, grouped_updates| [year, group_updates_by_day(grouped_updates)] }.reverse
+    end
+
+    def group_updates_by_day(updates)
+      updates.group_by { |update| updated_at(update["published_at"]) }
+             .sort_by { |day, _| day }
+             .map { |day, grouped_updates| [marked_up_date(day), group_updates_by_document(grouped_updates)] }.reverse
+    end
+
+    def group_updates_by_document(updates)
+      updates.group_by { |update| update["base_path"] }
+    end
+
+    def marked_up_date(date)
+      formatted_date = I18n.l(date, format: "%-d %B %Y") if date
+      updates_span = view_context.content_tag("span",
+                                              I18n.t("manuals.updates_amendments"),
+                                              class: "visuallyhidden")
+
+      formatted_date = "#{formatted_date} #{updates_span}"
+      view_context.sanitize(formatted_date)
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -92,6 +92,14 @@ class ContentItemPresenter
     content_id == "9315bc67-33e7-42e9-8dea-e022f56dabfa" && voting_is_open?
   end
 
+  def manual_updates?
+    view_context.request.path =~ /^\/guidance\/.*\/updates$/ && content_item["schema_name"] == "manual"
+  end
+
+  def hmrc_manual_updates?
+    view_context.request.path =~ /^\/hmrc-internal-manuals\/.*\/updates$/ && content_item["schema_name"] == "hmrc_manual"
+  end
+
 private
 
   def voting_is_open?

--- a/app/presenters/hmrc_manual_presenter.rb
+++ b/app/presenters/hmrc_manual_presenter.rb
@@ -1,0 +1,4 @@
+class HmrcManualPresenter < ContentItemPresenter
+  include ContentItem::Metadata
+  include ContentItem::Manual
+end

--- a/app/presenters/hmrc_manual_section_presenter.rb
+++ b/app/presenters/hmrc_manual_section_presenter.rb
@@ -1,0 +1,100 @@
+class HmrcManualSectionPresenter < ContentItemPresenter
+  include ContentItem::Metadata
+  include ContentItem::Manual
+  include ContentItem::ManualSection
+
+  def base_path
+    details["manual"]["base_path"]
+  end
+
+  def breadcrumbs
+    crumbs = manual_breadcrumbs.dup
+
+    return crumbs if content_item_breadcrumbs.blank?
+
+    content_item_breadcrumbs.each do |crumb|
+      crumbs.push(
+        {
+          title: crumb["section_id"],
+          url: crumb["base_path"],
+        },
+      )
+    end
+
+    crumbs
+  end
+
+  def previous_and_next_links
+    siblings = {}
+
+    if previous_sibling
+      siblings[:previous_page] = {
+        title: I18n.t("manuals.previous_page"),
+        url: previous_sibling["base_path"],
+      }
+    end
+
+    if next_sibling
+      siblings[:next_page] = {
+        title: I18n.t("manuals.next_page"),
+        url: next_sibling["base_path"],
+      }
+    end
+
+    siblings
+  end
+
+private
+
+  def previous_sibling
+    adjacent_siblings.first
+  end
+
+  def next_sibling
+    adjacent_siblings.last
+  end
+
+  def current_section_id
+    content_item["details"]["section_id"]
+  end
+
+  def siblings
+    return unless parent_for_section
+
+    child_section_groups = parent_for_section.dig("details", "child_section_groups")
+
+    sibling_child_sections = child_section_groups.map do |group|
+      included_section = group["child_sections"].find { |section| section["section_id"].include?(current_section_id) }
+      group["child_sections"] if included_section.present?
+    end
+
+    sibling_child_sections.compact.flatten
+  end
+
+  def adjacent_siblings
+    return unless siblings
+
+    before, after = siblings.split do |section|
+      section["section_id"] == current_section_id
+    end
+
+    [before.try(:last), after.try(:first)]
+  end
+
+  def manual
+    # TODO: Add the manual title to the HMRC section content item and then we can remove this request (manual_content_item)
+    parent_base_path == base_path ? parent_for_section : manual_content_item
+  end
+
+  def parent_base_path
+    content_item_breadcrumbs.present? ? content_item_breadcrumbs.last["base_path"] : base_path
+  end
+
+  def content_item_breadcrumbs
+    details["breadcrumbs"]
+  end
+
+  def parent_for_section
+    @parent_for_section ||= Services.content_store.content_item(parent_base_path)
+  end
+end

--- a/app/presenters/hmrc_manual_updates_presenter.rb
+++ b/app/presenters/hmrc_manual_updates_presenter.rb
@@ -1,0 +1,5 @@
+class HmrcManualUpdatesPresenter < ContentItemPresenter
+  include ContentItem::Metadata
+  include ContentItem::Manual
+  include ContentItem::ManualUpdates
+end

--- a/app/presenters/manual_presenter.rb
+++ b/app/presenters/manual_presenter.rb
@@ -1,0 +1,4 @@
+class ManualPresenter < ContentItemPresenter
+  include ContentItem::Metadata
+  include ContentItem::Manual
+end

--- a/app/presenters/manual_section_presenter.rb
+++ b/app/presenters/manual_section_presenter.rb
@@ -1,0 +1,59 @@
+class ManualSectionPresenter < ContentItemPresenter
+  include ContentItem::Metadata
+  include ContentItem::Manual
+  include ContentItem::ManualSection
+
+  def base_path
+    manual["base_path"]
+  end
+
+  def intro
+    return nil unless details["body"]
+
+    intro = Nokogiri::HTML::DocumentFragment.parse(details["body"])
+
+    # Strip all content following and including h2
+    intro.css("h2").xpath("following-sibling::*").remove
+    intro.css("h2").remove
+
+    intro.text.squeeze == "\n" ? "" : intro
+  end
+
+  def visually_expanded?
+    details.fetch("visually_expanded", false)
+  end
+
+  def main
+    return nil unless details["body"]
+
+    document = Nokogiri::HTML::DocumentFragment.parse(details["body"])
+
+    # Identifies all h2's and creates an array of objects from the heading and
+    # its proceeding content up to the next heading. This is so that it can be
+    # consumed by accordion components in the template.
+    document.css("h2").map do |heading|
+      content = []
+      heading.xpath("following-sibling::*").each do |element|
+        if element.name == "h2"
+          break
+        else
+          content << element.to_html
+        end
+      end
+
+      {
+        heading: {
+          text: heading.text,
+          id: heading[:id],
+        },
+        content: content.join,
+      }
+    end
+  end
+
+private
+
+  def manual
+    content_item["links"]["manual"].first
+  end
+end

--- a/app/presenters/manual_updates_presenter.rb
+++ b/app/presenters/manual_updates_presenter.rb
@@ -1,0 +1,5 @@
+class ManualUpdatesPresenter < ContentItemPresenter
+  include ContentItem::Metadata
+  include ContentItem::Manual
+  include ContentItem::ManualUpdates
+end

--- a/app/services/presenter_builder.rb
+++ b/app/services/presenter_builder.rb
@@ -34,11 +34,19 @@ private
   end
 
   def presenter_name
-    if service_sign_in_format?
-      return service_sign_in_presenter_name
-    end
+    return service_sign_in_presenter_name if service_sign_in_format?
+    return "ManualUpdatesPresenter" if manual_updates?
+    return "HmrcManualUpdatesPresenter" if hmrc_manual_updates?
 
     "#{content_item['schema_name'].classify}Presenter"
+  end
+
+  def manual_updates?
+    view_context.request.path =~ /^\/guidance\/.*\/updates$/ && content_item["schema_name"] == "manual"
+  end
+
+  def hmrc_manual_updates?
+    view_context.request.path =~ /^\/hmrc-internal-manuals\/.*\/updates$/ && content_item["schema_name"] == "hmrc_manual"
   end
 
   def service_sign_in_format?

--- a/app/views/content_items/hmrc_manual.html.erb
+++ b/app/views/content_items/hmrc_manual.html.erb
@@ -1,0 +1,28 @@
+<div id="manuals-frontend" class="manuals-frontend-body">
+
+<%= machine_readable_metadata(schema: :article) %>
+
+<%= render "content_items/manuals/hmrc_header", {
+  content_item: @content_item, heading_level: 1, margin_bottom: 3
+} %>
+
+<div class="manual-body">
+  <% if @content_item.description.present? %>
+    <%= render "govuk_publishing_components/components/lead_paragraph", {
+      text: @content_item.description
+    } %>
+  <% end %>
+  <% if @content_item.body.present? %>
+    <%= render "govuk_publishing_components/components/govspeak", {} do %>
+      <%= raw(@content_item.body) %>
+    <% end %>
+  <% end %>
+
+  <% @content_item.section_groups.each do |group| %>
+    <div class="subsection-collection">
+      <%= render "content_items/manuals/hmrc_sections", group: group %>
+    </div>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/print_link" %>
+</div>

--- a/app/views/content_items/hmrc_manual_section.html.erb
+++ b/app/views/content_items/hmrc_manual_section.html.erb
@@ -1,0 +1,49 @@
+<div id="manuals-frontend" class="manuals-frontend-body">
+  <%= render "content_items/manuals/hmrc_header", {
+    content_item: @content_item, heading_level: 1, margin_bottom: 6,
+  } %>
+
+  <div class="govuk-grid-row">
+    <div class="manual-body" id="content">
+      <article aria-labelledby="section-title">
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: @content_item.document_heading.join(" - "),
+            font_size: "m",
+            id: "section-title",
+            heading_level: 1,
+            margin_bottom: 4,
+          } %>
+        </div>
+
+        <% if @content_item.description.present? %>
+          <div class="govuk-grid-column-two-thirds">
+            <%= render "govuk_publishing_components/components/lead_paragraph", {
+              text: @content_item.description
+            } %>
+          </div>
+        <% end %>
+
+        <% if @content_item.body.present? %>
+          <div class="govuk-grid-column-two-thirds">
+            <%= render "govuk_publishing_components/components/govspeak", {} do %>
+              <%= raw(@content_item.body) %>
+            <% end %>
+          </div>
+        <% end %>
+
+        <% @content_item.section_groups.each do | group | %>
+          <div class="subsection-collection govuk-grid-column-full">
+            <%= render "content_items/manuals/hmrc_sections", group: group %>
+          </div>
+        <% end %>
+
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/previous_and_next_navigation", @content_item.previous_and_next_links %>
+        </div>
+      </article>
+    </div>
+  </div>
+
+  <%= render "govuk_publishing_components/components/print_link" %>
+</div>

--- a/app/views/content_items/hmrc_manual_updates.html.erb
+++ b/app/views/content_items/hmrc_manual_updates.html.erb
@@ -1,0 +1,7 @@
+<div id="manuals-frontend" class="manuals-frontend-body">
+  <%= render "content_items/manuals/hmrc_header", {
+    content_item: @content_item, heading_level: 2, margin_bottom: 6,
+  } %>
+
+  <%= render "content_items/manuals/updates", content_item: @content_item %>
+</div>

--- a/app/views/content_items/manual.html.erb
+++ b/app/views/content_items/manual.html.erb
@@ -1,0 +1,37 @@
+<div id="manuals-frontend" class="manuals-frontend-body">
+
+<%= machine_readable_metadata(schema: :article) %>
+
+<%= render "content_items/manuals/header", {
+  content_item: @content_item, heading_level: 1, margin_bottom: 3
+} %>
+
+<div class="manual-body">
+  <% if @content_item.description.present? %>
+    <%= render "govuk_publishing_components/components/lead_paragraph", {
+      text: @content_item.description
+    } %>
+  <% end %>
+  <% if @content_item.body.present? %>
+    <%= render "govuk_publishing_components/components/govspeak", {} do %>
+      <%= raw(@content_item.body) %>
+    <% end %>
+  <% end %>
+
+  <% @content_item.section_groups.each do |group| %>
+    <%= render "govuk_publishing_components/components/document_list", {
+        items: group["child_sections"].map do |section|
+          {
+            link: {
+              text: section["title"],
+              path: section["base_path"],
+              description: section["description"],
+              full_size_description: true,
+            }
+          }
+        end
+    } %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/print_link" %>
+</div>

--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -1,0 +1,75 @@
+<div id="manuals-frontend" class="manuals-frontend-body">
+  <%= render "content_items/manuals/header", {
+    content_item: @content_item, heading_level: 1, margin_bottom: 6,
+  } %>
+
+  <div class="govuk-grid-row">
+    <div class="manual-body" id="content">
+      <article aria-labelledby="section-title">
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: @content_item.document_heading.join(" - "),
+            font_size: "m",
+            id: "section-title",
+            heading_level: 1,
+            margin_bottom: 4,
+          } %>
+        </div>
+
+        <% if @content_item.description.present? %>
+          <div class="govuk-grid-column-two-thirds">
+            <%= render "govuk_publishing_components/components/lead_paragraph", {
+              text: @content_item.description
+            } %>
+          </div>
+        <% end %>
+
+        <div class="govuk-grid-column-two-thirds">
+          <% if @content_item.intro.present? %>
+            <%= render "govuk_publishing_components/components/govspeak", {} do
+              raw(@content_item.intro)
+            end %>
+          <% end %>
+
+          <% if @content_item.body.present? %>
+            <% if @content_item.visually_expanded? %>
+              <% @content_item.main.map do |item| %>
+                <div class="govuk-!-margin-bottom-3">
+                  <%= render "govuk_publishing_components/components/heading", {
+                    text: item[:heading][:text],
+                    font_size: "m",
+                    margin_bottom: 1,
+                    id: item[:heading][:id],
+                  } %>
+                </div>
+                <div class="govuk-body govuk-!-margin-bottom-1">
+                  <%= render "govuk_publishing_components/components/govspeak", {} do
+                    raw(item[:content])
+                  end %>
+                </div>
+              <% end %>
+            <% else %>
+              <%= render "govuk_publishing_components/components/accordion", {
+                anchor_navigation: true,
+                items: @content_item.main.map do |item|
+                  rendered_content = render "govuk_publishing_components/components/govspeak", {} do
+                    raw(item[:content])
+                  end
+
+                  {
+                    heading: item[:heading],
+                    content: {
+                      html: rendered_content,
+                    },
+                  }
+                end
+              } %>
+            <% end %>
+          <% end %>
+        </div>
+      </article>
+    </div>
+  </div>
+
+  <%= render "govuk_publishing_components/components/print_link" %>
+</div>

--- a/app/views/content_items/manual_updates.html.erb
+++ b/app/views/content_items/manual_updates.html.erb
@@ -1,0 +1,7 @@
+<div id="manuals-frontend" class="manuals-frontend-body">
+  <%= render "content_items/manuals/header", {
+    content_item: @content_item, heading_level: 2, margin_bottom: 6,
+  } %>
+
+  <%= render "content_items/manuals/updates", content_item: @content_item %>
+</div>

--- a/app/views/content_items/manuals/_header.html.erb
+++ b/app/views/content_items/manuals/_header.html.erb
@@ -1,4 +1,4 @@
-<header aria-labelledby="manual-title" class="govuk-grid-row">
+<header aria-labelledby="manual-title" class="govuk-grid-row manuals-header">
   <div class='govuk-grid-column-two-thirds'>
 
     <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/content_items/manuals/_header.html.erb
+++ b/app/views/content_items/manuals/_header.html.erb
@@ -1,0 +1,33 @@
+<header aria-labelledby="manual-title" class="govuk-grid-row">
+  <div class='govuk-grid-column-two-thirds'>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: content_item.title,
+      font_size: "l",
+      inverse: true,
+      id: "manual-title",
+      heading_level: heading_level,
+      margin_bottom: margin_bottom,
+    } %>
+
+    <%= render 'govuk_publishing_components/components/metadata', content_item.manual_metadata %>
+
+    <div class="in-manual-search">
+      <form action="/search/all" >
+
+        <input type='hidden' name="manual[]" value="<%= content_item.base_path %>">
+
+        <%= render "govuk_publishing_components/components/search", {
+          on_govuk_blue: true,
+          label_text: t("manuals.search_this_manual"),
+        } %>
+      </form>
+    </div>
+  </div>
+</header>
+
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+           border: "bottom",
+           breadcrumbs: @content_item.breadcrumbs,
+           collapse_on_mobile: false } %>
+

--- a/app/views/content_items/manuals/_hmrc_header.html.erb
+++ b/app/views/content_items/manuals/_hmrc_header.html.erb
@@ -1,4 +1,4 @@
-<header aria-labelledby="manual-title" class="hmrc govuk-grid-row">
+<header aria-labelledby="manual-title" class="manuals-header hmrc govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <span class="manual-type"><%= I18n.t("manuals.hmrc_manual_type") %></span>

--- a/app/views/content_items/manuals/_hmrc_header.html.erb
+++ b/app/views/content_items/manuals/_hmrc_header.html.erb
@@ -1,0 +1,34 @@
+<header aria-labelledby="manual-title" class="hmrc govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="manual-type"><%= I18n.t("manuals.hmrc_manual_type") %></span>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: content_item.title,
+      font_size: "l",
+      inverse: true,
+      id: "manual-title",
+      heading_level: heading_level,
+      margin_bottom: margin_bottom,
+    } %>
+
+    <%= render "govuk_publishing_components/components/metadata", content_item.manual_metadata %>
+
+    <div class="in-manual-search">
+      <form action="/search/all" >
+
+        <input type="hidden" name="manual[]" value="<%= content_item.base_path %>">
+
+        <%= render "govuk_publishing_components/components/search", {
+          on_govuk_blue: true,
+          label_text: t("manuals.search_this_manual"),
+        } %>
+      </form>
+    </div>
+  </div>
+</header>
+
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+           border: "bottom",
+           breadcrumbs: @content_item.breadcrumbs,
+           collapse_on_mobile: false } %>

--- a/app/views/content_items/manuals/_hmrc_sections.html.erb
+++ b/app/views/content_items/manuals/_hmrc_sections.html.erb
@@ -4,8 +4,8 @@
 
 <ol class="section-list hmrc">
   <% group["child_sections"].each do |section| %>
-    <li>
-      <%= link_to section["base_path"], class: "govuk-link" do %>
+    <li class="section-list-item">
+      <%= link_to section["base_path"], class: "govuk-link section-link" do %>
       <div class="title-wrap">
         <% if section["section_id"] %>
           <div class="subsection-id"><%= section["section_id"] %></div>

--- a/app/views/content_items/manuals/_hmrc_sections.html.erb
+++ b/app/views/content_items/manuals/_hmrc_sections.html.erb
@@ -1,0 +1,19 @@
+<% if group["title"] %>
+  <%= group["title"] %>
+<% end %>
+
+<ol class="section-list hmrc">
+  <% group["child_sections"].each do |section| %>
+    <li>
+      <%= link_to section["base_path"], class: "govuk-link" do %>
+      <div class="title-wrap">
+        <% if section["section_id"] %>
+          <div class="subsection-id"><%= section["section_id"] %></div>
+        <% end %>
+        <div class="subsection-title-text"><%= section["title"] %></div>
+        </div>
+      <% end %>
+    </li>
+  <% end %>
+</ol>
+

--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -1,0 +1,51 @@
+<div class="govuk-grid-row">
+  <div class="manual-body" id="content">
+    <article aria-labelledby="section-title">
+      <div class="govuk-grid-column-full">
+        <%= render "govuk_publishing_components/components/heading", {
+          font_size: "l",
+          heading_level: 1,
+          id: "section-title",
+          margin_bottom: 4,
+          text: t("manuals.updates_title", title: content_item.title),
+        } %>
+      </div>
+
+      <% content_item.presented_change_notes.each do |year, updates_by_year| %>
+        <div class="govuk-grid-column-two-thirds">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: year,
+            font_size: "l"
+          } %>
+
+          <%= render "govuk_publishing_components/components/accordion", {
+            heading_level: 3,
+            items: updates_by_year.map do |day, updated_documents|
+              accordion_content = capture do %>
+                <div class="govuk-!-margin-top-3">
+                  <% updated_documents.each do |_, change_notes| %>
+                    <% change_notes.each do |change_note| %>
+                      <p class="govuk-body"><%= link_to change_note["title"], change_note["base_path"], class: "govuk-link" %></p>
+                      <%= simple_format(change_note["change_note"], class: "govuk-body") %>
+                    <% end %>
+                  <% end %>
+                </div>
+              <% end
+
+              {
+                heading: {
+                  text: day,
+                },
+                content: {
+                  html: accordion_content
+                }
+              }
+            end
+          } %>
+        </div>
+      <% end %>
+    </article>
+  </div>
+</div>
+
+<%= render "govuk_publishing_components/components/print_link" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,9 +46,12 @@
       <% if @content_item.try(:back_link) %>
         <%= render 'govuk_publishing_components/components/back_link', href: @content_item.back_link %>
       <% elsif @content_item.brexit_child_taxon %>
-        <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: [ { url: "/", title: "Home" } , { url: "/brexit", title: "Brexit" } ] %>
+        <%= render 'govuk_publishing_components/components/breadcrumbs',
+                   breadcrumbs: [ { url: "/", title: "Home" } , { url: "/brexit", title: "Brexit" } ] %>
       <% else %>
-        <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.content_item.parsed_content %>
+        <!-- TODO: Remove manual_content_item after adding the same tagging to manual and hmrc manual section as the parent manual --!>
+        <%= render 'govuk_publishing_components/components/contextual_breadcrumbs',
+                   content_item: @content_item.try(:manual_content_item) || @content_item.content_item.parsed_content %>
       <% end %>
     <% end %>
 

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -122,9 +122,9 @@ ar:
         two:
         zero:
       coming_soon:
-        one:
         few:
         many:
+        one:
         other: قريبًا
         two:
         zero:
@@ -178,9 +178,9 @@ ar:
         two:
         zero:
       detailed_guide:
-        one:
         few:
         many:
+        one:
         other: توجيه
         two:
         zero:
@@ -262,9 +262,9 @@ ar:
         two:
         zero:
       guidance:
-        one:
         few:
         many:
+        one:
         other: توجيه
         two:
         zero:
@@ -276,9 +276,9 @@ ar:
         two:
         zero:
       imported:
-        one:
         few:
         many:
+        one:
         other: مستورد - في انتظار النوع
         two:
         zero:
@@ -290,9 +290,9 @@ ar:
         two:
         zero:
       international_development_fund:
-        one:
         few:
         many:
+        one:
         other: تمويل التنمية الدولية
         two:
         zero:
@@ -318,9 +318,9 @@ ar:
         two:
         zero:
       medical_safety_alert:
-        one:
         few:
         many:
+        one:
         other: تنبيهات واستدعاءات للأدوية والأجهزة الطبية
         two:
         zero:
@@ -332,9 +332,9 @@ ar:
         two:
         zero:
       national_statistics:
-        one:
         few:
         many:
+        one:
         other: الإحصاءات الوطنية
         two:
         zero:
@@ -374,9 +374,9 @@ ar:
         two:
         zero:
       official_statistics:
-        one:
         few:
         many:
+        one:
         other: الإحصاءات الرسمية
         two:
         zero:
@@ -430,9 +430,9 @@ ar:
         two:
         zero:
       promotional:
-        one:
         few:
         many:
+        one:
         other: مادة ترويجية
         two:
         zero:
@@ -458,9 +458,9 @@ ar:
         two:
         zero:
       research:
-        one:
         few:
         many:
+        one:
         other: البحث والتحليل
         two:
         zero:
@@ -472,9 +472,9 @@ ar:
         two:
         zero:
       service_sign_in:
-        one:
         few:
         many:
+        one:
         other: تسجيل الدخول إلى الخدمة
         two:
         zero:
@@ -486,9 +486,9 @@ ar:
         two:
         zero:
       speaking_notes:
-        one:
         few:
         many:
+        one:
         other: ملاحظات تحضيرية للخطاب
         two:
         zero:
@@ -528,16 +528,16 @@ ar:
         two:
         zero:
       statutory_guidance:
-        one:
         few:
         many:
+        one:
         other: التوجيه القانوني
         two:
         zero:
       take_part:
-        one:
         few:
         many:
+        one:
         other: شارك
         two:
         zero:
@@ -556,9 +556,9 @@ ar:
         two:
         zero:
       transparency:
-        one:
         few:
         many:
+        one:
         other: بيانات الشفافية
         two:
         zero:
@@ -730,6 +730,20 @@ ar:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: التالي
     previous_page: السابق

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -430,6 +430,20 @@ az:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Sonrakı
     previous_page: Əvvəlki

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -321,8 +321,8 @@ be:
         one: Прэс-рэліз
         other: Прэс-рэлізы
       product-safety-alert-report-recall:
-        many:
         few:
+        many:
         one:
         other:
       promotional:
@@ -580,6 +580,20 @@ be:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Далей
     previous_page: Папярэдні

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -430,6 +430,20 @@ bg:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Следваща
     previous_page: Предишна

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -430,6 +430,20 @@ bn:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: পরবর্তী
     previous_page: পূর্ববর্তী

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -505,6 +505,20 @@ cs:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Další
     previous_page: Předchozí

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -423,12 +423,12 @@ cy:
         two:
         zero:
       product-safety-alert-report-recall:
-        zero:
-        two:
-        many:
         few:
+        many:
         one:
         other:
+        two:
+        zero:
       promotional:
         few:
         many:
@@ -730,6 +730,20 @@ cy:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Nesaf
     previous_page: Blaenorol

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -442,6 +442,20 @@ da:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Næste
     previous_page: Forrige

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -430,6 +430,20 @@ de:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Weiter
     previous_page: Zurück

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -433,6 +433,20 @@ dr:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: قبلی
     previous_page: قبلی

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -430,6 +430,20 @@ el:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Επόμενο
     previous_page: Προηγούμενο

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -431,19 +431,19 @@ en:
     zh-hk: Cantonese
     zh-tw: Traditional Chinese
   manuals:
-    title: "%{title}Guidance"
-    hmrc_manual_type: "HMRC internal manual"
-    hmrc_title: "%{title}HMRC internal manual"
-    search_this_manual: Search this manual
-    updates_title: "Updates: %{title}"
-    updates_description: "List of updates to '%{title}'."
-    updates_page_title: "Updates - %{title}"
-    updates_amendments: published amendments
-    previous_page: Previous page
-    next_page: Next page
     breadcrumb_contents: Contents
-    updated: Updated
+    hmrc_manual_type: HMRC internal manual
+    hmrc_title: "%{title}HMRC internal manual"
+    next_page: Next page
+    previous_page: Previous page
+    search_this_manual: Search this manual
     see_all_updates: see all updates
+    title: "%{title}Guidance"
+    updated: Updated
+    updates_amendments: published amendments
+    updates_description: List of updates to '%{title}'.
+    updates_page_title: Updates - %{title}
+    updates_title: 'Updates: %{title}'
   multi_page:
     next_page: Next
     previous_page: Previous

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -430,6 +430,20 @@ en:
     zh: Chinese
     zh-hk: Cantonese
     zh-tw: Traditional Chinese
+  manuals:
+    title: "%{title}Guidance"
+    hmrc_manual_type: "HMRC internal manual"
+    hmrc_title: "%{title}HMRC internal manual"
+    search_this_manual: Search this manual
+    updates_title: "Updates: %{title}"
+    updates_description: "List of updates to '%{title}'."
+    updates_page_title: "Updates - %{title}"
+    updates_amendments: published amendments
+    previous_page: Previous page
+    next_page: Next page
+    breadcrumb_contents: Contents
+    updated: Updated
+    see_all_updates: see all updates
   multi_page:
     next_page: Next
     previous_page: Previous

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -430,6 +430,20 @@ es-419:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Siguiente
     previous_page: Anterior

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -430,6 +430,20 @@ es:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Siguiente
     previous_page: Anterior

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -430,6 +430,20 @@ et:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Edasi
     previous_page: Eelmine

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -430,6 +430,20 @@ fa:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: بعدی
     previous_page: قبلی

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -430,6 +430,20 @@ fi:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Seuraava
     previous_page: Edellinen

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -430,6 +430,20 @@ fr:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Suivant
     previous_page: Précédent

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -321,10 +321,10 @@ gd:
         other: Preaseisiúintí
         two:
       product-safety-alert-report-recall:
-        two:
         few:
         one:
         other:
+        two:
       promotional:
         few:
         one: Ábhar cur chun cinn
@@ -580,6 +580,20 @@ gd:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Ag leanúint
     previous_page: Roimhe seo

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -430,6 +430,20 @@ gu:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: આગળનું
     previous_page: પહેલાનું

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -430,6 +430,20 @@ he:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: הבא
     previous_page: הקודם

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -430,6 +430,20 @@ hi:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: अगला
     previous_page: पिछला

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -321,8 +321,8 @@ hr:
         one: Saopćenje za javnost
         other: Saopćenja za javnost
       product-safety-alert-report-recall:
-        many:
         few:
+        many:
         one:
         other:
       promotional:
@@ -580,6 +580,20 @@ hr:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Sljedeće
     previous_page: Prethodno

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -430,6 +430,20 @@ hu:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Következő
     previous_page: Előző

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -430,6 +430,20 @@ hy:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Հաջորդ
     previous_page: Նախորդ

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -355,6 +355,20 @@ id:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Selanjutnya
     previous_page: Sebelumnya

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -430,6 +430,20 @@ is:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Næsta
     previous_page: Fyrri

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -430,6 +430,20 @@ it:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Avanti
     previous_page: Precedente

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -355,6 +355,20 @@ ja:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: 次へ
     previous_page: 前へ

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -430,6 +430,20 @@ ka:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: შემდეგი
     previous_page: წინა

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -430,6 +430,20 @@ kk:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Келесі
     previous_page: Алдыңғы

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -355,6 +355,20 @@ ko:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: 다음
     previous_page: 이전

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -505,6 +505,20 @@ lt:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Kitas
     previous_page: Ankstesnis

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -430,6 +430,20 @@ lv:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Tālāk
     previous_page: Atpakaļ

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -355,6 +355,20 @@ ms:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Seterusnya
     previous_page: Sebelumnya

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -321,8 +321,8 @@ mt:
         one: Stqarrija għall-istampa
         other: Stqarrijiet għall-istampa
       product-safety-alert-report-recall:
-        many:
         few:
+        many:
         one:
         other:
       promotional:
@@ -580,6 +580,20 @@ mt:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Li jmiss
     previous_page: Ta' qabel

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -430,6 +430,20 @@ ne:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: अर्को
     previous_page: अघिल्लो

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -430,6 +430,20 @@ nl:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Volgende
     previous_page: Vorige

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -430,6 +430,20 @@
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Neste
     previous_page: Forrige

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -430,6 +430,20 @@ pa-pk:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: اگلا
     previous_page: پچھلا

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -430,6 +430,20 @@ pa:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: ਅਗਲਾ
     previous_page: ਪਿਛਲਾ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -321,8 +321,8 @@ pl:
         one: Informacja prasowa
         other: Informacje prasowe
       product-safety-alert-report-recall:
-        many:
         few:
+        many:
         one:
         other:
       promotional:
@@ -580,6 +580,20 @@ pl:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Następny
     previous_page: Poprzedni

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -430,6 +430,20 @@ ps:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: بل
     previous_page: مخکینی

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -430,6 +430,20 @@ pt:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Seguinte
     previous_page: Anterior

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -505,6 +505,20 @@ ro:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Continuare
     previous_page: Înapoi

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -321,8 +321,8 @@ ru:
         one: Пресс-релиз
         other: Пресс-релизы
       product-safety-alert-report-recall:
-        many:
         few:
+        many:
         one:
         other:
       promotional:
@@ -580,6 +580,20 @@ ru:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Следующий
     previous_page: Предыдущий

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -430,6 +430,20 @@ si:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: ඊළඟ
     previous_page: පෙර

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -505,6 +505,20 @@ sk:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Ďalšie
     previous_page: Predchádzajúce

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -321,10 +321,10 @@ sl:
         other: Sporočila za javnost
         two:
       product-safety-alert-report-recall:
-        two:
         few:
         one:
         other:
+        two:
       promotional:
         few:
         one: Promocijski material
@@ -580,6 +580,20 @@ sl:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Naslednji
     previous_page: Prejšnji

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -430,6 +430,20 @@ so:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Ku xiga
     previous_page: Hore

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -430,6 +430,20 @@ sq:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Tjetër
     previous_page: I mëparshëm

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -321,8 +321,8 @@ sr:
         one: Saopštenje za medije
         other: Saopštenja za štampu
       product-safety-alert-report-recall:
-        many:
         few:
+        many:
         one:
         other:
       promotional:
@@ -580,6 +580,20 @@ sr:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Sledeće
     previous_page: Prethodno

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -430,6 +430,20 @@ sv:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Nästa
     previous_page: Föregående

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -430,6 +430,20 @@ sw:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Unaofuata
     previous_page: Uliotangulia

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -430,6 +430,20 @@ ta:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: அடுத்து
     previous_page: முந்தையது

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -355,6 +355,20 @@ th:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: ถัดไป
     previous_page: ก่อนหน้า

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -430,6 +430,20 @@ tk:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Indiki
     previous_page: Öňki

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -430,6 +430,20 @@ tr:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Sonraki
     previous_page: Önceki

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -321,8 +321,8 @@ uk:
         one: Пресреліз
         other: Пресрелізи
       product-safety-alert-report-recall:
-        many:
         few:
+        many:
         one:
         other:
       promotional:
@@ -580,6 +580,20 @@ uk:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Далі
     previous_page: Назад

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -430,6 +430,20 @@ ur:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: اگلا
     previous_page: گزشتہ

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -430,6 +430,20 @@ uz:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Кейинги
     previous_page: Олдинги

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -355,6 +355,20 @@ vi:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: Tiếp theo
     previous_page: Trước

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -430,6 +430,20 @@ yi:
     zh:
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page:
     previous_page:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -430,6 +430,20 @@ zh-hk:
     zh:
     zh-hk: 中文
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: 下一項
     previous_page: 上一項

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -430,6 +430,20 @@ zh-tw:
     zh:
     zh-hk:
     zh-tw: 繁體中文
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: 接續
     previous_page: 先前

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -355,6 +355,20 @@ zh:
     zh: 中文
     zh-hk:
     zh-tw:
+  manuals:
+    breadcrumb_contents:
+    hmrc_manual_type:
+    hmrc_title:
+    next_page:
+    previous_page:
+    search_this_manual:
+    see_all_updates:
+    title:
+    updated:
+    updates_amendments:
+    updates_description:
+    updates_page_title:
+    updates_title:
   multi_page:
     next_page: 下一步
     previous_page: 上一步

--- a/test/integration/hmrc_manual_section_test.rb
+++ b/test/integration/hmrc_manual_section_test.rb
@@ -1,0 +1,91 @@
+require "test_helper"
+
+class HmrcManualSectionTest < ActionDispatch::IntegrationTest
+  test "page renders correctly" do
+    setup_and_visit_manual_section
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+
+    within ".manual-type" do
+      assert page.has_text?(I18n.t("manuals.hmrc_manual_type"))
+    end
+  end
+
+  test "renders metadata" do
+    setup_and_visit_manual_section
+
+    assert_has_metadata(
+      {
+        from: { "HM Revenue & Customs": "/government/organisations/hm-revenue-customs" },
+        first_published: "10 February 2015",
+        other: {
+          I18n.t("manuals.see_all_updates") => "#{@manual['base_path']}/updates",
+        },
+      },
+      extra_metadata_classes: ".gem-c-metadata--inverse",
+    )
+  end
+
+  test "renders search box" do
+    setup_and_visit_manual_section
+
+    within ".gem-c-search" do
+      assert page.has_text?(I18n.t("manuals.search_this_manual"))
+    end
+  end
+
+  test "renders manual specific breadcrumbs" do
+    setup_and_visit_manual_section
+
+    manual_specific_breadcrumbs = page.all(".gem-c-breadcrumbs")[1]
+    within manual_specific_breadcrumbs do
+      assert page.has_text?(I18n.t("manuals.breadcrumb_contents"))
+    end
+  end
+
+  test "renders section group" do
+    setup_and_visit_manual_section
+
+    within ".subsection-collection .section-list" do
+      first_group_children = page.all("li")
+
+      assert_equal 6, first_group_children.count
+
+      within first_group_children[0] do
+        assert page.has_link?(
+          "Introduction: scope of the manual",
+          href: "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb2100",
+        )
+        assert page.has_text?("VATGPB2100")
+      end
+    end
+  end
+
+  test "renders previous and next navigation" do
+    setup_and_visit_manual_section
+
+    within ".gem-c-pagination" do
+      assert page.has_link?(
+        I18n.t("manuals.previous_page"),
+        href: "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
+      )
+
+      assert page.has_link?(
+        I18n.t("manuals.next_page"),
+        href: "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb3000",
+      )
+    end
+  end
+
+  def setup_and_visit_manual_section(content_item = get_content_example("vatgpb2000"))
+    @manual = get_content_example_by_schema_and_name("hmrc_manual", "vat-government-public-bodies")
+    @content_item = content_item
+    manual_base_path = @content_item["details"]["manual"]["base_path"]
+
+    stub_content_store_has_item(manual_base_path, @manual.to_json)
+
+    stub_content_store_has_item(@content_item["base_path"], @content_item.to_json)
+    visit_with_cachebust((@content_item["base_path"]).to_s)
+  end
+end

--- a/test/integration/hmrc_manual_test.rb
+++ b/test/integration/hmrc_manual_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+class HmrcManualTest < ActionDispatch::IntegrationTest
+  test "page renders correctly" do
+    setup_and_visit_content_item("vat-government-public-bodies")
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+
+    within ".manual-type" do
+      assert page.has_text?(I18n.t("manuals.hmrc_manual_type"))
+    end
+  end
+
+  test "renders metadata" do
+    setup_and_visit_content_item("vat-government-public-bodies")
+
+    assert_has_metadata(
+      {
+        from: { "HM Revenue & Customs": "/government/organisations/hm-revenue-customs" },
+        first_published: "11 February 2015",
+        other: {
+          I18n.t("manuals.see_all_updates") => "#{@content_item['base_path']}/updates",
+        },
+      },
+      extra_metadata_classes: ".gem-c-metadata--inverse",
+    )
+  end
+
+  test "renders search box" do
+    setup_and_visit_content_item("vat-government-public-bodies")
+
+    within ".gem-c-search" do
+      assert page.has_text?(I18n.t("manuals.search_this_manual"))
+    end
+  end
+
+  test "renders manual specific breadcrumbs" do
+    setup_and_visit_content_item("vat-government-public-bodies")
+
+    manual_specific_breadcrumbs = page.all(".gem-c-breadcrumbs")[1]
+    within manual_specific_breadcrumbs do
+      assert page.has_text?(I18n.t("manuals.breadcrumb_contents"))
+    end
+  end
+
+  test "renders section groups" do
+    setup_and_visit_content_item("vat-government-public-bodies")
+
+    child_section_groups = page.all(".subsection-collection .section-list")
+
+    assert_equal 2, child_section_groups.count
+
+    within child_section_groups[0] do
+      first_group_children = page.all("li")
+
+      assert_equal 9, first_group_children.count
+
+      within first_group_children[0] do
+        assert page.has_link?(
+          "Introduction: contents",
+          href: "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
+        )
+        assert page.has_text?("VATGPB1000")
+      end
+    end
+
+    within child_section_groups[1] do
+      section_group_children = page.all("li")
+
+      assert_equal 1, section_group_children.count
+
+      within section_group_children[0] do
+        assert page.has_link?(
+          "VAT Government and public bodies: update index",
+          href: "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpbupdate001",
+        )
+        assert page.has_text?("VATGPBUPDATE001")
+      end
+    end
+  end
+end

--- a/test/integration/hmrc_manual_updates_test.rb
+++ b/test/integration/hmrc_manual_updates_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class HmrcManualUpdatesTest < ActionDispatch::IntegrationTest
+  test "page renders correctly" do
+    setup_and_visit_manual_updates
+
+    assert_has_component_title(I18n.t("manuals.updates_title", title: @content_item["title"]))
+
+    within ".manual-type" do
+      assert page.has_text?(I18n.t("manuals.hmrc_manual_type"))
+    end
+  end
+
+  test "renders metadata" do
+    setup_and_visit_manual_updates
+
+    assert_has_metadata(
+      {
+        from: { "HM Revenue & Customs": "/government/organisations/hm-revenue-customs" },
+        first_published: "11 February 2015",
+        other: {
+          I18n.t("manuals.see_all_updates") => "#{@content_item['base_path']}/updates",
+        },
+      },
+      extra_metadata_classes: ".gem-c-metadata--inverse",
+    )
+  end
+
+  test "renders search box" do
+    setup_and_visit_manual_updates
+
+    within ".gem-c-search" do
+      assert page.has_text?(I18n.t("manuals.search_this_manual"))
+    end
+  end
+
+  test "renders manual specific breadcrumbs" do
+    setup_and_visit_manual_updates
+
+    manual_specific_breadcrumbs = page.all(".gem-c-breadcrumbs")[1]
+    within manual_specific_breadcrumbs do
+      assert page.has_link?(I18n.t("manuals.breadcrumb_contents"), href: @content_item["base_path"])
+    end
+  end
+
+  test "renders change note updates" do
+    setup_and_visit_manual_updates
+    assert page.has_css?(".gem-c-accordion")
+
+    accordion_sections = page.all(".govuk-accordion__section")
+    assert_equal 2, accordion_sections.count
+
+    within accordion_sections[0] do
+      assert page.has_link?("Police authorities: summary of activities: liabilities T to Z",
+                            href: "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb5390")
+      assert page.has_text?("Updated content")
+    end
+
+    within accordion_sections[1] do
+      assert page.has_link?("Police authorities: summary of activities: liabilities I to M",
+                            href: "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb5350")
+      assert page.has_text?("Updated content")
+    end
+  end
+
+  def schema_type
+    "hmrc_manual"
+  end
+
+  def setup_and_visit_manual_updates
+    @content_item = get_content_example("vat-government-public-bodies").tap do |item|
+      stub_content_store_has_item("#{item['base_path']}/updates", item.to_json)
+      visit_with_cachebust("#{item['base_path']}/updates")
+    end
+  end
+end

--- a/test/integration/manual_section_test.rb
+++ b/test/integration/manual_section_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+class ManualSectionTest < ActionDispatch::IntegrationTest
+  test "page renders correctly" do
+    setup_and_visit_manual_section
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+  end
+
+  test "renders contextual breadcrumbs from parent manuals tagging" do
+    setup_and_visit_manual_section
+    manual_topic = @manual["links"]["topics"].first
+
+    within ".gem-c-contextual-breadcrumbs" do
+      assert page.has_link?(manual_topic["title"], href: manual_topic["base_path"])
+    end
+  end
+
+  test "renders document heading" do
+    setup_and_visit_manual_section
+
+    within ".govuk-heading-l" do
+      assert page.has_text?(@manual["title"])
+    end
+  end
+
+  test "renders manual specific breadcrumbs" do
+    setup_and_visit_manual_section
+
+    manual_specific_breadcrumbs = page.all(".gem-c-breadcrumbs")[1]
+    within manual_specific_breadcrumbs do
+      assert page.has_link?(I18n.t("manuals.breadcrumb_contents"), href: @manual["base_path"])
+    end
+  end
+
+  test "renders sections accordion" do
+    setup_and_visit_manual_section
+
+    assert page.has_css?(".gem-c-accordion")
+
+    accordion_sections = page.all(".govuk-accordion__section")
+    assert_equal 7, accordion_sections.count
+
+    within accordion_sections[0] do
+      assert page.has_text?("Designing content, not creating copy")
+    end
+  end
+
+  test "renders expanded sections if visually expanded " do
+    content_item = get_content_example("what-is-content-design")
+    content_item["details"]["visually_expanded"] = true
+
+    setup_and_visit_manual_section(content_item)
+
+    within ".manual-body" do
+      assert_equal 7, page.all("h2").count
+      first_section_heading = page.all("h2").first
+
+      assert_equal "Designing content, not creating copy", first_section_heading.text
+    end
+  end
+
+  def setup_and_visit_manual_section(content_item = get_content_example("what-is-content-design"))
+    @manual = get_content_example_by_schema_and_name("manual", "content-design")
+    @content_item = content_item
+    manual_base_path = @content_item["links"]["manual"].first["base_path"]
+
+    stub_content_store_has_item(manual_base_path, @manual.to_json)
+
+    stub_content_store_has_item(@content_item["base_path"], @content_item.to_json)
+    visit_with_cachebust((@content_item["base_path"]).to_s)
+  end
+end

--- a/test/integration/manual_test.rb
+++ b/test/integration/manual_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class ManualTest < ActionDispatch::IntegrationTest
+  test "page renders correctly" do
+    setup_and_visit_content_item("content-design")
+
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+  end
+
+  test "renders metadata" do
+    setup_and_visit_content_item("content-design")
+
+    assert_has_metadata(
+      {
+        from: { "Government Digital Service": "/government/organisations/government-digital-service" },
+        first_published: "27 April 2015",
+        other: {
+          I18n.t("manuals.see_all_updates") => "#{@content_item['base_path']}/updates",
+        },
+      },
+      extra_metadata_classes: ".gem-c-metadata--inverse",
+    )
+  end
+
+  test "renders search box" do
+    setup_and_visit_content_item("content-design")
+
+    within ".gem-c-search" do
+      assert page.has_text?(I18n.t("manuals.search_this_manual"))
+    end
+  end
+
+  test "renders manual specific breadcrumbs" do
+    setup_and_visit_content_item("content-design")
+
+    manual_specific_breadcrumbs = page.all(".gem-c-breadcrumbs")[1]
+    within manual_specific_breadcrumbs do
+      assert page.has_text?(I18n.t("manuals.breadcrumb_contents"))
+    end
+  end
+
+  test "renders body govspeak" do
+    setup_and_visit_content_item("content-design")
+
+    within ".gem-c-govspeak" do
+      assert page.has_text?("If you like yoga")
+    end
+  end
+
+  test "renders sections" do
+    setup_and_visit_content_item("content-design")
+
+    within ".gem-c-document-list" do
+      list_items = page.all(".gem-c-document-list__item")
+
+      assert_equal 3, list_items.count
+
+      within list_items[0] do
+        assert page.has_link?("What is content design?", href: "/guidance/content-design/what-is-content-design")
+        assert page.has_text?("Introduction to content design.")
+      end
+    end
+  end
+end

--- a/test/integration/manual_updates_test.rb
+++ b/test/integration/manual_updates_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class ManualUpdatesTest < ActionDispatch::IntegrationTest
+  test "page renders correctly" do
+    setup_and_visit_manual_updates
+
+    assert_has_component_title(I18n.t("manuals.updates_title", title: @content_item["title"]))
+  end
+
+  test "renders metadata" do
+    setup_and_visit_manual_updates
+
+    assert_has_metadata(
+      {
+        from: { "Government Digital Service": "/government/organisations/government-digital-service" },
+        first_published: "27 April 2015",
+        other: {
+          I18n.t("manuals.see_all_updates") => "#{@content_item['base_path']}/updates",
+        },
+      },
+      extra_metadata_classes: ".gem-c-metadata--inverse",
+    )
+  end
+
+  test "renders search box" do
+    setup_and_visit_manual_updates
+
+    within ".gem-c-search" do
+      assert page.has_text?(I18n.t("manuals.search_this_manual"))
+    end
+  end
+
+  test "renders manual specific breadcrumbs" do
+    setup_and_visit_manual_updates
+
+    manual_specific_breadcrumbs = page.all(".gem-c-breadcrumbs")[1]
+    within manual_specific_breadcrumbs do
+      assert page.has_link?(I18n.t("manuals.breadcrumb_contents"), href: @content_item["base_path"])
+    end
+  end
+
+  test "renders change note updates" do
+    setup_and_visit_manual_updates
+    assert page.has_css?(".gem-c-accordion")
+
+    accordion_sections = page.all(".govuk-accordion__section")
+    assert_equal 2, accordion_sections.count
+
+    within accordion_sections[0] do
+      assert page.has_link?("What is content design?", href: "/guidance/content-design/what-is-content-design")
+      assert page.has_text?("New section added.")
+    end
+
+    within accordion_sections[1] do
+      assert page.has_link?("Content types", href: "/guidance/content-design/content-types")
+      assert page.has_text?("New section added.")
+    end
+  end
+
+  def schema_type
+    "manual"
+  end
+
+  def setup_and_visit_manual_updates
+    @content_item = get_content_example("content-design").tap do |item|
+      stub_content_store_has_item("#{item['base_path']}/updates", item.to_json)
+      visit_with_cachebust("#{item['base_path']}/updates")
+    end
+  end
+end

--- a/test/presenter_test_helper.rb
+++ b/test/presenter_test_helper.rb
@@ -24,7 +24,7 @@ class PresenterTestCase < ActiveSupport::TestCase
     )
   end
 
-  def schema_item(type = schema_name)
-    govuk_content_schema_example(schema_name, type)
+  def schema_item(type = schema_name, schema = schema_name)
+    govuk_content_schema_example(schema, type)
   end
 end

--- a/test/presenters/content_item/manual_test.rb
+++ b/test/presenters/content_item/manual_test.rb
@@ -1,0 +1,86 @@
+require "test_helper"
+
+class ContentItemManualTest < ActiveSupport::TestCase
+  class DummyContentItem
+    include ContentItem::Manual
+    attr_reader :content_item, :view_context, :base_path, :public_updated_at, :title, :schema_name
+
+    def initialize(schema_name = "manual")
+      @view_context = ApplicationController.new.view_context
+      @content_item = {
+        "title" => "Super title",
+        "base_path" => "/a/base/path",
+        "public_updated_at" => "2022-03-23T08:30:20.000+00:00",
+        "schema_name" => schema_name,
+        "details" => {
+          "body" => "body",
+          "child_section_groups" => [{ "title" => "thing" }],
+        },
+        "links" => {
+          "organisations" => [
+            { "content_id" => SecureRandom.uuid, "title" => "blah", "base_path" => "/blah" },
+          ],
+        },
+      }
+      @base_path = content_item["base_path"]
+      @public_updated_at = content_item["public_updated_at"]
+      @title = content_item["title"]
+      @schema_name = content_item["schema_name"]
+    end
+  end
+
+  test "returns page title for manual" do
+    item = DummyContentItem.new
+
+    assert_equal "#{item.title} - Guidance", item.page_title
+  end
+
+  test "returns page title for HMRC manual" do
+    item = DummyContentItem.new("hmrc_manual")
+
+    assert_equal "#{item.title} - HMRC internal manual", item.page_title
+  end
+
+  test "returns breadcrumbs when the base_path is equal to the request path" do
+    item = DummyContentItem.new
+    item.view_context.stubs(:request)
+      .returns(ActionDispatch::TestRequest.create("PATH_INFO" => item.base_path))
+
+    assert_equal [{ title: I18n.t("manuals.breadcrumb_contents") }], item.breadcrumbs
+  end
+
+  test "returns breadcrumbs when the base_path is not equal to the request path" do
+    item = DummyContentItem.new
+    item.view_context.stubs(:request)
+      .returns(ActionDispatch::TestRequest.create("PATH_INFO" => "/some/other/base_path"))
+
+    assert_equal [{ title: I18n.t("manuals.breadcrumb_contents"), url: item.base_path }], item.breadcrumbs
+  end
+
+  test "returns section groups" do
+    item = DummyContentItem.new
+
+    assert_equal [{ "title" => "thing" }], item.section_groups
+  end
+
+  test "returns body" do
+    item = DummyContentItem.new
+
+    assert_equal "body", item.body
+  end
+
+  test "returns extra publisher metadata" do
+    item = DummyContentItem.new
+    item.stubs(:display_date).returns("23 March 2022")
+
+    expected_metadata = {
+      from: ["<a class=\"govuk-link\" href=\"/blah\">blah</a>"],
+      first_published: "23 March 2022",
+      inverse: true,
+      other: {
+        I18n.t("manuals.updated") => "23 March 2022, <a href=\"/a/base/path/updates\">#{I18n.t('manuals.see_all_updates')}</a>",
+      },
+    }
+    assert_equal expected_metadata, item.manual_metadata
+  end
+end

--- a/test/presenters/content_item/manual_updates_test.rb
+++ b/test/presenters/content_item/manual_updates_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+class ContentItemManualUpdatesTest < ActiveSupport::TestCase
+  class DummyContentItem
+    include ContentItem::ManualUpdates
+    attr_reader :content_item, :view_context, :manual_page_title, :details
+
+    def initialize
+      @view_context = ApplicationController.new.view_context
+      @content_item = {
+        "base_path" => "/a/base/path",
+        "public_updated_at" => "2022-03-23T08:30:20.000+00:00",
+        "details" => {
+          "change_notes" => [
+            {
+              "base_path" => "/guidance/content-design/what-is-content-design",
+              "title" => "What is content design?",
+              "change_note" => "New section added.",
+              "published_at" => "2014-10-06T19:49:25Z",
+            },
+            {
+              "base_path" => "/guidance/content-design/content-policy",
+              "title" => "Content policy",
+              "change_note" => "New section added.",
+              "published_at" => "2014-10-06T23:49:25Z",
+            },
+            {
+              "base_path" => "/guidance/content-design/user-needs",
+              "title" => "User needs",
+              "change_note" => "New section added.",
+              "published_at" => "2014-08-06T10:49:25Z",
+            },
+            {
+              "base_path" => "/guidance/content-design/random-section",
+              "title" => "Random section",
+              "change_note" => "New section added.",
+              "published_at" => "2013-11-06T10:49:25Z",
+            },
+          ],
+        },
+        "links" => {
+          "organisations" => [
+            { "content_id" => SecureRandom.uuid, "title" => "blah", "base_path" => "/blah" },
+          ],
+        },
+      }
+      @manual_page_title = "Super Title - Guidance"
+      @details = content_item["details"]
+    end
+  end
+
+  test "returns page title" do
+    item = DummyContentItem.new
+
+    assert_equal "Updates - Super Title - Guidance", item.page_title
+  end
+
+  test "returns description" do
+    item = DummyContentItem.new
+
+    assert_equal I18n.t("manuals.updates_description", title: item.manual_page_title),
+                 item.description
+  end
+
+  test "returns grouped change notes" do
+    item = DummyContentItem.new
+    first_note, second_note, third_note, fourth_note = item.details["change_notes"]
+    expected_grouped_changes_notes = [
+      [
+        2014,
+        [
+          [
+            "6 October 2014 <span class=\"visuallyhidden\">#{I18n.t('manuals.updates_amendments')}</span>",
+            {
+              (first_note["base_path"]).to_s => [first_note],
+              (second_note["base_path"]).to_s => [second_note],
+            },
+          ],
+          [
+            "6 August 2014 <span class=\"visuallyhidden\">#{I18n.t('manuals.updates_amendments')}</span>",
+            {
+              (third_note["base_path"]).to_s => [third_note],
+            },
+          ],
+        ],
+      ],
+      [
+        2013,
+        [
+          [
+            "6 November 2013 <span class=\"visuallyhidden\">#{I18n.t('manuals.updates_amendments')}</span>",
+            {
+              (fourth_note["base_path"]).to_s => [fourth_note],
+            },
+          ],
+        ],
+      ],
+    ]
+
+    assert_equal expected_grouped_changes_notes, item.presented_change_notes
+  end
+end

--- a/test/presenters/hmrc_manual_section_presenter_test.rb
+++ b/test/presenters/hmrc_manual_section_presenter_test.rb
@@ -1,0 +1,145 @@
+require "presenter_test_helper"
+
+class HmrcManualSectionPresenterTest
+  class HmrcManualSectionPresenterTestCase < PresenterTestCase
+    def schema_name
+      "hmrc_manual_section"
+    end
+  end
+
+  class PresentedHmrcManualSectionTest < HmrcManualSectionPresenterTestCase
+    test "has metadata" do
+      assert presented_manual_section.is_a?(ContentItem::Metadata)
+    end
+
+    test "has manual" do
+      assert presented_manual_section.is_a?(ContentItem::Manual)
+    end
+
+    test "has manual section" do
+      assert presented_manual_section.is_a?(ContentItem::ManualSection)
+    end
+
+    test "is linkable" do
+      assert presented_manual_section.is_a?(ContentItem::Linkable)
+    end
+
+    test "is updatable" do
+      assert presented_manual_section.is_a?(ContentItem::Updatable)
+    end
+
+    test "presents base_path" do
+      manual = schema_item("vatgpb2000")["details"]["manual"]
+      assert_equal manual["base_path"], presented_manual_section.base_path
+    end
+
+    test "presents basic breadcrumbs" do
+      presented_section = presented_manual_section
+      presented_section.view_context.stubs(:request)
+        .returns(ActionDispatch::TestRequest.create("PATH_INFO" => schema_item("vatgpb2000")["base_path"]))
+
+      expected_breadcrumbs = [
+        {
+          title: I18n.t("manuals.breadcrumb_contents"),
+          url: presented_section.base_path,
+        },
+      ]
+      assert_equal expected_breadcrumbs, presented_section.breadcrumbs
+    end
+
+    test "presents additional breadcrumbs if provided" do
+      content_item = schema_item("vatgpb2000")
+      additional_breadcrumbs = [
+        {
+          "section_id" => "VATGPB1100",
+          "section_url" => "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1100",
+        },
+      ]
+      content_item["details"] = content_item["details"].merge("breadcrumbs" => additional_breadcrumbs)
+
+      presented_section = presented_manual_section(content_item)
+
+      presented_section.view_context.stubs(:request)
+        .returns(ActionDispatch::TestRequest.create("PATH_INFO" => content_item["base_path"]))
+
+      expected_breadcrumbs = [
+        {
+          title: I18n.t("manuals.breadcrumb_contents"),
+          url: presented_section.base_path,
+        },
+        {
+          title: additional_breadcrumbs.first["section_id"],
+          url: additional_breadcrumbs.first["url"],
+        },
+      ]
+      assert_equal expected_breadcrumbs, presented_section.breadcrumbs
+    end
+
+    test "presents previous and next links" do
+      manual_base_path = schema_item("vatgpb2000")["details"]["manual"]["base_path"]
+      manual = schema_item("vat-government-public-bodies", "hmrc_manual")
+
+      stub_content_store_has_item(manual_base_path, manual.to_json)
+
+      expected_previous_and_next_links = {
+        previous_page: {
+          title: I18n.t("manuals.previous_page"),
+          url: "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
+        },
+        next_page: {
+          title: I18n.t("manuals.next_page"),
+          url: "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb3000",
+        },
+      }
+
+      assert_equal expected_previous_and_next_links, presented_manual_section.previous_and_next_links
+    end
+
+    test "presents only previous link if there is no next section" do
+      manual_base_path = schema_item("vatgpb2000")["details"]["manual"]["base_path"]
+      manual = schema_item("vat-government-public-bodies", "hmrc_manual")
+      child_section_groups = manual["details"]["child_section_groups"]
+
+      first_child_section = child_section_groups.first["child_sections"].first
+      next_child_sections = child_section_groups.first["child_sections"] - [first_child_section]
+
+      manual["details"]["child_section_groups"] = [{ "child_sections" => next_child_sections }]
+
+      stub_content_store_has_item(manual_base_path, manual.to_json)
+
+      expected_next_link = {
+        next_page: {
+          title: I18n.t("manuals.next_page"),
+          url: "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb3000",
+        },
+      }
+
+      assert_equal expected_next_link, presented_manual_section.previous_and_next_links
+    end
+
+    test "presents only next link if there is no previous section" do
+      manual_base_path = schema_item("vatgpb2000")["details"]["manual"]["base_path"]
+      manual = schema_item("vat-government-public-bodies", "hmrc_manual")
+      child_section_groups = manual["details"]["child_section_groups"]
+
+      first_two_child_section = child_section_groups.first["child_sections"][0..1]
+
+      manual["details"]["child_section_groups"] = [{ "child_sections" => first_two_child_section }]
+
+      stub_content_store_has_item(manual_base_path, manual.to_json)
+
+      expected_previous_link = {
+        previous_page: {
+          title: I18n.t("manuals.previous_page"),
+          url: "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
+        },
+      }
+
+      assert_equal expected_previous_link, presented_manual_section.previous_and_next_links
+    end
+
+    def presented_manual_section(overrides = {})
+      presented_item("vatgpb2000", overrides)
+    end
+  end
+end

--- a/test/presenters/manual_section_presenter_test.rb
+++ b/test/presenters/manual_section_presenter_test.rb
@@ -1,0 +1,83 @@
+require "presenter_test_helper"
+
+class ManualSectionPresenterTest
+  class ManualSectionPresenterTestCase < PresenterTestCase
+    def schema_name
+      "manual_section"
+    end
+  end
+
+  class PresentedManualSectionTest < ManualSectionPresenterTestCase
+    test "has metadata" do
+      assert presented_manual_section.is_a?(ContentItem::Metadata)
+    end
+
+    test "has manual" do
+      assert presented_manual_section.is_a?(ContentItem::Manual)
+    end
+
+    test "has manual section" do
+      assert presented_manual_section.is_a?(ContentItem::ManualSection)
+    end
+
+    test "is linkable" do
+      assert presented_manual_section.is_a?(ContentItem::Linkable)
+    end
+
+    test "is updatable" do
+      assert presented_manual_section.is_a?(ContentItem::Updatable)
+    end
+
+    test "presents base_path" do
+      manuals = schema_item("what-is-content-design")["links"]["manual"]
+      assert_equal manuals.first["base_path"], presented_manual_section.base_path
+    end
+
+    test "strips content under h2 and presents intro" do
+      assert_equal "", presented_manual_section.intro
+    end
+
+    test "presents intro with valid elements" do
+      body = "<p>Paragraph to be kept</p><h2>This is a heading to be stripped<\h2><p>This is a following paragraph to be stripped</p>"
+      manual_section = schema_item("what-is-content-design")
+      manual_section["details"] = manual_section["details"].merge("body" => body)
+
+      assert_equal "<p>Paragraph to be kept</p>", present_example(manual_section).intro.to_html
+    end
+
+    test "returns empty string if intro only contains h2 headings" do
+      manual_section = schema_item("what-is-content-design")
+
+      assert_equal "", present_example(manual_section).intro
+    end
+
+    test "returns false if section isn't visually expanded" do
+      assert_equal false, presented_manual_section.visually_expanded?
+    end
+
+    test "returns true if section is visually expanded" do
+      manual_section = schema_item("what-is-content-design")
+      manual_section["details"] = manual_section["details"].merge("visually_expanded" => true)
+
+      assert_equal true, present_example(manual_section).visually_expanded?
+    end
+
+    test "returns main object ready to be consumed by the accordion component" do
+      first_section_heading = {
+        heading: {
+          text: "Designing content, not creating copy",
+          id: "designing-content-not-creating-copy",
+        },
+      }
+      first_section_content_sample = "<p>Good content design allows people to do"
+
+      assert_equal 7, presented_manual_section.main.count
+      assert_equal first_section_heading[:heading], presented_manual_section.main.first[:heading]
+      assert_match first_section_content_sample, presented_manual_section.main.first[:content]
+    end
+
+    def presented_manual_section(overrides = {})
+      presented_item("what-is-content-design", overrides)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -99,8 +99,8 @@ class ActionDispatch::IntegrationTest
     assert_has_metadata(any_args)
   end
 
-  def assert_has_metadata(any_args)
-    within ".gem-c-metadata" do
+  def assert_has_metadata(any_args, extra_metadata_classes: nil)
+    within ".gem-c-metadata#{extra_metadata_classes}" do
       any_args.each do |_key, value|
         value = { value => nil } if value.is_a?(String)
         value.each do |text, href|


### PR DESCRIPTION
This PR migrates manuals, manual sections and updates pages to Government Frontend, from Manuals Frontend. HMRC manuals have also been migrated. I've treated each page as its own content item (with own views / presenters) as this follows convention within the application, even though the `/updates` pages aren't actually represented as a content items in content store. I've also tried to reduce duplication by using presenter modules and view partials. 

I've left some to-do's which should be resolved at a later date. They mainly concern extra requests to Content Store for manual section pages, as they need data that is only available on the parent manual page. We should add the extra data needed to the manual section when it is being published, which would solve the issue. 

Examples of these pages can be found below.

### Manual

* https://www.gov.uk/guidance/content-design (manual)
* https://www.gov.uk/guidance/content-design/what-is-content-design (manual section)
* https://www.gov.uk/guidance/content-design/updates (manual updates page)

### HMRC Manual

* https://www.gov.uk/hmrc-internal-manuals/admin-law-manual (HMRC manual)
* https://www.gov.uk/hmrc-internal-manuals/admin-law-manual/adml1000 (HMRC section)
* https://www.gov.uk/hmrc-internal-manuals/admin-law-manual/updates (HMRC updates page).

### Testing this PR

You can test the PR yourself either locally or on integration. Local testing is simpler and you can do this by running the app your self against imported or live data (e.g `./startup --live` script then localhost:3090/guidance/some-manual-path) or using [docker][1].

[1]: https://github.com/alphagov/govuk-docker/blob/9f2ce14097583111d18bf7ee12b3393929a517a8/projects/government-frontend/docker-compose.yml#L40

For testing on integration you will need to deploy two branches and then publish a manual from Manuals Publisher. You can only test a normal manual, unless you publish a manual with your Signon organisation set to HMRC (instead of GDS).

1) Deploy to integration: https://github.com/alphagov/manuals-publisher/pull/1844

2) Deploy to integration: https://github.com/alphagov/government-frontend/pull/2424

3) Publish new manual: https://manuals-publisher.integration.publishing.service.gov.uk/ 

4) View on: https://www.integration.publishing.service.gov.uk/

### Dependant on

- [x] https://github.com/alphagov/govuk-content-schemas/pull/1090

Trello:
https://trello.com/c/YmmLFXu5/1127-manuals-migrate-manuals-frontend-code-to-government-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
