### PR TITLE
Handle webchat CSP modifications in application 

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -13,6 +13,10 @@ class ContentItemsController < ApplicationController
 
   attr_accessor :content_item, :taxonomy_navigation
 
+  content_security_policy do |p|
+    p.connect_src(*p.connect_src, -> { csp_connect_src })
+  end
+
   def show
     load_content_item
 
@@ -211,5 +215,11 @@ private
     # Override the default from GovukPersonalisation::ControllerConcern so pages are cached on each flash message
     # variation, rather than caching pages per user
     response.headers["Vary"] = [response.headers["Vary"], "GOVUK-Account-Session-Exists", "GOVUK-Account-Session-Flash"].compact.join(", ")
+  end
+
+  def csp_connect_src
+    return if !@content_item || !@content_item.respond_to?(:csp_connect_src)
+
+    @content_item.csp_connect_src
   end
 end

--- a/app/models/webchat.rb
+++ b/app/models/webchat.rb
@@ -5,13 +5,14 @@ class Webchat
 
   validates :base_path, :open_url, :availability_url, presence: true
 
-  attr_reader :base_path, :open_url, :availability_url, :open_url_redirect
+  attr_reader :base_path, :open_url, :availability_url, :open_url_redirect, :csp_connect_src
 
   def initialize(attrs)
     @base_path = attrs["base_path"] if attrs["base_path"].present?
     @open_url = attrs["open_url"] if attrs["open_url"].present?
     @availability_url = attrs["availability_url"] if attrs["availability_url"].present?
     @open_url_redirect = attrs.fetch("open_url_redirect", nil)
+    @csp_connect_src = attrs["csp_connect_src"]
     validate!
   end
 

--- a/app/models/webchat.rb
+++ b/app/models/webchat.rb
@@ -8,10 +8,10 @@ class Webchat
   attr_reader :base_path, :open_url, :availability_url, :open_url_redirect, :csp_connect_src
 
   def initialize(attrs)
-    @base_path = attrs["base_path"] if attrs["base_path"].present?
-    @open_url = attrs["open_url"] if attrs["open_url"].present?
-    @availability_url = attrs["availability_url"] if attrs["availability_url"].present?
-    @open_url_redirect = attrs.fetch("open_url_redirect", nil)
+    @base_path = attrs["base_path"]
+    @open_url = attrs["open_url"]
+    @availability_url = attrs["availability_url"]
+    @open_url_redirect = attrs["open_url_redirect"]
     @csp_connect_src = attrs["csp_connect_src"]
     validate!
   end

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -93,6 +93,10 @@ class ContactPresenter < ContentItemPresenter
     content_item.dig("details", "more_info_webchat").try(:html_safe)
   end
 
+  def csp_connect_src
+    webchat&.csp_connect_src
+  end
+
 private
 
   def phone_numbers_in_group(group)

--- a/docs/webchat.md
+++ b/docs/webchat.md
@@ -39,14 +39,18 @@ Once this shim is removed we can move this component into Static as a GOV.UK Pub
 - base_path: /government/contact/my-amazing-service
   open_url: https://www.my-amazing-webchat.com/007/open-chat
   availability_url: https://www.my-amazing-webchat.com/007/check-availability
+  csp_connect_src: https://www.my-amazing-webchat.com
 ```
 
 3. Deploy changes
 4. Go to https://www.gov.uk/government/contact/my-amazing-service
 5. Finished
 
-## CORS considerations
-To avoid CORS and CSP issues a new provider would need to be added to the [Content Security Policy](https://docs.publishing.service.gov.uk/manual/content-security-policy.html)
+## Content Security Policy considerations
+
+For a webchat provider to integrate with GOV.UK it needs permissions from the [Content Security Policy](https://docs.publishing.service.gov.uk/manual/content-security-policy.html).
+
+This will be set-up for a provider by the `csp_connect_src` option which configures the `connect-src` directive, however other providers may need additional configuration, such as `script-src`. This configuration should be done in the same manner as `csp_connect_src` to only affect resources that embed webchat.
 
 ## Required configuration
 
@@ -83,4 +87,12 @@ By default the chat session would open in an a separate browser window. An addit
 The default response from the api as used by HMRC webchat provider is JSONP. To add a provider that responds using JSON the following entry needs to be added.
 ```yaml
   availability_payload_format: json
