### PR TITLE
Adds top margin to title component inside inverse-header

### DIFF
--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -37,7 +37,8 @@
         title: @content_item.title,
         context: I18n.t("content_item.schema_name.#{@content_item.format_sub_type}", count: 1),
         inverse: true,
-        margin_bottom: 0
+        margin_bottom: 0,
+        margin_top: 3
   %>
   <p class="publication-header__last-changed"><%= @content_item.last_changed %></p>
 <% end %>


### PR DESCRIPTION
[Github issue](https://github.com/alphagov/govuk_publishing_components/issues/3085)

This PR addresses a problem where the inverse header displays with uneven vertical spacing. This is caused by the way the component is rendered on the page rather than the component itself and requires that some extra padding is added to the top of the component so that it displays in a satisfactorily balanced way. 

|Current|Updated|
|-|-|
|![heading_before](https://user-images.githubusercontent.com/6080548/222208455-c7cfcdcf-68e5-421b-9469-a9d7b70eee4a.png)|![heading_after](https://user-images.githubusercontent.com/6080548/222208495-af6f4f8a-e4b2-4181-bf76-806bd3e57ac8.png)|