### PR TITLE
Implement the content list component on `manual_section` pages for Ministry of Justice only

### DIFF
--- a/app/presenters/content_item/contents_list.rb
+++ b/app/presenters/content_item/contents_list.rb
@@ -19,6 +19,7 @@ module ContentItem
     end
 
     def show_contents_list?
+      return false if exclude_contents_list_for_manual_section?
       return false if contents_items.count < 2
       return true if contents_items.count > 2
       return false if no_first_item?
@@ -109,6 +110,13 @@ module ContentItem
 
     def no_first_item?
       first_item.nil?
+    end
+
+    def exclude_contents_list_for_manual_section?
+      # MOJ require contents lists for manual section pages.
+
+      moj_content = content_item.dig("links", "organisations", 0, "content_id") == "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
+      document_type == "manual_section" && !moj_content
     end
   end
 end

--- a/app/presenters/content_item/manual.rb
+++ b/app/presenters/content_item/manual.rb
@@ -16,20 +16,8 @@ module ContentItem
     alias_method :manual_page_title, :page_title
 
     def breadcrumbs
-      crumbs = []
-
-      if view_context.request.path == base_path
-        crumbs.push({
-          title: I18n.t("manuals.breadcrumb_contents"),
-        })
-      else
-        crumbs.push({
-          title: I18n.t("manuals.breadcrumb_contents"),
-          url: base_path,
-        })
-      end
+      [{ title: I18n.t("manuals.breadcrumb_contents") }]
     end
-    alias_method :manual_breadcrumbs, :breadcrumbs
 
     def section_groups
       content_item.dig("details", "child_section_groups") || []

--- a/app/presenters/content_item/manual_section.rb
+++ b/app/presenters/content_item/manual_section.rb
@@ -15,6 +15,24 @@ module ContentItem
       document_heading << content_item["title"] if content_item["title"]
     end
 
+    def breadcrumbs
+      if show_contents_list?
+        [
+          {
+            title: I18n.t("manuals.contents_list_breadcrumb_contents"),
+            url: base_path,
+          },
+        ]
+      else
+        [
+          {
+            title: I18n.t("manuals.breadcrumb_contents"),
+            url: base_path,
+          },
+        ]
+      end
+    end
+
     def breadcrumb
       details["section_id"] || title
     end

--- a/app/presenters/content_item/manual_updates.rb
+++ b/app/presenters/content_item/manual_updates.rb
@@ -4,6 +4,15 @@ module ContentItem
       I18n.t("manuals.updates_page_title", title: manual_page_title)
     end
 
+    def breadcrumbs
+      [
+        {
+          title: I18n.t("manuals.breadcrumb_contents"),
+          url: base_path,
+        },
+      ]
+    end
+
     def description
       I18n.t("manuals.updates_description", title: manual_page_title)
     end

--- a/app/presenters/hmrc_manual_section_presenter.rb
+++ b/app/presenters/hmrc_manual_section_presenter.rb
@@ -8,7 +8,12 @@ class HmrcManualSectionPresenter < ContentItemPresenter
   end
 
   def breadcrumbs
-    crumbs = manual_breadcrumbs.dup
+    crumbs = [
+      {
+        title: I18n.t("manuals.breadcrumb_contents"),
+        url: base_path,
+      },
+    ]
 
     return crumbs if content_item_breadcrumbs.blank?
 

--- a/app/presenters/manual_section_presenter.rb
+++ b/app/presenters/manual_section_presenter.rb
@@ -1,6 +1,7 @@
 class ManualSectionPresenter < ContentItemPresenter
   include ContentItem::Metadata
   include ContentItem::Manual
+  include ContentItem::ContentsList
   include ContentItem::ManualSection
 
   def base_path

--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -3,6 +3,10 @@
     content_item: @content_item, heading_level: 1, margin_bottom: 6,
   } %>
 
+  <%= render "govuk_publishing_components/components/contents_list", {
+    aria_label: t("manuals.pages_in_manual_section"), contents: @content_item.contents, underline_links: true
+  } %>
+
   <div class="govuk-grid-row">
     <div class="manual-body" id="content">
       <article aria-labelledby="section-title">

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -732,9 +732,11 @@ ar:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -432,9 +432,11 @@ az:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -582,9 +582,11 @@ be:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -432,9 +432,11 @@ bg:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -432,9 +432,11 @@ bn:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -507,9 +507,11 @@ cs:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -732,9 +732,11 @@ cy:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -444,9 +444,11 @@ da:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -432,9 +432,11 @@ de:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -435,9 +435,11 @@ dr:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -432,9 +432,11 @@ el:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -432,9 +432,11 @@ en:
     zh-tw: Traditional Chinese
   manuals:
     breadcrumb_contents: Contents
