### PR TITLE
Add scroll tracking to requested MoJ pages

### DIFF
--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -2,6 +2,15 @@
   <%= machine_readable_metadata(
     schema: (@content_item.dataset? ? :dataset : :article)
   ) %>
+
+  <%
+    # As per request https://govuk.zendesk.com/agent/tickets/5176602
+    scroll_track_paths = %w[/government/publications/form-pa14-medical-certificate-probate /government/publications/find-a-will-or-probate-document-form-pa1s /government/publications/report-a-will-is-lost-to-support-a-probate-application]
+  %>
+
+  <% if scroll_track_paths.include?(@content_item.base_path) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker"/>
+  <% end %>
 <% end %>
 
 <%= render 'shared/email_subscribe_unsubscribe_flash' %>


### PR DESCRIPTION
Enables GA scroll tracking on:

* https://www.gov.uk/government/publications/form-pa14-medical-certificate-probate
* https://www.gov.uk/government/publications/find-a-will-or-probate-document-form-pa1s
* https://www.gov.uk/government/publications/report-a-will-is-lost-to-support-a-probate-application

See https://govuk.zendesk.com/agent/tickets/5176602

![Screenshot 2023-01-24 at 1 32 07 pm](https://user-images.githubusercontent.com/424772/214307985-d74fd09e-6101-4622-b62d-0d371fb95485.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