+```
+
+### CSP connect-src
+
+Updates the Content Security Policy for pages that embed webchat to grant permission to make requests to the host specified. This should be in the form of a hostname, ideally with a scheme. For more information see, [connect-src](https://content-security-policy.com/connect-src/).
+
+```yaml
+  csp_connect_src: https://webchat.host
 ```

--- a/docs/webchat.md
+++ b/docs/webchat.md
@@ -1,35 +1,4 @@
-# Webchat Component
-
-This Webchat can represent four 'busy', 'unavailable', 'available', 'error'.
-
-## Supporting backend API Proxy
-
-See the [reference implementation](https://github.com/alphagov/reference-webchat-proxy) for the backend API that is used alongside this component.
-
-## Usage
-
-The Webchat should be accessed through a shared [shared partial](https://github.com/alphagov/government-frontend/blob/main/app/views/shared/_webchat.html.erb) in which you need to pass the locals `webchat_availability_url` and `webchat_open_url`.
-
-`webchat_availability_url` will be polled at an interval to check for the webchat instances' avaliability.
-
-
-`webchat_open_url` is the page that will be opened when a user clicks the webchat call-to-action shown in the 'avaliable' state.
-
-
-Finally once you have your partial rendering on the page, you will need to make sure the [library](https://github.com/alphagov/government-frontend/blob/main/app/assets/javascripts/webchat/library.js) is included on your page and this in your initialisation code.
-
-```javascript
-  var webchats = document.querySelectorAll('.js-webchat')
-  for (var i = 0; i < webchats.length; i++) {
-    new GOVUK.Webchat(webchats[i])
-  }
-```
- a fuller example can be seen [here](https://github.com/alphagov/government-frontend/blob/main/app/assets/javascripts/webchat.js) that has an implementation of the normalisation as noted below
-
-### Note regarding response Normalisation
-As can be seen in the fuller example above, we currently have the option to do the normalisation in JavaScript, this is deprecated, and is shim code until all current users of Wbchat have their own proxies up and running.
-
-Once this shim is removed we can move this component into Static as a GOV.UK Publishing Component
+# Webchat
 
 ## How to add a new webchat provider
 

--- a/lib/webchat.yaml
+++ b/lib/webchat.yaml
@@ -1,4 +1,5 @@
 - base_path: /government/organisations/hm-passport-office/contact/hm-passport-office-webchat
   open_url: https://omni.eckoh.uk/v03.5/launcherV3.php?p=HMPO&d=717&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Chat&s=https://omni.eckoh.uk/v03.5&u=&wo=&uh=&pid=2&iif=0
   availability_url: https://omni.eckoh.uk/v03.5/providers/HMPO/api/availability.php
+  csp_connect_src: https://omni.eckoh.uk
   open_url_redirect: false

--- a/test/models/webchat_test.rb
+++ b/test/models/webchat_test.rb
@@ -6,6 +6,7 @@ class WebchatTest < ActiveSupport::TestCase
     "base_path" => "/government/contact/my-amazing-service",
     "open_url" => "https://www.tax.service.gov.uk/csp-partials/open/1023",
     "availability_url" => "https://www.tax.service.gov.uk/csp-partials/availability/1023",
+    "csp_connect_src" => "https://www.tax.service.gov.uk",
   }
 
   test "should create instance correctly" do
@@ -14,6 +15,7 @@ class WebchatTest < ActiveSupport::TestCase
     assert_equal(instance.base_path, webchat_config["base_path"])
     assert_equal(instance.open_url, webchat_config["open_url"])
     assert_equal(instance.availability_url, webchat_config["availability_url"])
+    assert_equal(instance.csp_connect_src, webchat_config["csp_connect_src"])
   end
 
   test "should return error if config is invalid" do

--- a/test/presenters/contact_presenter_test.rb
+++ b/test/presenters/contact_presenter_test.rb
@@ -99,5 +99,23 @@ class ContactPresenterTest
       assert_equal presented.webchat.availability_url, availability_url
       assert_equal presented.webchat.open_url, open_url
     end
+
+    test "returns csp_connect_src if a webchat is configured" do
+      webchat = Webchat.new({
+        "base_path" => "/content",
+        "open_url" => "https://webchat.host/open",
+        "availability_url" => "https://webchat.host/avaiable",
+        "csp_connect_src" => "https://webchat.host",
+      })
+
+      Webchat.stubs(:find).returns(webchat)
+      assert_equal "https://webchat.host", presented_item.csp_connect_src
+    end
+
+    test "returns a csp_connect_src of nil if webchat isn't configured" do
+      Webchat.stubs(:find).returns(nil)
+
+      assert_nil presented_item.csp_connect_src
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

Webchat integrations on GOV.UK require modifications to the Content
Security Policy (CSP), these previously have been handled in
govup_app_config [1]. Overtime we have ended up with these falling out
of date, with more CSP entries than used cases. It is also a pain to
deploy these as you need to update the gem first.

This PR moves the CSP configuration into this application, which
resolves these pain points and follows the convention in our CSP
documentation [2] to not apply config that is just for a single
application.

This applies an approach where the CSP modification is only applied on
the webchat page, so it won't be broadcast across all other GOV.UK
pages. I set this up to meet the needs of the one webchat integration we
have which has a single entry to connect-src. In future we may well also
need to add a script-src integration as well. I also considered setting
up the ability that connect-src could contain an array, but didn't
implement it as there wasn't precedence of a webchat with this. It
shouldn't be hard to configure though if that situation occurs.

A slight difference to the integration in the govuk_app_config CSP is
the prefix of `https://` [3]. Which requires any connections to
omni.eckoh.uk use TLS. I'm assuming we just didn't know we could specify
this when we first set-up our CSP and the precedence remained.

Setting up an integration test for this functionality was a little bit
of a pain as the controller tests don't execute the CSP code and thus
don't allow testing. I imagine this would be resolved by switching to
Rails request testing [4]. I therefore set the testing up for this in a
Capybara integration test.

I noticed while developing this that the omni.eckoh.uk provider seems to
have an integration problem (the available resource returns 404) which I
deemed as out-of-scope for this change.

[1]: https://github.com/alphagov/govuk_app_config/blob/7f060692720df50a27f6845f052b04eae2246226/lib/govuk_app_config/govuk_content_security_policy.rb#L77-L84
[2]: https://docs.publishing.service.gov.uk/manual/content-security-policy.html
[3]: https://github.com/alphagov/govuk_app_config/blob/7f060692720df50a27f6845f052b04eae2246226/lib/govuk_app_config/govuk_content_security_policy.rb#L83
[4]: https://guides.rubyonrails.org/testing.html#integration-testing

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
