### PR TITLE
Make the national applicability banner full width

### DIFF
--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -44,15 +44,10 @@
 
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/devolved_nations", {
-      national_applicability: @content_item.national_applicability || {},
-      type: @content_item.schema_name
-    } %>
-  </div>
-</div>
+<%= render "govuk_publishing_components/components/devolved_nations", {
+  national_applicability: @content_item.national_applicability || {},
+  type: @content_item.schema_name
+} %>
 
 <div
   class="govuk-grid-row sidebar-with-body"


### PR DESCRIPTION
## Description 

The devolved nations component was added to html publications in this PR https://github.com/alphagov/government-frontend/pull/2460
 
At the moment this renders at 2/3 width and looks a bit clunky. After speaking to Nikin we're going to make it full width pending feedback from Find & View designers.

### Before

<img width="968" alt="image" src="https://user-images.githubusercontent.com/42515961/173806704-19e7162e-8390-4f91-a91f-e77deeabc7fe.png">


### After

<img width="974" alt="image" src="https://user-images.githubusercontent.com/42515961/173806766-1ec5c4f8-f7ce-4c77-a1ca-0ea252da8532.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
