### PR TITLE
Remove unnecessary `mkdir /app` from Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,20 @@
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
- 
-FROM $builder_image AS builder
 
-RUN mkdir /app
+FROM $builder_image AS builder
 
 WORKDIR /app
 
-COPY Gemfile* .ruby-version /app/
-
+COPY Gemfile* .ruby-version ./
 RUN bundle install
 
 COPY . /app
-# TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
 RUN bundle exec rails assets:precompile && rm -rf /app/log
 
 
 FROM $base_image
 
+# TODO: remove PORT and set it in publishing-e2e-tests instead.
 ENV GOVUK_APP_NAME=government-frontend PORT=3090
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/


### PR DESCRIPTION
`WORKDIR` creates its directory anyway, and the mkdir fails now that we're creating `/app` in govuk-ruby-base. Thought I'd fixed all these before merging the change to govuk-ruby-base, but turns out I forgot to actually raise a bunch of the PRs that I'd prepared.