### PR TITLE
Rename GA4 tracking module

### DIFF
--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -57,7 +57,7 @@
 
                   {
                     data_attributes: {
-                      module: "gtm-track-click",
+                      module: "ga4-event-tracker",
                       ga4: {
                         event_name: "select_content",
                         type: "accordion",

--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -46,7 +46,7 @@
               <% end
               {
                 data_attributes: {
-                  module: "gtm-track-click",
+                  module: "ga4-event-tracker",
                   ga4: {
                     event_name: 'select_content',
                     type: 'accordion',


### PR DESCRIPTION
## What

Rename the GA4 tracking module to `ga4-event-tracker`.

## Why

The GA4 tracking module [has been renamed to `ga4-event-tracker`](https://github.com/alphagov/govuk_publishing_components/pull/2906).

[Trello](https://trello.com/c/0gjuZZxe/344-complete-the-implementation-of-ga4-accordions-on-all-frontend-apps)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️