### PR TITLE
Create basic page for Worldwide Organisations in government-frontend

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -91,3 +91,4 @@ $govuk-include-default-font-face: false;
 @import "views/help-page";
 @import "views/guide";
 @import "views/manual";
+@import "views/worldwide-organisation";

--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -1,0 +1,10 @@
+.worldwide-organisation-header {
+  margin-top: 12px;
+  margin-bottom: 12px;
+
+  .logo {
+    @include govuk-media-query($from: tablet) {
+      margin-top: 12px;
+    }
+  }
+}

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -1,0 +1,2 @@
+class WorldwideOrganisationPresenter < ContentItemPresenter
+end

--- a/app/views/content_items/worldwide_organisation.html.erb
+++ b/app/views/content_items/worldwide_organisation.html.erb
@@ -1,0 +1,18 @@
+<header class="worldwide-organisation-header govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds logo">
+    <%= render 'govuk_publishing_components/components/organisation_logo', {
+      organisation: {
+        name: @content_item.title,
+        crest: "single-identity",
+      },
+      heading_level: 1,
+      inline: true,
+    } %>
+  </div>
+</header>
+
+<section class="govuk-grid-row" id="about-us">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
+  </div>
+</section>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -792,3 +792,18 @@ ar:
   working_group:
     contact_details: تفاصيل جهة الاتصال
     policies: سياسات
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: تعرف على %{link}.
+      personal_information_charter_html: يوضح %{link} كيف نتعامل مع معلوماتك الشخصية.
+      publication_scheme_html: اقرأ عن أنواع المعلومات التي ننشرها بشكل روتيني في %{link}.
+      social_media_use_html: اقرأ سياستنا على %{link}.
+      welsh_language_scheme_html: تعرف على التزامنا بشأن %{link}.
+    find_out_more: اطلع على الملف الكامل وجميع تفاصيل الاتصال
+    headings:
+      contact_us: اتصل بنا
+      corporate_information: معلومات الشركة
+      follow_us: تابعنا
+      our_people: موظفونا
+    location: الموقع
+    part_of: جزء من

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -492,3 +492,18 @@ az:
   working_group:
     contact_details: Əlaqə məlumatları
     policies: Siyasətlər
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Öyrənin %{link}.
+      personal_information_charter_html: Bizim %{link} şəxsi məlumatlarınızla necə davrandığımızı izah edir.
+      publication_scheme_html: "%{link}-də adətən istifadə etdiyimiz məlumatların növləri barədə oxuyun."
+      social_media_use_html: "%{link}-də siyasətmizi oxuyun."
+      welsh_language_scheme_html: "%{link} ilə bağlı öhdəliyimiz barədə öyrənin."
+    find_out_more: Tam profil və əlaqə məlumatlarımıza baxın
+    headings:
+      contact_us: Bizimlə əlaqə saxlayın
+      corporate_information: Korporativ məlumat
+      follow_us: Bizi təqib edin
+      our_people: İnsanlarımız
+    location: Yer
+    part_of: Dövlət orqanının

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -642,3 +642,18 @@ be:
   working_group:
     contact_details: Кантактныя дадзеныя
     policies: Напрамкі дзейнасці
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Даведайцеся %{link}.
+      personal_information_charter_html: Наша %{link} тлумачыць, як мы ставімся да Вашай асабістай інфармацыі.
+      publication_scheme_html: Чытайце пра тыпы інфармацыі, якую мы рэгулярна публікуем, у нашым %{link}.
+      social_media_use_html: Прачытайце пра нашу палітыку датычна %{link}.
+      welsh_language_scheme_html: Даведайцеся аб нашых абавязках да публікацыі ў %{link}.
+    find_out_more: Паглядзець усю інфармацыю і кантактныя дадзеныя
+    headings:
+      contact_us: Звяжыцеся з намі
+      corporate_information: Карпаратыўная іфармацыя
+      follow_us: Сачыце за намі
+      our_people: Нашы людзі
+    location: Месцазнаходжанне
+    part_of: Частка

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -492,3 +492,18 @@ bg:
   working_group:
     contact_details: Данни за контакти
     policies: Политики
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Научете повече за %{link}.
+      personal_information_charter_html: В нашия %{link} е обяснено как работим с личната информация.
+      publication_scheme_html: Прочетете за видовете информация, които обичайно публикуваме на нашата %{link}.
+      social_media_use_html: Прочетете нашите правила на %{link}.
+      welsh_language_scheme_html: Научете повече за нашия ангажимент към %{link}.
+    find_out_more: Вижте пълния профил и всички данни за контакт
+    headings:
+      contact_us: Свържете се с нас
+      corporate_information: Фирмена информация
+      follow_us: Следвайте ни
+      our_people: Нашият народ
+    location: Местоположение
+    part_of: Част от

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -492,3 +492,18 @@ bn:
   working_group:
     contact_details: যোগাযোগের বিস্তারিত তথ্য
     policies: নীতিমালা
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: "%{link} খুঁজুন।"
+      personal_information_charter_html: আমরা কিভাবে আপনার ব্যক্তিগত তথ্য নিয়ে কাজ করি তা আমাদের %{link}-এ ব্যাখ্যা করা হয়েছে।
+      publication_scheme_html: আমরা নিয়মিতভাবে যে প্রকারের সংবাদ প্রকাশ করি তা আমাদের %{link}-এ পড়ুন।
+      social_media_use_html: "%{link}-এ আমাদের নীতিমালা পড়ুন।"
+      welsh_language_scheme_html: "%{link}-এ আপনার আমাদের অঙ্গীকার সম্পর্কে জানুন।"
+    find_out_more: সম্পূর্ণ প্রোফাইল ও সকল কন্টাক্টের বিস্তারিত তথ্য দেখুন
+    headings:
+      contact_us: আমাদের সাথে যোগাযোগ
+      corporate_information: কর্পোরেট তথ্য
+      follow_us: আমাদেরকে অনুসরণ করুন
+      our_people: আমাদের লোকজন
+    location: অবস্থান
+    part_of: এর অংশ

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -567,3 +567,18 @@ cs:
   working_group:
     contact_details: Kontaktní údaje
     policies: Politik
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Zjistěte %{link}.
+      personal_information_charter_html: Náš %{link} vysvětluje, jak nakládáme s vašimi osobními údaji.
+      publication_scheme_html: Přečtěte si, jaké informace běžně zveřejňujeme v našem %{link}.
+      social_media_use_html: Přečtěte si naše zásady na %{link}.
+      welsh_language_scheme_html: Přečtěte si o našem závazku k %{link}.
+    find_out_more: Zobrazit celý profil a všechny kontaktní údaje
+    headings:
+      contact_us: Kontaktujte nás
+      corporate_information: Firemní informace
+      follow_us: Sledujte nás
+      our_people: Naši lidé
+    location: Sídlo
+    part_of: Část

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -792,3 +792,18 @@ cy:
   working_group:
     contact_details: Manylion cyswllt
     policies: Polisïau
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Darganfod %{link}.
+      personal_information_charter_html: Mae ein %{link} yn esbonio sut rydyn ni'n ymdrin â'ch gwybodaeth bersonol.
+      publication_scheme_html: Darllenwch am y mathau o wybodaeth rydyn ni'n eu cyhoeddi'n rheolaidd yn ein %{link}.
+      social_media_use_html: Darllenwch ein polisi ar %{link}.
+      welsh_language_scheme_html: Dysgwch am ein hymrwymiad i %{link}.
+    find_out_more: Gweler y proffil llawn a'r holl fanylion cyswllt
+    headings:
+      contact_us: Cysylltu â ni
+      corporate_information: Gwybodaeth gorfforaethol
+      follow_us: Dilynwch ni
+      our_people: Ein pobl
+    location: Lleoliad
+    part_of: Rhan o

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -504,3 +504,18 @@ da:
   working_group:
     contact_details: Kontaktoplysninger
     policies: Politikker
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Find ud af %{link}.
+      personal_information_charter_html: Vores %{link} forklarer, hvordan vi behandler dine personlige oplysninger.
+      publication_scheme_html: Læs om de typer af oplysninger, som vi rutinemæssigt offentliggør i vores %{link}.
+      social_media_use_html: Læs vores politik om %{link}.
+      welsh_language_scheme_html: Learn more about our commitment to% {link}.
+    find_out_more: Se hele profilen og alle kontaktoplysninger
+    headings:
+      contact_us: Kontakt os
+      corporate_information: Virksomhedsoplysninger
+      follow_us: Følg os
+      our_people: Vores folk
+    location: Placering
+    part_of: del af

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -492,3 +492,18 @@ de:
   working_group:
     contact_details: Kontaktdaten
     policies: Richtlinien
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Finden Sie es heraus %{link}.
+      personal_information_charter_html: Unsere %{link} erläutert, wie wir mit Ihren persönlichen Daten umgehen.
+      publication_scheme_html: Lesen Sie in unserem %{link}, welche Arten von Informationen wir regelmäßig veröffentlichen.
+      social_media_use_html: Lesen Sie unsere Richtlinie zu %{link}.
+      welsh_language_scheme_html: Informieren Sie sich über unser Engagement für %{link}.
+    find_out_more: Vollständiges Profil und alle Kontaktdaten anzeigen
+    headings:
+      contact_us: Kontaktieren Sie uns
+      corporate_information: Unternehmensinformationen
+      follow_us: Folgen Sie uns
+      our_people: Unsere Mitarbeiter
+    location: Standort
+    part_of: Teil von

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -495,3 +495,18 @@ dr:
   working_group:
     contact_details: جزیٔیات تماس
     policies: سیاست ها
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: بیابید%{link}.
+      personal_information_charter_html: ما%{link}نحوهء برخورد ما با اطلاعات شخصی شما را بیان مینماید
+      publication_scheme_html: 'دربارهٔ اطلاعاتی که به طور معمول در%{link} نشر مینماییم، بخوانید '
+      social_media_use_html: سیایت مارا در%{link} بخوانید
+      welsh_language_scheme_html: در مورد تعهدات ما به%{link} بدانید
+    find_out_more: تمام پروفایل و جزیٔیات تماس با ما را مشاهده نماید
+    headings:
+      contact_us: با ما به تماس شوید
+      corporate_information: اطلاعات شرکت
+      follow_us: مارا دنبال نمایید
+      our_people: مردم ما
+    location: موقعیت
+    part_of: بخشی از

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -492,3 +492,18 @@ el:
   working_group:
     contact_details: Στοιχεία επικοινωνίας
     policies: Πολιτικές
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Μάθετε %{link}.
+      personal_information_charter_html: Το %{link} εξηγεί πώς αντιμετωπίζουμε τα προσωπικά σας στοιχεία.
+      publication_scheme_html: Διαβάστε σχετικά με τους τύπους πληροφοριών που δημοσιεύουμε συνήθως στο %{link}.
+      social_media_use_html: Διαβάστε την πολιτική μας στο %{link}.
+      welsh_language_scheme_html: Μάθετε για τη δέσμευσή μας στο %{link}.
+    find_out_more: Δείτε το πλήρες προφίλ και όλα τα στοιχεία επικοινωνίας
+    headings:
+      contact_us: Επικοινωνήστε μαζί μας
+      corporate_information: Εταιρικές πληροφορίες
+      follow_us: Ακολουθήστε μας
+      our_people: Οι άνθρωποί μας
+    location: Τοποθεσία
+    part_of: Μέρος του

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -492,3 +492,18 @@ en:
   working_group:
     contact_details: Contact details
     policies: Policies
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Find out %{link}.
+      personal_information_charter_html: Our %{link} explains how we treat your personal information.
+      publication_scheme_html: Read about the types of information we routinely publish in our %{link}.
+      social_media_use_html: Read our policy on %{link}.
+      welsh_language_scheme_html: Find out about our commitment to %{link}.
+    find_out_more: See full profile and all contact details
+    headings:
+      contact_us: Contact us
+      corporate_information: Corporate information
+      follow_us: Follow us
+      our_people: Our people
+    location: Location
+    part_of: Part of

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -492,3 +492,18 @@ es-419:
   working_group:
     contact_details: Datos de contacto
     policies: Normativas
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Conozca %{link}.
+      personal_information_charter_html: Nuestro %{link} explica cómo manejamos su información personal.
+      publication_scheme_html: Lea los tipos de información que publicamos habitualmente en nuestro %{link}.
+      social_media_use_html: Lea nuestra normativa en %{link}.
+      welsh_language_scheme_html: Conozca nuestro compromiso con %{link}.
+    find_out_more: Ver el perfil completo y todos los datos de contacto
+    headings:
+      contact_us: Contáctenos
+      corporate_information: Información corporativa
+      follow_us: Síguenos
+      our_people: Nuestra gente
+    location: Ubicación
+    part_of: Parte de

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -492,3 +492,18 @@ es:
   working_group:
     contact_details: Datos de contacto
     policies: Políticas
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Descubra %{link}.
+      personal_information_charter_html: El siguiente enlace %{link} explica cómo tratamos tu información personal
+      publication_scheme_html: Lea acerca del tipo de información que publicamos en el siguiente enlace %{link}.
+      social_media_use_html: Lea nuestra política en %{link}.
+      welsh_language_scheme_html: Encuentre más sobre nuestro compromiso de publicar en %{link}.
+    find_out_more: Vea el perfil completo y los detalles de contacto
+    headings:
+      contact_us: Contáctenos
+      corporate_information: Información corporativa
+      follow_us: Síguenos
+      our_people: Nuestro equipo
+    location: Estamos
+    part_of: Parte de

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -492,3 +492,18 @@ et:
   working_group:
     contact_details: Kontaktandmed
     policies: Eeskirjad
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Uuri välja %{link}.
+      personal_information_charter_html: Meie %{link} selgitab, kuidas me teie isikuandmeid käsitleme.
+      publication_scheme_html: Lisateavet selle kohta, millist teavet me regulaarselt avaldame oma saidil %{link}.
+      social_media_use_html: Lugege meie eeskirju saidil %{link}.
+      welsh_language_scheme_html: Lisateave meie pühendumuse kohta %{link}.
+    find_out_more: Vaata kogu profiili ja kõiki kontaktandmeid
+    headings:
+      contact_us: Võtke meiega ühendust
+      corporate_information: Ettevõtte teave
+      follow_us: Jälgige meid
+      our_people: Meie inimesed
+    location: Asukoht
+    part_of: Osa

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -492,3 +492,18 @@ fa:
   working_group:
     contact_details: جزئیات اطلاعات تماس
     policies: سیاست ها
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: اطلاعات کسب کنید %{link}.
+      personal_information_charter_html: "%{link} نحوه رفتار ما با اطلاعات شخصی شما را توضیح می‌دهد."
+      publication_scheme_html: درباره انواع اطلاعاتی که معمولاً در %{link} خود منتشر می‌کنیم، اطلاعات بیشتری کسب کنید.
+      social_media_use_html: سیاست ما را درباره %{link} مطالعه کنید.
+      welsh_language_scheme_html: درباره تعهد ما نسبت به %{link} اطلاعات کسب کنید.
+    find_out_more: مشاهده پروفایل کامل و تمام جزئیات تماس
+    headings:
+      contact_us: تماس با ما
+      corporate_information: اطلاعات شرکت
+      follow_us: ما را دنبال کنید
+      our_people: افراد ما
+    location: موقعیت مکانی
+    part_of: بخشی از

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -492,3 +492,18 @@ fi:
   working_group:
     contact_details: Yhteystiedot
     policies: Käytännöt
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Ota selvää %{link}.
+      personal_information_charter_html: "%{link} selittää, miten käsittelemme henkilötietojasi."
+      publication_scheme_html: Lue, millaisia tietoja julkaisemme rutiininomaisesti %{link}.
+      social_media_use_html: Lue käytäntömme osoitteesta %{link}.
+      welsh_language_scheme_html: Tutustu sitoumukseemme %{link}.
+    find_out_more: Katso koko profiili ja kaikki yhteystiedot
+    headings:
+      contact_us: Ota yhteyttä
+      corporate_information: Yritystiedot
+      follow_us: Seuraa meitä
+      our_people: Meidän ihmiset
+    location: Sijainti
+    part_of: Osa

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -492,3 +492,18 @@ fr:
   working_group:
     contact_details: Détails du contact
     policies: Politiques générales
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: En savoir plus %{link}.
+      personal_information_charter_html: Notre %{link} explique comment nous traitons vos renseignements personnels.
+      publication_scheme_html: En savoir plus sur le type d'information très souvent publié dans notre %{link}.
+      social_media_use_html: Lire notre politique générale dans %{link}.
+      welsh_language_scheme_html: En savoir plus sur notre engagement envers %{link}.
+    find_out_more: Afficher le profil complet et toutes les coordonnées
+    headings:
+      contact_us: Contactez-nous
+      corporate_information: Informations sur l'entreprise
+      follow_us: Suivez-nous
+      our_people: Notre équipe
+    location: Localisation
+    part_of: Fait partie de

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -642,3 +642,18 @@ gd:
   working_group:
     contact_details: Sonraí teagmhála
     policies: Polasaithe
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Amharc ar %{link}.
+      personal_information_charter_html: Míníonn ár %{link} conas a dhéanaimid do chuid smaointe pearsanta a rianú.
+      publication_scheme_html: Faigh amach na príomhchineálacha faisnéise a ndéanaimid cumarsáid rialta inár %{link}.
+      social_media_use_html: Léigh ár mbeartas ar %{link}.
+      welsh_language_scheme_html: Faigh amach ár gcomhréiteach ar an %{link}.
+    find_out_more: Féach ar phróifíl iomlán agus faisnéis teagmhála
+    headings:
+      contact_us: Glaoigh orainn
+      corporate_information: Faisnéis cuideachta
+      follow_us: Lean orainn
+      our_people: Ár gcomhoibritheoirí
+    location: Suíomh
+    part_of: Chuid

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -492,3 +492,18 @@ gu:
   working_group:
     contact_details: સંપર્ક વિગતો
     policies: નીતિઓ
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: "%{link} શોધી કાઢો."
+      personal_information_charter_html: અમારી %{link} માં સમજાવ્યું છે કે અમે તમારી વ્યક્તિગત માહિતી સાથે કેવી રીતે વર્તીએ છીએ.
+      publication_scheme_html: અમે અમારી %{link} માં સામાન્ય રીતે કઈ પ્રકારની માહિતી પ્રકાશિત કરીએ છીએ તે વાંચો
+      social_media_use_html: "%{link} પર અમારી નીતિ વાંચો."
+      welsh_language_scheme_html: "%{link} પ્રત્યે અમારી પ્રતિબદ્ધતા અંગે જાણો."
+    find_out_more: સંપૂર્ણ પ્રોફાઇલ અને તમામ સંપર્ક વિગતો જુઓ
+    headings:
+      contact_us: અમારો સંપર્ક કરો
+      corporate_information: કોર્પોરેટ માહિતી
+      follow_us: અમને ફોલો કરો
+      our_people: અમારા લોકો
+    location: લોકેશન
+    part_of: નો ભાગ

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -492,3 +492,18 @@ he:
   working_group:
     contact_details: פרטי קשר
     policies: מדיניות
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: 'גלה %{link}. '
+      personal_information_charter_html: ה%{link} מסביר אודות המדיניות שלנו כלפי מידע פרטי
+      publication_scheme_html: קרא על סוגי המידע שאנו מפרסמים באופן שגרתי ב- %{link} שלנו
+      social_media_use_html: קרא/י אודות המדיניות שלנו %{link}
+      welsh_language_scheme_html: מידע נוסף על המחויבות שלנו לפרסום %{link}.
+    find_out_more: ראה/י פרופיל מלא ופרטי התקשרות
+    headings:
+      contact_us: צור קשר
+      corporate_information: מידע תאגידי
+      follow_us: עקבו אחרינו
+      our_people: הצוות שלנו
+    location: מיקום
+    part_of: חלק של

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -492,3 +492,18 @@ hi:
   working_group:
     contact_details: संपर्क के विवरण
     policies: नीतियां
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: "%{link} खोजें।"
+      personal_information_charter_html: हमारे %{link} बताते हैं कि हम कैसे आपकी व्यक्तिगत सूचना का उपयोग करते हैं।
+      publication_scheme_html: सूचना के उन प्रकारों के बारे में पढ़ें, जिन्हें हम अपने %{link} में नियमित रूप से प्रकाशित करते हैं।
+      social_media_use_html: इस बारे में हमारी नीतियां पढ़ें %{link}।
+      welsh_language_scheme_html: हमारी प्रकाशन के प्रति वचनबद्धता के बारे में जानें %{link}।
+    find_out_more: पूरी रूप रेखा और समस्त संपर्क विवरण देखें
+    headings:
+      contact_us: हमसे संपर्क करें
+      corporate_information: कारपोरेट सूचना
+      follow_us: हमें फॉलो करें
+      our_people: हमारे लोग
+    location: स्थान
+    part_of: का भाग

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -567,3 +567,18 @@ hr:
   working_group:
     contact_details: Kontakt podaci
     policies: Pravila
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Saznajte %{link}.
+      personal_information_charter_html: Naš %{link} objašnjava kako postupamo s vašim osobnim podacima.
+      publication_scheme_html: Pročitajte o vrstama informacija koje redovito objavljujemo u našoj %{link}.
+      social_media_use_html: Pročitajte naša pravila na %{link}.
+      welsh_language_scheme_html: Saznajte o našoj predanosti %{link}.
+    find_out_more: Pogledajte cijeli profil i sve podatke za kontakt
+    headings:
+      contact_us: Kontaktirajte nas
+      corporate_information: Korporativne informacije
+      follow_us: Prati nas
+      our_people: Naši ljudi
+    location: Mjesto
+    part_of: Dio

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -492,3 +492,18 @@ hu:
   working_group:
     contact_details: Elérhetőségek
     policies: Irányelvek
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: 'Tudja meg: %{link}.'
+      personal_information_charter_html: 'A következő oldalon olvashat róla, hogy hogyan kezeljük a személyes adatokat: %{link}'
+      publication_scheme_html: 'Tekintse meg, hogy milyen jellegű információkat teszünk közzé: %{link}.'
+      social_media_use_html: 'Bővebb információk az alábbi témával kapcsolatban: %{link}.'
+      welsh_language_scheme_html: 'Tájékozódjon az információk közzétételével kapcsolatos elkötelezettségünkről: %{link}.'
+    find_out_more: A teljes profil és elérhetőség megtekintése
+    headings:
+      contact_us: Kapcsolat
+      corporate_information: Vállalati adatok
+      follow_us: Kövessen minket
+      our_people: Munkatársaink
+    location: Helyszín
+    part_of: 'Része a következőnek:'

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -492,3 +492,18 @@ hy:
   working_group:
     contact_details: Կոնտակտային տվյալներ
     policies: Քաղաքականություններ
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Տեղեկանալ %{link}։
+      personal_information_charter_html: Մեր %{link}-ում ներկայացված է, թե ինչպես ենք մշակում ձեր անձնական տվյալները
+      publication_scheme_html: Կարդալ մեր %{link}-ում պարբերաբար հրապարակվող տեղեկությունների տեսակների մասին։
+      social_media_use_html: 'Կարդալ մեր քաղաքականությունը %{link} հղումով:'
+      welsh_language_scheme_html: 'Տեղեկանալ մեր աշխատանքի մասին %{link} հղումով:'
+    find_out_more: Դիտել ամբողջական պրոֆիլը և կոնտակտային բոլոր տվյալները
+    headings:
+      contact_us: Կապը մեզ հետ
+      corporate_information: Կորպորատիվ տեղեկություն
+      follow_us: Հետևել մեզ
+      our_people: Մեր անձնակազմը
+    location: Տեղանք
+    part_of: Մաս է՝

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -417,3 +417,18 @@ id:
   working_group:
     contact_details: Detail kontak
     policies: Kebijakan
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Temukan %{link}.
+      personal_information_charter_html: "%{link} menjelaskan cara kami memperlakukan informasi pribadi Anda."
+      publication_scheme_html: Bacalah jenis-jenis informasi yang kami terbitkan secara rutin di %{link} kami.
+      social_media_use_html: Baca kebijakan kami di %{link}.
+      welsh_language_scheme_html: Cari tahu komitmen kami kepada %{link}.
+    find_out_more: Lihat profil lengkap dan semua detail kontak
+    headings:
+      contact_us: Hubungi kami
+      corporate_information: Informasi korporat
+      follow_us: Ikuti kami
+      our_people: Orang-orang kami
+    location: Lokasi
+    part_of: Bagian dari

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -492,3 +492,18 @@ is:
   working_group:
     contact_details: Upplýsingar til að hafa samband
     policies: Stefnur
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Kynntu þér %{link}.
+      personal_information_charter_html: "%{link} okkar útskýrir hvernig við meðhöndlum þínar persónulegu upplýsingar."
+      publication_scheme_html: Lestu um hvaða upplýsingar við birtum reglulega í %{link} okkar.
+      social_media_use_html: Lestu stefnuna okkar varðandi %{link}.
+      welsh_language_scheme_html: Kynntu þér skuldbindingu okkar við %{link}.
+    find_out_more: Sjá allan prófílinn og allar upplýsingar til að hafa samband
+    headings:
+      contact_us: Hafa samband við okkur
+      corporate_information: Upplýsingar um fyrirtæki
+      follow_us: Fylgja okkur
+      our_people: Okkar fólk
+    location: Staðsetning
+    part_of: Hluti af

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -492,3 +492,18 @@ it:
   working_group:
     contact_details: Dettagli di contatto
     policies: Informative
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Trova %{link}.
+      personal_information_charter_html: Il nostro %{link} spiega come trattiamo i tuoi dati personali.
+      publication_scheme_html: Leggi i tipi di informazioni che pubblichiamo abitualmente nel nostro %{link}.
+      social_media_use_html: Leggi la nostra informativa su %{link}.
+      welsh_language_scheme_html: Scopri il nostro impegno per %{link}.
+    find_out_more: Vedi il profilo completo e tutti i dettagli di contatto
+    headings:
+      contact_us: Contattaci
+      corporate_information: Informazioni aziendali
+      follow_us: Seguici
+      our_people: Il nostro personale
+    location: Posizione
+    part_of: Parte di

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -417,3 +417,18 @@ ja:
   working_group:
     contact_details: 連絡先の詳細
     policies: 方針
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: "％{link} をご覧ください。"
+      personal_information_charter_html: "％{link} で、お客様の個人情報の取り扱いについて説明しています。"
+      publication_scheme_html: "％{link} で、定期的に公開している情報の種類についてご覧ください。"
+      social_media_use_html: "％{link} に関する方針をご覧ください。"
+      welsh_language_scheme_html: "％{link} への取り組みについてご覧ください。"
+    find_out_more: プロフィール全体とすべての連絡先の詳細を見る
+    headings:
+      contact_us: お問い合わせ
+      corporate_information: 企業情報
+      follow_us: フォローする
+      our_people: 人々
+    location: 場所
+    part_of: 次の一部：

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -492,3 +492,18 @@ ka:
   working_group:
     contact_details: საკონტაქტო დეტალები
     policies: კანონები
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: შეიტყვეთ %{link}.
+      personal_information_charter_html: ჩვენი %{link} განმარტავს, თუ როგორ ვამუშავებთ ჩვენ თქვენს პირად ინფორმაციას.
+      publication_scheme_html: წაიკითხეთ ინფორმაციის ტიპების შესახებ, რომელსაც ჩვენ რეგულარულად ვაქვეყნებთ ჩვენს %{link}-ზე.
+      social_media_use_html: წაიკითხეთ ჩვენი პოლიტიკა %{link}-ზე.
+      welsh_language_scheme_html: გაეცანით ჩვენს ვალდებულებას %{link}.
+    find_out_more: იხილეთ სრული პროფილი და ყველა საკონტაქტო ინფორმაცია
+    headings:
+      contact_us: დაგვიკავშირდით
+      corporate_information: კორპორატიული ინფორმაცია
+      follow_us: გამოგვყევით
+      our_people: ჩვენი ხალხი
+    location: მდებარეობა
+    part_of: ნაწილი

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -492,3 +492,18 @@ kk:
   working_group:
     contact_details: Байланысу мәліметтері
     policies: Саясаттар
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: "%{link} туралы мәлімет алу."
+      personal_information_charter_html: Біздің %{link} жеке басқа қатысты ақпаратты қалай пайдалану керектігін түсіндіреді.
+      publication_scheme_html: Біз үнемі %{link} бөлімінде жариялайтын ақпарат түрлері туралы оқыңыз.
+      social_media_use_html: "%{link} мекенжайындағы саясатымызды оқыңыз."
+      welsh_language_scheme_html: "%{link} қосқан үлесіміз туралы оқыңыз."
+    find_out_more: Толық профильді және барлық байланыс мәліметтерін қараңыз
+    headings:
+      contact_us: Бізбен байланысыңыз
+      corporate_information: Корпоративтік ақпарат
+      follow_us: Бізге жазылыңыз
+      our_people: Біздің адамдар
+    location: Орны
+    part_of: Бөлігі

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -417,3 +417,18 @@ ko:
   working_group:
     contact_details: 콘택트 세부 정보
     policies: 정책
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: "%{link} 를 찾으십시오."
+      personal_information_charter_html: "%{link} 에서 개인정보 처리에 대한 안내."
+      publication_scheme_html: 정기적으로 공개되는 %{link} 정보에 대한 안내.
+      social_media_use_html: "%{link} 에서 정책 정보 확인."
+      welsh_language_scheme_html: "%{link} 에서 정보 공개에 대한 내용."
+    find_out_more: 프로필과 연락처 보기
+    headings:
+      contact_us: 연락처
+      corporate_information: 대사관 정보
+      follow_us: 소셜네트워크
+      our_people: 직원
+    location: 로케이션
+    part_of: 파트

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -567,3 +567,18 @@ lt:
   working_group:
     contact_details: Kontaktiniai duomenys
     policies: Strategijos
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Sužinokite čia %{link}.
+      personal_information_charter_html: Čia %{link} rasite paaiškinimą, kaip tvarkoma Jūsų asmeninė informacija.
+      publication_scheme_html: Sužinokite, kokią informaciją mes pastoviai pateikiame puslapyje %{link}.
+      social_media_use_html: Perskaitykite mūsų strategiją %{link}.
+      welsh_language_scheme_html: Sužinokite apie mūsų įsipareigojimą skelbti %{link}.
+    find_out_more: Visa informacija apie mus ir  kontaktai
+    headings:
+      contact_us: Parašykite mums
+      corporate_information: Korporatyvinė informacija
+      follow_us: Sekite mus
+      our_people: Mūsų darbuotojai
+    location: Vieta
+    part_of: Dalis

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -492,3 +492,18 @@ lv:
   working_group:
     contact_details: Kontaktinformācija
     policies: Politikas
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Papildinformācija %{link}.
+      personal_information_charter_html: Šeit %{link} izskaidrots, kā tiks apstrādāta Jūsu sniegtā personīgā informācija.
+      publication_scheme_html: Iepazīsties ar informāciju, kāda parasti tiek publicēta mūsu %{link}.
+      social_media_use_html: Iepazīsties ar mūsu nostāju par %{link}.
+      welsh_language_scheme_html: Vairāk par mūsu apņemšanos nodrošināt informācijas pieejamību %{link}.
+    find_out_more: Skatīt pilnu profilu un kontaktinformāciju
+    headings:
+      contact_us: Sazinies ar mums
+      corporate_information: Korporatīvā informācija
+      follow_us: Seko mums
+      our_people: Darbinieki
+    location: Atrašanās vieta
+    part_of: Daļa no

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -417,3 +417,18 @@ ms:
   working_group:
     contact_details: Butiran hubungan
     policies: Dasar
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Ketahui %{link}.
+      personal_information_charter_html: "%{link} kami menerangkan bagaimana kami menggunakan maklumat peribadi anda."
+      publication_scheme_html: Baca tentang jenis maklumat yang kami biasa terbitkan dalam %{link} kami.
+      social_media_use_html: Baca dasar kami di %{link}.
+      welsh_language_scheme_html: Ketahui tentang komitmen kami kepada %{link}.
+    find_out_more: Lihat profil lengkap dan semua butiran hubungan
+    headings:
+      contact_us: Hubungi kami
+      corporate_information: Maklumat korporat
+      follow_us: Ikuti kami
+      our_people: Rakyat kami
+    location: Lokasi
+    part_of: Sebahagian daripada

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -642,3 +642,18 @@ mt:
   working_group:
     contact_details: Dettalji tal-kuntatt
     policies: Politiki
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Skopri %{link}.
+      personal_information_charter_html: Il-link tagħna %{link} tispjega kif aħna nittrattaw l-informazzjoni personali tiegħek
+      publication_scheme_html: 'Aqra dwar it-tipi ta'' informazzjoni li aħna nippubblikaw regolarment fil- %{link}. '
+      social_media_use_html: Aqra dwar il-politika tagħna fuq  %{link}.
+      welsh_language_scheme_html: Skopri iktar dwar l-impenn tagħna għal %{link}.
+    find_out_more: Ara l-profil kollu u d-dettalji tal-kuntatt
+    headings:
+      contact_us: Ikkuntattjana
+      corporate_information: Informazzjoni korporattiva
+      follow_us: Segwina
+      our_people: In-nies tagħna
+    location: Post
+    part_of: Parti minn

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -492,3 +492,18 @@ ne:
   working_group:
     contact_details: सम्पर्क विवरण
     policies: नीतिहरु
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: पत्ता लगाउनुहोस् %{link}।
+      personal_information_charter_html: हाम्रो %{link} ले हामी तपाईंको व्यक्तिगत जानकारीलाई कसरी व्यवहार गर्छौं भनेर व्याख्या गर्छ।
+      publication_scheme_html: हामी नियमित रूपमा हाम्रो %{link} मा प्रकाशित जानकारीको प्रकारको बारेमा पढ्नुहोस्।
+      social_media_use_html: "%{link} मा हाम्रो नीति पढ्नुहोस्।"
+      welsh_language_scheme_html: "%{link} को हाम्रो प्रतिबद्धताको बारेमा जानकारी पाउनुहोस्।"
+    find_out_more: पूर्ण प्रोफाइल र सबै सम्पर्क विवरण हेर्नुहोस्
+    headings:
+      contact_us: हामीलाई सम्पर्क गर्नुहोस
+      corporate_information: निगम जानकारी
+      follow_us: हमीलाई अनुगमन गर्नुहोस्
+      our_people: हाम्रा जनता
+    location: स्थान
+    part_of: को भाग

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -492,3 +492,18 @@ nl:
   working_group:
     contact_details: Contact gegevens
     policies: Beleid
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Ontdek %{link}.
+      personal_information_charter_html: In onze %{link} leggen wij uit hoe wij met uw persoonlijke informatie omgaan.
+      publication_scheme_html: Lees over de soorten informatie die wij routinematig publiceren in onze %{link}.
+      social_media_use_html: Lees ons beleid inzake %{link}.
+      welsh_language_scheme_html: Lees meer over onze inzet voor %{link}.
+    find_out_more: Bekijk het volledige profiel en alle contactgegevens
+    headings:
+      contact_us: Neem contact met ons op
+      corporate_information: Bedrijfsinformatie
+      follow_us: Volg ons op
+      our_people: Onze mensen
+    location: Vestiging
+    part_of: Deel van

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -492,3 +492,18 @@
   working_group:
     contact_details: Kontaktinformasjon
     policies: Retningslinjer
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Finn ut %{link}.
+      personal_information_charter_html: Vår %{link} forklarer hvordan vi behandler dine personopplysninger.
+      publication_scheme_html: Les om informasjonstypene vi rutinemessig publiserer i %{link}.
+      social_media_use_html: Les retningslinjene våre på %{link}.
+      welsh_language_scheme_html: Finn ut mer om vårt engasjement for %{link}.
+    find_out_more: Se hele profilen og alle kontaktdetaljer
+    headings:
+      contact_us: Kontakt oss
+      corporate_information: Bedriftsinformasjon
+      follow_us: Følg oss
+      our_people: Våre folk
+    location: Sted
+    part_of: Del av

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -492,3 +492,18 @@ pa-pk:
   working_group:
     contact_details: رابطہ تی تفصیلات
     policies: حکمت عملی دا کاغذ
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: ایندے وچوں لبھو {link}%.
+      personal_information_charter_html: ساڈا {link}%  ایہ وضاحت کردا اے کہ تہاڈی ذاتی معلومات نال کس طراں سلوک کردے آں
+      publication_scheme_html: ایہ پڑھو کہ کیس طراں دی معلومات عام طور پر  اسی شائع کرنے آں {link}%.
+      social_media_use_html: ایندے تے ساڈی پالیسی پڑھو {link}%.
+      welsh_language_scheme_html: ساڈی وابستگی دے بارے جانو {link}%.
+    find_out_more: ساری تصویر تے رابطہ دی تفصیلات ویکھو
+    headings:
+      contact_us: ساڈے نال رابطہ کرو
+      corporate_information: کاروبار دیاں خبراں
+      follow_us: ساڈے پچھے آؤ
+      our_people: ساڈے لوک
+    location: تھاں
+    part_of: دا  حصہ

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -492,3 +492,18 @@ pa:
   working_group:
     contact_details: ਸੰਪਰਕ ਵੇਰਵੇ
     policies: ਨੀਤੀਆਂ
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: "%{link} ਪਤਾ ਕਰੋ।"
+      personal_information_charter_html: ਸਾਡਾ %{link} ਦੱਸਦਾ ਹੈ ਕਿ ਅਸੀਂ ਤੁਹਾਡੀ ਨਿੱਜੀ ਜਾਣਕਾਰੀ ਨਾਲ ਕਿਵੇਂ ਵਿਵਹਾਰ ਕਰਦੇ ਹਾਂ।
+      publication_scheme_html: ਉਹਨਾਂ ਜਾਣਕਾਰੀ ਦੀਆਂ ਕਿਸਮਾਂ ਬਾਰੇ ਪੜ੍ਹੋ ਜੋ ਅਸੀਂ ਨਿਯਮਿਤ ਤੌਰ ਤੇ ਸਾਡੇ %{link} ਵਿੱਚ ਪ੍ਰਕਾਸ਼ਤ ਕਰਦੇ ਹਾਂ।
+      social_media_use_html: "%{link} 'ਤੇ ਸਾਡੀ ਨੀਤੀ ਪੜ੍ਹੋ।"
+      welsh_language_scheme_html: "%{link} ਪ੍ਰਤੀ ਸਾਡੀ ਵਚਨਬੱਧਤਾ ਬਾਰੇ ਜਾਣੋ."
+    find_out_more: ਪੂਰਾ ਪ੍ਰੋਫਾਈਲ ਅਤੇ ਸਾਰੇ ਸੰਪਰਕ ਵੇਰਵੇ ਵੇਖੋ
+    headings:
+      contact_us: ਸਾਡੇ ਨਾਲ ਸੰਪਰਕ ਕਰੋ
+      corporate_information: ਕਾਰਪੋਰੇਟ ਜਾਣਕਾਰੀ
+      follow_us: ਸਾਨੂੰ ਫਾਲੋ ਕਰੋ
+      our_people: ਸਾਡੇ ਲੋਕ
+    location: ਟਿਕਾਣਾ
+    part_of: ਦਾ ਹਿੱਸਾ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -642,3 +642,18 @@ pl:
   working_group:
     contact_details: Dane kontaktowe
     policies: Polityka
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Dowiedz się %{link}.
+      personal_information_charter_html: Nasz %{link} pokazuje, w jaki sposób traktujemy Państwa informacje osobiste.
+      publication_scheme_html: Przeczytaj, jakiego rodzaju wiadomości publikujemy zwykle w naszym %{link}.
+      social_media_use_html: Przeczytaj naszą politykę dotyczącą %{link}.
+      welsh_language_scheme_html: Poznaj nasze zobowiązania związane z publikowaniem w %{link}.
+    find_out_more: Zobacz pełen profil i wszystkie dane kontaktowe
+    headings:
+      contact_us: Skontaktuj się z nami
+      corporate_information: Informacje korporacyjne
+      follow_us: Obserwuj nasz profil
+      our_people: Nasi ludzie
+    location: Lokalizacja
+    part_of: Część

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -492,3 +492,18 @@ ps:
   working_group:
     contact_details: د اړیکو نیولو معلومات
     policies: پالیسۍ
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: "%{link} ومومئ."
+      personal_information_charter_html: زموږ%{link} تشریح کوي چې موږ ستاسو شخصي معلوماتو سره څنګه چلند کوو.
+      publication_scheme_html: د هغه معلوماتو ډولونو په اړه ولولئ چې موږ یې په منظم ډول زموږ په %{link} کې خپروو.
+      social_media_use_html: زموږ پالیسي په %{link} ولولئ.
+      welsh_language_scheme_html: "%{link} ته زموږ د ژمنتیا په اړه معلومات ترلاسه کړئ."
+    find_out_more: بشپړ پروفایل او د اړیکې ټول توضیحات وګورئ
+    headings:
+      contact_us: موږ سره اړیکه ونیسئ
+      corporate_information: د شرکت معلومات
+      follow_us: مونږ پسی راځه
+      our_people: زموږ خلک
+    location: ځای
+    part_of: برخه

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -492,3 +492,18 @@ pt:
   working_group:
     contact_details: Informações de contacto
     policies: Políticas
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Saiba mais %{link}.
+      personal_information_charter_html: O nosso %{link} explica como tratamos as suas informações pessoais.
+      publication_scheme_html: Leia sobre os tipos de informação que publicamos no nosso %{link}.
+      social_media_use_html: Leia a nossa política em %{link}.
+      welsh_language_scheme_html: Saiba mais sobre o nosso compromisso para com %{link}.
+    find_out_more: Ver o perfil completo e todas as informações de contacto
+    headings:
+      contact_us: Contacte-nos
+      corporate_information: Informações da empresa
+      follow_us: Siga-nos
+      our_people: A nosso povo
+    location: Local
+    part_of: Parte de

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -567,3 +567,18 @@ ro:
   working_group:
     contact_details: Detalii de contact
     policies: Politici
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Aflați %{link}.
+      personal_information_charter_html: "%{link} explică cum tratăm informațiile dvs. cu caracter personal."
+      publication_scheme_html: Citiți despre tipurile de informații pe care le publicăm de obicei în %{link}.
+      social_media_use_html: Citiți politica noastră pe %{link}.
+      welsh_language_scheme_html: Aflați mai multe despre angajamentul nostru pentru %{link}.
+    find_out_more: Vedeți profilul complet și toate detaliile de contact
+    headings:
+      contact_us: Constactați-ne
+      corporate_information: Informații despre corporație
+      follow_us: Urmăriți-ne
+      our_people: Oamenii noștri
+    location: Locație
+    part_of: Parte din

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -642,3 +642,18 @@ ru:
   working_group:
     contact_details: Контактная информация
     policies: Политика
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Узнайте %{link}.
+      personal_information_charter_html: По %{link} вы можете ознакомиться с пояснением о том, как мы обращаемся с вашей личной информацией.
+      publication_scheme_html: Ознакомьтесь с типами информации, которую мы обычно публикуем, по указанной %{link}.
+      social_media_use_html: Ознакомиться с нашей политикой по %{link}.
+      welsh_language_scheme_html: Ознакомиться с нашими обязательствами можно по %{link}.
+    find_out_more: Общая информация и контакты
+    headings:
+      contact_us: Обратная связь
+      corporate_information: Корпоративная информация
+      follow_us: Следите за нами
+      our_people: Наши сотрудники
+    location: Расположение
+    part_of: Является частью

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -492,3 +492,18 @@ si:
   working_group:
     contact_details: විමසීම් විස්තර
     policies: ප්රතිපත්ති
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: "%{link} සොයන්න."
+      personal_information_charter_html: අගේ %{link} අපි ඔබගේ පුද්ගලික තොරතුරු හසුරුවන ආකාරය විස්තර කරයි.
+      publication_scheme_html: අපේ %{link} තුල අපි ආකාරික ලෙස ප්රකාශයට පත් කරන තොරතුරු වර්ග ගැන කියවන්න.
+      social_media_use_html: අපේ ප්රතිපත්තිය කියවන්න %{link}.
+      welsh_language_scheme_html: "%{link} සඳහා අපේ කැපවීම ගැන සොයා බලන්න."
+    find_out_more: සම්පූර්ණ පැතිකඩ සහ සියලු සබඳතා විස්තර බලන්න
+    headings:
+      contact_us: අපව සම්බන්ධ කරගන්න
+      corporate_information: ආයතනික තොරතුරු
+      follow_us: අපව අනුගමනය කරන්න
+      our_people: අපේ ජනතාව
+    location: ස්ථානය
+    part_of: කොටසක්

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -567,3 +567,18 @@ sk:
   working_group:
     contact_details: Kontaktné údaje
     policies: Politiky
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Zistite %{link}.
+      personal_information_charter_html: Náš %{link} vysvetľuje, ako zaobchádzame s vašimi osobnými údajmi.
+      publication_scheme_html: Prečítajte si o typoch informácií, ktoré bežne zverejňujeme v našom %{link}.
+      social_media_use_html: Prečítajte si naše zásady na %{link}.
+      welsh_language_scheme_html: Prečítajte si o našom záväzku voči %{link}.
+    find_out_more: Pozrite si celý profil a všetky kontaktné údaje
+    headings:
+      contact_us: Kontaktujte nás
+      corporate_information: Firemné informácie
+      follow_us: Sledujte nás
+      our_people: Naši ľudia
+    location: Umiestnenie
+    part_of: Časť

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -642,3 +642,18 @@ sl:
   working_group:
     contact_details: Kontaktni podatki
     policies: Politike
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Izvedite %{link}.
+      personal_information_charter_html: Na povezavi %{link} je razloženo, kako ravnamo z vašimi osebnimi podatki.
+      publication_scheme_html: Več o vrstah informacij, ki jih redno objavljamo, preberite v naši %{link}.
+      social_media_use_html: Preberite si našo politiko na %{link}.
+      welsh_language_scheme_html: Izvedite več o naši zavezanosti %{link}.
+    find_out_more: Oglejte si celoten profil in vse kontaktne podatke
+    headings:
+      contact_us: Obrnite se na nas
+      corporate_information: Informacije o podjetju
+      follow_us: Sledite nam
+      our_people: Naši ljudje
+    location: Lokacija
+    part_of: Del

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -492,3 +492,18 @@ so:
   working_group:
     contact_details: Faahfaahinta xidhiidhka
     policies: Siyaasadaha
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Ka raadi %{link}.
+      personal_information_charter_html: Sharaxadahayagu %{link} waxay sheegayaan sida loola dhaqmayo macluumaadkaaga shaqsiyeed.
+      publication_scheme_html: Akhri waxyaabaha ku saabsan nooca macluumaadka aan si joogto ugu daabacno %{link}.
+      social_media_use_html: Ka akhri siyaasadayahaga %{link}.
+      welsh_language_scheme_html: Raadi waxyaabaha ku saabsan ka go'naanshahayaga %{link}.
+    find_out_more: Eeg borofaayl dhamaystiran iyo dhamaan faahfaahinta meesha lagala xidhiidhayo
+    headings:
+      contact_us: Nagala soo xidhiidh
+      corporate_information: Macluumaadka shirkada
+      follow_us: Nagala soco
+      our_people: Dadkayaga
+    location: Goobta
+    part_of: Ka qeyba

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -492,3 +492,18 @@ sq:
   working_group:
     contact_details: Detajet e kontaktit
     policies: Politikat
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Gjeni %{link}.
+      personal_information_charter_html: "%{link} jonë shpjegon se si i trajtojmë informacionet tuaja personale."
+      publication_scheme_html: Lexoni për llojet e informacionit që publikojmë në mënyrë rutinore në %{link} tonë.
+      social_media_use_html: Lexoni politikën tonë në %{link}.
+      welsh_language_scheme_html: Mësoni rreth angazhimit tonë ndaj %{link}.
+    find_out_more: Shikoni profilin e plotë dhe të gjitha detajet e kontaktit
+    headings:
+      contact_us: Na kontaktoni
+      corporate_information: Informacioni i korporatës
+      follow_us: Na ndiqni
+      our_people: Njerëzit tanë
+    location: Vendndodhja
+    part_of: Pjesë e

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -567,3 +567,18 @@ sr:
   working_group:
     contact_details: Detalji za kontakt
     policies: Politike
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Saznajte %{link}.
+      personal_information_charter_html: U dokumentu %{link} objašnjeno je na koji način koristimo vaše lične podatke.
+      publication_scheme_html: Pročitajte koje vrste podataka redovno objavljujemo na lokaciji %{link}.
+      social_media_use_html: Pročitajte našu politiku na %{link}.
+      welsh_language_scheme_html: Saznajte više o našoj posvećenosti %{link}.
+    find_out_more: Pogledajte pun profil i sve kontakt detalje
+    headings:
+      contact_us: Obratite nam se
+      corporate_information: Poslovni podaci
+      follow_us: Pratite nas
+      our_people: Naši ljudi
+    location: Lokacija
+    part_of: Deo

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -492,3 +492,18 @@ sv:
   working_group:
     contact_details: Kontaktuppgifter
     policies: Policys
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Ta reda på %{link}.
+      personal_information_charter_html: Vår %{link} förklarar hur vi behandlar dina personuppgifter.
+      publication_scheme_html: Läs om vilka typer av information vi rutinmässigt publicerar i vår %{link}.
+      social_media_use_html: Läs vår policy för %{link}.
+      welsh_language_scheme_html: Ta reda på vårt åtagande om %{link}.
+    find_out_more: Se hela profilen och alla kontaktuppgifter
+    headings:
+      contact_us: Kontakta oss
+      corporate_information: Företagsinformation
+      follow_us: Följ oss
+      our_people: Vår personal
+    location: Plats
+    part_of: Del av

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -492,3 +492,18 @@ sw:
   working_group:
     contact_details: Anwani za mawasiliano
     policies: Sera
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Pata maelezo kuhusu %{link}.
+      personal_information_charter_html: "%{link} yetu inafafanua jinsi tunavyoshughulikia maelezo yako ya kibinafsi."
+      publication_scheme_html: Soma maelezo kuhusu aina za maelezo tunayochapisha kila wakati kwenye %{link} yetu.
+      social_media_use_html: Soma sera yetu kwenye %{link}.
+      welsh_language_scheme_html: Pata maelezo kuhusu wajibu wetu wa %{link}.
+    find_out_more: Angalia wasifu wote na anwani zote za mawasiliano
+    headings:
+      contact_us: Wasiliana nasi
+      corporate_information: Maelezo ya shirika
+      follow_us: Tufuatilie
+      our_people: Watu wetu
+    location: Mahali
+    part_of: Sehemu ya

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -492,3 +492,18 @@ ta:
   working_group:
     contact_details: தொடர்பு விபரங்கள்
     policies: கொள்கைகள்
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: கண்டறியுங்கள் %{link}.
+      personal_information_charter_html: எங்கள் %{link} உங்கள் தனிப்பட்ட தகவல்களை நாங்கள் எவ்வாறு கையாள்கிறோம் என்பதை விளக்குகிறது.
+      publication_scheme_html: எங்கள் %{link}-ல் நாங்கள் வழக்கமாக வெளியிடும் தகவல்களின் வகைகள் குறித்து வாசியுங்கள்..
+      social_media_use_html: "%{link}-ல் எங்கள் கொள்கை குறித்து வாசியுங்கள்."
+      welsh_language_scheme_html: "%{link}-க்கு எங்கள் கடப்பாடு குறித்துக் கண்டறியுங்கள்."
+    find_out_more: முழு சுயவிபரத்தையும் அனைத்து தொடர்பு விபரங்களையும் காண்க
+    headings:
+      contact_us: எங்களைத் தொடர்பு கொள்ளுங்கள்
+      corporate_information: குழுமத் தகவல்கள்
+      follow_us: எங்களைப் பின்தொடர்க
+      our_people: எங்கள் மக்கள்
+    location: இருப்பிடம்
+    part_of: பகுதி

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -417,3 +417,18 @@ th:
   working_group:
     contact_details: รายละเอียดการติดต่อ
     policies: นโยบาย
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: ดูข้อมูลเพิ่มเติมที่ %{link}
+      personal_information_charter_html: "%{link} ของเราอธิบายว่าเราปฏิบัติต่อข้อมูลส่วนบุคคลของคุณอย่างไร"
+      publication_scheme_html: อ่านเกี่ยวกับประเภทข้อมูลที่เราเผยแพร่เป็นประจำใน %{link} ของเรา
+      social_media_use_html: อ่านนโยบายของเราที่ %{link}
+      welsh_language_scheme_html: ดูข้อมูลเพิ่มเติมเกี่ยวกับพันธกิจของเราสำหรับ %{link}
+    find_out_more: ดูรายแฟ้มประวัติฉบับเต็มและรายละเอียดการติดต่อทั้งหมด
+    headings:
+      contact_us: ติดต่อเรา
+      corporate_information: ข้อมูลองค์กร
+      follow_us: ติดตามเรา
+      our_people: บุคลากรของเรา
+    location: ตำแหน่งที่ตั้ง
+    part_of: ส่วนหนึ่งของ

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -492,3 +492,18 @@ tk:
   working_group:
     contact_details: Habarlaşmak üçin maglumatlar
     policies: Syýasatlar
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Öwreniň %{link}.
+      personal_information_charter_html: Biziň %{link} baglanyşygymyz siziň şahsy maglumatlaryňyza nähili çemeleşýändigimiz barada habar berýär.
+      publication_scheme_html: Biziň %{link} baglanyşygymyzdan nähili habarlary yzygiderli neşir edýändigimizi okaň.
+      social_media_use_html: Biziň syýasatymyz barada %{link} baglanyşygymyzda okaň.
+      welsh_language_scheme_html: Niýetimiz barada %{link}-da okaň.
+    find_out_more: Doly maglumatlarymyzy we ähli habarlaşmak üçin maglumatlarymyzy okaň
+    headings:
+      contact_us: Biziň bilen habarlaşyň
+      corporate_information: Korporatiw maglumatlar
+      follow_us: Bizi yzarlaň
+      our_people: Biziň adamlarymyz
+    location: Ýerleşýän ýeri
+    part_of: Bir bölegi

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -492,3 +492,18 @@ tr:
   working_group:
     contact_details: İrtibat ayrıntıları
     policies: Politikalar
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: "%{link} bağlantısını keşfedin."
+      personal_information_charter_html: "%{link} bağlantımız özel bilgilerinizi nasıl işlediğimizi açıklamaktadır."
+      publication_scheme_html: "%{link} bağlantımızda düzenli olarak yayınladığımız bilgi türlerini okuyun."
+      social_media_use_html: "%{link} bağlantısındaki politikamızı okuyun."
+      welsh_language_scheme_html: "%{link} bağlantısına taahhüdümüzü okuyun."
+    find_out_more: Tüm profil ve tüm irtibat bilgilerine bakın
+    headings:
+      contact_us: Bize Ulaşın
+      corporate_information: Kurumsal bilgiler
+      follow_us: Bizi takip edin
+      our_people: İnsan kaynağımız
+    location: Konum
+    part_of: Şunun kısmı

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -642,3 +642,18 @@ uk:
   working_group:
     contact_details: Контактні дані
     policies: Політики
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Дізнатися %{link}.
+      personal_information_charter_html: Наш %{link} пояснює, як ми обробляємо ваші персональні дані.
+      publication_scheme_html: Про те, які типи інформації ми регулярно публікуємо, читайте у нашому %{link}.
+      social_media_use_html: Ознайомтеся із нашою політикою на %{link}.
+      welsh_language_scheme_html: Дізнайтесь про дотримання нами %{link}.
+    find_out_more: Дивіться повний профіль та всі контактні дані
+    headings:
+      contact_us: Зв'яжіться з нами
+      corporate_information: Корпоративна інформація
+      follow_us: Слідкуйте за нами
+      our_people: Наші співробітники
+    location: Розташування
+    part_of: Частина

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -492,3 +492,18 @@ ur:
   working_group:
     contact_details: رابطے کی تفصیلات
     policies: پالیسیاں
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: "%{link} کو جانیے۔"
+      personal_information_charter_html: ہماری %{link} بیان کرتی ہے کہ ہم آپ کی ذاتی معلومات سے کیسے نمٹتے ہیں۔
+      publication_scheme_html: ہماری %{link} میں ہماری جانب سے معمول کے حساب سے شائع کی جانے والی معلومات کی اقسام کے بارے میں پڑھیں۔
+      social_media_use_html: "%{link} پر ہماری پالیسی کو پڑھیں۔"
+      welsh_language_scheme_html: "%{link} کے ساتھ ہماری وابستگی کے بارے میں جانیں۔"
+    find_out_more: پوری پروفائل اور رابطے کی تمام تفصیلات دیکھیں
+    headings:
+      contact_us: ہمارے ساتھ رابطہ کریں
+      corporate_information: کارپوریٹ معلومات
+      follow_us: ہمیں فالو کریں
+      our_people: ہمارے لوگ
+    location: مقام
+    part_of: حصہ از

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -492,3 +492,18 @@ uz:
   working_group:
     contact_details: Батафсил маълумотлар
     policies: Сиёсатлар
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Билиб олиш %{link}.
+      personal_information_charter_html: Бизнинг %{link} қандай қилиб шахсий маълумот билан ишлашимиз ҳақида сизга маълумот беради.
+      publication_scheme_html: Биз доимий тарзда нашр этаётган маълумотлар ҳақида %{link} ўқинг.
+      social_media_use_html: Бизнинг дастуримиз ҳақида батафсил маълумотларни %{link} ўқинг.
+      welsh_language_scheme_html: Нашр этиш учун биз олиб бораётган фаолиятимиз ҳақида %{link} ўқинг.
+    find_out_more: Тўлиқ профиль ва боғланиш учун маълумотларни кўринг
+    headings:
+      contact_us: Биз билан боғланинг
+      corporate_information: Корпоратив маълумот
+      follow_us: Бизга аъзо бўлинг
+      our_people: Бизнинг одамлар
+    location: Жойлашиш жойи
+    part_of: Қисми

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -417,3 +417,18 @@ vi:
   working_group:
     contact_details: Chi tiết liên hệ
     policies: Chính sách
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Tìm hiểu %{link}.
+      personal_information_charter_html: "%{link} của chúng tôi giải thích cách chúng tôi xử lý thông tin cá nhân của bạn."
+      publication_scheme_html: Tìm hiểu về các loại thông tin chúng tôi thường xuyên xuất bản trong %{link} của chúng tôi.
+      social_media_use_html: Đọc chính sách của chúng tôi trên %{link}.
+      welsh_language_scheme_html: Tìm hiểu về cam kết của chúng tôi đối với %{link}.
+    find_out_more: Xem hồ sơ đầy đủ và tất cả các chi tiết liên hệ
+    headings:
+      contact_us: Liên hệ với chúng tôi
+      corporate_information: Thông tin doanh nghiệp
+      follow_us: Theo dõi chúng tôi
+      our_people: Đội ngũ của chúng tôi
+    location: Vị trí
+    part_of: Một phần của

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -492,3 +492,18 @@ yi:
   working_group:
     contact_details:
     policies:
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html:
+      personal_information_charter_html:
+      publication_scheme_html:
+      social_media_use_html:
+      welsh_language_scheme_html:
+    find_out_more:
+    headings:
+      contact_us:
+      corporate_information:
+      follow_us:
+      our_people:
+    location:
+    part_of:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -417,3 +417,18 @@ zh-hk:
   working_group:
     contact_details: 聯絡詳情
     policies: 政策
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: 按 %{link} 此處了解。
+      personal_information_charter_html: 我們的 %{link} 解釋我們如何處理你的個人資料。
+      publication_scheme_html: 查閱我們在 %{link} 定期發布的資訊。
+      social_media_use_html: 查閱我們在 %{link} 的政策。
+      welsh_language_scheme_html: 查閱我們在 %{link} 的發布承諾。
+    find_out_more: 查閱全部資訊和聯絡資料
+    headings:
+      contact_us: 聯絡我們
+      corporate_information: 詳細的資訊
+      follow_us: 關注我們
+      our_people: 主要館員
+    location: 位置
+    part_of: 隸屬於

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -417,3 +417,18 @@ zh-tw:
   working_group:
     contact_details: 聯繫細節
     policies: 政策
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: 了解 %{link}。
+      personal_information_charter_html: 我們的 %{link} 說明了我們是如何處理你的個資。
+      publication_scheme_html: 閱讀我們在 %{link} 中定期發布的資訊類型。
+      social_media_use_html: 在 %{link} 上閱讀我們政策。
+      welsh_language_scheme_html: 了解我們對 %{link} 的承諾。
+    find_out_more: 查看完整資料和所有聯繫細節
+    headings:
+      contact_us: 聯繫我們
+      corporate_information: 公司資訊
+      follow_us: 追蹤我們
+      our_people: 我們的人
+    location: 地點
+    part_of: 部分

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -417,3 +417,18 @@ zh:
   working_group:
     contact_details: 联系方式
     policies: 策略
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: 查找 %{link}。
+      personal_information_charter_html: 我们的 %{link} 解释我们如何处理您的个人信息。
+      publication_scheme_html: 阅读我们在 %{link} 中例行发布的信息类型。
+      social_media_use_html: 阅读我们在 %{link} 的政策。
+      welsh_language_scheme_html: 查看我们对 %{link} 的承诺。
+    find_out_more: 查看完整简介和全部联系方式
+    headings:
+      contact_us: 联系方式
+      corporate_information: 公司信息
+      follow_us: 关注我们
+      our_people: 我们的员工
+    location: 位置
+    part_of: 一部分

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
+  test "renders basic worldwide organisation page" do
+    setup_and_visit_content_item("worldwide_organisation")
+    assert_has_component_title(@content_item["title"])
+    assert page.has_text?(@content_item["description"])
+  end
+end

