### PR TITLE
Add Cost of living survey banner

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -34,3 +34,7 @@
   max-width: 30em;
   padding-top: govuk-spacing(2);
 }
+
+.gem-c-intervention {
+  margin-top: govuk-spacing(4);
+}

--- a/app/presenters/content_item/cost_of_living_banner.rb
+++ b/app/presenters/content_item/cost_of_living_banner.rb
@@ -1,0 +1,31 @@
+module ContentItem
+  module CostOfLivingBanner
+    COST_OF_LIVING_SURVEY_URL = "https://surveys.publishing.service.gov.uk/s/XS2YWV/".freeze
+
+    SURVEY_URL_MAPPINGS = {
+      "/guidance/cost-of-living-payment" => COST_OF_LIVING_SURVEY_URL,
+      "/cost-living-help-local-council" => COST_OF_LIVING_SURVEY_URL,
+      "/benefits-calculators" => COST_OF_LIVING_SURVEY_URL,
+      "/the-warm-home-discount-scheme" => COST_OF_LIVING_SURVEY_URL,
+      "/universal-credit" => COST_OF_LIVING_SURVEY_URL,
+      "/universal-credit/eligibility" => COST_OF_LIVING_SURVEY_URL,
+      "/universal-credit/what-youll-get" => COST_OF_LIVING_SURVEY_URL,
+      "/universal-credit/how-to-claim" => COST_OF_LIVING_SURVEY_URL,
+      "/universal-credit/other-financial-support" => COST_OF_LIVING_SURVEY_URL,
+      "/universal-credit/contact-universal-credit" => COST_OF_LIVING_SURVEY_URL,
+      "/new-state-pension/what-youll-get" => COST_OF_LIVING_SURVEY_URL,
+      "/get-help-energy-bills" => COST_OF_LIVING_SURVEY_URL,
+      "/get-help-energy-bills/getting-discount-energy-bill" => COST_OF_LIVING_SURVEY_URL,
+      "/pension-credit" => COST_OF_LIVING_SURVEY_URL,
+    }.freeze
+
+    def survey_url
+      cost_of_living_test_url
+    end
+
+    def cost_of_living_test_url
+      key = content_item["base_path"]
+      SURVEY_URL_MAPPINGS[key]
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,5 +1,7 @@
 class ContentItemPresenter
+  include ContentItem::CostOfLivingBanner
   include ContentItem::Withdrawable
+
   attr_reader :content_item,
               :requested_path,
               :view_context,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,6 +62,15 @@
       <% end %>
     <% end %>
 
+    <% if @content_item.survey_url %>
+      <%= render "govuk_publishing_components/components/intervention", {
+        suggestion_text: "Help improve GOV.UK",
+        suggestion_link_text: "Take part in user research",
+        suggestion_link_url: @content_item.survey_url,
+        new_tab: true,
+      } %>
+    <% end %>
+
     <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">
       <%= yield %>
     </main>

--- a/test/integration/cost_of_living_banner_test.rb
+++ b/test/integration/cost_of_living_banner_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "Cost of living survey banner is displayed on pages of interest" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+
+    pages_of_interest = %w[
+      /guidance/cost-of-living-payment
+      /cost-living-help-local-council
+      /benefits-calculators
+      /the-warm-home-discount-scheme
+      /universal-credit
+      /universal-credit/eligibility
+      /universal-credit/what-youll-get
+      /universal-credit/how-to-claim
+      /universal-credit/other-financial-support
+      /universal-credit/contact-universal-credit
+      /new-state-pension/what-youll-get
+      /get-help-energy-bills
+      /get-help-energy-bills/getting-discount-energy-bill
+      /pension-credit
+    ]
+
+    pages_of_interest.each do |path|
+      guide["base_path"] = path
+      stub_content_store_has_item(guide["base_path"], guide.to_json)
+      visit guide["base_path"]
+
+      assert page.has_css?(".gem-c-intervention")
+      assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/XS2YWV/")
+    end
+  end
+
+  test "Cost of living recruitment banner is not displayed on all pages" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    guide["base_path"] = "/nothing-to-see-here"
+    stub_content_store_has_item(guide["base_path"], guide.to_json)
+    visit guide["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/XS2YWV/")
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why

Add an intervention banner that links to the Cost of living survey banner.

Paths affected:

/guidance/cost-of-living-payment
      /cost-living-help-local-council
      /benefits-calculators
      /the-warm-home-discount-scheme
      /universal-credit
      /universal-credit/eligibility
      /universal-credit/what-youll-get
      /universal-credit/how-to-claim
      /universal-credit/other-financial-support
      /universal-credit/contact-universal-credit
      /new-state-pension/what-youll-get
      /get-help-energy-bills
      /get-help-energy-bills/getting-discount-energy-bill
      /pension-credit

[Trello](https://trello.com/c/XozIyJgB/1670-cost-of-living-col-1-of-2-surveys-user-research-banner-request-m)

## Screenshots

### Before

![www gov uk_guidance_cost-of-living-payment](https://user-images.githubusercontent.com/424772/222146973-20500a9d-6fff-4166-a686-a7b9900e8aa8.png)

### After

![localhost_3090_guidance_cost-of-living-payment](https://user-images.githubusercontent.com/424772/222147012-fd8fe1f1-870a-448d-a296-04dd3fe715df.png)
