### PR TITLE
Moving to the UK for Work: Scroll tracking on visa content pages

### DIFF
--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -17,6 +17,7 @@
       "/guidance/brexit-guidance-for-businesses",
       "/guidance/brexit-guidance-for-individuals-and-families",
       "/guidance/import-and-export-goods-using-preference-agreements",
+      "/guidance/financial-evidence-for-sponsored-or-endorsed-work-routes",
     ]
   %>
   <% if scroll_track_headings_paths.include?(@content_item.base_path) %>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -14,10 +14,18 @@
       "/taking-goods-out-uk-temporarily/get-an-ata-carnet",
     ]
 
+    scroll_track_percent_paths = [
+      "/skilled-worker-visa",
+      "/skilled-worker-visa/documents-you-must-provide",
+      "/apply-to-come-to-the-uk",
+    ]
+
     full_url = [@content_item.base_path, @content_item.part_slug].compact.join('/')
   %>
   <% if scroll_track_headings_paths.include?(full_url) %>
     <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker" data-track-type="headings"/>
+  <% elsif scroll_track_percent_paths.include?(@content_item.base_path) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker"/>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
## What
The Moving to the UK for Work team would like to implement scroll tracking on some of the work visa pages to get some insights into how far down the page users tend to scroll.

The pages we would like to do this on are:
- Applying for a visa to come to the UK: (https://www.gov.uk/apply-to-come-to-the-uk)
- Skilled Worker visa (Overview) (https://www.gov.uk/skilled-worker-visa)
- Skilled Worker visa (Documents) (https://www.gov.uk/skilled-worker-visa/documents-you-must-provide)
- Financial evidence for sponsored or endorsed work routes: (https://www.gov.uk/guidance/financial-evidence-for-sponsored-or-endorsed-work-routes)

## Why
Scroll tracking will help us to analyse user behaviour and gain better insights, so that we can implement useful content changes.

Co-authored-by: Alex Newton <alex.newton@digital.cabinet-office.gov.uk>

[Trello](https://trello.com/c/8uJJm1CD/53-moving-to-the-uk-for-work-scroll-tracking-on-visa-content-pages)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
