### PR TITLE
Bump publishing components version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
     govuk_personalisation (0.13.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (34.7.1)
+    govuk_publishing_components (34.8.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown


### PR DESCRIPTION
Applies [1] which will fix the issue spotted in [2].

[1]: https://github.com/alphagov/govuk_publishing_components/pull/3243
[2]: https://govuk.zendesk.com/agent/tickets/5207548.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
