### PR TITLE
Add recruitment banner for cost of living tree test

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -34,3 +34,7 @@
   max-width: 30em;
   padding-top: govuk-spacing(2);
 }
+
+.gem-c-intervention {
+  margin-top: govuk-spacing(4);
+}

--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,0 +1,32 @@
+module ContentItem
+  module RecruitmentBanner
+    COST_OF_LIVING_SURVEY_URL = "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a".freeze
+    SURVEY_URL_MAPPINGS = {
+      "/guidance/cost-of-living-payment" => COST_OF_LIVING_SURVEY_URL,
+      "/universal-credit" => COST_OF_LIVING_SURVEY_URL,
+      "/the-warm-home-discount-scheme" => COST_OF_LIVING_SURVEY_URL,
+      "/winter-fuel-payment" => COST_OF_LIVING_SURVEY_URL,
+      "/pay-self-assessment-tax-bill" => COST_OF_LIVING_SURVEY_URL,
+      "/universal-credit/eligibility" => COST_OF_LIVING_SURVEY_URL,
+      "/universal-credit/what-youll-get" => COST_OF_LIVING_SURVEY_URL,
+      "/universal-credit/how-to-claim" => COST_OF_LIVING_SURVEY_URL,
+      "/winter-fuel-payment/how-much-youll-get" => COST_OF_LIVING_SURVEY_URL,
+      "/government/publications/autumn-statement-2022-cost-of-living-support-factsheet/cost-of-living-support-factsheet" => COST_OF_LIVING_SURVEY_URL,
+      "/new-state-pension/what-youll-get" => COST_OF_LIVING_SURVEY_URL,
+      "/check-if-youre-eligible-for-warm-home-discount" => COST_OF_LIVING_SURVEY_URL,
+      "/universal-credit/other-financial-support" => COST_OF_LIVING_SURVEY_URL,
+      "/guidance/getting-the-energy-bills-support-scheme-discount" => COST_OF_LIVING_SURVEY_URL,
+      "/pension-credit" => COST_OF_LIVING_SURVEY_URL,
+      "/child-benefit" => COST_OF_LIVING_SURVEY_URL,
+    }.freeze
+
+    def recruitment_survey_url
+      cost_of_living_test_url
+    end
+
+    def cost_of_living_test_url
+      key = content_item["base_path"]
+      SURVEY_URL_MAPPINGS[key]
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,5 +1,6 @@
 class ContentItemPresenter
   include ContentItem::Withdrawable
+  include ContentItem::RecruitmentBanner
   attr_reader :content_item,
               :requested_path,
               :view_context,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,14 @@
 </head>
 <body>
   <div id="wrapper" class="<%= wrapper_class %>">
-    <% if @content_item.show_phase_banner? %>
+    <% if @content_item.recruitment_survey_url %>
+      <%= render "govuk_publishing_components/components/intervention", {
+        suggestion_text: "Help improve GOV.UK",
+        suggestion_link_text: "Take part in user research",
+        suggestion_link_url: @content_item.recruitment_survey_url,
+        new_tab: true,
+      } %>
+    <% elsif @content_item.show_phase_banner? %>
       <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase %>
     <% end %>
 

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "Cost of living recruitment banner is displayed on pages of interest" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+
+    pages_of_interest =
+      [
+        "/guidance/cost-of-living-payment",
+        "/universal-credit",
+        "/the-warm-home-discount-scheme",
+        "/winter-fuel-payment",
+        "/pay-self-assessment-tax-bill",
+        "/universal-credit/eligibility",
+        "/universal-credit/what-youll-get",
+        "/universal-credit/how-to-claim",
+        "/winter-fuel-payment/how-much-youll-get",
+        "/government/publications/autumn-statement-2022-cost-of-living-support-factsheet/cost-of-living-support-factsheet",
+        "/new-state-pension/what-youll-get",
+        "/check-if-youre-eligible-for-warm-home-discount",
+        "/universal-credit/other-financial-support",
+        "/guidance/getting-the-energy-bills-support-scheme-discount",
+        "/pension-credit",
+        "/child-benefit",
+      ]
+
+    pages_of_interest.each do |path|
+      guide["base_path"] = path
+      stub_content_store_has_item(guide["base_path"], guide.to_json)
+      visit guide["base_path"]
+
+      assert page.has_css?(".gem-c-intervention")
+      assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a")
+    end
+  end
+
+  test "Cost of living recruitment banner is not displayed on all pages" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    guide["base_path"] = "/nothing-to-see-here"
+    stub_content_store_has_item(guide["base_path"], guide.to_json)
+    visit guide["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a")
+  end
+end


### PR DESCRIPTION
Trello https://trello.com/c/woeqmUsz/1521-banner-request-for-cost-of-living-tree-test-m

Page served by this app with banner
https://government-frontend-pr-2630.herokuapp.com/guidance/cost-of-living-payment

<img width="1026" alt="Screenshot 2022-12-13 at 15 03 19" src="https://user-images.githubusercontent.com/17908089/207368877-34c99f81-0117-4989-9c75-9bd1601a6eb9.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
