### PR TITLE
Update banner text for about pages

### DIFF
--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -7,7 +7,7 @@
 <% if @content_item.show_organisation_changing_banner? %>
   <div class="govuk-width-container govuk-!-margin-top-8">
     <%= render "govuk_publishing_components/components/notice", {
-      title: sanitize('This organisation is changing. Read the <a href="https://www.gov.uk/government/news/making-government-deliver-for-the-british-people">latest updates on government departments</a> or visit the <a href="https://twitter.com/10DowningStreet">10 Downing Street Twitter feed</a>.'),
+      title: sanitize('This organisation is changing. Read about <a href="https://www.gov.uk/government/publications/making-government-deliver-for-the-british-people/making-government-deliver-for-the-british-people-html">recent government updates</a>.'),
       margin_bottom: 3,
     } %>
   </div>


### PR DESCRIPTION
Content request: the banner text should reflect the org pages [1].

[1]: https://www.gov.uk/government/organisations/department-for-international-trade

## Before

<img width="1457" alt="Screenshot 2023-03-30 at 13 34 29" src="https://user-images.githubusercontent.com/24479188/228837447-d4e4652c-37c8-4a5d-922e-6cb48093aef4.png">


## After

<img width="1471" alt="Screenshot 2023-03-30 at 13 34 22" src="https://user-images.githubusercontent.com/24479188/228837478-398f6377-8399-4202-afac-ec9db62a1316.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
