### PR TITLE
Add GA4 accordion tracking to manuals

### DIFF
--- a/app/helpers/manuals_helper.rb
+++ b/app/helpers/manuals_helper.rb
@@ -1,0 +1,7 @@
+module ManualsHelper
+  def sanitize_manual_update_title(title)
+    return "" if title.nil?
+
+    strip_tags(title).gsub(I18n.t("manuals.updates_amendments"), "").gsub(/\s+/, " ").strip
+  end
+end

--- a/app/presenters/content_item/manual_updates.rb
+++ b/app/presenters/content_item/manual_updates.rb
@@ -42,7 +42,7 @@ module ContentItem
       formatted_date = I18n.l(date, format: "%-d %B %Y") if date
       updates_span = view_context.content_tag("span",
                                               I18n.t("manuals.updates_amendments"),
-                                              class: "visuallyhidden")
+                                              class: "govuk-visually-hidden")
 
       formatted_date = "#{formatted_date} #{updates_span}"
       view_context.sanitize(formatted_date)

--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -49,20 +49,45 @@
                 </div>
               <% end %>
             <% else %>
-              <%= render "govuk_publishing_components/components/accordion", {
-                anchor_navigation: true,
-                items: @content_item.main.map do |item|
+              <%
+                items = @content_item.main.each.with_index(1).map do |item, index|
                   rendered_content = render "govuk_publishing_components/components/govspeak", {} do
                     raw(item[:content])
                   end
 
                   {
+                    data_attributes: {
+                      module: "gtm-track-click",
+                      ga4: {
+                        event_name: "select_content",
+                        type: "accordion",
+                        text: item[:heading],
+                        index: index,
+                        index_total: @content_item.main.length,
+                      }
+                    },
                     heading: item[:heading],
                     content: {
                       html: rendered_content,
                     },
                   }
                 end
+              %>
+
+              <%
+                ga4_attributes = {
+                  event_name: "select_content",
+                  type: "accordion",
+                  index: 0,
+                  index_total: @content_item.main.length,
+                }
+              %>
+              <%= render "govuk_publishing_components/components/accordion", {
+                data_attributes_show_all: {
+                  "ga4": ga4_attributes.to_json
+                },
+                anchor_navigation: true,
+                items: items,
               } %>
             <% end %>
           <% end %>

--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -18,23 +18,45 @@
             font_size: "l"
           } %>
 
