### PR TITLE
Remove deprecated Jenkinsfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 .gitignore
 .github
 Dockerfile
-Jenkinsfile
 Procfile
 README.md
 coverage

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,0 @@
-#!/usr/bin/env groovy
-
-library("govuk")
-
-REPOSITORY = 'government-frontend'
-
-node {
-  govuk.buildProject()
-}


### PR DESCRIPTION
We no longer use Jenkins for testing, and the file needs to be removed to prevent github from reassigning jenkins jobs to the branch settings.

https://trello.com/c/nLIJ54Qs/1746-remove-jenkinsfile-from-our-branches-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
