### PR TITLE
Fix failing test

### DIFF
--- a/test/presenters/content_item/manual_section_test.rb
+++ b/test/presenters/content_item/manual_section_test.rb
@@ -50,15 +50,8 @@ class ContentItemManualSectionTest < ActiveSupport::TestCase
 
   test "returns manual_content_item" do
     stub_request(:get, "https://content-store.test.gov.uk/content/a/base/path")
-    .with(
-      headers: {
-        "Accept" => "application/json",
-        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-        "Host" => "content-store.test.gov.uk",
-        "User-Agent" => "gds-api-adapters/79.1.2 ()",
-      },
-    )
-    .to_return(status: 200, body: "{}", headers: {})
+      .to_return(status: 200, body: "{}", headers: {})
+
     item = DummyContentItem.new
 
     assert_equal({}, item.manual_content_item.parsed_content)


### PR DESCRIPTION
This test failed on CI as the gds-api-adapters version had been bumped,
meaning the hardcoded user-agent version was no longer the same and the
stub failed to match the request.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
