### PR TITLE
Fix redirecting to incorrect assets domain

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ end
 
 group :test do
   gem "capybara"
+  gem "climate_control"
   gem "faker"
   gem "i18n-coverage"
   gem "minitest-reporters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    climate_control (1.1.1)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crack (0.4.3)
@@ -377,6 +378,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara
+  climate_control
   dalli
   faker
   gds-api-adapters

--- a/app/controllers/asset_manager_redirect_controller.rb
+++ b/app/controllers/asset_manager_redirect_controller.rb
@@ -1,10 +1,6 @@
 class AssetManagerRedirectController < ApplicationController
   def show
-    asset_url = Plek.new.asset_root
-    if request.host.start_with?("draft-")
-      asset_url = Plek.new.external_url_for("draft-assets")
-    end
-
+    asset_url = Plek.new.external_url_for("assets")
     expires_in 1.day, public: true
     redirect_to host: URI.parse(asset_url).host, status: :moved_permanently
   end

--- a/test/controllers/asset_manager_redirect_controller_test.rb
+++ b/test/controllers/asset_manager_redirect_controller_test.rb
@@ -1,11 +1,6 @@
 require "test_helper"
 
 class AssetManagerRedirectControllerTest < ActionController::TestCase
-  setup do
-    Plek.any_instance.stubs(:asset_root).returns("http://asset-host.com")
-    Plek.any_instance.stubs(:external_url_for).returns("http://draft-asset-host.com")
-  end
-
   test "sets the cache-control max-age to 1 day" do
     request.host = "some-host.com"
     get :show, params: { path: "asset.txt" }
@@ -13,24 +8,17 @@ class AssetManagerRedirectControllerTest < ActionController::TestCase
     assert_equal @response.headers["Cache-Control"], "max-age=86400, public"
   end
 
-  test "redirects asset requests made via public host to the public asset host" do
-    request.host = "some-host.com"
+  test "redirects asset requests to the assets hostname" do
     get :show, params: { path: "asset.txt" }
 
-    assert_redirected_to "http://asset-host.com/government/uploads/asset.txt"
+    assert_redirected_to "http://assets.test.gov.uk/government/uploads/asset.txt"
   end
 
-  test "redirects asset requests made via draft host to the draft asset host" do
-    request.host = "draft-some-host.com"
-    get :show, params: { path: "asset.txt" }
+  test "redirects to assets hostname respect the draft stack" do
+    ClimateControl.modify PLEK_HOSTNAME_PREFIX: "draft-" do
+      get :show, params: { path: "asset.txt" }
 
-    assert_redirected_to "http://draft-asset-host.com/government/uploads/asset.txt"
-  end
-
-  test "redirects asset preview requests made via public host to the public asset host" do
-    request.host = "some-host.com"
-    get :show, params: { path: "asset.csv/preview" }
-
-    assert_redirected_to "http://asset-host.com/government/uploads/asset.csv/preview"
+      assert_redirected_to "http://draft-assets.test.gov.uk/government/uploads/asset.txt"
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/nvG4055w/510-asset-redirects-are-broken-in-draft-draft-draft-assets

The previous code had a bug where a redirect to the draft assets host
was incorrect. It was redirecting to a double prefixed asset host as the
"draft-" was implicit. Illustrated by:

```
➜  ~ govuk-connect app-console -e production draft_frontend/government-frontend
irb(main):001:0> Plek.new.external_url_for("draft-assets")
=> "https://draft-draft-assets.publishing.service.gov.uk"
irb(main):002:0> Plek.new.external_url_for("assets")
=> "https://draft-assets.publishing.service.gov.uk"
```

This resolves the problem by using the external_url_for method for both
scenarios. As when we are on the draft stack there will be an env var
that prefixes hostnames accordingly.

I added climate_control to test this, since a regression test seemed
appropriate. I removed the preview test as there was no logic written
for this and the other tests cover that code path.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
