### PR TITLE
Update how contents list is called

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -47,7 +47,7 @@
         href: "#guide-contents"
       } %>
       <aside class="part-navigation-container" role="complementary">
-        <%= render "govuk_publishing_components/components/contents_list", aria_label: t("guide.pages_in_guide"), contents: @content_item.part_link_elements, underline_links: true %>
+        <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("guide.pages_in_guide") }, contents: @content_item.part_link_elements, underline_links: true %>
       </aside>
     <% end %>
   </div>

--- a/app/views/content_items/guide_single.html.erb
+++ b/app/views/content_items/guide_single.html.erb
@@ -20,7 +20,7 @@
 
     <% if @content_item.show_guide_navigation? %>
       <aside class="part-navigation-container" role="complementary">
-        <%= render "govuk_publishing_components/components/contents_list", aria_label: t("guide.pages_in_guide"), contents: @content_item.part_link_elements, underline_links: true %>
+        <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("guide.pages_in_guide") }, contents: @content_item.part_link_elements, underline_links: true %>
       </aside>
     <% end %>
   </div>

--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -4,7 +4,7 @@
   } %>
 
   <%= render "govuk_publishing_components/components/contents_list", {
-    aria_label: t("manuals.pages_in_manual_section"), contents: @content_item.contents, underline_links: true
+    aria: { label: t("manuals.pages_in_manual_section") }, contents: @content_item.contents, underline_links: true
   } %>
 
   <div class="govuk-grid-row">

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -16,7 +16,7 @@
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
 
     <aside class="part-navigation-container" role="complementary">
-      <%= render "govuk_publishing_components/components/contents_list", aria_label: t("travel_advice.pages"), contents: @content_item.part_link_elements, underline_links: true %>
+      <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("travel_advice.pages") }, contents: @content_item.part_link_elements, underline_links: true %>
 
       <%= render 'govuk_publishing_components/components/subscription_links',
         email_signup_link: @content_item.email_signup_link,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Updates how the contents list component is called. Specifically the `aria_label` option for the contents list component has been replaced with the `aria` option (passing a hash of aria options).

## Why
Updates to the component in the gem mean that this option would no longer work, needed updating. Note that this PR should not be merged until the change below is merged into a new version of the gem and updated in this application as part of this PR.

Related PR: https://github.com/alphagov/govuk_publishing_components/pull/3254

## Visual changes
None.