### PR TITLE
Add id reference to 'ways to respond' section of consultation template

### DIFF
--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -146,7 +146,7 @@
     </div>
 
     <% if @content_item.ways_to_respond? %>
-      <div class="consultation-ways-to-respond">
+      <div id="ways-to-respond" class="consultation-ways-to-respond">
         <%= render 'govuk_publishing_components/components/heading', text: t("consultation.ways_to_respond"), mobile_top_margin: true %>
           <% @ways_to_respond_body = capture do %>
             <% if @content_item.respond_online_url %>


### PR DESCRIPTION
## What

https://trello.com/c/sxOV4t11/1190-add-id-reference-to-ways-to-respond-section-of-consultation-template

There's a section called _Ways to respond_. An id reference `#ways-to-respond` has been added to this section.

## Why

So that departments can link directly to the section when needing to mention it in external places.

## Visual changes

https://user-images.githubusercontent.com/87758239/165786888-f7b083aa-3daf-4c6c-a32f-be0a52d5e06b.mov