### PR TITLE
Fix date format on Get Involved page

### DIFF
--- a/app/presenters/get_involved_presenter.rb
+++ b/app/presenters/get_involved_presenter.rb
@@ -87,7 +87,7 @@ private
         link: {
           text: item["title"],
           path: item["link"],
-          description: "#{close_status} #{item['end_date'].to_date.strftime('%d %B %z')}",
+          description: "#{close_status} #{item['end_date'].to_date.strftime('%d %B %Y')}",
         },
         metadata: {
           public_updated_at: Time.zone.parse(org_time(item)),


### PR DESCRIPTION
This was incorrectly added in
https://github.com/alphagov/government-frontend/pull/2712, so fixing to display the year instead of the timezone.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
