### PR TITLE
Use CSS sticky on HTML publications instead of custom script

### DIFF
--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -25,6 +25,9 @@
     @include govuk-media-query($from: desktop) {
       position: sticky;
       top: govuk-spacing(2);
+      max-height: 100vh;
+      overflow-y: auto;
+      margin-bottom: govuk-spacing(4);
     }
 
     .direction-rtl & {

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -22,6 +22,11 @@
   }
 
   .contents-list-container {
+    @include govuk-media-query($from: desktop) {
+      position: sticky;
+      top: govuk-spacing(2);
+    }
+
     .direction-rtl & {
       float: right;
     }

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -49,11 +49,7 @@
   type: @content_item.schema_name
 } %>
 
-<div
-  class="govuk-grid-row sidebar-with-body"
-  data-module="sticky-element-container"
-  id="contents"
->
+<div class="govuk-grid-row sidebar-with-body" id="contents">
   <% if @content_item.contents.any? %>
     <div class="govuk-grid-column-one-quarter-from-desktop contents-list-container">
       <%= render 'govuk_publishing_components/components/contents_list', contents: @content_item.contents, format_numbers: true %>
@@ -75,14 +71,8 @@
       <%= raw(@content_item.govspeak_body[:content]) %>
     <% end %>
   </div>
+</div>
 
-  <div data-sticky-element class="sticky-element">
-    <%= render 'components/back-to-top', href: "#contents" %>
-    <div class="sticky-element__print-link">
-      <%= render "govuk_publishing_components/components/print_link", {
-          margin_top: 0,
-          margin_bottom: 6,
-        } %>
-    </div>
-  </div>
+<div class="govuk-grid-row">
+  <%= render 'components/back-to-top', href: "#contents" %>
 </div>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -75,6 +75,6 @@
   </div>
 
   <div class="govuk-grid-row">
-    <%= render 'components/back-to-top', href: "#contents" %>
+    <%= render 'components/back-to-top', href: "#contents", text: "Back to top" %>
   </div>
 </div>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -49,30 +49,32 @@
   type: @content_item.schema_name
 } %>
 
-<div class="govuk-grid-row sidebar-with-body" id="contents">
-  <% if @content_item.contents.any? %>
-    <div class="govuk-grid-column-one-quarter-from-desktop contents-list-container">
-      <%= render 'govuk_publishing_components/components/contents_list', contents: @content_item.contents, format_numbers: true %>
-      <%= render "govuk_publishing_components/components/print_link", {
-        margin_top: 0,
-        margin_bottom: 6,
-      } %>
-    </div>
-  <% end %>
-
-  <div class="print-wrapper">
-    <div class="print-meta-data">
-      <%= render partial: "content_items/html_publication/print_meta_data" %>
-    </div>
-  </div>
-
-  <div class="main-content-container<% unless @content_item.contents.any? %> offset-empty-contents-list<% end %>">
-    <%= render "govuk_publishing_components/components/govspeak_html_publication", {} do %>
-      <%= raw(@content_item.govspeak_body[:content]) %>
+<div class="sidebar-with-body" id="contents">
+  <div class="govuk-grid-row">
+    <% if @content_item.contents.any? %>
+      <div class="govuk-grid-column-one-quarter-from-desktop contents-list-container">
+        <%= render 'govuk_publishing_components/components/contents_list', contents: @content_item.contents, format_numbers: true %>
+        <%= render "govuk_publishing_components/components/print_link", {
+          margin_top: 0,
+          margin_bottom: 6,
+        } %>
+      </div>
     <% end %>
-  </div>
-</div>
 
-<div class="govuk-grid-row">
-  <%= render 'components/back-to-top', href: "#contents" %>
+    <div class="print-wrapper">
+      <div class="print-meta-data">
+        <%= render partial: "content_items/html_publication/print_meta_data" %>
+      </div>
+    </div>
+
+    <div class="main-content-container<% unless @content_item.contents.any? %> offset-empty-contents-list<% end %>">
+      <%= render "govuk_publishing_components/components/govspeak_html_publication", {} do %>
+        <%= raw(@content_item.govspeak_body[:content]) %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <%= render 'components/back-to-top', href: "#contents" %>
+  </div>
 </div>

