### PR TITLE
Use bootsnap to improve startup time.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.dockerignore
+.git
+.gitignore
+Dockerfile
+Jenkinsfile
+Procfile
+README.md
+coverage
+docs
+features
+log
+spec
+test
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,24 +3,22 @@ ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
 
 FROM $builder_image AS builder
 
-WORKDIR /app
-
+WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
-
-COPY . /app
-RUN bundle exec rails assets:precompile && rm -rf /app/log
+COPY . ./
+RUN bundle exec bootsnap precompile --gemfile .
+RUN bundle exec rails assets:precompile && rm -rf log
 
 
 FROM $base_image
 
-# TODO: remove PORT and set it in publishing-e2e-tests instead.
-ENV GOVUK_APP_NAME=government-frontend PORT=3090
+ENV GOVUK_APP_NAME=government-frontend
 
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH/ $BUNDLE_PATH/
+COPY --from=builder $BOOTSNAP_CACHE_DIR/ $BOOTSNAP_CACHE_DIR/
+COPY --from=builder $APP_HOME ./
 
 USER app
-WORKDIR /app
-
-CMD ["bundle", "exec", "puma"]
+CMD ["puma"]

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "7.0.4"
 
+gem "bootsnap", require: false
 gem "dalli"
 gem "gds-api-adapters"
 gem "govuk_ab_testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
       smart_properties
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.15.0)
+      msgpack (~> 1.2)
     brakeman (5.3.1)
     builder (3.2.4)
     capybara (3.38.0)
@@ -206,6 +208,8 @@ GEM
       ruby2_keywords (>= 0.0.5)
     net-imap (0.3.2)
       date
+    msgpack (1.6.0)
+    net-imap (0.3.1)
       net-protocol
     net-pop (0.1.2)
       net-protocol
@@ -395,6 +399,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
+  bootsnap
   capybara
   climate_control
   dalli

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup"


### PR DESCRIPTION
We seem to be using [bootsnap](https://github.com/Shopify/bootsnap) on most of the publisher apps but not on the frontends.

We don't care much about startup time per se, but reducing the CPU spike on pod startup is helpful for capacity planning and helps to keep the overall performance of the cluster more predictable.

Tested: works on the integration k8s cluster. Benchmarking locally with `docker run` showed [\>40% improvement](https://docs.google.com/spreadsheets/d/13-acYdjnMcqV_JzrHR-fWFK8vYsM2aCXJuw6X_cRoAY/edit#gid=0) in startup time and savings of roughly 2 core-seconds per pod startup. Regression tested on EC2 by deploying to the integration environment, checking that smoke tests still pass there and checking there were no errors/warnings in app logs.