### PR TITLE
[object Object] 'text' values for accordions on manual_section pages

### DIFF
--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -65,7 +65,7 @@
                       ga4: {
                         event_name: "select_content",
                         type: "accordion",
-                        text: item[:heading],
+                        text: item[:heading][:text],
                         index: index,
                         index_total: @content_item.main.length,
                       }


### PR DESCRIPTION
## What

Use only the `text` attribute of the object that is used to render the accordion headings on manual sections.

## Why

Currently, when the value arrives in Google Analytics (GA) the `ga4['text']` value is showing as `[object Object]` and not a simple string. Looking at the values within the HTML for the accordion, a sub-object is clearly visible (see before screenshot).

## Screenshot

| Before | After |
|---|---|
| <img width="1125" alt="Screenshot 2022-09-07 at 10 07 07" src="https://user-images.githubusercontent.com/44037625/188839990-5f79620b-d9d4-44e4-9591-f1a030394e87.png"> | <img width="1125" alt="Screenshot 2022-09-07 at 10 07 35" src="https://user-images.githubusercontent.com/44037625/188840026-389462ed-f78b-4b5e-a37c-2ae1eb08f485.png"> |

[Trello](https://trello.com/c/4WHhMr96/373-object-object-text-values-for-accordions-on-manualsection-pages)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
