### PR TITLE
Move 'the' to prefix the link text

### DIFF
--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -7,7 +7,7 @@
 <% if @content_item.show_organisation_changing_banner? %>
   <div class="govuk-width-container govuk-!-margin-top-8">
     <%= render "govuk_publishing_components/components/notice", {
-      title: sanitize('This organisation is changing. Read <a href="https://www.gov.uk/government/news/making-government-deliver-for-the-british-people">the latest updates on government departments</a> or visit the <a href="https://twitter.com/10DowningStreet">10 Downing Street Twitter feed</a>.'),
+      title: sanitize('This organisation is changing. Read the <a href="https://www.gov.uk/government/news/making-government-deliver-for-the-british-people">latest updates on government departments</a> or visit the <a href="https://twitter.com/10DowningStreet">10 Downing Street Twitter feed</a>.'),
       margin_bottom: 3,
     } %>
   </div>


### PR DESCRIPTION
### Before

<img width="1059" alt="Screenshot 2023-02-07 at 14 28 44" src="https://user-images.githubusercontent.com/24479188/217272566-cf7a2264-83e1-4a14-a600-667ae9336ee2.png">

### After

<img width="1034" alt="Screenshot 2023-02-07 at 14 28 33" src="https://user-images.githubusercontent.com/24479188/217272634-a25bb3fa-bd09-458a-a56a-44a37db40c05.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
