### PR TITLE
Refactor the Manual Pages

### DIFF
--- a/app/views/content_items/hmrc_manual.html.erb
+++ b/app/views/content_items/hmrc_manual.html.erb
@@ -8,42 +8,10 @@
   } %>
 <% end %>
 
-<div id="manuals-frontend" class="manuals-frontend-body">
-
-<%= machine_readable_metadata(schema: :article) %>
-
-
-
-<div class="manual-body">
-  <% if @content_item.description.present? %>
-    <%= render "govuk_publishing_components/components/lead_paragraph", {
-      text: @content_item.description
-    } %>
-  <% end %>
-  <% if @content_item.body.present? %>
-    <%= render "govuk_publishing_components/components/govspeak", {} do %>
-      <%= raw(@content_item.body) %>
-    <% end %>
-  <% end %>
-
+<%= render "content_items/manuals/manual_layout" do %>
   <% @content_item.section_groups.each do |group| %>
     <div class="subsection-collection">
       <%= render "content_items/manuals/hmrc_sections", group: group %>
     </div>
   <% end %>
-
-  <%= render 'govuk_publishing_components/components/print_link', {
-    data_attributes: {
-      module: "ga4-event-tracker",
-      ga4_event: {
-        event_name: 'print_page',
-        type: 'print page',
-        index: {
-          index_link: 1,
-        },
-        index_total: 1,
-        section: 'Footer',
-      },
-    },
-  } %>
-</div>
+<% end %>

--- a/app/views/content_items/hmrc_manual_section.html.erb
+++ b/app/views/content_items/hmrc_manual_section.html.erb
@@ -8,61 +8,22 @@
   } %>
 <% end %>
 
-<div id="manuals-frontend" class="manuals-frontend-body">
-  <div class="govuk-grid-row">
-    <div class="manual-body">
-      <article aria-labelledby="section-title">
-        <div class="govuk-grid-column-full">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: @content_item.document_heading.join(" - "),
-            font_size: "m",
-            id: "section-title",
-            heading_level: 1,
-            margin_bottom: 4,
-          } %>
-        </div>
-
-        <% if @content_item.description.present? %>
-          <div class="govuk-grid-column-two-thirds">
-            <%= render "govuk_publishing_components/components/lead_paragraph", {
-              text: @content_item.description
-            } %>
-          </div>
-        <% end %>
-
-        <% if @content_item.body.present? %>
-          <div class="govuk-grid-column-two-thirds">
-            <%= render "govuk_publishing_components/components/govspeak", {} do %>
-              <%= raw(@content_item.body) %>
-            <% end %>
-          </div>
-        <% end %>
-
-        <% @content_item.section_groups.each do | group | %>
-          <div class="subsection-collection govuk-grid-column-full">
-            <%= render "content_items/manuals/hmrc_sections", group: group %>
-          </div>
-        <% end %>
-
-        <div class="govuk-grid-column-full">
-          <%= render "govuk_publishing_components/components/previous_and_next_navigation", @content_item.previous_and_next_links %>
-        </div>
-      </article>
+<%= render "content_items/manuals/manual_section_layout" do %>
+  <% if @content_item.body.present? %>
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/govspeak", {} do %>
+        <%= raw(@content_item.body) %>
+      <% end %>
     </div>
-  </div>
+  <% end %>
 
-  <%= render 'govuk_publishing_components/components/print_link', {
-    data_attributes: {
-      module: "ga4-event-tracker",
-      ga4_event: {
-        event_name: 'print_page',
-        type: 'print page',
-        index: {
-          index_link: 1,
-        },
-        index_total: 1,
-        section: 'Footer',
-      },
-    },
-  } %>
-</div>
+  <% @content_item.section_groups.each do | group | %>
+    <div class="subsection-collection govuk-grid-column-full">
+      <%= render "content_items/manuals/hmrc_sections", group: group %>
+    </div>
+  <% end %>
+
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/previous_and_next_navigation", @content_item.previous_and_next_links %>
+  </div>
+<% end %>

--- a/app/views/content_items/hmrc_manual_updates.html.erb
+++ b/app/views/content_items/hmrc_manual_updates.html.erb
@@ -8,6 +8,4 @@
   } %>
 <% end %>
 
-<div id="manuals-frontend" class="manuals-frontend-body">
-  <%= render "content_items/manuals/updates", content_item: @content_item %>
-</div>
+<%= render "content_items/manuals/manual_updates_layout" %>

--- a/app/views/content_items/manual.html.erb
+++ b/app/views/content_items/manual.html.erb
@@ -6,23 +6,7 @@
   } %>
 <% end %>
 
