### PR TITLE
Bump Rails Translation Manager and use new plural file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "plek"
 gem "rack_strip_client_ip"
 gem "rails-controller-testing"
 gem "rails-i18n"
+gem "rails_translation_manager"
 gem "rss"
 gem "sassc-rails"
 gem "slimmer"
@@ -22,7 +23,6 @@ gem "uglifier"
 group :development, :test do
   gem "govuk_schemas"
   gem "govuk_test"
-  gem "rails_translation_manager"
   gem "rubocop-govuk"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
     public_suffix (5.0.0)
     puma (6.0.0)
       nio4r (~> 2.0)
-    racc (1.6.0)
+    racc (1.6.1)
     rack (2.2.4)
     rack-proxy (0.7.4)
       rack
@@ -259,7 +259,7 @@ GEM
     rails-i18n (7.0.6)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
-    rails_translation_manager (1.6.0)
+    rails_translation_manager (1.6.3)
       activesupport
       csv (~> 3.2)
       i18n-tasks

--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -1,1 +1,0 @@
-GovukI18n.plurals

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -57,226 +57,152 @@ zh-hk:
       updated: 已更新
     schema_name:
       aaib_report:
-        one: 空中意外事故調查報告
         other: 其他空中意外事故調查報告
       announcement:
-        one: 公告
         other: 其他公告
       asylum_support_decision:
-        one: 庇護支援裁判決定
         other: 其他庇護支援裁判決定
       authored_article:
-        one: 撰寫文章
         other: 其他撰寫文章
       business_finance_support_scheme:
-        one: 商業融資支援計劃
         other: 其他商業融資支援計劃
       case_study:
-        one: 案例研究
         other: 其他案例研究
       closed_consultation:
-        one: 專屬諮詢
         other: 其他專屬諮詢
       cma_case:
-        one: 競爭及市場管理案例
         other: 其他競爭及市場管理案例
       coming_soon:
-        one: 即將推出之項目
         other: 其他即將推出之項目
       consultation:
-        one: 諮詢
         other: 其他諮詢
       consultation_outcome:
-        one: 諮詢結果
         other: 其他諮詢結果
       corporate_information_page:
-        one: 資訊頁面
         other: 其他資訊頁面
       corporate_report:
-        one: 政府報告
         other: 其他政府報告
       correspondence:
-        one: 通信
         other: 其他通信
       countryside_stewardship_grant:
-        one: 鄉村管理補助金
         other: 其他鄉村管理補助金
       decision:
-        one: 決定
         other: 其他決定
       detailed_guide:
-        one: 詳細指引
         other: 其他詳細指引
       dfid_research_output:
-        one: 發展成果之研究
         other: 其他發展成果之研究
       document_collection:
-        one: 系列
         other: 其他系列
       draft_text:
-        one: 內容
         other: 其他內容
       drug_safety_update:
-        one: 藥物安全更新
         other: 其他藥物安全更新
       employment_appeal_tribunal_decision:
-        one: 僱傭上訴法庭裁決
         other: 其他僱傭上訴法庭裁決
       employment_tribunal_decision:
-        one: 僱傭法庭裁決
         other: 其他僱傭法庭裁決
       esi_fund:
-        one: 歐洲結構與投資基金 (ESIF)
         other: 其他歐洲結構與投資基金 (ESIF)
       fatality_notice:
-        one: 安全事故通知
         other: 其他安全事故通知
       foi_release:
-        one: 資訊自由(FOI)資訊發布
         other: 其他資訊自由(FOI)資訊發布
       form:
-        one: 表格
         other: 其他表格
       government_response:
-        one: 政府回應
         other: 政府其他回應
       guidance:
-        one: 指引
         other: 其他指引
       impact_assessment:
-        one: 影響評估
         other: 其他影響評估
       imported:
-        one: 輸入-等待類型中
         other: 輸入-等待類型中
       independent_report:
-        one: 獨立報告
         other: 其他獨立報告
       international_development_fund:
-        one: 國際發展籌資
         other: 國際發展籌資
       international_treaty:
-        one: 國際條約
         other: 其他國際條約
       maib_report:
-        one: 海洋事故調查處報告
         other: 其他海洋事故調查處報告
       map:
-        one: 地圖
         other: 其他地圖
       medical_safety_alert:
-        one: 藥品及醫療器械警示及召回
         other: 其他藥品及醫療器械警示及召回
       national:
-        one: 國家統計數據公告
         other: 其他國家統計數據公告
       national_statistics:
-        one: 國家統計數據
         other: 其他國家統計數據
       national_statistics_announcement:
-        one: 國家統計數據公告
         other: 其他國家統計數據公告
       news_article:
-        one: 新聞
         other: 其他新聞
       news_story:
-        one: 新聞
         other: 其他新聞
       notice:
-        one: 通知
         other: 其他通知
       official:
-        one: 官方統計數據公告
         other: 其他官方統計數據公告
       official_statistics:
-        one: 統計資料
         other: 其他統計資料
       official_statistics_announcement:
-        one: 官方統計數據公告
         other: 其他官方統計數據公告
       open_consultation:
