### PR TITLE
Subscribe and Print Buttons on Same Row

### DIFF
--- a/app/assets/stylesheets/components/_back-to-top.scss
+++ b/app/assets/stylesheets/components/_back-to-top.scss
@@ -1,6 +1,6 @@
 .app-c-back-to-top {
   display: inline-block;
-  margin-bottom: govuk-spacing(3);
+  margin-bottom: govuk-spacing(2);
   margin-left: govuk-spacing(3);
   margin-right: govuk-spacing(3);
 }

--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -21,3 +21,19 @@
     }
   }
 }
+
+.detailed-guide-bottom-button-container {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    flex-direction: row;
+  }
+}
+
+.detailed-guide-bottom-button-container form {
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: govuk-spacing(3);
+  }
+  @include govuk-media-query($from: tablet) {
+    margin-right: govuk-spacing(4);
+  }
+}

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -100,24 +100,8 @@
         <%= raw(@content_item.govspeak_body[:content]) %>
       <% end %>
 
-      <div class="responsive-bottom-margin">
-        <%= render 'shared/published_dates_with_notification_button' %>
-      </div>
+      <%= render 'shared/published_dates_with_notification_button' %>
     <% end %>
-    <%= render "govuk_publishing_components/components/print_link", {
-        margin_top: 0,
-        margin_bottom: 6,
-        data_attributes: {
-          module: "ga4-event-tracker",
-          ga4_event: {
-            event_name: 'print_page',
-            type: 'print page',
-            index: 2,
-            index_total: 2,
-            section: 'Footer',
-          },
-        },
-      } %>
   </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -2,11 +2,29 @@
     published: @content_item.published,
     last_updated: @content_item.updated,
     history: @content_item.history,
-    margin_bottom: 3,
+    margin_bottom: 5,
   } %>
-<%= render 'govuk_publishing_components/components/single_page_notification_button', {
+
+<div class="detailed-guide-bottom-button-container">
+  <%= render 'govuk_publishing_components/components/single_page_notification_button', {
     base_path: @content_item.base_path,
     js_enhancement: @has_govuk_account,
     button_location: "bottom",
-    margin_bottom: 0,
-} if @content_item.has_single_page_notifications? %>
+    margin_bottom: 3,
+  } if @content_item.has_single_page_notifications? %>
+  <%= render "govuk_publishing_components/components/print_link", {
+    margin_top: 0,
+    margin_bottom: 8,
+    data_attributes: {
+      module: "ga4-event-tracker",
+      ga4_event: {
+        event_name: 'print_page',
+        type: 'print page',
+        index: 2,
+        index_total: 2,
+        section: 'Footer',
+      },
+    },
+  } %>
+</div>
+


### PR DESCRIPTION
## What

At the bottom of content item pages, the email subscription button and print button have been moved to be on the same row.

## Why 

This was a request from the designers of the Navigation and Presentation team.

[Relevant Trello Card](https://trello.com/c/Jlix7XV6/1489-move-placement-of-email-subscription-and-print-this-page-buttons-on-guidance-pages-s)

## Visual Differences

### Before

#### Desktop

![Screenshot 2023-01-16 at 15 08 26](https://user-images.githubusercontent.com/3727504/212710177-0648afe0-db84-483f-8449-f93fad662415.png)

#### Mobile

![Screenshot 2023-01-16 at 15 08 33](https://user-images.githubusercontent.com/3727504/212710223-ef52069c-d94a-4051-8f98-78549cf02972.png)

### After

#### Desktop

![Screenshot 2023-01-16 at 15 09 06](https://user-images.githubusercontent.com/3727504/212710273-93718249-01bd-4fbd-91da-2bd501cd06cd.png)

#### Mobile

![Screenshot 2023-01-16 at 15 09 11](https://user-images.githubusercontent.com/3727504/212710303-ccb25c92-86e3-4977-a35a-07dafb5ea8d9.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

