### PR TITLE
Update page for reshuffle banner

### DIFF
--- a/app/presenters/corporate_information_page_presenter.rb
+++ b/app/presenters/corporate_information_page_presenter.rb
@@ -8,7 +8,7 @@ class CorporateInformationPagePresenter < ContentItemPresenter
   ORG_CHANGING_BANNER_BASE_PATHS = %w[
     /government/organisations/department-for-business-energy-and-industrial-strategy/about
     /government/organisations/department-for-international-trade/about
-    /government/organisations/department-for-business-energy-and-industrial-strategy/about
+    /government/organisations/department-for-digital-culture-media-sport/about
   ].freeze
 
   def page_title


### PR DESCRIPTION
Missing from https://github.com/alphagov/government-frontend/pull/2687

#### Before

<img width="1049" alt="Screenshot 2023-02-07 at 14 12 36" src="https://user-images.githubusercontent.com/17908089/217268533-8fa11dd4-a100-4470-ac68-de7d05752430.png">

#### After

<img width="1127" alt="Screenshot 2023-02-07 at 14 13 35" src="https://user-images.githubusercontent.com/17908089/217268748-2434cac0-1189-4f5d-9d3c-85ba61ad689b.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
