### PR TITLE
Use manual timestamps for manual section header

### DIFF
--- a/app/presenters/content_item/manual.rb
+++ b/app/presenters/content_item/manual.rb
@@ -51,8 +51,12 @@ module ContentItem
   private
 
     def other_metadata
+      updated_metadata(public_updated_at)
+    end
+
+    def updated_metadata(updated_at)
       updates_link = view_context.link_to(I18n.t("manuals.see_all_updates"), "#{base_path}/updates")
-      { I18n.t("manuals.updated") => "#{display_date(public_updated_at)}, #{updates_link}" }
+      { I18n.t("manuals.updated") => "#{display_date(updated_at)}, #{updates_link}" }
     end
 
     def details

--- a/app/presenters/content_item/manual_section.rb
+++ b/app/presenters/content_item/manual_section.rb
@@ -22,7 +22,16 @@ module ContentItem
     def manual_content_item
       # TODO: Add the same tagging to a normal section as a manual for contextual breadcrumbs
       # TODO: Add the manual title to the HMRC section content item and then we can remove this request (manual_content_item)
+      # TODO: Add the manual published / public updated at to both manual sections (normal and HMRC)
       @manual_content_item ||= Services.content_store.content_item(base_path)
+    end
+
+    def published
+      display_date(manual_content_item["first_published_at"])
+    end
+
+    def other_metadata
+      updated_metadata(manual_content_item["public_updated_at"])
     end
   end
 end

--- a/test/integration/hmrc_manual_section_test.rb
+++ b/test/integration/hmrc_manual_section_test.rb
@@ -18,7 +18,7 @@ class HmrcManualSectionTest < ActionDispatch::IntegrationTest
     assert_has_metadata(
       {
         from: { "HM Revenue & Customs": "/government/organisations/hm-revenue-customs" },
-        first_published: "10 February 2015",
+        first_published: "11 February 2015",
         other: {
           I18n.t("manuals.see_all_updates") => "#{@manual['base_path']}/updates",
         },

--- a/test/integration/manual_section_test.rb
+++ b/test/integration/manual_section_test.rb
@@ -17,6 +17,29 @@ class ManualSectionTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "renders metadata" do
+    setup_and_visit_manual_section
+
+    assert_has_metadata(
+      {
+        from: { "Government Digital Service": "/government/organisations/government-digital-service" },
+        first_published: "27 April 2015",
+        other: {
+          I18n.t("manuals.see_all_updates") => "#{@manual['base_path']}/updates",
+        },
+      },
+      extra_metadata_classes: ".gem-c-metadata--inverse",
+    )
+  end
+
+  test "renders search box" do
+    setup_and_visit_manual_section
+
+    within ".gem-c-search" do
+      assert page.has_text?(I18n.t("manuals.search_this_manual"))
+    end
+  end
+
   test "renders document heading" do
     setup_and_visit_manual_section
 


### PR DESCRIPTION
Currently (in Government Frontend) , a manual section's timestamps for
published at and last updated at originate from the manual section.

However, the live version (Manuals Frontend) uses the parents manual
timestamps. This commit applies parent manuals timestamps 
as we should keep the behaviour the same.

### Tests dependant on:

- [ ] https://github.com/alphagov/govuk-content-schemas/pull/1095

### Parent manual's header

<img width="1045" alt="Screenshot 2022-05-17 at 16 27 49" src="https://user-images.githubusercontent.com/24479188/168850128-91424821-e869-479e-957f-bf5e2d90ce04.png">

### Manual section (before)

<img width="1440" alt="Screenshot 2022-05-17 at 16 28 23" src="https://user-images.githubusercontent.com/24479188/168850092-bcfc48a1-0495-4c2c-89f8-d6e4653c07b1.png">

### Manual section (after)

<img width="1395" alt="Screenshot 2022-05-17 at 16 28 04" src="https://user-images.githubusercontent.com/24479188/168849888-21d0dc73-2140-48b0-8632-d3a511a36e3f.png">

Trello:
https://trello.com/c/qCSHqqN7/1287-use-parent-manual-timestamps-for-manual-sections

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
