### PR TITLE
Add single page notification button to document collections

### DIFF
--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -4,6 +4,7 @@ class DocumentCollectionPresenter < ContentItemPresenter
   include ContentItem::Political
   include ContentItem::TitleAndContext
   include ContentItem::ContentsList
+  include ContentItem::SinglePageNotificationButton
 
   def contents_items
     groups.map do |group|

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -22,6 +22,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'shared/single_page_notification_button', content_item: @content_item %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -22,7 +22,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
-<%= render 'shared/single_page_notification_button', content_item: @content_item %>
+<%= render 'shared/single_page_notification_button', content_item: @content_item, skip_account: "true" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -1,4 +1,5 @@
 <% add_view_stylesheet("published-dates-button-group") %>
+<% skip_account = skip_account || "false" %>
 
 <%= render 'components/published_dates', {
     published: @content_item.published,
@@ -13,6 +14,7 @@
     js_enhancement: @has_govuk_account,
     button_location: "bottom",
     margin_bottom: 3,
+    skip_account: skip_account,
     ga4_data_attributes: {
       module: "ga4-link-tracker",
       ga4_link: {
@@ -24,7 +26,7 @@
         index_total: 2,
         section: "Footer"
       }
-  }
+    }
   } if @content_item.has_single_page_notifications? %>
   <%= render "govuk_publishing_components/components/print_link", {
     margin_top: 0,

--- a/app/views/shared/_single_page_notification_button.html.erb
+++ b/app/views/shared/_single_page_notification_button.html.erb
@@ -14,6 +14,7 @@
 %>
 
 <% ga4_data_attributes = ga4_data_attributes || default_ga4_data_attributes %>
+<% skip_account = skip_account || "false" %>
 
 <%= render 'govuk_publishing_components/components/single_page_notification_button', {
   base_path: @content_item.base_path,
@@ -21,4 +22,5 @@
   ga4_data_attributes: ga4_data_attributes,
   margin_bottom: 6,
   button_location: "top",
+  skip_account: skip_account,
 } if @content_item.has_single_page_notifications? %>

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -154,8 +154,8 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "does not render with the single page notification button" do
+  test "renders with the single page notification button" do
     setup_and_visit_content_item("document_collection")
-    assert_not page.has_css?(".gem-c-single-page-notification-button")
+    assert page.has_css?(".gem-c-single-page-notification-button")
   end
 end


### PR DESCRIPTION
## What

Add the single page notification button to document collections. Pass in the `skip_account` flag to the component so that users sign up via the non GOV.UK account route. 

Review app: https://government-frontend-pr-2535.herokuapp.com/government/collections/technology-case-studies

| Before | After |
| --------| ---------- |
| <img width="777" alt="Screenshot 2023-02-03 at 16 32 08" src="https://user-images.githubusercontent.com/17908089/216656408-06fb4d2d-240b-4920-a043-d45a1d8a9102.png"> | <img width="879" alt="Screenshot 2023-06-30 at 09 36 31" src="https://github.com/alphagov/government-frontend/assets/17908089/718bd762-84c6-4d86-97fd-58c7dd1d454f">|

Related work:

- https://github.com/alphagov/email-alert-frontend/pull/1489
- https://github.com/alphagov/govuk_publishing_components/pull/3229

Trello: https://trello.com/c/fXCk2Vck/1614-turn-on-email-notifications-for-document-collections-m


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