+    contents_list_breadcrumb_contents: Manual homepage
     hmrc_manual_type: HMRC internal manual
     hmrc_title: "%{title}HMRC internal manual"
     next_page: Next page
+    pages_in_manual_section: Manual section pages
     previous_page: Previous page
     search_this_manual: Search this manual
     see_all_updates: see all updates

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -432,9 +432,11 @@ es-419:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -432,9 +432,11 @@ es:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -432,9 +432,11 @@ et:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -432,9 +432,11 @@ fa:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -432,9 +432,11 @@ fi:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -432,9 +432,11 @@ fr:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -582,9 +582,11 @@ gd:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -432,9 +432,11 @@ gu:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -432,9 +432,11 @@ he:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -432,9 +432,11 @@ hi:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -507,9 +507,11 @@ hr:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -432,9 +432,11 @@ hu:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -432,9 +432,11 @@ hy:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -357,9 +357,11 @@ id:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -432,9 +432,11 @@ is:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -432,9 +432,11 @@ it:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -357,9 +357,11 @@ ja:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -432,9 +432,11 @@ ka:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -432,9 +432,11 @@ kk:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -357,9 +357,11 @@ ko:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -507,9 +507,11 @@ lt:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -432,9 +432,11 @@ lv:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -357,9 +357,11 @@ ms:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -582,9 +582,11 @@ mt:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -432,9 +432,11 @@ ne:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -432,9 +432,11 @@ nl:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -432,9 +432,11 @@
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -432,9 +432,11 @@ pa-pk:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -432,9 +432,11 @@ pa:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -582,9 +582,11 @@ pl:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -432,9 +432,11 @@ ps:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -432,9 +432,11 @@ pt:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -507,9 +507,11 @@ ro:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -582,9 +582,11 @@ ru:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -432,9 +432,11 @@ si:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -507,9 +507,11 @@ sk:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -582,9 +582,11 @@ sl:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -432,9 +432,11 @@ so:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -432,9 +432,11 @@ sq:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -507,9 +507,11 @@ sr:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -432,9 +432,11 @@ sv:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -432,9 +432,11 @@ sw:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -432,9 +432,11 @@ ta:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -357,9 +357,11 @@ th:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -432,9 +432,11 @@ tk:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -432,9 +432,11 @@ tr:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -582,9 +582,11 @@ uk:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -432,9 +432,11 @@ ur:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -432,9 +432,11 @@ uz:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -357,9 +357,11 @@ vi:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -432,9 +432,11 @@ yi:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -432,9 +432,11 @@ zh-hk:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -432,9 +432,11 @@ zh-tw:
     zh-tw: 繁體中文
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -357,9 +357,11 @@ zh:
     zh-tw:
   manuals:
     breadcrumb_contents:
+    contents_list_breadcrumb_contents:
     hmrc_manual_type:
     hmrc_title:
     next_page:
+    pages_in_manual_section:
     previous_page:
     search_this_manual:
     see_all_updates:

--- a/test/integration/manual_section_test.rb
+++ b/test/integration/manual_section_test.rb
@@ -84,6 +84,19 @@ class ManualSectionTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "renders content lists if published by MOJ" do
+    content_item = get_content_example("what-is-content-design")
+    organisations = { "organisations" => [{ "content_id" => "dcc907d6-433c-42df-9ffb-d9c68be5dc4d" }] }
+    content_item["links"] = content_item["links"].merge(organisations)
+
+    setup_and_visit_manual_section(content_item)
+
+    assert_has_contents_list([
+      { text: "Designing content, not creating copy", id: "designing-content-not-creating-copy" },
+      { text: "Content design always starts with user needs", id: "content-design-always-starts-with-user-needs" },
+    ])
+  end
+
   def setup_and_visit_manual_section(content_item = get_content_example("what-is-content-design"))
     @manual = get_content_example_by_schema_and_name("manual", "content-design")
     @content_item = content_item

--- a/test/presenters/content_item/contents_list_test.rb
+++ b/test/presenters/content_item/contents_list_test.rb
@@ -2,7 +2,20 @@ require "test_helper"
 
 class ContentItemContentsListTest < ActiveSupport::TestCase
   def setup
+    content_item = {
+      "title" => "thing",
+      "document_type" => "manual_section",
+      "links" => {
+        "organisations" => [
+          {
+            "content_id" => "dcc907d6-433c-42df-9ffb-d9c68be5dc4d",
+          },
+        ],
+      },
+    }
     @contents_list = Object.new
+    @contents_list.stubs(:content_item).returns(content_item)
+    @contents_list.stubs(:document_type).returns(content_item["document_type"])
     @contents_list.stubs(:view_context)
                   .returns(ApplicationController.new.view_context)
     @contents_list.extend(ContentItem::ContentsList)
