### PR TITLE
Update links in Webchat README

### DIFF
--- a/docs/webchat.md
+++ b/docs/webchat.md
@@ -8,25 +8,23 @@ See the [reference implementation](https://github.com/alphagov/reference-webchat
 
 ## Usage
 
-The Webchat should be accessed through a shared [shared partial](https://github.com/alphagov/government-frontend/blob/957e3fb325eb3ff78b277ceb7054417849009756/app/views/shared/_webchat.html.erb) in which you need to pass the locals `webchat_availability_url` and `webchat_open_url`.
+The Webchat should be accessed through a shared [shared partial](https://github.com/alphagov/government-frontend/blob/main/app/views/shared/_webchat.html.erb) in which you need to pass the locals `webchat_availability_url` and `webchat_open_url`.
 
 `webchat_availability_url` will be polled at an interval to check for the webchat instances' avaliability.
 
 
-`webchat_open_url` is the page that will be opened when a user clicks the webchat call-to-action showm in the 'avaliable' state.
+`webchat_open_url` is the page that will be opened when a user clicks the webchat call-to-action shown in the 'avaliable' state.
 
 
-Finally once you have your partial rendering on the page, you will need to make sure the [library](https://github.com/alphagov/government-frontend/blob/957e3fb325eb3ff78b277ceb7054417849009756/app/assets/javascripts/webchat/library.js) is included on your page and this in your initialisation code.
+Finally once you have your partial rendering on the page, you will need to make sure the [library](https://github.com/alphagov/government-frontend/blob/main/app/assets/javascripts/webchat/library.js) is included on your page and this in your initialisation code.
 
+```javascript
+  var webchats = document.querySelectorAll('.js-webchat')
+  for (var i = 0; i < webchats.length; i++) {
+    new GOVUK.Webchat(webchats[i])
+  }
 ```
-  $('.js-webchat').map(function () {
-    return new GOVUK.Webchat({
-      $el: $(this),
-    })
-  })
-
-```
- a fuller example can be seen [here](https://github.com/alphagov/government-frontend/blob/957e3fb325eb3ff78b277ceb7054417849009756/app/assets/javascripts/webchat.js#L31-L41) that has an implementation of the normalisation as noted below
+ a fuller example can be seen [here](https://github.com/alphagov/government-frontend/blob/main/app/assets/javascripts/webchat.js) that has an implementation of the normalisation as noted below
 
 ### Note regarding response Normalisation
 As can be seen in the fuller example above, we currently have the option to do the normalisation in JavaScript, this is deprecated, and is shim code until all current users of Wbchat have their own proxies up and running.
@@ -48,7 +46,7 @@ Once this shim is removed we can move this component into Static as a GOV.UK Pub
 5. Finished
 
 ## CORS considerations
-To avoid CORS and CSP issues a new provider would need to be added to the Content Security Policy
+To avoid CORS and CSP issues a new provider would need to be added to the [Content Security Policy](https://docs.publishing.service.gov.uk/manual/content-security-policy.html)
 
 ## Required configuration
 


### PR DESCRIPTION
After talking to HMPO and their new service provider, it became clear that they were looking at an old version of the code for the Webchat implementation and quoting incorrect polling times etc.

Removing the link to a specific commit means that we are always linking to the current version of the code.
There is a risk that the file could move and the link could break, but if that seems a more acceptable risk than having to also update these docs if any of the hardcoded values change.

Also removes the jQuery example code and replaces it with vanilla Javascript as jQuery has been removed from all of the frontend GOV.UK applications and we don't want to encourage its return.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