-<div id="manuals-frontend" class="manuals-frontend-body">
-
-<%= machine_readable_metadata(schema: :article) %>
-
-
-<div class="manual-body">
-  <% if @content_item.description.present? %>
-    <%= render "govuk_publishing_components/components/lead_paragraph", {
-      text: @content_item.description
-    } %>
-  <% end %>
-  <% if @content_item.body.present? %>
-    <%= render "govuk_publishing_components/components/govspeak", {} do %>
-      <%= raw(@content_item.body) %>
-    <% end %>
-  <% end %>
-
+<%= render "content_items/manuals/manual_layout" do %>
   <% @content_item.section_groups.each do |group| %>
     <%= render "govuk_publishing_components/components/document_list", {
         items: group["child_sections"].map do |section|
@@ -37,19 +21,4 @@
         end
     } %>
   <% end %>
-
-  <%= render 'govuk_publishing_components/components/print_link', {
-    data_attributes: {
-      module: "ga4-event-tracker",
-      ga4_event: {
-        event_name: 'print_page',
-        type: 'print page',
-        index: {
-          index_link: 1,
-        },
-        index_total: 1,
-        section: 'Footer',
-      },
-    },
-  } %>
-</div>
+<% end %>

--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -4,105 +4,63 @@
   } %>
 <% end %>
 
-<div id="manuals-frontend" class="manuals-frontend-body">
-  <%= render "govuk_publishing_components/components/contents_list", {
-    aria: { label: t("manuals.pages_in_manual_section") }, contents: @content_item.contents, underline_links: true
-  } %>
+<%= render "content_items/manuals/manual_section_layout", { show_contents: true } do %>
+  <div class="govuk-grid-column-two-thirds">
+    <% if @content_item.intro.present? %>
+      <%= render "govuk_publishing_components/components/govspeak", {} do
+        raw(@content_item.intro)
+      end %>
+    <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="manual-body">
-      <article aria-labelledby="section-title">
-        <div class="govuk-grid-column-full">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: @content_item.document_heading.join(" - "),
-            font_size: "m",
-            id: "section-title",
-            heading_level: 1,
-            margin_bottom: 4,
-          } %>
-        </div>
-
-        <% if @content_item.description.present? %>
-          <div class="govuk-grid-column-two-thirds">
-            <%= render "govuk_publishing_components/components/lead_paragraph", {
-              text: @content_item.description
+    <% if @content_item.body.present? %>
+      <% if @content_item.visually_expanded? %>
+        <% @content_item.main.map do |item| %>
+          <div class="govuk-!-margin-bottom-3">
+            <%= render "govuk_publishing_components/components/heading", {
+              text: item[:heading][:text],
+              font_size: "m",
+              margin_bottom: 1,
+              id: item[:heading][:id],
             } %>
           </div>
-        <% end %>
-
-        <div class="govuk-grid-column-two-thirds">
-          <% if @content_item.intro.present? %>
+          <div class="govuk-body govuk-!-margin-bottom-1">
             <%= render "govuk_publishing_components/components/govspeak", {} do
-              raw(@content_item.intro)
+              raw(item[:content])
             end %>
-          <% end %>
+          </div>
+        <% end %>
+      <% else %>
+        <%
+          items = @content_item.main.each.with_index(1).map do |item, index|
+            rendered_content = render "govuk_publishing_components/components/govspeak", {} do
+              raw(item[:content])
+            end
 
-          <% if @content_item.body.present? %>
-            <% if @content_item.visually_expanded? %>
-              <% @content_item.main.map do |item| %>
-                <div class="govuk-!-margin-bottom-3">
-                  <%= render "govuk_publishing_components/components/heading", {
-                    text: item[:heading][:text],
-                    font_size: "m",
-                    margin_bottom: 1,
-                    id: item[:heading][:id],
-                  } %>
-                </div>
-                <div class="govuk-body govuk-!-margin-bottom-1">
-                  <%= render "govuk_publishing_components/components/govspeak", {} do
-                    raw(item[:content])
-                  end %>
-                </div>
-              <% end %>
-            <% else %>
-              <%
-                items = @content_item.main.each.with_index(1).map do |item, index|
-                  rendered_content = render "govuk_publishing_components/components/govspeak", {} do
-                    raw(item[:content])
-                  end
+            {
+              data_attributes: {
+                ga4_event: {
+                  event_name: "select_content",
+                  type: "accordion",
+                  text: item[:heading][:text],
+                  index: index,
+                  index_total: @content_item.main.length,
+                }
+              },
+              heading: item[:heading],
+              content: {
+                html: rendered_content,
+              },
+            }
+          end
+        %>
 
-                  {
-                    data_attributes: {
-                      ga4_event: {
-                        event_name: "select_content",
-                        type: "accordion",
-                        text: item[:heading][:text],
-                        index: index,
-                        index_total: @content_item.main.length,
-                      }
-                    },
-                    heading: item[:heading],
-                    content: {
-                      html: rendered_content,
-                    },
-                  }
-                end
-              %>
-
-              <%= render "govuk_publishing_components/components/accordion", {
-                ga4_tracking: true,
-                anchor_navigation: true,
-                items: items,
-              } %>
-            <% end %>
-          <% end %>
-        </div>
-      </article>
-    </div>
+        <%= render "govuk_publishing_components/components/accordion", {
+          ga4_tracking: true,
+          anchor_navigation: true,
+          items: items,
+        } %>
+      <% end %>
+    <% end %>
   </div>
+<% end %>
 
-  <%= render 'govuk_publishing_components/components/print_link', {
-    data_attributes: {
-      module: "ga4-event-tracker",
-      ga4_event: {
-        event_name: 'print_page',
-        type: 'print page',
-        index: {
-          index_link: 1,
-        },
-        index_total: 1,
-        section: 'Footer',
-      },
-    },
-  } %>
-</div>

--- a/app/views/content_items/manual_updates.html.erb
+++ b/app/views/content_items/manual_updates.html.erb
@@ -4,6 +4,4 @@
   } %>
 <% end %>
 
