### PR TITLE
Turn off font

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,11 @@ $govuk-typography-use-rem: false;
 $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 
+// This flag stops the font from being included in this application's
+// stylesheet - the font is being served by Static across all of GOV.UK, so is
+// not needed here.
+$govuk-include-default-font-face: false;
+
 // Components from govuk_publishing_components gem
 @import "govuk_publishing_components/govuk_frontend_support";
 


### PR DESCRIPTION
## What

Prevent the font from being included in `government-frontend`'s stylesheet.

## Why

We should be serving the font files from `static` so they're cached across the entirety of GOVUK - so the font shouldn't be included in `government-frontend`'s stylesheet.

With the font being served by each application, users need to re-download it every time they went from a page rendered in one application to a page rendered in another application.

Serving it from `static` means that the same font URI is used in each application, allowing the fonts to be cached and reused.

## Visual changes

None - the same font is being served from `static`, instead of `government-frontend`.

Before (the font paths contains `government-frontend`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181217533-96f4a5a9-03fd-4fe9-8594-89ac3c6dbdd4.png">

After (the font path contains `static`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181217347-f8c7b164-e830-4e83-9ca9-1581e8cfd372.png">

---

## Search page examples to sanity check:

- https://government-frontend-br-turn-of.herokuapp.com/guidance/salary-sacrifice-and-the-effects-on-paye