+          <%
+            show_all_attributes = {
+              event_name: "select_content",
+              type: "accordion",
+              index: 0,
+              index_total: updates_by_year.length,
+            }
+          %>
           <%= render "govuk_publishing_components/components/accordion", {
             heading_level: 3,
-            items: updates_by_year.map do |day, updated_documents|
+            data_attributes_show_all: {
+              "ga4": show_all_attributes.to_json
+            },
+            items: updates_by_year.each.with_index(1).map do |updated_documents, index|
               accordion_content = capture do %>
+                <% change_notes = updated_documents.last %>
                 <div class="govuk-!-margin-top-3">
-                  <% updated_documents.each do |_, change_notes| %>
-                    <% change_notes.each do |change_note| %>
-                      <p class="govuk-body"><%= link_to change_note["title"], change_note["base_path"], class: "govuk-link" %></p>
-                      <%= simple_format(change_note["change_note"], class: "govuk-body") %>
-                    <% end %>
+                  <% change_notes.each do |change_note_entry| %>
+                    <% change_note = change_note_entry.flatten.last %>
+                    <p class="govuk-body">
+                      <%= link_to change_note["title"], change_note["base_path"], class: "govuk-link" %>
+                    </p>
+                    <%= simple_format(change_note["change_note"], class: "govuk-body") %>
                   <% end %>
                 </div>
               <% end
-
               {
+                data_attributes: {
+                  module: "gtm-track-click",
+                  ga4: {
+                    event_name: 'select_content',
+                    type: 'accordion',
+                    text: sanitize_manual_update_title(updated_documents.first),
+                    index: index,
+                    index_total: updates_by_year.length,
+                  }
+                },
                 heading: {
-                  text: day,
+                  text: updated_documents.first,
                 },
                 content: {
                   html: accordion_content

--- a/test/helpers/manuals_helper_test.rb
+++ b/test/helpers/manuals_helper_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class ManualsHelperTest < ActionView::TestCase
+  test "it returns an empty string when given an empty string" do
+    expected = ""
+    actual = ""
+    assert_equal(expected, sanitize_manual_update_title(actual))
+  end
+
+  test "it returns an empty string when given nil" do
+    expected = ""
+    actual = nil
+    assert_equal(expected, sanitize_manual_update_title(actual))
+  end
+
+  test "it removes HTML from the title" do
+    expected = "Hello world"
+    actual = " <h1> Hello world </h1> "
+    assert_equal(expected, sanitize_manual_update_title(actual))
+  end
+
+  test "it removes the manuals.updates_amendments string from the title" do
+    expected = "Hello world"
+    actual = " <h1> Hello world </h1> <span> #{I18n.t('manuals.updates_amendments')} </span> "
+    assert_equal(expected, sanitize_manual_update_title(actual))
+  end
+
+  test "it only the unrequired elements from the title" do
+    expected = "Hello world ABC XYZ"
+    actual = " <h1> Hello world </h1> <span> ABC #{I18n.t('manuals.updates_amendments')} XYZ </span> "
+    assert_equal(expected, sanitize_manual_update_title(actual))
+  end
+end

--- a/test/presenters/content_item/manual_updates_test.rb
+++ b/test/presenters/content_item/manual_updates_test.rb
@@ -70,14 +70,14 @@ class ContentItemManualUpdatesTest < ActiveSupport::TestCase
         2014,
         [
           [
-            "6 October 2014 <span class=\"visuallyhidden\">#{I18n.t('manuals.updates_amendments')}</span>",
+            "6 October 2014 <span class=\"govuk-visually-hidden\">#{I18n.t('manuals.updates_amendments')}</span>",
             {
               (first_note["base_path"]).to_s => [first_note],
               (second_note["base_path"]).to_s => [second_note],
             },
           ],
           [
-            "6 August 2014 <span class=\"visuallyhidden\">#{I18n.t('manuals.updates_amendments')}</span>",
+            "6 August 2014 <span class=\"govuk-visually-hidden\">#{I18n.t('manuals.updates_amendments')}</span>",
             {
               (third_note["base_path"]).to_s => [third_note],
             },
@@ -88,7 +88,7 @@ class ContentItemManualUpdatesTest < ActiveSupport::TestCase
         2013,
         [
           [
-            "6 November 2013 <span class=\"visuallyhidden\">#{I18n.t('manuals.updates_amendments')}</span>",
+            "6 November 2013 <span class=\"govuk-visually-hidden\">#{I18n.t('manuals.updates_amendments')}</span>",
             {
               (fourth_note["base_path"]).to_s => [fourth_note],
             },


### PR DESCRIPTION
We are currently working to complete the implementation of GA4 tracking on all accordions, across all frontend apps.

This PR adds tracking to the accordions on the following pages:
- [x] [/app/views/content_items/manuals/_updates.html.erb](https://github.com/alphagov/government-frontend/blob/main/app/views/content_items/manuals/_updates.html.erb)
- [x] [/app/views/content_items/manual_section.html.erb](https://github.com/alphagov/government-frontend/blob/main/app/views/content_items/manual_section.html.erb)

Example URL(s):
- https://www.gov.uk/hmrc-internal-manuals/employment-income-manual/updates
- https://www.gov.uk/guidance/understanding-your-driving-test-result/car-driving-test

There are more [example pages](https://docs.publishing.service.gov.uk/repos/manuals-publisher.html) listed in the manuals publisher docs.

Also, in this PR is a bug fix. Currently, the I18N `manuals.updates_amendments` string is visible on the rendered page. This is because the `visuallyhidden` class has been replaced by the `govuk-visually-hidden` class. The `visuallyhidden` class has been replaced and appropriate tests added.

Co-authored-by: Graham Lewis <@gclssvglx>

[Trello](https://trello.com/c/0gjuZZxe/344-complete-the-implementation-of-ga4-accordions-on-all-frontend-apps)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