--- a/test/presenters/worldwide_organisation_presenter_test.rb
+++ b/test/presenters/worldwide_organisation_presenter_test.rb
@@ -1,0 +1,11 @@
+require "presenter_test_helper"
+
+class WorldwideOrganisationPresenterTest < PresenterTestCase
+  def schema_name
+    "worldwide_organisation"
+  end
+
+  test "presents the title" do
+    assert_equal schema_item["title"], presented_item.title
+  end
+end


### PR DESCRIPTION
Create initial basic page for Worldwide Organisations in government-frontend.

The page currently only consists of the title and content item description, more parts of the page can be added later when more is presented to the content store by whitehall, metadata, page body etc. 

Also included basic testing which can be built upon later as the page is migrated. 

The breadcrumb trail at the top of the page wasn't previously in the whitehall rendering, but I feel it adds something to the page to show that, happy to be corrected though.

<img width="982" alt="image" src="https://user-images.githubusercontent.com/24547183/207890674-db5d8823-afe6-47ba-937a-e92ecbe64e16.png">
 
New page running locally ⬆️ 

Old page on whitehall (with full content) ⬇️ 

<img width="965" alt="image" src="https://user-images.githubusercontent.com/24547183/207891081-80cf0aaa-ae33-4b30-8971-f5f607bd9f76.png">



Trello: https://trello.com/c/uiw7XFjE/379-create-routes-controllers-and-views-for-worldwide-organisation-pages-in-government-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
