### PR TITLE
Use govuk design system information banner for historical editions and html attachments

### DIFF
--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -2,6 +2,7 @@ class HtmlPublicationPresenter < ContentItemPresenter
   include ContentItem::Body
   include ContentItem::OrganisationBranding
   include ContentItem::ContentsList
+  include ContentItem::Political
 
   def isbn
     content_item["details"]["isbn"]

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -42,6 +42,7 @@
   <p class="publication-header__last-changed"><%= @content_item.last_changed %></p>
 <% end %>
 
+<%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
 <div

--- a/app/views/shared/_history_notice.html.erb
+++ b/app/views/shared/_history_notice.html.erb
@@ -1,3 +1,5 @@
 <% if content_item.historically_political? %>
-  <%= render 'components/banner', text: t("shared.historically_political", government: content_item.publishing_government) %>
+  <%= render "govuk_publishing_components/components/notice", {
+    title: t("shared.historically_political", government: content_item.publishing_government),
+  } %>
 <% end %>

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -39,7 +39,7 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
   test "historically political detailed guide" do
     setup_and_visit_content_item("political_detailed_guide")
 
-    within ".app-c-banner" do
+    within ".govuk-notification-banner__content" do
       assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
     end
   end

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -148,7 +148,7 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
   test "historically political collection" do
     setup_and_visit_content_item("document_collection_political")
 
-    within ".app-c-banner" do
+    within ".govuk-notification-banner__content" do
       assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
     end
   end

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -74,6 +74,14 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "historically political html publication" do
+    setup_and_visit_html_publication("published_with_history_mode")
+
+    within ".govuk-notification-banner__content" do
+      assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
+    end
+  end
+
   test "withdrawn html publication" do
     content_item = GovukSchemas::Example.find("html_publication", example_name: "prime_ministers_office")
     content_item["withdrawn_notice"] = {

--- a/test/integration/news_article_test.rb
+++ b/test/integration/news_article_test.rb
@@ -38,7 +38,7 @@ class NewsArticleTest < ActionDispatch::IntegrationTest
   test "renders history notice" do
     setup_and_visit_content_item("news_article_history_mode")
 
-    within ".app-c-banner" do
+    within ".govuk-notification-banner__content" do
       assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
     end
   end

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -59,7 +59,7 @@ class PublicationTest < ActionDispatch::IntegrationTest
   test "historically political publication" do
     setup_and_visit_content_item("political_publication")
 
-    within ".app-c-banner" do
+    within ".govuk-notification-banner__content" do
       assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
     end
   end

--- a/test/integration/statistical_data_set_test.rb
+++ b/test/integration/statistical_data_set_test.rb
@@ -35,7 +35,7 @@ class StatisticalDataSetTest < ActionDispatch::IntegrationTest
   test "historically political statistical data set" do
     setup_and_visit_content_item("statistical_data_set_political")
 
-    within ".app-c-banner" do
+    within ".govuk-notification-banner__content" do
       assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
     end
   end

--- a/test/integration/world_location_news_article_test.rb
+++ b/test/integration/world_location_news_article_test.rb
@@ -43,7 +43,7 @@ class WorldLocationNewsArticleTest < ActionDispatch::IntegrationTest
 
   test "renders history notice" do
     setup_and_visit_content_item("world_location_news_article_history_mode")
-    within ".app-c-banner" do
+    within ".govuk-notification-banner__content" do
       assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
     end
   end

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -5,6 +5,10 @@ class HtmlPublicationPresenterTest < PresenterTestCase
     "html_publication"
   end
 
+  test "includes political" do
+    assert presented_item("published").is_a?(ContentItem::Political)
+  end
+
   test "presents the basic details of a content item" do
     assert_equal schema_item("published")["schema_name"], presented_item("published").schema_name
     assert_equal schema_item("published")["links"]["parent"][0]["document_type"], presented_item("published").format_sub_type


### PR DESCRIPTION
## Description 

We're doing some work to expose a history banner on html attachments to let the user know that a publication was published under a previous government. This means that we need to expose whether a html publication is political and which government it was published under on the object passed to the frontend.

This PR exposes the history banner on the Frontend when a html publication is historically political 

<img width="914" alt="image" src="https://user-images.githubusercontent.com/42515961/170970463-9c475f40-c3b6-44a2-83ab-57c60ccb69c2.png">

### Whitehall PR 

https://github.com/alphagov/whitehall/pull/6585

### GOVUK Content Schema PR

https://github.com/alphagov/govuk-content-schemas/pull/1096

## Trello card

https://trello.com/c/xWMcmTqb/409-implement-history-mode-banner-on-html-attachments

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
