### PR TITLE
Fix failing test which uses incorrect helper method

### DIFF
--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -118,7 +118,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   end
 
   test "HTML publication that only applies to a set of nations, with alternative urls" do
-    setup_and_visit_content_item("national_applicability_alternative_url_html_publication")
+    setup_and_visit_html_publication("national_applicability_alternative_url_html_publication")
     assert_has_devolved_nations_component("Applies to England, Scotland and Wales", [
       {
         text: "Publication for Northern Ireland",


### PR DESCRIPTION
This was accidentally merged as part of https://github.com/alphagov/government-frontend/pull/2460. It uses the helper method for publications when it should be using the HTML Publication helper method.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
