### PR TITLE
Add GA4 analytics tracking to print links

### DIFF
--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -105,6 +105,16 @@
       <%= render "govuk_publishing_components/components/print_link", {
         margin_top: 0,
         margin_bottom: 6,
+        data_attributes: {
+          module: "ga4-event-tracker",
+          ga4: {
+            event_name: 'print_page',
+            type: 'Print this page',
+            index: 1,
+            index_total: 2,
+            section: 'Contents',
+          },
+        },
       } unless brexit_child_taxon %>
 
       <% if brexit_child_taxon %>
@@ -122,6 +132,16 @@
     <%= render "govuk_publishing_components/components/print_link", {
         margin_top: 0,
         margin_bottom: 6,
+        data_attributes: {
+          module: "ga4-event-tracker",
+          ga4: {
+            event_name: 'print_page',
+            type: 'Print this page',
+            index: 2,
+            index_total: 2,
+            section: 'Footer',
+          },
+        },
       } unless brexit_child_taxon %>
   </div>
   <%= render 'shared/sidebar_navigation' %>

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row" id="guide-print">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', { 
+    <%= render 'govuk_publishing_components/components/title', {
       margin_bottom: 6,
       title: @content_item.title,
     } %>
@@ -21,10 +21,17 @@
 
     <%= render 'govuk_publishing_components/components/print_link', {
       data_attributes: {
+        module: "ga4-event-tracker",
         "track-category": "printButton",
         "track-action": "clicked",
         "track-label": t("components.print_link.text"),
-        module: "print-link"
+        ga4: {
+          event_name: 'print_page',
+          type: 'Print this page',
+          index: 1,
+          index_total: 2,
+          section: 'Contents',
+        },
       },
       margin_bottom: 8,
       text: t("components.print_link.text"),
@@ -45,10 +52,17 @@
 
     <%= render 'govuk_publishing_components/components/print_link', {
       data_attributes: {
+        module: "ga4-event-tracker",
         "track-category": "printButton",
         "track-action": "clicked",
         "track-label": t("components.print_link.text"),
-        module: "print-link"
+        ga4: {
+          event_name: 'print_page',
+          type: 'Print this page',
+          index: 2,
+          index_total: 2,
+          section: 'Footer',
+        },
       },
       text: t("components.print_link.text")
     } %>

--- a/app/views/content_items/hmrc_manual.html.erb
+++ b/app/views/content_items/hmrc_manual.html.erb
@@ -24,5 +24,16 @@
     </div>
   <% end %>
 
-  <%= render "govuk_publishing_components/components/print_link" %>
+  <%= render 'govuk_publishing_components/components/print_link', {
+    data_attributes: {
+      module: "ga4-event-tracker",
+      ga4: {
+        event_name: 'print_page',
+        type: 'Print this page',
+        index: 1,
+        index_total: 1,
+        section: 'Footer',
+      },
+    },
+  } %>
 </div>

--- a/app/views/content_items/hmrc_manual_section.html.erb
+++ b/app/views/content_items/hmrc_manual_section.html.erb
@@ -45,5 +45,16 @@
     </div>
   </div>
 
-  <%= render "govuk_publishing_components/components/print_link" %>
+  <%= render 'govuk_publishing_components/components/print_link', {
+    data_attributes: {
+      module: "ga4-event-tracker",
+      ga4: {
+        event_name: 'print_page',
+        type: 'Print this page',
+        index: 1,
+        index_total: 1,
+        section: 'Footer',
+      },
+    },
+  } %>
 </div>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -54,9 +54,20 @@
     <% if @content_item.contents.any? %>
       <div class="govuk-grid-column-one-quarter-from-desktop contents-list-container">
         <%= render 'govuk_publishing_components/components/contents_list', contents: @content_item.contents, format_numbers: true %>
-        <%= render "govuk_publishing_components/components/print_link", {
+
+        <%= render 'govuk_publishing_components/components/print_link', {
           margin_top: 0,
           margin_bottom: 6,
+          data_attributes: {
+            module: "ga4-event-tracker",
+            ga4: {
+              event_name: 'print_page',
+              type: 'Print this page',
+              index: 1,
+              index_total: 1,
+              section: 'Contents',
+            },
+          },
         } %>
       </div>
     <% end %>

--- a/app/views/content_items/manual.html.erb
+++ b/app/views/content_items/manual.html.erb
@@ -33,5 +33,16 @@
     } %>
   <% end %>
 
-  <%= render "govuk_publishing_components/components/print_link" %>
+  <%= render 'govuk_publishing_components/components/print_link', {
+    data_attributes: {
+      module: "ga4-event-tracker",
+      ga4: {
+        event_name: 'print_page',
+        type: 'Print this page',
+        index: 1,
+        index_total: 1,
+        section: 'Footer',
+      },
+    },
+  } %>
 </div>

--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -96,5 +96,16 @@
     </div>
   </div>
 
-  <%= render "govuk_publishing_components/components/print_link" %>
+  <%= render 'govuk_publishing_components/components/print_link', {
+    data_attributes: {
+      module: "ga4-event-tracker",
+      ga4: {
+        event_name: 'print_page',
+        type: 'Print this page',
+        index: 1,
+        index_total: 1,
+        section: 'Footer',
+      },
+    },
+  } %>
 </div>

--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -70,4 +70,15 @@
   </div>
 </div>
 
-<%= render "govuk_publishing_components/components/print_link" %>
+<%= render 'govuk_publishing_components/components/print_link', {
+  data_attributes: {
+    module: "ga4-event-tracker",
+    ga4: {
+      event_name: 'print_page',
+      type: 'Print this page',
+      index: 1,
+      index_total: 1,
+      section: 'Footer',
+    },
+  },
+} %>

--- a/app/views/content_items/travel_advice.html+print.erb
+++ b/app/views/content_items/travel_advice.html+print.erb
@@ -20,10 +20,17 @@
 
     <%= render 'govuk_publishing_components/components/print_link', {
       data_attributes: {
+        module: "ga4-event-tracker",
         "track-category": "printButton",
         "track-action": "clicked",
         "track-label": t("components.print_link.text"),
-        module: "print-link"
+        ga4: {
+          event_name: 'print_page',
+          type: 'Print this page',
+          index: 1,
+          index_total: 2,
+          section: 'Contents',
+        },
       },
       margin_bottom: 8,
       text: t("components.print_link.text"),
@@ -45,10 +52,17 @@
 
     <%= render 'govuk_publishing_components/components/print_link', {
       data_attributes: {
+        module: "ga4-event-tracker",
         "track-category": "printButton",
         "track-action": "clicked",
         "track-label": t("components.print_link.text"),
-        module: "print-link"
+        ga4: {
+          event_name: 'print_page',
+          type: 'Print this page',
+          index: 2,
+          index_total: 2,
+          section: 'Footer',
+        },
       },
       text: t("components.print_link.text")
     } %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Add GA4 tracking to 'print this page' links on GOV.UK.

Note that these changes are only active on integration, not live.

Pages affected:

- detailed guides ([example detailed guide](https://www.gov.uk/guidance/register-a-trust-as-a-trustee))
- guides ([example guide](https://www.gov.uk/change-address-driving-licence/print))
- HMRC manuals ([example manual](https://www.gov.uk/hmrc-internal-manuals/employment-income-manual) and [example manual section](https://www.gov.uk/hmrc-internal-manuals/employment-income-manual/eim00100) and [example updates page](https://www.gov.uk/hmrc-internal-manuals/trust-registration-service-manual/updates))
- HTML publication ([example HTML publication](https://www.gov.uk/government/publications/budget-2016-documents/budget-2016))
- manuals ([example manual section](https://www.gov.uk/guidance/the-highway-code/general-rules-techniques-and-advice-for-all-drivers-and-riders-103-to-158) and [example manual](https://www.gov.uk/guidance/academy-trust-handbook))
- travel advice ([example travel advice](https://www.gov.uk/foreign-travel-advice/usa/print))

In some of these commits I've removed the explicit passing of `module: "print-link"` in the data attributes. This is because it is not needed - [the component adds this itself](https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_print_link.html.erb#L9) regardless of what is passed.

## Why
Part of the GA4 test rollout.

## Visual changes
None.

Trello card: https://trello.com/c/GlsJk20k/350-print-this-page
