### PR TITLE
Enable CI in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,12 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    uses: alphagov/govuk-infrastructure/.github/workflows/ci.yaml@add-ci-workflow

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,4 +9,6 @@ on:
 jobs:
   test:
     name: Test
-    uses: alphagov/govuk-infrastructure/.github/workflows/ci.yaml@add-ci-workflow
+    uses: alphagov/govuk-infrastructure/.github/workflows/test-rails.yaml@main
+    with:
+      requiresJavaScript: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,19 +17,18 @@ on:
         - staging
         - production
         default: 'integration'
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "Jenkinsfile"
-      - ".git**"
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
 
 jobs:
   build-and-publish-image:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
     with:
-      gitRef: ${{ github.event.inputs.gitRef }}
+      gitRef: ${{ github.event.inputs.gitRef || github.ref }}
     secrets:
       AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
@@ -39,7 +38,6 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yaml@main
     with:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
-      workflowTrigger: ${{ github.event_name }}
       environment: ${{ github.event.inputs.environment }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN }}


### PR DESCRIPTION
This enables a GitHub Action workflow to run CI using a re-usable workflow template in govuk-infrastructure repo. This is part of the re-platforming work as we migrate away from Jenkins.