### PR TITLE
Turn on GA4 tracking in sidebar and footer

### DIFF
--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -44,6 +44,6 @@
     <% end %>
   </div>
   <div class="govuk-grid-column-one-third">
-    <%= render 'govuk_publishing_components/components/related_navigation', content_item: @content_item.content_item.parsed_content, context: :sidebar %>
+    <%= render 'govuk_publishing_components/components/related_navigation', content_item: @content_item.content_item.parsed_content, context: :sidebar, ga4_tracking: true %>
   </div>
 </div>

--- a/app/views/shared/_footer_navigation.html.erb
+++ b/app/views/shared/_footer_navigation.html.erb
@@ -1,6 +1,5 @@
 <% @contextual_footer = capture do %>
-  <%= render 'govuk_publishing_components/components/contextual_footer',
-             content_item: @content_item.content_item.parsed_content %>
+  <%= render 'govuk_publishing_components/components/contextual_footer', content_item: @content_item.content_item.parsed_content, ga4_tracking: true %>
 <% end %>
 
 <% if @contextual_footer.present? %>

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -3,5 +3,5 @@
 %>
 
 <div class="govuk-grid-column-one-third">
-  <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
+  <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item, ga4_tracking: true %>
 </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Turn on GA4 tracking in the related navigation, contextual sidebar and contextual footer components. Note that this will enable tracking for the related navigation and the step by step navigation components, where they are present inside the contextual sidebar component.

Example pages:

- [contextual sidebar containing a step by step navigation](https://www.gov.uk/national-minimum-wage-rates)
- [contextual sidebar and contextual footer both containing related navigation](https://www.gov.uk/government/statistics/uk-armed-forces-recovery-capability-wounded-injured-and-sick-in-the-recovery-pathway-financial-year-201516)
- [another example of the previous link](https://www.gov.uk/guidance/waste-exemption-nwfd-2-temporary-storage-at-the-place-of-production--2)

## Why
Part of implementing analytics using GA4.

## Visual changes
None.

Trello card: https://trello.com/c/IMjw2dHg/382-add-tracking-related-links-contextual-sidebar-and-contextual-footer
