### PR TITLE
Use canonical name when connecting to search-api.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
     faker (2.23.0)
       i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
-    gds-api-adapters (83.0.0)
+    gds-api-adapters (84.0.0)
       addressable
       link_header
       null_logger

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -27,7 +27,7 @@ module Services
 
   def self.search_api
     @search_api = GdsApi::Search.new(
-      Plek.find("search"),
+      Plek.find("search-api"),
     )
   end
 end

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -38,7 +38,7 @@
           </tr>
           <tr>
             <td>Search</td>
-            <td><%= link_to remove_secrets(Plek.find('search')), remove_secrets(Plek.find('search')) %></td>
+            <td><%= link_to remove_secrets(Plek.find('search-api')), remove_secrets(Plek.find('search-api')) %></td>
           </tr>
         </table>
 

--- a/test/controllers/get_involved_controller_test.rb
+++ b/test/controllers/get_involved_controller_test.rb
@@ -96,7 +96,7 @@ class GetInvolvedControllerTest < ActionController::TestCase
 private
 
   def stub_search_query(query:, response:)
-    stub_request(:get, /\A#{Plek.new.find('search')}\/search.json/)
+    stub_request(:get, /\A#{Plek.new.find('search-api')}\/search.json/)
       .with(query:)
       .to_return(body: response.to_json)
   end


### PR DESCRIPTION
See alphagov/gds-api-adapters#1170 for context.