### PR TITLE
Update for event tracker changes

### DIFF
--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -88,10 +88,10 @@
           module: "ga4-event-tracker",
           ga4_event: {
             event_name: 'print_page',
-            type: 'Print this page',
+            type: 'print page',
             index: 1,
             index_total: 2,
-            section: 'Contents',
+            section: 'Content',
           },
         },
       } %>
@@ -111,7 +111,7 @@
           module: "ga4-event-tracker",
           ga4_event: {
             event_name: 'print_page',
-            type: 'Print this page',
+            type: 'print page',
             index: 2,
             index_total: 2,
             section: 'Footer',

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -86,7 +86,7 @@
         margin_bottom: 6,
         data_attributes: {
           module: "ga4-event-tracker",
-          ga4: {
+          ga4_event: {
             event_name: 'print_page',
             type: 'Print this page',
             index: 1,
@@ -109,7 +109,7 @@
         margin_bottom: 6,
         data_attributes: {
           module: "ga4-event-tracker",
-          ga4: {
+          ga4_event: {
             event_name: 'print_page',
             type: 'Print this page',
             index: 2,

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -25,7 +25,7 @@
         "track-category": "printButton",
         "track-action": "clicked",
         "track-label": t("components.print_link.text"),
-        ga4: {
+        ga4_event: {
           event_name: 'print_page',
           type: 'Print this page',
           index: 1,
@@ -56,7 +56,7 @@
         "track-category": "printButton",
         "track-action": "clicked",
         "track-label": t("components.print_link.text"),
-        ga4: {
+        ga4_event: {
           event_name: 'print_page',
           type: 'Print this page',
           index: 2,

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -27,10 +27,10 @@
         "track-label": t("components.print_link.text"),
         ga4_event: {
           event_name: 'print_page',
-          type: 'Print this page',
+          type: 'print page',
           index: 1,
           index_total: 2,
-          section: 'Contents',
+          section: 'Content',
         },
       },
       margin_bottom: 8,
@@ -58,7 +58,7 @@
         "track-label": t("components.print_link.text"),
         ga4_event: {
           event_name: 'print_page',
-          type: 'Print this page',
+          type: 'print page',
           index: 2,
           index_total: 2,
           section: 'Footer',

--- a/app/views/content_items/hmrc_manual.html.erb
+++ b/app/views/content_items/hmrc_manual.html.erb
@@ -27,7 +27,7 @@
   <%= render 'govuk_publishing_components/components/print_link', {
     data_attributes: {
       module: "ga4-event-tracker",
-      ga4: {
+      ga4_event: {
         event_name: 'print_page',
         type: 'Print this page',
         index: 1,

--- a/app/views/content_items/hmrc_manual.html.erb
+++ b/app/views/content_items/hmrc_manual.html.erb
@@ -29,7 +29,7 @@
       module: "ga4-event-tracker",
       ga4_event: {
         event_name: 'print_page',
-        type: 'Print this page',
+        type: 'print page',
         index: 1,
         index_total: 1,
         section: 'Footer',

--- a/app/views/content_items/hmrc_manual_section.html.erb
+++ b/app/views/content_items/hmrc_manual_section.html.erb
@@ -48,7 +48,7 @@
   <%= render 'govuk_publishing_components/components/print_link', {
     data_attributes: {
       module: "ga4-event-tracker",
-      ga4: {
+      ga4_event: {
         event_name: 'print_page',
         type: 'Print this page',
         index: 1,

--- a/app/views/content_items/hmrc_manual_section.html.erb
+++ b/app/views/content_items/hmrc_manual_section.html.erb
@@ -50,7 +50,7 @@
       module: "ga4-event-tracker",
       ga4_event: {
         event_name: 'print_page',
-        type: 'Print this page',
+        type: 'print page',
         index: 1,
         index_total: 1,
         section: 'Footer',

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -60,7 +60,7 @@
           margin_bottom: 6,
           data_attributes: {
             module: "ga4-event-tracker",
-            ga4: {
+            ga4_event: {
               event_name: 'print_page',
               type: 'Print this page',
               index: 1,

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -62,10 +62,10 @@
             module: "ga4-event-tracker",
             ga4_event: {
               event_name: 'print_page',
-              type: 'Print this page',
+              type: 'print page',
               index: 1,
               index_total: 1,
-              section: 'Contents',
+              section: 'Content',
             },
           },
         } %>

--- a/app/views/content_items/manual.html.erb
+++ b/app/views/content_items/manual.html.erb
@@ -36,7 +36,7 @@
   <%= render 'govuk_publishing_components/components/print_link', {
     data_attributes: {
       module: "ga4-event-tracker",
-      ga4: {
+      ga4_event: {
         event_name: 'print_page',
         type: 'Print this page',
         index: 1,

--- a/app/views/content_items/manual.html.erb
+++ b/app/views/content_items/manual.html.erb
@@ -38,7 +38,7 @@
       module: "ga4-event-tracker",
       ga4_event: {
         event_name: 'print_page',
-        type: 'Print this page',
+        type: 'print page',
         index: 1,
         index_total: 1,
         section: 'Footer',

--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -61,7 +61,7 @@
 
                   {
                     data_attributes: {
-                      ga4: {
+                      ga4_event: {
                         event_name: "select_content",
                         type: "accordion",
                         text: item[:heading][:text],
@@ -77,21 +77,8 @@
                 end
               %>
 
-              <%
-                ga4_attributes = {
-                  event_name: "select_content",
-                  type: "accordion",
-                  index: 0,
-                  index_total: @content_item.main.length,
-                }
-              %>
               <%= render "govuk_publishing_components/components/accordion", {
-                data_attributes_show_all: {
-                  "ga4": ga4_attributes.to_json
-                },
-                data_attributes: {
-                  module: "ga4-event-tracker",
-                },
+                ga4_tracking: true,
                 anchor_navigation: true,
                 items: items,
               } %>
@@ -105,7 +92,7 @@
   <%= render 'govuk_publishing_components/components/print_link', {
     data_attributes: {
       module: "ga4-event-tracker",
-      ga4: {
+      ga4_event: {
         event_name: 'print_page',
         type: 'Print this page',
         index: 1,

--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -94,7 +94,7 @@
       module: "ga4-event-tracker",
       ga4_event: {
         event_name: 'print_page',
-        type: 'Print this page',
+        type: 'print page',
         index: 1,
         index_total: 1,
         section: 'Footer',

--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -64,7 +64,7 @@
     module: "ga4-event-tracker",
     ga4_event: {
       event_name: 'print_page',
-      type: 'Print this page',
+      type: 'print page',
       index: 1,
       index_total: 1,
       section: 'Footer',

--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -18,22 +18,9 @@
             font_size: "l"
           } %>
 
-          <%
-            show_all_attributes = {
-              event_name: "select_content",
-              type: "accordion",
-              index: 0,
-              index_total: updates_by_year.length,
-            }
-          %>
           <%= render "govuk_publishing_components/components/accordion", {
             heading_level: 3,
-            data_attributes: {
-              module: "ga4-event-tracker",
-            },
-            data_attributes_show_all: {
-              "ga4": show_all_attributes.to_json
-            },
+            ga4_tracking: true,
             items: updates_by_year.each.with_index(1).map do |updated_documents, index|
               accordion_content = capture do %>
                 <% change_notes = updated_documents.last %>
@@ -49,7 +36,7 @@
               <% end
               {
                 data_attributes: {
-                  ga4: {
+                  ga4_event: {
                     event_name: 'select_content',
                     type: 'accordion',
                     text: sanitize_manual_update_title(updated_documents.first),
@@ -75,7 +62,7 @@
 <%= render 'govuk_publishing_components/components/print_link', {
   data_attributes: {
     module: "ga4-event-tracker",
-    ga4: {
+    ga4_event: {
       event_name: 'print_page',
       type: 'Print this page',
       index: 1,

--- a/app/views/content_items/travel_advice.html+print.erb
+++ b/app/views/content_items/travel_advice.html+print.erb
@@ -26,10 +26,10 @@
         "track-label": t("components.print_link.text"),
         ga4_event: {
           event_name: 'print_page',
-          type: 'Print this page',
+          type: 'print page',
           index: 1,
           index_total: 2,
-          section: 'Contents',
+          section: 'Content',
         },
       },
       margin_bottom: 8,
@@ -58,7 +58,7 @@
         "track-label": t("components.print_link.text"),
         ga4_event: {
           event_name: 'print_page',
-          type: 'Print this page',
+          type: 'print page',
           index: 2,
           index_total: 2,
           section: 'Footer',

--- a/app/views/content_items/travel_advice.html+print.erb
+++ b/app/views/content_items/travel_advice.html+print.erb
@@ -24,7 +24,7 @@
         "track-category": "printButton",
         "track-action": "clicked",
         "track-label": t("components.print_link.text"),
-        ga4: {
+        ga4_event: {
           event_name: 'print_page',
           type: 'Print this page',
           index: 1,
@@ -56,7 +56,7 @@
         "track-category": "printButton",
         "track-action": "clicked",
         "track-label": t("components.print_link.text"),
-        ga4: {
+        ga4_event: {
           event_name: 'print_page',
           type: 'Print this page',
           index: 2,


### PR DESCRIPTION
**NOT TO BE MERGED unless also including the [new version of the components gem](https://github.com/alphagov/govuk_publishing_components/pull/3091) that includes the changes detailed below**

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Update references to GA4 event tracker to cope with breaking changes introduced in https://github.com/alphagov/govuk_publishing_components/pull/3057

- GA4 event tracker has been rewritten to use a `data-ga-event` attribute in place of `data-ga4`
- updating for tracking on various pages for print link

Pages affected:

- detailed guides ([example detailed guide](https://www.gov.uk/guidance/register-a-trust-as-a-trustee))
- guides ([example guide](https://www.gov.uk/change-address-driving-licence/print))
- HMRC manuals ([example manual](https://www.gov.uk/hmrc-internal-manuals/employment-income-manual) and [example manual section](https://www.gov.uk/hmrc-internal-manuals/employment-income-manual/eim00100) and [example updates page](https://www.gov.uk/hmrc-internal-manuals/trust-registration-service-manual/updates))
- HTML publication ([example HTML publication](https://www.gov.uk/government/publications/budget-2016-documents/budget-2016))
- manuals ([example manual section](https://www.gov.uk/guidance/the-highway-code/general-rules-techniques-and-advice-for-all-drivers-and-riders-103-to-158) and [example manual](https://www.gov.uk/guidance/academy-trust-handbook))
- travel advice ([example travel advice](https://www.gov.uk/foreign-travel-advice/usa/print))

Also updates print link tracking for GA4 - minor change in the values passed.

## Visual changes
None.

Trello cards: 

- https://trello.com/c/uMgCIdtY/289-update-link-tracking
- https://trello.com/c/QFQG5IKA/363-change-some-values-on-printpage-events
