### PR TITLE
Tidy up stylesheets and JavaScript

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,9 +1,7 @@
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/accordion
-//= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/details
 //= require govuk_publishing_components/components/error-summary
-//= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/print-link

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,32 +6,23 @@ $govuk-new-link-styles: true;
 
 // Components from govuk_publishing_components gem
 @import "govuk_publishing_components/govuk_frontend_support";
-@import "govuk_publishing_components/component_support";
 
 @import "govuk_publishing_components/components/accordion";
 @import "govuk_publishing_components/components/attachment";
 @import "govuk_publishing_components/components/back-link";
 @import "govuk_publishing_components/components/big-number";
-@import "govuk_publishing_components/components/breadcrumbs";
-@import "govuk_publishing_components/components/button";
 @import "govuk_publishing_components/components/contents-list";
 @import "govuk_publishing_components/components/contextual-sidebar";
 @import "govuk_publishing_components/components/details";
 @import "govuk_publishing_components/components/devolved-nations";
 @import "govuk_publishing_components/components/document-list";
-@import "govuk_publishing_components/components/error-message";
 @import "govuk_publishing_components/components/error-summary";
-@import "govuk_publishing_components/components/feedback";
 @import "govuk_publishing_components/components/fieldset";
 @import "govuk_publishing_components/components/govspeak";
 @import "govuk_publishing_components/components/govspeak-html-publication";
-@import "govuk_publishing_components/components/heading";
-@import "govuk_publishing_components/components/hint";
 @import "govuk_publishing_components/components/image-card";
-@import "govuk_publishing_components/components/input";
 @import "govuk_publishing_components/components/inset-text";
 @import "govuk_publishing_components/components/inverse-header";
-@import "govuk_publishing_components/components/label";
 @import "govuk_publishing_components/components/lead-paragraph";
 @import "govuk_publishing_components/components/metadata";
 @import "govuk_publishing_components/components/notice";
@@ -48,9 +39,7 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/components/step-by-step-nav-related";
 @import "govuk_publishing_components/components/subscription-links";
 @import "govuk_publishing_components/components/success-alert";
-@import "govuk_publishing_components/components/title";
 @import "govuk_publishing_components/components/translation-nav";
-@import "govuk_publishing_components/components/skip-link";
 
 // government-frontend mixins
 @import "mixins/margins";

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,7 +1,9 @@
 @import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/components/print/accordion";
 @import "govuk_publishing_components/components/print/contents-list";
 @import "govuk_publishing_components/components/print/govspeak";
 @import "govuk_publishing_components/components/print/govspeak-html-publication";
+@import "govuk_publishing_components/components/print/organisation-logo";
 @import "govuk_publishing_components/components/print/step-by-step-nav";
 @import "govuk_publishing_components/components/print/step-by-step-nav-header";
 @import "govuk_publishing_components/components/print/title";

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,5 +1,4 @@
 @import "govuk_publishing_components/govuk_frontend_support";
-@import "govuk_publishing_components/components/print/button";
 @import "govuk_publishing_components/components/print/contents-list";
 @import "govuk_publishing_components/components/print/govspeak";
 @import "govuk_publishing_components/components/print/govspeak-html-publication";


### PR DESCRIPTION
## What

* Remove `component_support`
* Remove included component stylesheets that are now being served by Static
* Add accordion and organisation logo print stylesheets

Reduces `applications.css` from 287.91 kB to 218.13 kB uncompressed.

Reduces `application.js` from 116.95 kB to 109.60 kB uncompressed.

## Why

Component support includes a set of base styles needed by the components; and component styles used by multiple rendering applications are also included in `static`'s stylesheet. Because both of this they don't need to be duplicated in `government-frontend`.

The missing print stylesheets needed to be included to ensure a consistent print experience across GOV.UK - missing them out of one application would mean that these components would print differently depending on which page was being printed.

## Visual changes
None.

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