-<div id="manuals-frontend" class="manuals-frontend-body">
-  <%= render "content_items/manuals/updates", content_item: @content_item %>
-</div>
+<%= render "content_items/manuals/manual_updates_layout" %>

--- a/app/views/content_items/manuals/_manual_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_layout.html.erb
@@ -1,0 +1,35 @@
+<% content_for :main do %>
+  <div id="manuals-frontend" class="manuals-frontend-body">
+
+  <%= machine_readable_metadata(schema: :article) %>
+
+  <div class="manual-body">
+    <% if @content_item.description.present? %>
+      <%= render "govuk_publishing_components/components/lead_paragraph", {
+        text: @content_item.description
+      } %>
+    <% end %>
+    <% if @content_item.body.present? %>
+      <%= render "govuk_publishing_components/components/govspeak", {} do %>
+        <%= raw(@content_item.body) %>
+      <% end %>
+    <% end %>
+
+    <%= yield %>
+
+    <%= render 'govuk_publishing_components/components/print_link', {
+      data_attributes: {
+        module: "ga4-event-tracker",
+        ga4_event: {
+          event_name: 'print_page',
+          type: 'print page',
+          index: {
+            index_link: 1,
+          },
+          index_total: 1,
+          section: 'Footer',
+        },
+      },
+    } %>    
+  </div>
+<% end %>

--- a/app/views/content_items/manuals/_manual_section_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_section_layout.html.erb
@@ -1,0 +1,52 @@
+<% show_contents ||= false %>
+
+<% content_for :main do %>
+  <div id="manuals-frontend" class="manuals-frontend-body">
+    <% if show_contents %>
+      <%= render "govuk_publishing_components/components/contents_list", {
+        aria: { label: t("manuals.pages_in_manual_section") }, contents: @content_item.contents, underline_links: true
+      } %>
+    <% end %>
+
+    <div class="govuk-grid-row">
+      <div class="manual-body">
+        <article aria-labelledby="section-title">
+          <div class="govuk-grid-column-full">
+            <%= render "govuk_publishing_components/components/heading", {
+              text: @content_item.document_heading.join(" - "),
+              font_size: "m",
+              id: "section-title",
+              heading_level: 1,
+              margin_bottom: 4,
+            } %>
+          </div>
+
+          <% if @content_item.description.present? %>
+            <div class="govuk-grid-column-two-thirds">
+              <%= render "govuk_publishing_components/components/lead_paragraph", {
+                text: @content_item.description
+              } %>
+            </div>
+          <% end %>
+
+          <%= yield %>
+        </article>
+      </div>
+    </div>
+
+    <%= render 'govuk_publishing_components/components/print_link', {
+      data_attributes: {
+        module: "ga4-event-tracker",
+        ga4_event: {
+          event_name: 'print_page',
+          type: 'print page',
+          index: {
+            index_link: 1,
+          },
+          index_total: 1,
+          section: 'Footer',
+        },
+      },
+    } %>
+  </div>
+<% end %>

--- a/app/views/content_items/manuals/_manual_updates_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_updates_layout.html.erb
@@ -1,0 +1,5 @@
+<% content_for :main do %>
+  <div id="manuals-frontend" class="manuals-frontend-body">
+    <%= render "content_items/manuals/updates", content_item: @content_item %>
+  </div>
+<% end %>


### PR DESCRIPTION
## What

Refactor the manual and HMRC manual partials so that they have common layout partials with the mark-up that is common to both of them.

## Why

The partials _hrmc_manual.html.erb/_manual.html.erb, _manual_section.html.erb/_hmrc_manual_section.html.erb and _hmrc_manual_updates.html.erb/_manual_updates.html.erb in content_items/manuals/ shared much of the same mark-up. Reducing duplicated mark-up makes things more maintainable.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

[Relevant Trello Card](https://trello.com/c/CuRc02VB/1697-refactor-manual-pages-in-government-frontend-m)