@@ -93,6 +106,24 @@ class ContentItemContentsListTest < ActiveSupport::TestCase
       end
     end
     assert @contents_list.show_contents_list?
+  end
+
+  test "#show_contents_list? returns false if the content item is a manual section but excluded from displaying content lists" do
+    content_item = {
+      "title" => "thing",
+      "document_type" => "manual_section",
+      "links" => {
+        "organisations" => [
+          {
+            "content_id" => "91cd6143-69d5-4f27-99ff-a52fb0d51c74",
+          },
+        ],
+      },
+    }
+
+    @contents_list.stubs(:content_item).returns(content_item)
+    @contents_list.stubs(:document_type).returns(content_item["document_type"])
+    assert_not @contents_list.show_contents_list?
   end
 
   test "#show_contents_list? returns true if number of contents items is 2 and the first item's character count is above 415 including a list" do

--- a/test/presenters/content_item/manual_section_test.rb
+++ b/test/presenters/content_item/manual_section_test.rb
@@ -34,6 +34,34 @@ class ContentItemManualSectionTest < ActiveSupport::TestCase
     assert_equal(%w[ADML1000 manualsectiontest], item.document_heading)
   end
 
+  test "returns breadcrumbs when showing contents list" do
+    item = DummyContentItem.new
+    item.stubs(:show_contents_list?).returns(true)
+
+    breadcrumbs = [
+      {
+        title: I18n.t("manuals.contents_list_breadcrumb_contents"),
+        url: item.base_path,
+      },
+    ]
+
+    assert_equal(breadcrumbs, item.breadcrumbs)
+  end
+
+  test "returns breadcrumbs when not showing contents list" do
+    item = DummyContentItem.new
+    item.stubs(:show_contents_list?).returns(false)
+
+    breadcrumbs = [
+      {
+        title: I18n.t("manuals.breadcrumb_contents"),
+        url: item.base_path,
+      },
+    ]
+
+    assert_equal(breadcrumbs, item.breadcrumbs)
+  end
+
   test "returns breadcrumb when section_id is present" do
     item = DummyContentItem.new
 

--- a/test/presenters/content_item/manual_test.rb
+++ b/test/presenters/content_item/manual_test.rb
@@ -41,20 +41,10 @@ class ContentItemManualTest < ActiveSupport::TestCase
     assert_equal "#{item.title} - HMRC internal manual", item.page_title
   end
 
-  test "returns breadcrumbs when the base_path is equal to the request path" do
+  test "returns breadcrumbs" do
     item = DummyContentItem.new
-    item.view_context.stubs(:request)
-      .returns(ActionDispatch::TestRequest.create("PATH_INFO" => item.base_path))
 
     assert_equal [{ title: I18n.t("manuals.breadcrumb_contents") }], item.breadcrumbs
-  end
-
-  test "returns breadcrumbs when the base_path is not equal to the request path" do
-    item = DummyContentItem.new
-    item.view_context.stubs(:request)
-      .returns(ActionDispatch::TestRequest.create("PATH_INFO" => "/some/other/base_path"))
-
-    assert_equal [{ title: I18n.t("manuals.breadcrumb_contents"), url: item.base_path }], item.breadcrumbs
   end
 
   test "returns section groups" do


### PR DESCRIPTION
## What
https://trello.com/c/564ra84M/1132-manuals-implement-list-of-contents-for-manuals

Implement the content list component on `manual_section` pages and for **Ministry of Justice** only

## Why

Feature request as sections are easier to navigate with a list of contents.

## Visual changes
Sample pages created on Integration.

## Manual (Ministry of Justice)
Sample page based on https://www.justice.gov.uk/courts/procedure-rules/civil/rules

<img width="1379" alt="Screenshot 2022-08-15 at 14 33 08" src="https://user-images.githubusercontent.com/87758239/184645497-c1371935-4f0b-4ca3-9078-aeb546d4888b.png">

## Manual section (Ministry of Justice)
Sample page based on https://www.justice.gov.uk/courts/procedure-rules/civil/rules/raprnotes

<img width="1379" alt="Screenshot 2022-08-15 at 14 33 34" src="https://user-images.githubusercontent.com/87758239/184645665-f6f6b931-b997-421e-868f-9559ffd44789.png">

## Manual section (Ministry of Justice)
Sample page based on https://www.justice.gov.uk/courts/procedure-rules/civil/rules/part01

<img width="1379" alt="Screenshot 2022-08-15 at 14 33 55" src="https://user-images.githubusercontent.com/87758239/184645732-f08fdc1e-83b1-41b6-9b5d-8bb92b42d499.png">

## Manual updates (Ministry of Justice)

<img width="1379" alt="Screenshot 2022-08-15 at 14 35 23" src="https://user-images.githubusercontent.com/87758239/184645833-48df48cb-d8dd-448f-86d2-01650be4a206.png">

## Anything else

