### PR TITLE
Replace subscription email link with component

### DIFF
--- a/app/assets/stylesheets/modules/_related-content.scss
+++ b/app/assets/stylesheets/modules/_related-content.scss
@@ -3,12 +3,3 @@
     border-top: 1px solid $govuk-border-colour;
   }
 }
-
-.related-item {
-  &__email-link {
-    padding-left: 25px;
-    font-weight: bold;
-    background: image-url("service-manual/mail-icon-x2.png") 0 40% no-repeat;
-    background-size: 20px 14px;
-  }
-}

--- a/app/views/shared/_email_signup.html.erb
+++ b/app/views/shared/_email_signup.html.erb
@@ -5,7 +5,12 @@
     margin_bottom: 2,
     id: "related-subscriptions",
   } %>
-  <p class="govuk-body">When any guidance within this topic is updated
-    <%= link_to "email", @content_item.email_alert_signup_link, class: 'govuk-link related-item__email-link' %>
-  </p>
+
+  <div class="related-item__subscription-link">
+    <%= render "govuk_publishing_components/components/subscription_links", {
+      hide_heading: true,
+      email_signup_link_text: "Get emails when any guidance within this topic is updated",
+      email_signup_link: @content_item.email_alert_signup_link
+    } %>
+  </div>
 </div>


### PR DESCRIPTION
## What

Replace email subscription link on service manual pages with subscription link component.

## Why

Adjustment to the design of the email subscription link on service manual pages.

## Visual Changes

### Before

![image](https://user-images.githubusercontent.com/3727504/227562027-aecc0b60-6a8c-453a-a7c0-2f7f77ff7e13.png)


### After

![image](https://user-images.githubusercontent.com/3727504/227562045-73c09720-b131-4110-a031-833b7b9b4bf2.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
