### PR TITLE
Small amends to service manual pages

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -95,6 +95,7 @@ private
       service_manual_service_standard
       service_manual_topic
       service_manual_homepage
+      service_manual_service_toolkit
     ]
 
     @do_not_show_breadcrumbs =

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -92,7 +92,7 @@ class ContentItemPresenter
     phase.in?(%w[alpha beta])
   end
 
-  def show_service_manual_phase_banner?
+  def service_manual?
     false
   end
 

--- a/app/presenters/service_manual_presenter.rb
+++ b/app/presenters/service_manual_presenter.rb
@@ -11,7 +11,7 @@ class ServiceManualPresenter < ContentItemPresenter
     true
   end
 
-  def show_service_manual_phase_banner?
+  def service_manual?
     true
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,13 @@
   <%= yield :extra_head_content %>
 </head>
 <body>
+  <% if @content_item.service_manual? %>
+    <div class="slimmer-inside-header">
+      <span class="govuk-header__product-name gem-c-header__product-name">
+        <%= "Service Manual" %>
+      </span>
+    </div>
+  <% end %>
   <div id="wrapper" class="<%= wrapper_class %>">
 
     <% if @content_item.show_phase_banner? || @content_item.service_manual? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,14 +32,14 @@
 <body>
   <div id="wrapper" class="<%= wrapper_class %>">
 
-    <% if @content_item.show_phase_banner? || @content_item.show_service_manual_phase_banner? %>
+    <% if @content_item.show_phase_banner? || @content_item.service_manual? %>
       <div class="govuk-width-container">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
             <% if @content_item.show_phase_banner? %>
               <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase %>
             <% end %>
-            <% if @content_item.show_service_manual_phase_banner? %>
+            <% if @content_item.service_manual? %>
               <%= render_phase_label @content_item, content_for(:phase_message) %>
             <% end %>
           </div>


### PR DESCRIPTION
A few minor tweaks to service manual pages, following on from https://github.com/alphagov/government-frontend/pull/2583

1. Remove unwanted breadcrumb from /service-toolkit
2. Add "service manual" to the page title

### Before

<img width="1128" alt="Screenshot 2023-02-08 at 13 55 16" src="https://user-images.githubusercontent.com/17908089/217549762-a9071b01-e120-4d37-8416-0b9ff6154605.png">


### After
<img width="732" alt="after" src="https://user-images.githubusercontent.com/17908089/217550470-446f0352-321e-40dc-8973-47ccfecc5319.png">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