--- a/test/integration/html_publication_test.rb
+++ b/test/integration/html_publication_test.rb
@@ -26,7 +26,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   test "html publications with meta data" do
     setup_and_visit_html_publication("print_with_meta_data")
 
-    within ".govuk-grid-row.sidebar-with-body" do
+    within ".sidebar-with-body" do
       assert page.find(".print-meta-data", visible: false)
 
       assert page.has_no_text?("© Crown copyright #{@content_item['details']['public_timestamp'].to_date.year}")
@@ -37,7 +37,7 @@ class HtmlPublicationTest < ActionDispatch::IntegrationTest
   test "html publications with meta data - print version" do
     setup_and_visit_html_publication("print_with_meta_data", "?medium=print")
 
-    within ".govuk-grid-row.sidebar-with-body" do
+    within ".sidebar-with-body" do
       assert page.find(".print-meta-data", visible: true)
 
       assert page.has_text?("© Crown copyright #{@content_item['details']['public_timestamp'].to_date.year}")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Stop using `sticky-element-container.js` on [HTML publication pages](https://www.gov.uk/government/publications/heatwave-plan-for-england/beat-the-heat-staying-safe-in-hot-weather) and instead use native CSS sticky.

The page layout has a contents list in the left hand column and the main content in the right. The script was used to keep a jump link to the contents (and a print this page button) visible at all times when scrolling, so users can jump back to the top at any time.

This change switches from using the script to the native CSS position: sticky attribute. It has been applied to the contents list, so now the entire contents list is visible in the left column when the page is scrolled. It also stops in the right position automatically when reaching the bottom.

Internet Explorer doesn't support the CSS sticky property, so this doesn't work in that browser. It fails gracefully though, in that nothing bad happens.

Behaviour on mobile remains the same - contents stack at top, link at bottom jumps back to top, no sticky.

## Why
`sticky-element-container.js` isn't perfect - it has a bug under certain conditions that makes the sticky element overlap the footer. It's also very complicated, and something we'd like to retire, but it's used on another page still so it's still needed.

I've kept the 'Contents' jump link at the foot of the page but renamed it to 'Back to top', as that is more of an accurate description. However now that the whole contents menu scrolls with the page it's possible that we don't need this link at all (except possibly for Internet Explorer users).

## Visual changes

| Before | After |
------- | -------
Initial state at the top of the page (unchanged) | Initial state at the top of the page (unchanged)
![Screenshot 2022-07-20 at 11 50 05](https://user-images.githubusercontent.com/861310/179973432-bafa46b0-ab55-44fb-b75f-a6a02a417f6b.png) | ![Screenshot 2022-07-20 at 12 43 53](https://user-images.githubusercontent.com/861310/179973993-5a9d1299-6fde-4fa6-87a4-30c326d1d250.png)
When scrolling down - just contents link and print button visible | When scrolling down - whole contents menu and print button visible
![Screenshot 2022-07-20 at 11 50 17](https://user-images.githubusercontent.com/861310/179973729-e7e116a6-5561-4f7f-9d9e-63bfd6c5746b.png) | ![Screenshot 2022-07-20 at 12 44 02](https://user-images.githubusercontent.com/861310/179974050-ab34c3fb-6405-4d02-bc8b-e4c4779f2047.png)
At the bottom - print button and contents link stop | At the bottom - contents stop, back to top link replaces contents link (but does the same thing)
![Screenshot 2022-07-20 at 11 50 28](https://user-images.githubusercontent.com/861310/179973781-a49ca7d1-73e2-4a54-b8d3-acae7fec95d9.png) | ![Screenshot 2022-07-20 at 12 44 15](https://user-images.githubusercontent.com/861310/179974092-a24e5b70-e52a-4d0f-b613-188ac75042d5.png)



