### PR TITLE
Update Chinese (Hong Kong) plurals

### DIFF
--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -57,153 +57,153 @@ zh-hk:
       updated: 已更新
     schema_name:
       aaib_report:
-        other: 其他空中意外事故調查報告
+        other: 空中意外事故調查報告
       announcement:
-        other: 其他公告
+        other: 公告
       asylum_support_decision:
-        other: 其他庇護支援裁判決定
+        other: 庇護支援裁判決定
       authored_article:
-        other: 其他撰寫文章
+        other: 撰寫文章
       business_finance_support_scheme:
-        other: 其他商業融資支援計劃
+        other: 商業融資支援計劃
       case_study:
-        other: 其他案例研究
+        other: 案例研究
       closed_consultation:
-        other: 其他專屬諮詢
+        other: 專屬諮詢
       cma_case:
-        other: 其他競爭及市場管理案例
+        other: 競爭及市場管理案例
       coming_soon:
-        other: 其他即將推出之項目
+        other: 即將推出之項目
       consultation:
-        other: 其他諮詢
+        other: 諮詢
       consultation_outcome:
-        other: 其他諮詢結果
+        other: 諮詢結果
       corporate_information_page:
-        other: 其他資訊頁面
+        other: 資訊頁面
       corporate_report:
-        other: 其他政府報告
+        other: 政府報告
       correspondence:
-        other: 其他通信
+        other: 通信
       countryside_stewardship_grant:
-        other: 其他鄉村管理補助金
+        other: 鄉村管理補助金
       decision:
-        other: 其他決定
+        other: 決定
       detailed_guide:
-        other: 其他詳細指引
+        other: 詳細指引
       dfid_research_output:
-        other: 其他發展成果之研究
+        other: 發展成果之研究
       document_collection:
-        other: 其他系列
+        other: 系列
       draft_text:
-        other: 其他內容
+        other: 內容
       drug_safety_update:
-        other: 其他藥物安全更新
+        other: 藥物安全更新
       employment_appeal_tribunal_decision:
-        other: 其他僱傭上訴法庭裁決
+        other: 僱傭上訴法庭裁決
       employment_tribunal_decision:
-        other: 其他僱傭法庭裁決
+        other: 僱傭法庭裁決
       esi_fund:
-        other: 其他歐洲結構與投資基金 (ESIF)
+        other: 歐洲結構與投資基金 (ESIF)
       fatality_notice:
-        other: 其他安全事故通知
+        other: 安全事故通知
       foi_release:
-        other: 其他資訊自由(FOI)資訊發布
+        other: 資訊自由(FOI)資訊發布
       form:
-        other: 其他表格
+        other: 表格
       government_response:
-        other: 政府其他回應
+        other: 政府回應
       guidance:
-        other: 其他指引
+        other: 指引
       impact_assessment:
-        other: 其他影響評估
+        other: 影響評估
       imported:
         other: 輸入-等待類型中
       independent_report:
-        other: 其他獨立報告
+        other: 獨立報告
       international_development_fund:
         other: 國際發展籌資
       international_treaty:
-        other: 其他國際條約
+        other: 國際條約
       maib_report:
-        other: 其他海洋事故調查處報告
+        other: 海洋事故調查處報告
       map:
-        other: 其他地圖
+        other: 地圖
       medical_safety_alert:
-        other: 其他藥品及醫療器械警示及召回
+        other: 藥品及醫療器械警示及召回
       national:
-        other: 其他國家統計數據公告
+        other: 國家統計數據公告
       national_statistics:
-        other: 其他國家統計數據
+        other: 國家統計數據
       national_statistics_announcement:
-        other: 其他國家統計數據公告
+        other: 國家統計數據公告
       news_article:
-        other: 其他新聞
+        other: 新聞
       news_story:
-        other: 其他新聞
+        other: 新聞
       notice:
-        other: 其他通知
+        other: 通知
       official:
-        other: 其他官方統計數據公告
+        other: 官方統計數據公告
       official_statistics:
-        other: 其他統計資料
+        other: 統計資料
       official_statistics_announcement:
-        other: 其他官方統計數據公告
+        other: 官方統計數據公告
       open_consultation:
-        other: 其他公開諮詢
+        other: 公開諮詢
       oral_statement:
-        other: 提交國會的其他口頭聲明
+        other: 提交國會的口頭聲明
       policy:
-        other: 其他政策
+        other: 政策
       policy_paper:
-        other: 其他政策文件
+        other: 政策文件
       press_release:
-        other: 其他新聞稿
+        other: 新聞稿
       product-safety-alert-report-recall:
         other:
       promotional:
-        other: 其他宣傳資料
+        other: 宣傳資料
       publication:
-        other: 其他出版物
+        other: 出版物
       raib_report:
-        other: 其他鐵路意外調查處公告
+        other: 鐵路意外調查處公告
       regulation:
-        other: 其他規定
+        other: 規定
       research:
-        other: 其他研究與分析
+        other: 研究與分析
       residential_property_tribunal_decision:
-        other: 其他住宅物業法庭裁決
+        other: 住宅物業法庭裁決
       service_sign_in:
         other: 服務登入
       service_standard_report:
-        other: 其他服務標準報告
+        other: 服務標準報告
       speaking_notes:
-        other: 其他演講稿
+        other: 演講稿
       speech:
-        other: 其他演講
+        other: 演講
       standard:
-        other: 其他標準
+        other: 標準
       statement_to_parliament:
-        other: 提交國會的其他聲明
+        other: 提交國會的聲明
       statistical_data_set:
-        other: 其他統計數據資料
+        other: 統計數據資料
       statistics_announcement:
-        other: 其他統計數據資料發佈公告
+        other: 統計數據資料發佈公告
       statutory_guidance:
         other: 法定指引
       take_part:
         other: 參加活動
       tax_tribunal_decision:
-        other: 其他稅務及大法官法庭裁決
+        other: 稅務及大法官法庭裁決
       transcript:
-        other: 其他談話副本
+        other: 談話副本
       transparency:
-        other: 其他透明化數據
+        other: 透明化數據
       utaac_decision:
-        other: 其他行政上訴法庭裁決
+        other: 行政上訴法庭裁決
       world_news_story:
-        other: 其他世界新聞故事
+        other: 世界新聞故事
       written_statement:
-        other: 提交國會的其他書面聲明
+        other: 提交國會的書面聲明
   corporate_information_page:
     about_our_services_html: 找尋 %{link}。
     corporate_information: 政府資訊
@@ -368,7 +368,7 @@ zh-hk:
   publication:
     details: 詳情
     documents:
-      other: 其他文件
+      other: 文件
   service_sign_in:
     continue: 繼續
     error:


### PR DESCRIPTION
We removed `one` in [1], which complied with Chinese plural rules, however the value of `one` was actually the correct value for the `other` key. This PR swaps the the values for each plural.

[1]: https://github.com/alphagov/government-frontend/pull/2621/commits/a181f038a63a25aa929410297ee0f55d63ea6afd

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
