### PR TITLE
Refactor single page notification button logic prior to adding new functionality

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -138,7 +138,7 @@ private
 
     # use these and `@content_item.base_path` in the template
     @notification_button_visible = @content_item.has_single_page_notifications?
-    @include_single_page_notification_button_js = account_session_header.present?
+    @has_govuk_account = account_session_header.present?
 
     request.variant = :print if params[:variant] == "print"
 

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -136,8 +136,7 @@ private
       return
     end
 
-    # use these and `@content_item.base_path` in the template
-    @notification_button_visible = @content_item.has_single_page_notifications?
+    # use this and `@content_item.base_path` in the template
     @has_govuk_account = account_session_header.present?
 
     request.variant = :print if params[:variant] == "print"

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -6,6 +6,7 @@ class ConsultationPresenter < ContentItemPresenter
   include ContentItem::Shareable
   include ContentItem::TitleAndContext
   include ContentItem::Attachments
+  include ContentItem::SinglePageNotificationButton
 
   def opening_date_time
     content_item["details"]["opening_date"]

--- a/app/presenters/content_item/single_page_notification_button.rb
+++ b/app/presenters/content_item/single_page_notification_button.rb
@@ -8,14 +8,8 @@ module ContentItem
       5f9c6c15-7631-11e4-a3cb-005056011aef
     ].freeze
 
-    ALLOWED_DOCUMENT_TYPES = %w[
-      publication
-      detailed_guide
-      consultation
-    ].freeze
-
     def has_single_page_notifications?
-      (!EXEMPTION_LIST.include? content_item["content_id"]) && (ALLOWED_DOCUMENT_TYPES.include? content_item["schema_name"])
+      !EXEMPTION_LIST.include? content_item["content_id"]
     end
   end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,6 +1,5 @@
 class ContentItemPresenter
   include ContentItem::Withdrawable
-  include ContentItem::SinglePageNotificationButton
   attr_reader :content_item,
               :requested_path,
               :view_context,
@@ -44,6 +43,10 @@ class ContentItemPresenter
   end
 
   def requesting_a_service_sign_in_page?
+    false
+  end
+
+  def has_single_page_notifications?
     false
   end
 

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -5,6 +5,7 @@ class DetailedGuidePresenter < ContentItemPresenter
   include ContentItem::NationalApplicability
   include ContentItem::Political
   include ContentItem::TitleAndContext
+  include ContentItem::SinglePageNotificationButton
 
   def title_and_context
     super.tap do |t|

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -4,6 +4,7 @@ class PublicationPresenter < ContentItemPresenter
   include ContentItem::NationalStatisticsLogo
   include ContentItem::Political
   include ContentItem::Attachments
+  include ContentItem::SinglePageNotificationButton
 
   def details
     content_item["details"]["body"]

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -14,6 +14,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo', content_item: @content_item %>
+<%= render 'shared/single_page_notification_button', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component %>
 

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -68,6 +68,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'shared/single_page_notification_button', content_item: @content_item %>
 
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -22,6 +22,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
+<%= render 'shared/single_page_notification_button', content_item: @content_item %>
 
 <%= render 'shared/history_notice', content_item: @content_item %>
 

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -9,4 +9,4 @@
     js_enhancement: @has_govuk_account,
     button_location: "bottom",
     margin_bottom: 0,
-} if @notification_button_visible %>
+} if @content_item.has_single_page_notifications? %>

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -6,7 +6,7 @@
   } %>
 <%= render 'govuk_publishing_components/components/single_page_notification_button', {
     base_path: @content_item.base_path,
-    js_enhancement: @include_single_page_notification_button_js,
+    js_enhancement: @has_govuk_account,
     button_location: "bottom",
     margin_bottom: 0,
 } if @notification_button_visible %>

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -16,10 +16,3 @@
     </div>
   </div>
 </div>
-
-<%= render 'govuk_publishing_components/components/single_page_notification_button', {
-  base_path: @content_item.base_path,
-  js_enhancement: @include_single_page_notification_button_js,
-  margin_bottom: 6,
-  button_location: "top",
-} if @notification_button_visible %>

--- a/app/views/shared/_single_page_notification_button.html.erb
+++ b/app/views/shared/_single_page_notification_button.html.erb
@@ -1,0 +1,6 @@
+<%= render 'govuk_publishing_components/components/single_page_notification_button', {
+  base_path: @content_item.base_path,
+  js_enhancement: @has_govuk_account,
+  margin_bottom: 6,
+  button_location: "top",
+} if @notification_button_visible %>

--- a/app/views/shared/_single_page_notification_button.html.erb
+++ b/app/views/shared/_single_page_notification_button.html.erb
@@ -3,4 +3,4 @@
   js_enhancement: @has_govuk_account,
   margin_bottom: 6,
   button_location: "top",
-} if @notification_button_visible %>
+} if @content_item.has_single_page_notifications? %>

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -149,5 +149,12 @@ class ConsultationPresenterTest
       assert_equal "https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.test.gov.uk%2Fgovernment%2Fconsultations%2Fpostgraduate-doctoral-loans", presented_item("open_consultation").share_links[0][:href]
       assert_equal "https://twitter.com/share?url=https%3A%2F%2Fwww.test.gov.uk%2Fgovernment%2Fconsultations%2Fpostgraduate-doctoral-loans&text=Postgraduate%20doctoral%20loans", presented_item("open_consultation").share_links[1][:href]
     end
+
+    test "presents the single page notification button" do
+      schema = schema_item("open_consultation")
+      presented = presented_item("open_consultation", schema)
+
+      assert presented.has_single_page_notifications?
+    end
   end
 end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -83,4 +83,9 @@ class DetailedGuidePresenterTest < PresenterTestCase
     }
     assert_equal presented.logo, expected
   end
+
+  test "presents the single page notification button" do
+    presented = presented_item("national_applicability_detailed_guide")
+    assert presented.has_single_page_notifications?
+  end
 end

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -74,4 +74,9 @@ class PublicationPresenterTest < PresenterTestCase
     assert_equal(presented.national_applicability[:wales][:applicable], false)
     assert_equal(presented.national_applicability[:wales][:alternative_url], "http://wales.gov.uk/topics/statistics/headlines/housing2012/121025/?lang=en")
   end
+
+  test "presents the single page notification button" do
+    presented = presented_item("statistics_publication")
+    assert presented.has_single_page_notifications?
+  end
 end


### PR DESCRIPTION
There are no user facing changes here, it's just a reorganisation of the existing code. 

We will soon be wanting to add the button to a new document type (document collections) with custom button text, so doing a bit of a tidy up first to make the code easier to extend.

See commit messages for more detail.

https://trello.com/c/gpch42Uc/1456-enable-custom-text-for-the-single-page-notification-button-component-l

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
