### PR TITLE
Fix Plek URL for Static in development

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
       "value": "https://www.gov.uk/api"
     },
     "PLEK_SERVICE_STATIC_URI": {
-      "value": "assets.digital.cabinet-office.gov.uk"
+      "value": "https://assets.publishing.service.gov.uk"
     },
     "RAILS_SERVE_STATIC_ASSETS": {
       "value": "yes"

--- a/startup.sh
+++ b/startup.sh
@@ -13,7 +13,7 @@ function set_env() {
 if [[ $1 == "--live" ]] ; then
   set_env "gov.uk"
   export GOVUK_PROXY_STATIC_ENABLED=true
-  export PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk}
+  export PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-https://assets.publishing.service.gov.uk}
 else
   echo "ERROR: other startup modes are not supported"
   echo ""


### PR DESCRIPTION
This updates the URLs to use the asset domain and use HTTPS. This
is required for the Static proxy to correctly forward request.
