### PR TITLE
Updating base image to use a new image with Ruby on Minideb.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,29 @@
-ARG base_image=ruby:2.7.6-slim
-
-FROM $base_image AS builder
-
-ENV RAILS_ENV=production
-# TODO: have a separate build image which already contains the build-only deps.
-RUN apt-get update -qy && \
-    apt-get upgrade -y && \
-    apt-get install -y build-essential nodejs && \
-    apt-get clean 
-    
-RUN bundle config set force_ruby_platform true
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
+ 
+FROM $builder_image AS builder
 
 RUN mkdir /app
 
 WORKDIR /app
 
-COPY Gemfile Gemfile.lock .ruby-version /app/
+COPY Gemfile* .ruby-version /app/
 
-RUN bundle config set deployment 'true' && \
-    bundle config set without 'development test' && \
-    bundle install --jobs 4 --retry=2
+RUN bundle install
 
 COPY . /app
 # TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
-RUN GOVUK_APP_DOMAIN=www.gov.uk \
-    GOVUK_WEBSITE_ROOT=https://www.gov.uk \
-    bundle exec rails assets:precompile
+RUN bundle exec rails assets:precompile && rm -rf /app/log
+
 
 FROM $base_image
 
-ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=government-frontend GOVUK_APP_DOMAIN=www.gov.uk GOVUK_WEBSITE_ROOT=https://www.gov.uk PORT=3090
-
-RUN apt-get update -qy && \
-    apt-get upgrade -y && \
-    apt-get install -y nodejs && \
-    apt-get clean
-
-WORKDIR /app
+ENV GOVUK_APP_NAME=government-frontend PORT=3090
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app ./
+COPY --from=builder /app /app/
+
+USER app
+WORKDIR /app
 
 CMD bundle exec puma


### PR DESCRIPTION
Updating base image to use a new base and builder image. 

New Images are based on Ruby built from source on top of [Minideb](https://github.com/bitnami/minideb)


Base image repo, for more info:
https://github.com/alphagov/govuk-ruby-images

Further details:
https://trello.com/c/Zy0fd25w/970-use-base-builder-images-in-all-the-app-dockerfiles
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
