### PR TITLE
Fix content schema tests

### DIFF
--- a/test/contracts/govuk_content_schemas_test.rb
+++ b/test/contracts/govuk_content_schemas_test.rb
@@ -3,9 +3,10 @@ require "test_helper"
 class GovukContentSchemasTest < ActionDispatch::IntegrationTest
   include GovukContentSchemaExamples
 
-  all_examples_for_supported_schemas.each do |content_item|
-    test "can successfully render #{content_item['base_path']} schema example" do
+  all_examples_for_supported_schemas.each_with_index do |content_item, index|
+    test "can successfully render #{content_item['document_type']} #{index} example" do
       stub_content_store_has_item(content_item["base_path"], content_item)
+      stub_parent_breadcrumbs(content_item, content_item["document_type"])
 
       get content_item["base_path"]
 

--- a/test/support/govuk_content_schema_examples.rb
+++ b/test/support/govuk_content_schema_examples.rb
@@ -29,9 +29,16 @@ module GovukContentSchemaExamples
     GovukSchemas::Example.find(schema_name, example_name:)
   end
 
+  def stub_parent_breadcrumbs(document, schema)
+    parents = document.dig("links", "parent")
+    return if parents.nil?
+
+    stub_content_store_has_item(parents.first["base_path"], document) if schema == "html_publication"
+  end
+
   module ClassMethods
     def all_examples_for_supported_schemas
-      GovukSchemas::Example.find_all(supported_schemas)
+      supported_schemas.flat_map { |format| GovukSchemas::Example.find_all(format) }
     end
 
     def supported_schemas
@@ -39,7 +46,6 @@ module GovukContentSchemaExamples
         case_study
         coming_soon
         html_publication
-        redirect
         statistics_announcement
         take_part
         topical_event_about_page


### PR DESCRIPTION
The test file test/contracts/govuk_content_schemas_test.rb was not actually testing anything because there was a typo in the support file, such that GovukSchemas::Example.find_all(supported_schemas) was returning [] 

- This is because the `find_all` method expects a single string param. See [here](https://github.com/alphagov/govuk_schemas/blob/4fef0aa95be24c3534a00b622a59ea7f1e8175fa/lib/govuk_schemas/example.rb#L5)

- Also removes redirect, as there is no frontend rendering. https://github.com/alphagov/publishing-api/tree/main/content_schemas/examples/redirect

- Minitest won't run tests of the same name, and multiple schema examples have the same basepath. Hence adding in the index to the iterator.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
https://trello.com/c/1gPCngv0/1136-migrate-service-manual-frontend-templates-into-government-frontend-m