### PR TITLE
switch from using dummy content store to using gov api

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
       "value": "true"
     },
     "PLEK_SERVICE_CONTENT_STORE_URI": {
-      "value": "https://govuk-content-store-examples.herokuapp.com/api"
+      "value": "https://www.gov.uk/api"
     },
     "PLEK_SERVICE_RUMMAGER_URI": {
       "value": "https://www.gov.uk/api"

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -42,36 +42,6 @@
           </tr>
         </table>
 
-        <h2>Examples</h2>
-
-        <p>
-          The content schemas contain <%= link_to 'handmade examples', 'https://github.com/alphagov/govuk-content-schemas/tree/master/examples' %>
-          for each schema rendered by this app. These are used in tests.
-        </p>
-
-        <p>
-          If this application is pointed at the <%= link_to 'dummy content store', 'https://github.com/alphagov/govuk-content-schemas/blob/master/docs/running-frontend-against-examples.md' %>
-          you can use the links below to view pages using the examples. For a
-          full list of examples, see <%= link_to 'govspeak-examples guide', 'https://govuk-content-store-examples.herokuapp.com' %>.
-        </p>
-        <table>
-          <% @schema_names.each do |schema_name| %>
-            <tr>
-              <td>
-                <%= schema_name %>
-              </td>
-              <td>
-                <%= link_to "Canonical example", "/examples/#{schema_name}/#{schema_name}" %>*
-              </td>
-              <td>
-                <%= link_to "Random example", "/examples/#{schema_name}/random" %>*
-              </td>
-            </tr>
-          <% end %>
-        </table>
-
-        * Will only work if this app is pointed at the <%= link_to 'dummy content store', 'https://github.com/alphagov/govuk-content-schemas/blob/master/docs/running-frontend-against-examples.md' %>.
-
         <h2>Examples from GOV.UK</h2>
 
         <p>These pages are good examples of the types of pages rendered by this application.</p>


### PR DESCRIPTION
We are retiring the dummy content store as part of replatforming work, making it easier for us to deploy content schemas in the new world. Switching to using gov.uk/api for PLEK_SERVICE_CONTENT_STORE_URI brings us this application in line with most other applications.

This brings this application in line with most other frontend applications, e.g. [collections](https://github.com/alphagov/collections/blob/e983dc77e4239bff031b33088b54c9f34f387216/app.json#L15)

This PR also removes the dummy content store examples from the PR index page. Instead, the examples from the live site which are found on the same page can be used.

[Trello](https://trello.com/c/z08hU3Ov/360-retire-the-dummy-content-store)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
