### PR TITLE
Fetch title from manuals content item

### DIFF
--- a/app/presenters/content_item/manual_section.rb
+++ b/app/presenters/content_item/manual_section.rb
@@ -23,6 +23,10 @@ module ContentItem
       @manual_content_item ||= Services.content_store.content_item(base_path)
     end
 
+    def parsed_content_item
+      manual_content_item.parsed_content
+    end
+
     def published
       display_date(manual_content_item["first_published_at"])
     end

--- a/app/presenters/content_item/manual_section.rb
+++ b/app/presenters/content_item/manual_section.rb
@@ -20,8 +20,6 @@ module ContentItem
     end
 
     def manual_content_item
-      # TODO: Add the same tagging to a normal section as a manual for contextual breadcrumbs
-      # TODO: Add the manual published / public updated at to both manual sections (normal and HMRC)
       @manual_content_item ||= Services.content_store.content_item(base_path)
     end
 

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -36,6 +36,10 @@ class ContentItemPresenter
     @part_slug = requesting_a_part? ? requested_path.split("/").last : nil
   end
 
+  def parsed_content_item
+    content_item.parsed_content
+  end
+
   def requesting_a_part?
     false
   end

--- a/app/presenters/hmrc_manual_section_presenter.rb
+++ b/app/presenters/hmrc_manual_section_presenter.rb
@@ -7,10 +7,6 @@ class HmrcManualSectionPresenter < ContentItemPresenter
     details["manual"]["base_path"]
   end
 
-  def title
-    details["manual"]["title"]
-  end
-
   def breadcrumbs
     crumbs = manual_breadcrumbs.dup
 
@@ -83,6 +79,10 @@ private
     end
 
     [before.try(:last), after.try(:first)]
+  end
+
+  def manual
+    parent_base_path == base_path ? parent_for_section : manual_content_item
   end
 
   def parent_base_path

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,8 +42,7 @@
         <%= render 'govuk_publishing_components/components/breadcrumbs',
                    breadcrumbs: [ { url: "/", title: "Home" } , { url: "/brexit", title: "Brexit" } ] %>
       <% else %>
-        <%= render 'govuk_publishing_components/components/contextual_breadcrumbs',
-                   content_item: @content_item.try(:manual_content_item) || @content_item.content_item.parsed_content %>
+        <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.parsed_content_item %>
       <% end %>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,6 @@
         <%= render 'govuk_publishing_components/components/breadcrumbs',
                    breadcrumbs: [ { url: "/", title: "Home" } , { url: "/brexit", title: "Brexit" } ] %>
       <% else %>
-        <!-- TODO: Remove manual_content_item after adding the same tagging to manual and hmrc manual section as the parent manual --!>
         <%= render 'govuk_publishing_components/components/contextual_breadcrumbs',
                    content_item: @content_item.try(:manual_content_item) || @content_item.content_item.parsed_content %>
       <% end %>

--- a/test/presenters/hmrc_manual_section_presenter_test.rb
+++ b/test/presenters/hmrc_manual_section_presenter_test.rb
@@ -34,7 +34,10 @@ class HmrcManualSectionPresenterTest
     end
 
     test "presents manual title" do
-      manual = schema_item("vatgpb2000")["details"]["manual"]
+      manual_base_path = schema_item("vatgpb2000")["details"]["manual"]["base_path"]
+      manual = schema_item("vat-government-public-bodies", "hmrc_manual")
+      stub_content_store_has_item(manual_base_path, manual.to_json)
+
       assert_equal manual["title"], presented_manual_section.title
     end
 


### PR DESCRIPTION
This PR does the following:

* Fetch title from manuals content item for a HMRC section, rather than pulling it from it's own content item, as this functionality is going to be removed soon 
* Removes TODOs that no longer apply
* Improves how we fetch the manual content item for breadcrumbs by reducing coupling    

Trello:
https://trello.com/c/ItYKGMqF/1464-revert-add-parent-manuals-title-to-the-hmrc-section-content-item

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
