### PR TITLE
Add UR recruitment banner to pages tagged to Working browse

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,7 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/components/image-card";
 @import "govuk_publishing_components/components/input";
 @import "govuk_publishing_components/components/inset-text";
+@import "govuk_publishing_components/components/intervention";
 @import "govuk_publishing_components/components/inverse-header";
 @import "govuk_publishing_components/components/label";
 @import "govuk_publishing_components/components/lead-paragraph";

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -34,3 +34,7 @@
   max-width: 30em;
   padding-top: govuk-spacing(2);
 }
+
+.gem-c-intervention {
+  margin-top: govuk-spacing(4);
+}

--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,0 +1,27 @@
+module ContentItem
+  module RecruitmentBanner
+    SURVEY_URL_ONE = "https://GDSUserResearch.optimalworkshop.com/treejack/3z828uy6".freeze
+    SURVEY_URLS = {
+      "/browse/working" => SURVEY_URL_ONE,
+    }.freeze
+
+    def recruitment_survey_url
+      key = SURVEY_URLS.keys.find { |k| content_tagged_to(k).present? }
+      SURVEY_URLS[key]
+    end
+
+  private
+
+    def mainstream_browse_pages
+      content_item["links"]["mainstream_browse_pages"] if content_item["links"]
+    end
+
+    def content_tagged_to(browse_base_path)
+      return [] unless mainstream_browse_pages
+
+      mainstream_browse_pages.find do |mainstream_browse_page|
+        mainstream_browse_page["base_path"].starts_with? browse_base_path
+      end
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -2,6 +2,7 @@ class ContentItemPresenter
   include ContentItem::Withdrawable
   include ContentItem::BrexitTaxons
   include ContentItem::SinglePageNotificationButton
+  include ContentItem::RecruitmentBanner
   attr_reader :content_item,
               :requested_path,
               :view_context,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,14 @@
 </head>
 <body>
   <div id="wrapper" class="<%= wrapper_class %>">
-    <% if @content_item.show_phase_banner? %>
+    <% if @content_item.recruitment_survey_url %>
+      <%= render "govuk_publishing_components/components/intervention", {
+        suggestion_text: "Help improve GOV.UK",
+        suggestion_link_text: "Take part in user research",
+        suggestion_link_url: @content_item.recruitment_survey_url,
+        new_tab: true,
+      } %>
+    <% elsif @content_item.show_phase_banner? %>
       <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase %>
     <% end %>
 

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "Recruitment Banner is displayed for any page tagged to Working, jobs and pensions" do
+    @working_browse_page = {
+      "content_id" => "123",
+      "title" => "Self Assessment",
+      "base_path" => "/browse/working/self-assessment",
+    }
+
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    guide["links"]["mainstream_browse_pages"] = []
+    guide["links"]["mainstream_browse_pages"] << @working_browse_page
+
+    stub_content_store_has_item(guide["base_path"], guide.to_json)
+    visit guide["base_path"]
+
+    assert page.has_css?(".gem-c-intervention")
+    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/3z828uy6")
+  end
+
+  test "Recruitment Banner is not displayed unless page is tagged to a topic of interest" do
+    @not_of_interest = {
+      "content_id" => "123",
+      "title" => "I am not interesting",
+      "base_path" => "/browse/boring",
+    }
+
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    guide["links"]["mainstream_browse_pages"] = []
+    guide["links"]["mainstream_browse_pages"] << @not_of_interest
+    stub_content_store_has_item(guide["base_path"], guide.to_json)
+    visit_with_cachebust guide["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://GDSUserResearch.optimalworkshop.com/treejack/3z828uy6")
+  end
+end


### PR DESCRIPTION
The number of responses hasn't been as much as we hoped, so I'd like to put the
banner out more widely. This adds the banner to all pages tagged to 'Working,
jobs and pensions' mainstream browse. Excluding the mainstream browse page itself,
as that's been looked at in the A/B test.

[Trello](https://trello.com/c/1Mo3VmGB/1106-launch-and-monitor-the-tree-test-using-the-intervention-banner-baseline)

<kbd>
<img width="794" alt="Screenshot 2022-07-08 at 11 16 27" src="https://user-images.githubusercontent.com/38078064/177973306-92346fe1-eb71-401f-8974-f2a949ef226c.png">
</kbd>

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
