### PR TITLE
Expose national applicability information for HMTL Attachments

### DIFF
--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -3,6 +3,7 @@ class HtmlPublicationPresenter < ContentItemPresenter
   include ContentItem::OrganisationBranding
   include ContentItem::ContentsList
   include ContentItem::Political
+  include ContentItem::NationalApplicability
 
   def isbn
     content_item["details"]["isbn"]

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -45,6 +45,15 @@
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/devolved_nations", {
+      national_applicability: @content_item.national_applicability || {},
+      type: @content_item.schema_name
+    } %>
+  </div>
+</div>
+
 <div
   class="govuk-grid-row sidebar-with-body"
   data-module="sticky-element-container"

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -116,4 +116,14 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
     setup_and_visit_html_publication("published")
     assert_not page.has_css?(".gem-c-single-page-notification-button")
   end
+
+  test "HTML publication that only applies to a set of nations, with alternative urls" do
+    setup_and_visit_content_item("national_applicability_alternative_url_html_publication")
+    assert_has_devolved_nations_component("Applies to England, Scotland and Wales", [
+      {
+        text: "Publication for Northern Ireland",
+        alternative_url: "http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for",
+      },
+    ])
+  end
 end

--- a/test/presenters/html_publication_presenter_test.rb
+++ b/test/presenters/html_publication_presenter_test.rb
@@ -9,6 +9,10 @@ class HtmlPublicationPresenterTest < PresenterTestCase
     assert presented_item("published").is_a?(ContentItem::Political)
   end
 
+  test "includes NationalApplicability" do
+    assert presented_item("published").is_a?(ContentItem::NationalApplicability)
+  end
+
   test "presents the basic details of a content item" do
     assert_equal schema_item("published")["schema_name"], presented_item("published").schema_name
     assert_equal schema_item("published")["links"]["parent"][0]["document_type"], presented_item("published").format_sub_type


### PR DESCRIPTION
## Description

We're doing some work to expose national applicability data for html attachments. If a consultation or Publication only relates to some of the devolved nations, then it also renders for html attachments that belong to it.

This commit does the work to render the component on the page when national applicability information is contained in the details hash of a piece of content

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/42515961/173343250-d312caf0-d484-4d0c-b261-eeb70259e17d.png">

## Related PRs 

Whitehall - https://github.com/alphagov/whitehall/pull/6606

GOVUK Content Schema - https://github.com/alphagov/govuk-content-schemas/pull/1100

## Trello card

https://trello.com/c/pLnsviDN/402-implement-devolved-nations-national-applicability-banner-on-html-attachments

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
