### PR TITLE
Remove banner from DCMS about page

### DIFF
--- a/app/presenters/corporate_information_page_presenter.rb
+++ b/app/presenters/corporate_information_page_presenter.rb
@@ -8,7 +8,6 @@ class CorporateInformationPagePresenter < ContentItemPresenter
   ORG_CHANGING_BANNER_BASE_PATHS = %w[
     /government/organisations/department-for-business-energy-and-industrial-strategy/about
     /government/organisations/department-for-international-trade/about
-    /government/organisations/department-for-digital-culture-media-sport/about
   ].freeze
 
   def page_title


### PR DESCRIPTION
Content request: DCMS [1] has now been closed and we can remove the org is changing banner. department-for-business-energy-and-industrial-strategy and department-for-international-trade will be closing soon, at which point we can remove this bespoke banner code entirely.

We also need to remove the banner code for the actual org page which lives in collections. Once an org is closed in Whitehall the bespoke banner gets replaced automatically as a different view is rendered [2] vs [3]. This means we don't have to remove each orgs custom banner as it gets replaced anyway. We will still need to remove the banner code in Collections when all three orgs are closed.

[1]: https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport/
[2]: https://github.com/alphagov/collections/blob/6ded61a31a81b7c053151bf74c80c2cd84d001e8/app/views/organisations/separate_website.html.erb#L11-L13
[3]: https://github.com/alphagov/collections/blob/6ded61a31a81b7c053151bf74c80c2cd84d001e8/app/views/organisations/show.html.erb#L7-L13

Trello:
https://trello.com/c/ZATeFciM/244-remove-temporary-banner-for-certain-org-about-pages

## Before

<img width="1472" alt="Screenshot 2023-03-29 at 15 20 34" src="https://user-images.githubusercontent.com/24479188/228568844-5e0cdeb5-20c6-4519-be15-a83e16b03e17.png">

## After

<img width="1287" alt="Screenshot 2023-03-29 at 15 20 52" src="https://user-images.githubusercontent.com/24479188/228568885-745101e0-1d89-41fc-be1a-e3c386129dca.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