-        one: 公開諮詢
         other: 其他公開諮詢
       oral_statement:
-        one: 提交國會的口頭聲明
         other: 提交國會的其他口頭聲明
       policy:
-        one: 政策
         other: 其他政策
       policy_paper:
-        one: 政策文件
         other: 其他政策文件
       press_release:
-        one: 新聞稿
         other: 其他新聞稿
       product-safety-alert-report-recall:
-        one:
         other:
       promotional:
-        one: 宣傳資料
         other: 其他宣傳資料
       publication:
-        one: 出版物
         other: 其他出版物
       raib_report:
-        one: 鐵路意外調查處公告
         other: 其他鐵路意外調查處公告
       regulation:
-        one: 規定
         other: 其他規定
       research:
-        one: 研究與分析
         other: 其他研究與分析
       residential_property_tribunal_decision:
-        one: 住宅物業法庭裁決
         other: 其他住宅物業法庭裁決
       service_sign_in:
-        one: 服務登入
         other: 服務登入
       service_standard_report:
-        one: 服務標準報告
         other: 其他服務標準報告
       speaking_notes:
-        one: 演講稿
         other: 其他演講稿
       speech:
-        one: 演講
         other: 其他演講
       standard:
-        one: 標準
         other: 其他標準
       statement_to_parliament:
-        one: 提交國會的聲明
         other: 提交國會的其他聲明
       statistical_data_set:
-        one: 統計數據資料
         other: 其他統計數據資料
       statistics_announcement:
-        one: 統計數據資料發佈公告
         other: 其他統計數據資料發佈公告
       statutory_guidance:
-        one: 法定指引
         other: 法定指引
       take_part:
-        one: 參加活動
         other: 參加活動
       tax_tribunal_decision:
-        one: 稅務及大法官法庭裁決
         other: 其他稅務及大法官法庭裁決
       transcript:
-        one: 談話副本
         other: 其他談話副本
       transparency:
-        one: 透明化數據
         other: 其他透明化數據
       utaac_decision:
-        one: 行政上訴法庭裁決
         other: 其他行政上訴法庭裁決
       world_news_story:
-        one: 世界新聞故事
         other: 其他世界新聞故事
       written_statement:
-        one: 提交國會的書面聲明
         other: 提交國會的其他書面聲明
   corporate_information_page:
     about_our_services_html: 找尋 %{link}。
@@ -442,7 +368,6 @@ zh-hk:
   publication:
     details: 詳情
     documents:
-      one: 文件
       other: 其他文件
   service_sign_in:
     continue: 繼續

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -57,226 +57,152 @@ zh-tw:
       updated: 更新
     schema_name:
       aaib_report:
-        one: 航空事故調查局報告
         other: 航空事故調查局報告
       announcement:
-        one: 公告
         other: 公告
       asylum_support_decision:
-        one: 庇護支援法庭裁決
         other: 庇護支援法庭裁決
       authored_article:
-        one: 授權文章
         other: 授權文章
       business_finance_support_scheme:
-        one: 企業融資支援計劃
         other: 企業融資支援計劃
       case_study:
-        one: 案例分析
         other: 案例分析
       closed_consultation:
-        one: 非公開協商
         other: 非公開協商
       cma_case:
-        one: 競爭及市場管理局案例
         other: 競爭及市場管理局案例
       coming_soon:
-        one: 即將推出
         other: 即將推出
       consultation:
-        one: 諮詢
         other: 諮詢
       consultation_outcome:
-        one: 協商結果
         other: 協商結果
       corporate_information_page:
-        one: 資訊頁
         other: 資訊頁
       corporate_report:
-        one: 企業報告
         other: 企業報告
       correspondence:
-        one: 信函
         other: 信函
       countryside_stewardship_grant:
-        one: 地方管理補助
         other: 地方管理補助
       decision:
-        one: 決定
         other: 決定
       detailed_guide:
-        one: 指導
         other: 指導
       dfid_research_output:
-        one: 發展成果研究
         other: 發展成果研究
       document_collection:
-        one: 收集
         other: 收集
       draft_text:
-        one: 草稿文本
         other: 草稿文本
       drug_safety_update:
-        one: 藥物安全更新
         other: 藥物安全更新
       employment_appeal_tribunal_decision:
-        one: 勞資上訴審裁處裁決
         other: 勞資上訴審裁處裁決
       employment_tribunal_decision:
-        one: 勞資審裁處裁決
         other: 勞資審裁處裁決
       esi_fund:
-        one: 歐洲結構與投資基金（ESIF）
         other: 歐洲結構與投資基金（ESIF）
       fatality_notice:
-        one: 死亡通知
         other: 死亡通知
       foi_release:
-        one: 資訊自由發布
         other: 資訊自由發布
       form:
-        one: 形式
         other: 形式
       government_response:
-        one: 政府回應
         other: 政府回應
       guidance:
-        one: 指導
         other: 指導
       impact_assessment:
-        one: 影響評估
         other: 影響評估
       imported:
-        one: 進口－等待類型
         other: 進口－等待類型
       independent_report:
-        one: 獨立報告
         other: 獨立報告
       international_development_fund:
-        one: 國際發展基金
         other: 國際發展基金
       international_treaty:
-        one: 國際條約
         other: 國際條約
       maib_report:
-        one: 海事事故調查局報告
         other: 海事事故調查局報告
       map:
-        one: 地圖
         other: 地圖
       medical_safety_alert:
-        one: 藥品和醫療器材的警示召回
         other: 藥品和醫療器材的警示召回
       national:
-        one: 國家統計公告
         other: 國家統計公告
       national_statistics:
-        one: 國家統計
         other: 國家統計
       national_statistics_announcement:
-        one: 國家統計公告
         other: 國家統計公告
       news_article:
-        one: 新聞文章
         other: 新聞文章
       news_story:
-        one: 新聞報導
         other: 新聞報導
       notice:
-        one: 通知
         other: 通知
       official:
-        one: 官方統計公告
         other: 官方統計公告
       official_statistics:
-        one: 官方統計
         other: 官方統計
       official_statistics_announcement:
-        one: 官方統計公告
         other: 官方統計公告
       open_consultation:
-        one: 公開諮詢
         other: 公開諮詢
       oral_statement:
-        one: 對議會的口頭聲明
         other: 對議會的口頭聲明
       policy:
-        one: 政策
         other: 政策
       policy_paper:
-        one: 政策文件
         other: 政策文件
       press_release:
-        one: 新聞稿
         other: 新聞稿
       product-safety-alert-report-recall:
-        one:
         other:
       promotional:
-        one: 宣傳資料
         other: 宣傳資料
       publication:
-        one: 出版
         other: 出版
       raib_report:
-        one: 鐵路事故調查局報告
         other: 海事事故調查局報告
       regulation:
-        one: 法規
         other: 法規
       research:
-        one: 研究與分析
         other: 研究與分析
       residential_property_tribunal_decision:
-        one: 住宅房產法庭裁決
         other: 住宅房產法庭裁決
       service_sign_in:
-        one: 服務登入
         other: 服務登入
       service_standard_report:
-        one: 服務標準報告
         other: 服務標準報告
       speaking_notes:
-        one: 發言筆記
         other: 發言筆記
       speech:
-        one: 演說
         other: 演說
       standard:
-        one: 標準
         other: 標準
       statement_to_parliament:
-        one: 向議會發表聲明
         other: 向議會發表聲明
       statistical_data_set:
-        one: 統計數據組
         other: 統計數據組
       statistics_announcement:
-        one: 統計發佈公告
         other: 統計發佈公告
       statutory_guidance:
-        one: 法令指導
         other: 法令指導
       take_part:
-        one: 參與
         other: 參與
       tax_tribunal_decision:
-        one: 稅務和衡平法院裁決
         other: 稅務和衡平法院裁決
       transcript:
-        one: 副本
         other: 副本
       transparency:
-        one: 透明數據
         other: 透明數據
       utaac_decision:
-        one: 行政上訴審裁處裁決
         other: 勞資上訴審裁處裁決
       world_news_story:
-        one: 世界新聞報導
         other: 世界新聞報導
       written_statement:
-        one: 對議會的書面聲明
         other: 對議會的書面聲明
   corporate_information_page:
     about_our_services_html: 了解 %{link}。
@@ -442,7 +368,6 @@ zh-tw:
   publication:
     details: 細節
     documents:
-      one: 文檔
       other: 文檔
   service_sign_in:
     continue: 繼續


### PR DESCRIPTION
We're now using the extra plural rules defined by RTM as a prod
dependency [1]. This will replace the list defined in govuk_app_config
and so the reference has also been removed. RTM's version loads
automatically [2] and so we don't have to explicitly include the file in
the app.

Testing locally on a production rails server:

Fetching from plural file [1]:
```
[6] pry(#<ContentItemsController>)> plural_form = I18n.with_locale("cy") { I18n.t!("i18n.plural.keys") }.sort
=> [:few, :many, :one, :other, :two, :zero]
[7] pry(#<ContentItemsController>)> plural_form = I18n.with_locale("zh") { I18n.t!("i18n.plural.keys") }.sort
=> [:other]
[8] pry(#<ContentItemsController>)> plural_form = I18n.with_locale("dr") { I18n.t!("i18n.plural.keys") }.sort
=> [:one, :other]
```

Fetching from the default store (rails-i18n) [3]:
```
[11] pry(#<ContentItemsController>)> plural_form = I18n.with_locale("ar") { I18n.t!("i18n.plural.keys") }.sort
=> [:few, :many, :one, :other, :two, :zero]
```

[1]: https://github.com/alphagov/rails_translation_manager/blob/main/config/locales/plurals.rb
[2]: https://github.com/alphagov/rails_translation_manager/blob/f18fd2e178719dd0a103981160f898771957fa43/lib/rails_translation_manager.rb#L24
[3]: https://github.com/svenfuchs/rails-i18n/blob/ad26c50e1fea0eac2c9b85815f2c051f33a78045/rails/pluralization/ar.rb

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
