### PR TITLE
[TEST CONFIG] Update Webchat urls for HMPO contact page

### DIFF
--- a/app/models/webchat.rb
+++ b/app/models/webchat.rb
@@ -12,7 +12,7 @@ class Webchat
     @open_url = attrs["open_url"]
     @availability_url = attrs["availability_url"]
     @open_url_redirect = attrs["open_url_redirect"]
-    @csp_connect_src = attrs["csp_connect_src"]
+    @csp_connect_src = attrs["csp_connect_src"].split(",")
     validate!
   end
 

--- a/app/models/webchat.rb
+++ b/app/models/webchat.rb
@@ -12,7 +12,7 @@ class Webchat
     @open_url = attrs["open_url"]
     @availability_url = attrs["availability_url"]
     @open_url_redirect = attrs["open_url_redirect"]
-    @csp_connect_src = attrs["csp_connect_src"].split(",")
+    @csp_connect_src = attrs["csp_connect_src"]&.split(",")
     validate!
   end
 

--- a/lib/webchat.yaml
+++ b/lib/webchat.yaml
@@ -1,5 +1,5 @@
 - base_path: /government/organisations/hm-passport-office/contact/hm-passport-office-webchat
   open_url: https://d111an2s3izxxc.cloudfront.net/open/index.html
   availability_url: https://3mtmlaplvb.execute-api.eu-west-2.amazonaws.com/uat/availability/18529796
-  csp_connect_src: https://d111an2s3izxxc.cloudfront.net
+  csp_connect_src: https://d111an2s3izxxc.cloudfront.net,https://3mtmlaplvb.execute-api.eu-west-2.amazonaws.com
   open_url_redirect: false

--- a/lib/webchat.yaml
+++ b/lib/webchat.yaml
@@ -1,5 +1,5 @@
 - base_path: /government/organisations/hm-passport-office/contact/hm-passport-office-webchat
-  open_url: https://d111an2s3izxxc.cloudfront.net/open/4603493
-  availability_url: https://d111an2s3izxxc.cloudfront.net/availability/4603493
+  open_url: https://d111an2s3izxxc.cloudfront.net/open/index.html
+  availability_url: https://3mtmlaplvb.execute-api.eu-west-2.amazonaws.com/uat/availability/18529796
   csp_connect_src: https://d111an2s3izxxc.cloudfront.net
   open_url_redirect: false

--- a/lib/webchat.yaml
+++ b/lib/webchat.yaml
@@ -1,5 +1,5 @@
 - base_path: /government/organisations/hm-passport-office/contact/hm-passport-office-webchat
-  open_url: https://omni.eckoh.uk/v03.5/launcherV3.php?p=HMPO&d=717&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Chat&s=https://omni.eckoh.uk/v03.5&u=&wo=&uh=&pid=2&iif=0
-  availability_url: https://omni.eckoh.uk/v03.5/providers/HMPO/api/availability.php
-  csp_connect_src: https://omni.eckoh.uk
+  open_url: https://d111an2s3izxxc.cloudfront.net/open/4603493
+  availability_url: https://d111an2s3izxxc.cloudfront.net/availability/4603493
+  csp_connect_src: https://d111an2s3izxxc.cloudfront.net
   open_url_redirect: false

--- a/test/integration/contact_test.rb
+++ b/test/integration/contact_test.rb
@@ -65,7 +65,7 @@ class ContactTest < ActionDispatch::IntegrationTest
       "base_path" => "/content",
       "open_url" => "https://webchat.host/open",
       "availability_url" => "https://webchat.host/avaiable",
-      "csp_connect_src" => ["https://webchat.host", "https://webchat2.host"],
+      "csp_connect_src" => "https://webchat.host,https://webchat2.host",
     })
 
     Webchat.stubs(:find).returns(webchat)

--- a/test/integration/contact_test.rb
+++ b/test/integration/contact_test.rb
@@ -65,7 +65,7 @@ class ContactTest < ActionDispatch::IntegrationTest
       "base_path" => "/content",
       "open_url" => "https://webchat.host/open",
       "availability_url" => "https://webchat.host/avaiable",
-      "csp_connect_src" => "https://webchat.host",
+      "csp_connect_src" => ["https://webchat.host", "https://webchat2.host"],
     })
 
     Webchat.stubs(:find).returns(webchat)
@@ -77,6 +77,7 @@ class ContactTest < ActionDispatch::IntegrationTest
                      .each_with_object({}) { |directive, memo| memo[directive.first] = directive[1..] }
 
     assert_includes parsed_csp["connect-src"], "https://webchat.host"
+    assert_includes parsed_csp["connect-src"], "https://webchat2.host"
 
     # reset back to default driver
     Capybara.use_default_driver

--- a/test/models/webchat_test.rb
+++ b/test/models/webchat_test.rb
@@ -15,7 +15,7 @@ class WebchatTest < ActiveSupport::TestCase
     assert_equal(instance.base_path, webchat_config["base_path"])
     assert_equal(instance.open_url, webchat_config["open_url"])
     assert_equal(instance.availability_url, webchat_config["availability_url"])
-    assert_equal(instance.csp_connect_src, webchat_config["csp_connect_src"])
+    assert_equal(instance.csp_connect_src, [webchat_config["csp_connect_src"]])
   end
 
   test "should return error if config is invalid" do

--- a/test/presenters/contact_presenter_test.rb
+++ b/test/presenters/contact_presenter_test.rb
@@ -109,7 +109,7 @@ class ContactPresenterTest
       })
 
       Webchat.stubs(:find).returns(webchat)
-      assert_equal "https://webchat.host", presented_item.csp_connect_src
+      assert_equal ["https://webchat.host"], presented_item.csp_connect_src
     end
 
     test "returns a csp_connect_src of nil if webchat isn't configured" do


### PR DESCRIPTION
Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5053254

The urls provided are for testing against the integration environment.

Trello Card: https://trello.com/c/qkzOuOJc/2155-help-hmpo-set-up-new-webchat-provider

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
