### PR TITLE
Add get involved tests to replace Smokey tests

### DIFF
--- a/app/views/content_items/get_involved.html.erb
+++ b/app/views/content_items/get_involved.html.erb
@@ -1,8 +1,3 @@
-<%# 
-Changes to this page impacts smokey tests that may need to be updated in parallel.
-https://github.com/alphagov/smokey/blob/main/features/step_definitions/get_involved_page_steps.rb 
-%>
-
 <% page_title %>
 <% page_class "govuk-main-wrapper" %>
   <%= render "govuk_publishing_components/components/breadcrumbs", {

--- a/app/views/content_items/get_involved.html.erb
+++ b/app/views/content_items/get_involved.html.erb
@@ -53,14 +53,14 @@
         <%= render "govuk_publishing_components/components/big_number", {
           number: @open_consultation_count,
           label: t('get_involved.open_consultations'),
-          href: "/government/organisations#ministerial_departments"
+          href: "/search/policy-papers-and-consultations?content_store_document_type=open_consultations"
         } %>
       </div>
       <div class="govuk-grid-column-two-thirds">
         <%= render "govuk_publishing_components/components/big_number", {
           number: @closed_consultation_count,
           label: t('get_involved.closed_consultations'),
-          href: "/government/organisations#ministerial_departments"
+          href: "/search/policy-papers-and-consultations?content_store_document_type=closed_consultations"
         } %>
       </div>
     </div>

--- a/app/views/content_items/get_involved.html.erb
+++ b/app/views/content_items/get_involved.html.erb
@@ -70,17 +70,19 @@ https://github.com/alphagov/smokey/blob/main/features/step_definitions/get_invol
       </div>
     </div>
 
-    <%# Attention to closing consultation  %>
-    <%= render "govuk_publishing_components/components/inset_text", {
-    } do %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: time_until_closure(@next_closing_consultation),
-        heading_level: 3
-      } %>
-      <p class="govuk-body">
-        <%= @next_closing_consultation['title'] %>
-      </p>
-      <%= link_to t('get_involved.read_respond'), @next_closing_consultation['link'], class: "govuk-link" %>
+    <% if @next_closing_consultation %>
+      <%# Attention to closing consultation  %>
+      <%= render "govuk_publishing_components/components/inset_text", {
+      } do %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: time_until_closure(@next_closing_consultation),
+          heading_level: 3
+        } %>
+        <p class="govuk-body">
+          <%= @next_closing_consultation['title'] %>
+        </p>
+        <%= link_to t('get_involved.read_respond'), @next_closing_consultation['link'], class: "govuk-link" %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/test/controllers/get_involved_controller_test.rb
+++ b/test/controllers/get_involved_controller_test.rb
@@ -7,22 +7,23 @@ class GetInvolvedControllerTest < ActionController::TestCase
 
   def setup
     content_item_body = {
+      "document_type" => "get_involved",
+      "schema_name" => "get_involved",
+      "details" => {},
       "links" => {
         "take_part_pages" => [
           {
-            "title": "Page 1",
+            "title" => "Take part page 1",
+            "base_path" => "/take-part-1",
             "details" => {
-              "body" => "",
               "image" => {},
-              "ordering" => 1,
             },
           },
           {
-            "title": "Page 2",
+            "title" => "Take part page 2",
+            "base_path" => "/take-part-2",
             "details" => {
-              "body" => "",
               "image" => {},
-              "ordering" => 2,
             },
           },
         ],
@@ -30,49 +31,89 @@ class GetInvolvedControllerTest < ActionController::TestCase
     }
 
     stub_content_store_has_item("/government/get-involved", content_item_body)
+
+    no_results = { "results" => {}, "total" => 0, "start" => 0 }
+    stub_any_search.to_return("body" => no_results.to_json)
   end
 
-  test "retrieves correct number of open consultations from search_api" do
-    body = {
-      "results" => {},
-      "total" => 83,
-      "start" => 0,
-    }
-    stub_search(body)
-
-    @controller.load_get_involved_data
-    assert_equal @controller.instance_variable_get(:@open_consultation_count), 83
+  test "returns a 200 response" do
+    get :show
+    assert_response :ok
   end
 
-  test "retrieves correct number of closed consultations from search_api" do
-    body = {
-      "results" => {},
-      "total" => 42,
-      "start" => 0,
-    }
-    stub_search(body)
+  test "showing total number of open consultations" do
+    stub_search_query(query: hash_including(filter_content_store_document_type: "open_consultation"),
+                      response: { "results" => [], "total" => 83 })
 
-    assert_equal @controller.retrieve_date_filtered_closed_consultations(0), 42
+    get :show
+    assert_select ".gem-c-big-number", /83.+Open consultations/m
   end
 
-  test "retrieves next closing consultation from search_api" do
-    body = {
-      "results" => {
-        "first result" => {},
-        "second result" => {},
-        "third result" => {},
-      },
-      "total" => 42,
-      "start" => 0,
-    }
-    stub_search(body)
+  test "showing total number of closed consultations" do
+    stub_search_query(query: hash_including(filter_content_store_document_type: "closed_consultation"),
+                      response: { "results" => [], "total" => 110 })
 
-    assert_equal @controller.retrieve_next_closing, ["first result", {}]
+    get :show
+    assert_select ".gem-c-big-number", /110.+Closed consultations/m
+  end
+
+  test "showing the next closing consultation" do
+    Timecop.freeze do
+      title = "Next closing consultation on time zones"
+      stub_search_query(query: hash_including(filter_content_store_document_type: "open_consultation",
+                                              filter_end_date: "from: #{Time.zone.now.to_date}"),
+                        response: { "results" => [consultation_result(title: title)] })
+
+      get :show
+      assert_select ".gem-c-inset-text", /#{title}/
+    end
+  end
+
+  test "showing recently opened consultations" do
+    title = "Open consultation on time zones"
+    stub_search_query(query: hash_including(filter_content_store_document_type: "open_consultation"),
+                      response: { "results" => [consultation_result(title: title)] })
+
+    get :show
+    assert response.body.include?(title)
+  end
+
+  test "showing recent consultation outcomes" do
+    title = "Consultation outcome on time zones"
+    stub_search_query(query: hash_including(filter_content_store_document_type: "consultation_outcome"),
+                      response: { "results" => [consultation_result(title: title)] })
+
+    get :show
+    assert response.body.include?(title)
+  end
+
+  test "shows the take part pages" do
+    get :show
+    assert response.body.include?("Take part page 1")
+    assert response.body.include?("Take part page 2")
   end
 
 private
 
-  def stub_search(body)
-    stub_any_search.to_return("body" => body.to_json)
+  def stub_search_query(query:, response:)
+    stub_request(:get, /\A#{Plek.current.find('search')}\/search.json/)
+      .with(query: query)
+      .to_return(body: response.to_json)
+  end
+
+  def consultation_result(title: "Consulting on time zones")
+    {
+      "title" => title,
+      "public_timestamp" => "2022-02-14T00:00:00.000+01:00",
+      "end_date" => "2022-02-14T00:00:00.000+01:00",
+      "link" => "/consultation/link",
+      "organisations" => [{
+        "slug" => "ministry-of-justice",
+        "link" => "/government/organisations/ministry-of-justice",
+        "title" => "Ministry of Justice",
+        "acronym" => "MoJ",
+        "organisation_state" => "live",
+      }],
+    }
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

The /government/get-involved page was previously tested in a rather unusual way where there weren't any real tests for the endpoint in this application but there was an unusually thorough set of tests in Smokey. This isn't ideal because the Smokey tests are expensive and unnecessary since the logic is in this app. 

This rewrites the tests to allow for the majority of the Smokey tests to be removed.