### PR TITLE
Fix layout of /government/history and remove use of inline styles

### DIFF
--- a/app/views/histories/10_downing_street.html.erb
+++ b/app/views/histories/10_downing_street.html.erb
@@ -21,7 +21,7 @@
 
 <div class="govuk-grid-row">
   <nav class="govuk-grid-column-one-third">
-    <%= image_tag "history/buildings/number-10-300.jpg", alt: "The front door of 10 Downing Street", loading: "lazy", style: "width:100%" %>
+    <%= image_tag "history/buildings/number-10-300.jpg", alt: "The front door of 10 Downing Street", loading: "lazy", class: "govuk-!-width-full" %>
 
     <%= render "govuk_publishing_components/components/contents_list", {
       contents: [

--- a/app/views/histories/10_downing_street.html.erb
+++ b/app/views/histories/10_downing_street.html.erb
@@ -91,13 +91,11 @@
     <p>The Romans first came to Britain under the command of Julius Caesar in 55 BC. Making their capital at Londinium downriver, the Romans chose Thorney Island &ndash; a marshy piece of land lying between two branches of the river Tyburn that flowed from Hampstead Heath to the Thames &ndash; as the site for their early settlement.</p>
     <p>These Roman settlements, and those of the Anglo-Saxons and Normans who supplanted them, were not very successful. The area was prone to plague and its inhabitants were very poor. A charter granted by the Mercian King Offa in the year 785 refers to &ldquo;the terrible place called Thorney Island&rdquo;. It took royal patronage to give the area prestige. King Canute (reigned 1017 to 1035) built a palace in the area, and Edward the Confessor (reigned 1042 to 1066) and William the Conqueror (reigned 1066 to 1087) maintained a royal presence there. The position of Westminster (as the area became known) as the centre of government and the church was solidified following the construction of the great abbey nearby, on Edward's orders.</p>
 
-    <figure class="image embedded">
-      <div class="img">
-        <img src="<%= image_path("history/buildings/whitehall.jpg") %>" alt="Whitehall from St James’s Park – Hendrick Danckerts c.1675">
-        <figcaption>
-          <p>Whitehall from St James’s Park – Hendrick Danckerts c.1675</p>
-        </figcaption>
-      </div>
+    <figure>
+      <img src="<%= image_path("history/buildings/whitehall.jpg") %>" alt="Whitehall from St James’s Park – Hendrick Danckerts c.1675">
+      <figcaption>
+        <p>Whitehall from St James’s Park – Hendrick Danckerts c.1675</p>
+      </figcaption>
     </figure>
 
     <p>The earliest building known to have stood on the site of Downing Street was the Axe brewery owned by the Abbey of Abingdon in the Middle Ages. By the early 1500s, it had fallen into disuse.</p>
@@ -271,13 +269,11 @@
     <p>Larry has been in residence since 15 February 2011, he is the first cat at Number 10 to be bestowed with the official title Chief Mouser.</p>
     <p>Larry was recruited from <a href="http://www.battersea.org.uk/" rel="external" class="govuk-link">Battersea Dogs &amp; Cats Home</a> on recommendation for his mousing skills. He joined the Number 10 household and has made a significant impact.</p>
 
-    <figure class="image embedded">
-      <div class="img">
-        <img src="<%= image_path("history/buildings/larry-the-cat.jpg") %>" alt="Larry the cat sitting on a table where the cabinet meet.">
-        <figcaption>
-          <p>Larry the cat</p>
-        </figcaption>
-      </div>
+    <figure>
+      <img src="<%= image_path("history/buildings/larry-the-cat.jpg") %>" alt="Larry the cat sitting on a table where the cabinet meet.">
+      <figcaption>
+        <p>Larry the cat</p>
+      </figcaption>
     </figure>
 
     <p>He has captured the hearts of the Great British public and the press teams often camped outside the front door. In turn the nation sends him gifts and treats daily.</p>

--- a/app/views/histories/11_downing_street.html.erb
+++ b/app/views/histories/11_downing_street.html.erb
@@ -21,7 +21,7 @@
 
 <div class="govuk-grid-row">
   <nav class="govuk-grid-column-one-third">
-    <%= image_tag "history/buildings/number-11-300.jpg", alt: "The front of 11 Downing Street", loading: "lazy", style: "width:100%" %>
+    <%= image_tag "history/buildings/number-11-300.jpg", alt: "The front of 11 Downing Street", loading: "lazy", class: "govuk-!-width-full" %>
 
     <%= render "govuk_publishing_components/components/contents_list", {
       contents: [

--- a/app/views/histories/1_horse_guards_road.html.erb
+++ b/app/views/histories/1_horse_guards_road.html.erb
@@ -21,7 +21,7 @@
 
 <div class="govuk-grid-row">
   <nav class="govuk-grid-column-one-third">
-    <%= image_tag "history/buildings/1-horse-guards-300.jpg", alt: "1 Horse Guards Road", loading: "lazy", style: "width:100%" %>
+    <%= image_tag "history/buildings/1-horse-guards-300.jpg", alt: "1 Horse Guards Road", loading: "lazy", class: "govuk-!-width-full" %>
     <%= render "govuk_publishing_components/components/contents_list", {
       contents: [
         {

--- a/app/views/histories/history.html.erb
+++ b/app/views/histories/history.html.erb
@@ -27,7 +27,7 @@
     </div>
     <div class="govuk-grid-column-one-third">
       <figure class="govuk-!-margin-0">
-        <%= image_tag "history/horse-guards-vintage.jpg", alt: "An old painting of the Horse Guards building.", loading: "lazy", style: "width:100%" %>
+        <%= image_tag "history/horse-guards-vintage.jpg", alt: "An old painting of the Horse Guards building.", loading: "lazy", class: "govuk-!-width-full" %>
         <figcaption>Thomas Shotter Boys &ndash; A View of the Horse Guards from Whitehall. Government Art Collection.</figcaption>
       </figure>
     </div>
@@ -38,7 +38,7 @@
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
     </div>
     <div class="govuk-grid-column-one-half">
-      <%= image_tag 'how-gov-works/churchill_01.jpg', alt: "", loading: "lazy", style: "width:100%" %>
+      <%= image_tag 'how-gov-works/churchill_01.jpg', alt: "", loading: "lazy", class: "govuk-!-width-full" %>
     </div>
     <div class="govuk-grid-column-one-half">
       <%= render "govuk_publishing_components/components/heading", {
@@ -103,7 +103,7 @@
       </ul>
     </div>
     <div class="govuk-grid-column-one-half">
-      <%= image_tag 'history/government-buildings.jpg', alt: "", loading: "lazy", style: "width:100%" %>
+      <%= image_tag 'history/government-buildings.jpg', alt: "", loading: "lazy", class: "govuk-!-width-full" %>
     </div>
   </div>
 
@@ -112,7 +112,7 @@
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
     </div>
     <div class="govuk-grid-column-one-half">
-      <%= image_tag 'history/historical-documents.jpg', alt: "", loading: "lazy", style: "width:100%" %>
+      <%= image_tag 'history/historical-documents.jpg', alt: "", loading: "lazy", class: "govuk-!-width-full" %>
     </div>
     <div class="govuk-grid-column-one-half">
       <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/histories/history.html.erb
+++ b/app/views/histories/history.html.erb
@@ -12,7 +12,7 @@
 </header>
 
 <div class="govuk-body govuk-!-padding-bottom-6">
-  <div class="govuk-grid-row introduction">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
     </div>
@@ -25,17 +25,17 @@
       <p class="govuk-body-l">Governments are remembered for their leaders and the course they set for their country. The British government has a long and fascinating history, and exploring its past can help us understand how it is run today.</p>
       <p class="govuk-body">The information here provides a starting point for research. It includes objective factual content and research carried out by independent and civil service historians.</p>
     </div>
-    <figure class="govuk-grid-column-one-third image">
+    <figure class="govuk-grid-column-one-third">
       <%= image_tag "history/horse-guards-vintage.jpg", alt: "An old painting of the Horse Guards building.", loading: "lazy", style: "width:100%" %>
       <figcaption>Thomas Shotter Boys &ndash; A View of the Horse Guards from Whitehall. Government Art Collection.</figcaption>
     </figure>
   </div>
 
-  <div class="govuk-grid-row notable-people">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
     </div>
-    <div class="govuk-grid-column-one-half image">
+    <div class="govuk-grid-column-one-half">
       <%= image_tag 'how-gov-works/churchill_01.jpg', alt: "", loading: "lazy", style: "width:100%" %>
     </div>
     <div class="govuk-grid-column-one-half">
@@ -61,7 +61,7 @@
     </div>
   </div>
 
-  <div class="govuk-grid-row government-buildings">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
     </div>
@@ -100,16 +100,16 @@
         </li>
       </ul>
     </div>
-    <div class="govuk-grid-column-one-half image">
+    <div class="govuk-grid-column-one-half">
       <%= image_tag 'history/government-buildings.jpg', alt: "", loading: "lazy", style: "width:100%" %>
     </div>
   </div>
 
-  <div class="govuk-grid-row documents-and-records">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
     </div>
-    <div class="govuk-grid-column-one-half image">
+    <div class="govuk-grid-column-one-half">
       <%= image_tag 'history/historical-documents.jpg', alt: "", loading: "lazy", style: "width:100%" %>
     </div>
     <div class="govuk-grid-column-one-half">

--- a/app/views/histories/history.html.erb
+++ b/app/views/histories/history.html.erb
@@ -25,10 +25,12 @@
       <p class="govuk-body-l">Governments are remembered for their leaders and the course they set for their country. The British government has a long and fascinating history, and exploring its past can help us understand how it is run today.</p>
       <p class="govuk-body">The information here provides a starting point for research. It includes objective factual content and research carried out by independent and civil service historians.</p>
     </div>
-    <figure class="govuk-grid-column-one-third">
-      <%= image_tag "history/horse-guards-vintage.jpg", alt: "An old painting of the Horse Guards building.", loading: "lazy", style: "width:100%" %>
-      <figcaption>Thomas Shotter Boys &ndash; A View of the Horse Guards from Whitehall. Government Art Collection.</figcaption>
-    </figure>
+    <div class="govuk-grid-column-one-third">
+      <figure class="govuk-!-margin-0">
+        <%= image_tag "history/horse-guards-vintage.jpg", alt: "An old painting of the Horse Guards building.", loading: "lazy", style: "width:100%" %>
+        <figcaption>Thomas Shotter Boys &ndash; A View of the Horse Guards from Whitehall. Government Art Collection.</figcaption>
+      </figure>
+    </div>
   </div>
 
   <div class="govuk-grid-row">

--- a/app/views/histories/king_charles_street.html.erb
+++ b/app/views/histories/king_charles_street.html.erb
@@ -21,7 +21,7 @@
 
 <div class="govuk-grid-row">
   <nav class="govuk-grid-column-one-third">
-    <%= image_tag "history/buildings/king-charles-street-300.jpg", alt: "King Charles Street", loading: "lazy", style: "width:100%" %>
+    <%= image_tag "history/buildings/king-charles-street-300.jpg", alt: "King Charles Street", loading: "lazy", class: "govuk-!-width-full" %>
 
     <%= render "govuk_publishing_components/components/contents_list", {
       contents: [

--- a/app/views/histories/lancaster_house.html.erb
+++ b/app/views/histories/lancaster_house.html.erb
@@ -94,10 +94,8 @@
 
     <h2 id="the-grand-hall-and-staircase">The grand hall and staircase</h2>
 
-    <figure class="image embedded">
-      <div class="img">
-        <img src="<%= image_path("history/buildings/lancaster-house-main-hall.jpg") %>" alt="Lancaster House grand hall and staircase">
-      </div>
+    <figure>
+      <img src="<%= image_path("history/buildings/lancaster-house-main-hall.jpg") %>" alt="Lancaster House grand hall and staircase">
     </figure>
 
     <p>On entering the house through the portico, the hall opens up to reveal a sweeping staircase in a deliberate echo of Versailles. This and the rococo balustrade are both part of Benjamin Wyatt’s original design.</p>
@@ -105,10 +103,8 @@
 
     <h2 id="the-long-gallery">The long gallery</h2>
 
-    <figure class="image embedded">
-      <div class="img">
-        <img src="<%= image_path("history/buildings/lancaster-house-long-gallery.jpg") %>" alt="Lancaster House long gallery">
-      </div>
+    <figure>
+      <img src="<%= image_path("history/buildings/lancaster-house-long-gallery.jpg") %>" alt="Lancaster House long gallery">
     </figure>
 
     <p>The long gallery can hold up to 200 people seated theatre-style or 150 for a seated dinner. Alternatively, it can accommodate a conference table for up to 60, with a further 120 people seated beside and behind the table. The long gallery provides a dramatic backdrop for big events; it is perfect for opening or closing ceremonies and receptions for up to 350 people.</p>
@@ -119,10 +115,8 @@
 
     <h2 id="the-music-room">The music room</h2>
 
-    <figure class="image embedded">
-      <div class="img">
-        <img src="<%= image_path("history/buildings/lancaster-house-music-room.jpg") %>" alt="Lancaster House music room">
-      </div>
+    <figure>
+      <img src="<%= image_path("history/buildings/lancaster-house-music-room.jpg") %>" alt="Lancaster House music room">
     </figure>
 
     <p>The music room can accommodate a boardroom table for 36 and theatre style for 100. It can also accommodate lunch or dinner for up to 76 people.</p>
@@ -131,10 +125,8 @@
 
     <h2 id="the-state-drawing-room">The state drawing room</h2>
 
-    <figure class="image embedded">
-      <div class="img">
-        <img src="<%= image_path("history/buildings/lancaster-house-state-drawing-room.jpg") %>" alt="Lancaster House state drawing room">
-      </div>
+    <figure>
+      <img src="<%= image_path("history/buildings/lancaster-house-state-drawing-room.jpg") %>" alt="Lancaster House state drawing room">
     </figure>
 
     <p>The state drawing room is suitable for a wide range of events. It can accommodate 40 people at a boardroom table, 34 for a lunch or dinner, and 120 for a reception.</p>
@@ -143,10 +135,8 @@
 
     <h2 id="the-green-room">The green room</h2>
 
-    <figure class="image embedded">
-      <div class="img">
-        <img src="<%= image_path("history/buildings/lancaster-house-green-room.jpg") %>" alt="Lancaster House green room">
-      </div>
+    <figure>
+      <img src="<%= image_path("history/buildings/lancaster-house-green-room.jpg") %>" alt="Lancaster House green room">
     </figure>
 
     <p>The green room is ideal as a dining room for up to 20 people. As a press briefing room, it can seat 28 people theatre style. Ministers have also used it as a private office during conferences.</p>

--- a/app/views/histories/lancaster_house.html.erb
+++ b/app/views/histories/lancaster_house.html.erb
@@ -21,7 +21,7 @@
 
 <div class="govuk-grid-row">
   <nav class="govuk-grid-column-one-third">
-    <%= image_tag "history/buildings/lancaster-house-300.jpg", alt: "Lancaster House", loading: "lazy", style: "width:100%" %>
+    <%= image_tag "history/buildings/lancaster-house-300.jpg", alt: "Lancaster House", loading: "lazy", class: "govuk-!-width-full" %>
 
     <%= render "govuk_publishing_components/components/contents_list", {
       contents: [


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

The changes here have been made in order for this application to be compatible with the changes coming in https://github.com/alphagov/govuk_app_config/pull/279, where inline styles will no longer be permitted. The scope grew a little to do a bit of a clean-up in the history pages where inline styles were present.

This change:
- removes classes that have no effect
- fixes a layout bug
- replaces inline styles with a class

The layout bug is demonstrated below

Before:

<img width="1040" alt="Screenshot 2023-01-13 at 18 25 12" src="https://user-images.githubusercontent.com/282717/212392507-a6f478d7-f4b1-4dc2-aee4-56004d127446.png">

After:

<img width="1082" alt="Screenshot 2023-01-13 at 18 31 42" src="https://user-images.githubusercontent.com/282717/212393509-5603b52c-bff7-4ea7-a54c-ea59fb4041c6.png">

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
