### PR TITLE
Enable Static proxy for development

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,6 +8,9 @@
     "GOVUK_WEBSITE_ROOT": {
       "value": "https://www.gov.uk"
     },
+    "GOVUK_PROXY_STATIC_ENABLED": {
+      "value": "true"
+    },
     "PLEK_SERVICE_CONTENT_STORE_URI": {
       "value": "https://govuk-content-store-examples.herokuapp.com/api"
     },

--- a/startup.sh
+++ b/startup.sh
@@ -12,6 +12,7 @@ function set_env() {
 
 if [[ $1 == "--live" ]] ; then
   set_env "gov.uk"
+  export GOVUK_PROXY_STATIC_ENABLED=true
   export PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk}
 else
   echo "ERROR: other startup modes are not supported"


### PR DESCRIPTION
This sets the GOVUK_PROXY_STATIC_ENABLED env var to enable the proxy to Static in production. This is so the application continues, when Static changes to use relative URLs for assets. See https://github.com/alphagov/govuk_app_config/pull/261 and https://github.com/alphagov/govuk-puppet/pull/11801

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
