### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "govuk_app_config"
 gem "govuk_personalisation"
 gem "govuk_publishing_components"
 gem "htmlentities"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "plek"
 gem "rails-controller-testing"
 gem "rails-i18n"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,11 +185,8 @@ GEM
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -206,10 +203,9 @@ GEM
       ruby-progressbar
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
+    msgpack (1.6.0)
     net-imap (0.3.2)
       date
-    msgpack (1.6.0)
-    net-imap (0.3.1)
       net-protocol
     net-pop (0.1.2)
       net-protocol
@@ -413,6 +409,7 @@ DEPENDENCIES
   govuk_test
   htmlentities
   i18n-coverage
+  mail (~> 2.7.1)
   minitest-reporters
   mocha
   plek


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
