### PR TITLE
Visa service recruitment banner

### DIFF
--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -4,13 +4,35 @@ module ContentItem
     TREE_TEST_PAGE = "/browse/working".freeze
     TREE_TEST_MAPPINGS = { TREE_TEST_PAGE => TREE_TEST_URL }.freeze
 
+    VISA_TEST_URL = "https://surveys.publishing.service.gov.uk/s/0DZCPX/".freeze
+    VISA_TEST_MAPPINGS = {
+      "/apply-to-come-to-the-uk" => VISA_TEST_URL,
+      "/healthcare-immigration-application" => VISA_TEST_URL,
+      "/tb-test-visa" => VISA_TEST_URL,
+      "/faster-decision-visa-settlement" => VISA_TEST_URL,
+      "/skilled-worker-visa" => VISA_TEST_URL,
+      "/health-care-worker-visa" => VISA_TEST_URL,
+      "/temporary-worker-charity-worker-visa" => VISA_TEST_URL,
+      "/seasonal-worker-visa" => VISA_TEST_URL,
+      "/graduate-visa" => VISA_TEST_URL,
+      "/uk-family-visa" => VISA_TEST_URL,
+      "/find-a-visa-application-centre" => VISA_TEST_URL,
+      "/guidance/visa-decision-waiting-times-applications-outside-the-uk" => VISA_TEST_URL,
+      "/government/publications/skilled-worker-visa-shortage-occupations/skilled-worker-visa-shortage-occupations" => VISA_TEST_URL,
+    }.freeze
+
     def recruitment_survey_url
-      tree_test_url
+      tree_test_url || visa_test_url
     end
 
     def tree_test_url
       key = TREE_TEST_MAPPINGS.keys.find { |k| content_tagged_to(k).present? }
       TREE_TEST_MAPPINGS[key]
+    end
+
+    def visa_test_url
+      key = content_item["base_path"]
+      VISA_TEST_MAPPINGS[key]
     end
 
   private

--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,13 +1,16 @@
 module ContentItem
   module RecruitmentBanner
-    SURVEY_URL_ONE = "https://GDSUserResearch.optimalworkshop.com/treejack/834dm2s6".freeze
-    SURVEY_URLS = {
-      "/browse/working" => SURVEY_URL_ONE,
-    }.freeze
+    TREE_TEST_URL = "https://GDSUserResearch.optimalworkshop.com/treejack/834dm2s6".freeze
+    TREE_TEST_PAGE = "/browse/working".freeze
+    TREE_TEST_MAPPINGS = { TREE_TEST_PAGE => TREE_TEST_URL }.freeze
 
     def recruitment_survey_url
-      key = SURVEY_URLS.keys.find { |k| content_tagged_to(k).present? }
-      SURVEY_URLS[key]
+      tree_test_url
+    end
+
+    def tree_test_url
+      key = TREE_TEST_MAPPINGS.keys.find { |k| content_tagged_to(k).present? }
+      TREE_TEST_MAPPINGS[key]
     end
 
   private

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -35,4 +35,44 @@ class RecruitmentBannerTest < ActionDispatch::IntegrationTest
     assert_not page.has_css?(".gem-c-intervention")
     assert_not page.has_link?("Take part in user research", href: "https://GDSUserResearch.optimalworkshop.com/treejack/834dm2s6")
   end
+
+  test "Visa test recruitment banner is displayed on pages of interest" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+
+    pages_of_interest =
+      [
+        "/apply-to-come-to-the-uk",
+        "/healthcare-immigration-application",
+        "/tb-test-visa",
+        "/faster-decision-visa-settlement",
+        "/skilled-worker-visa",
+        "/health-care-worker-visa",
+        "/temporary-worker-charity-worker-visa",
+        "/seasonal-worker-visa",
+        "/graduate-visa",
+        "/uk-family-visa",
+        "/find-a-visa-application-centre",
+        "/guidance/visa-decision-waiting-times-applications-outside-the-uk",
+        "/government/publications/skilled-worker-visa-shortage-occupations/skilled-worker-visa-shortage-occupations",
+      ]
+
+    pages_of_interest.each do |path|
+      guide["base_path"] = path
+      stub_content_store_has_item(guide["base_path"], guide.to_json)
+      visit guide["base_path"]
+
+      assert page.has_css?(".gem-c-intervention")
+      assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/0DZCPX/")
+    end
+  end
+
+  test "Visa test recruitment banner is not displayed on all pages" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    guide["base_path"] = "/nothing-to-see-here"
+    stub_content_store_has_item(guide["base_path"], guide.to_json)
+    visit guide["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://surveys.publishing.service.gov.uk/s/0DZCPX/")
+  end
 end

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class RecruitmentBannerTest < ActionDispatch::IntegrationTest
-  test "Recruitment Banner is displayed for any page tagged to Working, jobs and pensions" do
+  test "Tree test recruitment banner is displayed for any page tagged to Working, jobs and pensions" do
     @working_browse_page = {
       "content_id" => "123",
       "title" => "Self Assessment",
@@ -19,7 +19,7 @@ class RecruitmentBannerTest < ActionDispatch::IntegrationTest
     assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/834dm2s6")
   end
 
-  test "Recruitment Banner is not displayed unless page is tagged to a topic of interest" do
+  test "Tree test recruitment banner is not displayed unless page is tagged to a topic of interest" do
     @not_of_interest = {
       "content_id" => "123",
       "title" => "I am not interesting",


### PR DESCRIPTION
Add recruitment banner to pages related to the UK visa service.

See [trello](https://trello.com/c/4oYXIjMN/1173-add-a-research-recruitment-banner-for-the-visa-journeys-team-s) card for list of pages.

<img width="1041" alt="Screenshot 2022-08-03 at 14 29 39" src="https://user-images.githubusercontent.com/17908089/182620055-4ea589c1-c0b4-4b3f-b8a9-80393475df42.png">
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
