### PR TITLE
Accordion `show/hide all sections` not working on manual pages

### DIFF
--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -61,7 +61,6 @@
 
                   {
                     data_attributes: {
-                      module: "ga4-event-tracker",
                       ga4: {
                         event_name: "select_content",
                         type: "accordion",
@@ -89,6 +88,9 @@
               <%= render "govuk_publishing_components/components/accordion", {
                 data_attributes_show_all: {
                   "ga4": ga4_attributes.to_json
+                },
+                data_attributes: {
+                  module: "ga4-event-tracker",
                 },
                 anchor_navigation: true,
                 items: items,

--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -28,6 +28,9 @@
           %>
           <%= render "govuk_publishing_components/components/accordion", {
             heading_level: 3,
+            data_attributes: {
+              module: "ga4-event-tracker",
+            },
             data_attributes_show_all: {
               "ga4": show_all_attributes.to_json
             },
@@ -46,7 +49,6 @@
               <% end
               {
                 data_attributes: {
-                  module: "ga4-event-tracker",
                   ga4: {
                     event_name: 'select_content',
                     type: 'accordion',


### PR DESCRIPTION
## What 

Add the `module` to the `data_attributes` hash within the accordion component.

## Why 

The `Show/hide all sections` part of the accordion on the manuals pages is not being tracked and the `dataLayer` push is not firing.

[Trello](https://trello.com/c/PiCNfSZq/374-datalayer-push-not-functioning-on-some-show-hide-all-sections-accordion-interactions)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
