### PR TITLE
Configure AssetHelper to load individual stylesheets

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,10 @@
 //= link application.js
 //= link webchat.js
 //= link application.css
+//= link views/_guide.css
+//= link views/_html-publication.css
+//= link views/_manual.css
+//= link views/_published-dates-button-group.css
+//= link views/_service_manual_guide.css
+//= link views/_specialist-document.css
+//= link views/_travel-advice.css

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,6 +2,15 @@
 //= link application.js
 //= link webchat.js
 //= link application.css
+//= link components/_back-to-top.css
+//= link components/_banner.css
+//= link components/_contents-list-with-body.css
+//= link components/_download-link.css
+//= link components/_error-message.css
+//= link components/_figure.css
+//= link components/_important-metadata.css
+//= link components/_published-dates.css
+//= link components/_publisher-metadata.css
 //= link views/_guide.css
 //= link views/_html-publication.css
 //= link views/_manual.css

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,9 +23,6 @@ $govuk-include-default-font-face: false;
 @import "helpers/publisher-metadata-with-logo";
 @import "helpers/sticky-element-container";
 
-// Components from this application
-@import "components/*";
-
 // pages specific view imports
 @import "views/worldwide-organisation";
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,40 +11,6 @@ $govuk-include-default-font-face: false;
 
 // Components from govuk_publishing_components gem
 @import "govuk_publishing_components/govuk_frontend_support";
-@import "govuk_publishing_components/components/accordion";
-@import "govuk_publishing_components/components/attachment";
-@import "govuk_publishing_components/components/back-link";
-@import "govuk_publishing_components/components/big-number";
-@import "govuk_publishing_components/components/contents-list";
-@import "govuk_publishing_components/components/contextual-sidebar";
-@import "govuk_publishing_components/components/details";
-@import "govuk_publishing_components/components/devolved-nations";
-@import "govuk_publishing_components/components/document-list";
-@import "govuk_publishing_components/components/error-summary";
-@import "govuk_publishing_components/components/fieldset";
-@import "govuk_publishing_components/components/govspeak";
-@import "govuk_publishing_components/components/govspeak-html-publication";
-@import "govuk_publishing_components/components/image-card";
-@import "govuk_publishing_components/components/inset-text";
-@import "govuk_publishing_components/components/intervention";
-@import "govuk_publishing_components/components/inverse-header";
-@import "govuk_publishing_components/components/lead-paragraph";
-@import "govuk_publishing_components/components/metadata";
-@import "govuk_publishing_components/components/notice";
-@import "govuk_publishing_components/components/organisation-logo";
-@import "govuk_publishing_components/components/phase-banner";
-@import "govuk_publishing_components/components/previous-and-next-navigation";
-@import "govuk_publishing_components/components/print-link";
-@import "govuk_publishing_components/components/radio";
-@import "govuk_publishing_components/components/related-navigation";
-@import "govuk_publishing_components/components/share-links";
-@import "govuk_publishing_components/components/single-page-notification-button";
-@import "govuk_publishing_components/components/step-by-step-nav";
-@import "govuk_publishing_components/components/step-by-step-nav-header";
-@import "govuk_publishing_components/components/step-by-step-nav-related";
-@import "govuk_publishing_components/components/subscription-links";
-@import "govuk_publishing_components/components/success-alert";
-@import "govuk_publishing_components/components/translation-nav";
 
 // government-frontend mixins
 @import "mixins/margins";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,13 +27,6 @@ $govuk-include-default-font-face: false;
 @import "components/*";
 
 // pages specific view imports
-@import "views/html-publication";
-@import "views/travel-advice";
-@import "views/service_manual_guide";
-@import "views/specialist-document";
-@import "views/guide";
-@import "views/manual";
-@import "views/published-dates-button-group";
 @import "views/worldwide-organisation";
 
 .case-study,

--- a/app/assets/stylesheets/components/_back-to-top.scss
+++ b/app/assets/stylesheets/components/_back-to-top.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .app-c-back-to-top {
   display: inline-block;
   margin-bottom: govuk-spacing(2);

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .app-c-banner {
   @include responsive-bottom-margin;
   @include govuk-font(19);

--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .app-c-contents-list-with-body__link-container {
   margin: 0 auto;
   padding: 0;

--- a/app/assets/stylesheets/components/_download-link.scss
+++ b/app/assets/stylesheets/components/_download-link.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .app-c-download-link {
   display: inline-block;
   @include govuk-font(19, $weight: bold);

--- a/app/assets/stylesheets/components/_error-message.scss
+++ b/app/assets/stylesheets/components/_error-message.scss
@@ -1,3 +1,4 @@
+@import "govuk_publishing_components/individual_component_support";
 @import "helpers/variables";
 
 .app-c-error-message {

--- a/app/assets/stylesheets/components/_figure.scss
+++ b/app/assets/stylesheets/components/_figure.scss
@@ -1,3 +1,6 @@
+@import "govuk_publishing_components/individual_component_support";
+@import "../mixins/margins";
+
 .app-c-figure {
   @include govuk-clearfix;
   @include responsive-bottom-margin;

--- a/app/assets/stylesheets/components/_important-metadata.scss
+++ b/app/assets/stylesheets/components/_important-metadata.scss
@@ -1,3 +1,6 @@
+@import "govuk_publishing_components/individual_component_support";
+@import "../mixins/margins";
+
 .app-c-important-metadata {
   background: $govuk-brand-colour;
   color: govuk-colour("white");

--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .app-c-published-dates {
   direction: ltr;
   line-height: 1.45em;

--- a/app/assets/stylesheets/components/_publisher-metadata.scss
+++ b/app/assets/stylesheets/components/_publisher-metadata.scss
@@ -1,3 +1,6 @@
+@import "govuk_publishing_components/individual_component_support";
+@import "../mixins/margins";
+
 .app-c-publisher-metadata {
   @include responsive-bottom-margin;
   direction: ltr;

--- a/app/assets/stylesheets/views/_guide.scss
+++ b/app/assets/stylesheets/views/_guide.scss
@@ -1,3 +1,7 @@
+@import "govuk_publishing_components/individual_component_support";
+@import "../helpers/parts";
+@import "../mixins/margins";
+
 .guide {
   @include parts;
 

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .html-publication {
   .publication-external {
     margin-bottom: govuk-spacing(4);

--- a/app/assets/stylesheets/views/_manual.scss
+++ b/app/assets/stylesheets/views/_manual.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .manuals-frontend-body {
   padding-bottom: govuk-spacing(6);
 }

--- a/app/assets/stylesheets/views/_published-dates-button-group.scss
+++ b/app/assets/stylesheets/views/_published-dates-button-group.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .published-dates-button-group {
   @include govuk-media-query($from: tablet) {
     display: flex;

--- a/app/assets/stylesheets/views/_service_manual_guide.scss
+++ b/app/assets/stylesheets/views/_service_manual_guide.scss
@@ -1,3 +1,4 @@
+@import "govuk_publishing_components/individual_component_support";
 @import "../modules/*";
 
 .js-enabled {

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -1,3 +1,6 @@
+@import "govuk_publishing_components/individual_component_support";
+@import "../helpers/parts";
+
 .travel-advice {
   @include parts;
 

--- a/app/views/components/_back_to_top.html.erb
+++ b/app/views/components/_back_to_top.html.erb
@@ -1,3 +1,4 @@
+<% add_app_component_stylesheet("back-to-top") %>
 <%
   text ||= t('content_item.contents', default: "Contents")
 %>

--- a/app/views/components/_banner.html.erb
+++ b/app/views/components/_banner.html.erb
@@ -1,3 +1,4 @@
+<% add_app_component_stylesheet("banner") %>
 <%
   title ||= false
   aside ||= false

--- a/app/views/components/_contents_list_with_body.html.erb
+++ b/app/views/components/_contents_list_with_body.html.erb
@@ -1,3 +1,4 @@
+<% add_app_component_stylesheet("contents-list-with-body") %>
 <% block = yield %>
 <% unless block.empty? %>
   <%

--- a/app/views/components/_download_link.html.erb
+++ b/app/views/components/_download_link.html.erb
@@ -1,3 +1,4 @@
+<% add_app_component_stylesheet("download-link") %>
 <%
   link_text ||= "Download File"
 %>

--- a/app/views/components/_error_message.html.erb
+++ b/app/views/components/_error_message.html.erb
@@ -1,3 +1,4 @@
+<% add_app_component_stylesheet("error-message") %>
 <% id ||= false %>
 <span
   class="app-c-error-message"

--- a/app/views/components/_figure.html.erb
+++ b/app/views/components/_figure.html.erb
@@ -1,3 +1,4 @@
+<% add_app_component_stylesheet("figure") %>
 <%
   alt ||= ''
   caption ||= ''

--- a/app/views/components/_important_metadata.html.erb
+++ b/app/views/components/_important_metadata.html.erb
@@ -1,3 +1,4 @@
+<% add_app_component_stylesheet("important-metadata") %>
 <%
   title = local_assigns[:title]
   items = local_assigns[:items] || {}

--- a/app/views/components/_published_dates.html.erb
+++ b/app/views/components/_published_dates.html.erb
@@ -1,3 +1,4 @@
+<% add_app_component_stylesheet("published-dates") %>
 <%
   published ||= false
   history ||= []

--- a/app/views/components/_publisher_metadata.html.erb
+++ b/app/views/components/_publisher_metadata.html.erb
@@ -1,3 +1,4 @@
+<% add_app_component_stylesheet("publisher-metadata") %>
 <%
   published ||= false
   last_updated ||= false

--- a/app/views/content_items/_attachments.html.erb
+++ b/app/views/content_items/_attachments.html.erb
@@ -10,6 +10,7 @@
       <%= render 'govuk_publishing_components/components/govspeak', {
         direction: page_text_direction,
       } do %>
+        <% add_gem_component_stylesheet("details") if legacy_pre_rendered_documents.include? "govuk\-details" %>
         <%= raw(legacy_pre_rendered_documents) %>
       <% end %>
     <% else %>

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("guide") %>
 <%
   content_for :title, "Print #{@content_item.page_title}"
   content_for :simple_header, true

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("guide") %>
 <% content_for :extra_head_content do %>
   <%= machine_readable_metadata(
     schema: :article,

--- a/app/views/content_items/guide_single.html.erb
+++ b/app/views/content_items/guide_single.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("guide") %>
 <% content_for :extra_head_content do %>
   <%= machine_readable_metadata(
     schema: :article,

--- a/app/views/content_items/hmrc_manual.html.erb
+++ b/app/views/content_items/hmrc_manual.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("manual") %>
 <% content_for :header do %>
   <%= render "content_items/manuals/header", {
     content_item: @content_item,

--- a/app/views/content_items/hmrc_manual_section.html.erb
+++ b/app/views/content_items/hmrc_manual_section.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("manual") %>
 <% content_for :header do %>
   <%= render "content_items/manuals/header", {
     content_item: @content_item,

--- a/app/views/content_items/hmrc_manual_updates.html.erb
+++ b/app/views/content_items/hmrc_manual_updates.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("manual") %>
 <% content_for :header do %>
   <%= render "content_items/manuals/header", {
     content_item: @content_item,

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("html-publication") %>
 <% content_for :extra_head_content do %>
   <%= machine_readable_metadata(
     schema: :html_publication

--- a/app/views/content_items/manual.html.erb
+++ b/app/views/content_items/manual.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("manual") %>
 <% content_for :header do %>
   <%= render "content_items/manuals/header", {
     content_item: @content_item,

--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("manual") %>
 <% content_for :header do %>
   <%= render "content_items/manuals/header", {
     content_item: @content_item, heading_level: 1, margin_bottom: 6,

--- a/app/views/content_items/manual_updates.html.erb
+++ b/app/views/content_items/manual_updates.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("manual") %>
 <% content_for :header do %>
   <%= render "content_items/manuals/header", {
     content_item: @content_item, heading_level: 2, margin_bottom: 6,

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("service_manual_guide") %>
 <%= content_for :title, "#{@content_item.title} - Service Manual" %>
 
 <% content_for :extra_head do %>

--- a/app/views/content_items/service_manual_homepage.html.erb
+++ b/app/views/content_items/service_manual_homepage.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("service_manual_guide") %>
 <%
   content_for :title, "Service Manual"
   content_for :phase_message do

--- a/app/views/content_items/service_manual_service_standard.html.erb
+++ b/app/views/content_items/service_manual_service_standard.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("service_manual_guide") %>
 <%= content_for :title, "#{@content_item.title} - Service Manual" %>
 
 <% content_for :phase_message do %>

--- a/app/views/content_items/service_manual_service_toolkit.html.erb
+++ b/app/views/content_items/service_manual_service_toolkit.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("service_manual_guide") %>
 <%
   content_for :title, "Service Toolkit"
   content_for :header_title, "Service Toolkit"

--- a/app/views/content_items/service_manual_topic.html.erb
+++ b/app/views/content_items/service_manual_topic.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("service_manual_guide") %>
 <%= content_for :title, "#{@content_item.title} - Service Manual" %>
 
 <% content_for :phase_message do %>

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("specialist-document") %>
 <% content_for :extra_head_content do %>
   <%= machine_readable_metadata(
     schema: :article

--- a/app/views/content_items/travel_advice.html+print.erb
+++ b/app/views/content_items/travel_advice.html+print.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("travel-advice") %>
 <%
   content_for :title, "Print #{@content_item.page_title}"
   content_for :simple_header, true

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -1,3 +1,4 @@
+<% add_view_stylesheet("travel-advice") %>
 <% content_for :simple_header, true %>
 
 <% content_for :extra_head_content do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,42 +4,8 @@
   <% end %>
 <% end %>
 
-<!DOCTYPE html>
-<html>
-<head>
-  <title lang="<%= I18n.locale %>">
-    <% if content_for?(:title) %>
-      <%= yield :title %> - GOV.UK
-    <% else %>
-      <%= @content_item.page_title %> - GOV.UK
-    <% end %>
-  </title>
-
-  <% if ENV['HEROKU_APP_NAME'].present? %>
-    <meta name="robots" content="noindex, nofollow">
-  <% end %>
-
-  <%= stylesheet_link_tag "application", :media => "all", integrity: false %>
-  <%= javascript_include_tag "application", integrity: false %>
-  <%= csrf_meta_tags %>
-  <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item.content_item %>
-
-  <% if @content_item.description.present? %>
-    <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
-  <% end %>
-
-  <%= yield :extra_head_content %>
-</head>
-<body>
-  <% if @content_item.service_manual? %>
-    <div class="slimmer-inside-header">
-      <span class="govuk-header__product-name gem-c-header__product-name">
-        <%= "Service Manual" %>
-      </span>
-    </div>
-  <% end %>
+<% content_for :body do %>
   <div id="wrapper" class="<%= wrapper_class %>">
-
     <% if @content_item.show_phase_banner? || @content_item.service_manual? %>
       <div class="govuk-width-container">
         <div class="govuk-grid-row">
@@ -77,5 +43,45 @@
       <%= yield :main %>
     </main>
   </div>
+<% end %>
+
+<!DOCTYPE html>
+<html>
+<head>
+  <title lang="<%= I18n.locale %>">
+    <% if content_for?(:title) %>
+      <%= yield :title %> - GOV.UK
+    <% else %>
+      <%= @content_item.page_title %> - GOV.UK
+    <% end %>
+  </title>
+
+  <% if ENV['HEROKU_APP_NAME'].present? %>
+    <meta name="robots" content="noindex, nofollow">
+  <% end %>
+
+  <%= stylesheet_link_tag "application", :media => "all", integrity: false %>
+  <%= javascript_include_tag "application", integrity: false %>
+  <%= csrf_meta_tags %>
+  <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item.content_item %>
+
+  <% if @content_item.description.present? %>
+    <meta name="description" content="<%= strip_tags(@content_item.description) %>" />
+  <% end %>
+
+  <%= yield :extra_head_content %>
+  <%=
+    render_component_stylesheets
+  %>
+</head>
+<body>
+  <% if @content_item.service_manual? %>
+    <div class="slimmer-inside-header">
+      <span class="govuk-header__product-name gem-c-header__product-name">
+        <%= "Service Manual" %>
+      </span>
+    </div>
+  <% end %>
+  <%= yield :body %>
 </body>
 </html>

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -1,3 +1,5 @@
+<% add_view_stylesheet("published-dates-button-group") %>
+
 <%= render 'components/published_dates', {
     published: @content_item.published,
     last_updated: @content_item.updated,


### PR DESCRIPTION
## What

https://trello.com/c/fc41oyEK/1923-enable-individual-loading-of-stylesheets-in-government-frontend

Changes to load component and view style sheets only required on the page being viewed. For example, CSS for `_detailed-guide` only loads on the following page type e.g. [waste exemption: NWFD 2 temporary storage at the place of production](https://www.gov.uk/guidance/waste-exemption-nwfd-2-temporary-storage-at-the-place-of-production--2).

## Why

This reduces the amount of CSS required for each page and increases the ability of a browser to cache the stylesheets - this should mean a faster load time for both first time and repeat visitors.

See [RFC #149](https://github.com/alphagov/govuk-rfcs/pull/152) for more details.

## Review URL(s)

- [Answer](https://www.gov.uk/national-minimum-wage-rates)
- [Case study](https://www.gov.uk/government/case-studies/2013-elections-in-swaziland)
- Coming soon
- [Consultation](https://www.gov.uk/government/consultations/soft-drinks-industry-levy)
- [Contacts](https://www.gov.uk/government/organisations/hm-revenue-customs/contact/excise-enquiries)
- [Corporate information](https://www.gov.uk/government/organisations/government-digital-service/about)
- [Detailed guide](https://www.gov.uk/guidance/waste-exemption-nwfd-2-temporary-storage-at-the-place-of-production--2)
- [Document collection](https://www.gov.uk/government/collections/statutory-guidance-schools)
- [Fatality notice](https://www.gov.uk/government/fatalities/corporal-lee-churcher-dies-in-iraq)
- [Field of operation](https://www.gov.uk/government/fields-of-operation/iraq)
- [Fields of operation](https://www.gov.uk/government/fields-of-operation)
- [Help](https://www.gov.uk/help/about-govuk)
- [HTML publication](https://www.gov.uk/government/publications/budget-2016-documents/budget-2016)
- [Guide](https://www.gov.uk/log-in-register-hmrc-online-services)
- [News](https://www.gov.uk/government/news/the-personal-independence-payment-amendment-regulations-2017-statement-by-paul-gray)
- [Publication](https://www.gov.uk/government/publications/budget-2016-documents)
- [Specialist document](https://www.gov.uk/business-finance-support/access-to-finance-advice-north-west-england)
- [Statistics announcement](https://www.gov.uk/government/statistics/announcements/diagnostic-imaging-dataset-for-september-2015)
- [Statistical data set](https://www.gov.uk/government/statistical-data-sets/unclaimed-estates-list)
- [Speech](https://www.gov.uk/government/speeches/government-at-your-service-ben-gummer-speech)
- [Take part](https://www.gov.uk/government/get-involved/take-part/become-a-councillor)
- [Topical event about](https://www.gov.uk/government/topical-events/2014-overseas-territories-joint-ministerial-council/about)
- [Travel advice](https://www.gov.uk/foreign-travel-advice/nepal)
- Unpublishing / gone
- [Working group](https://www.gov.uk/government/groups/abstraction-reform)

Service manual
- [Home page](https://www.gov.uk/service-manual)
- [Kit](https://www.gov.uk/service-toolkit)
- [Standard](https://www.gov.uk/service-manual/service-standard)
- [Topic](https://www.gov.uk/service-manual/agile-delivery)
- [Guide](https://www.gov.uk/service-manual/agile-delivery/agile-methodologies)

Manuals
- [Manual](https://www.gov.uk/guidance/content-design)
- [Manual section](https://www.gov.uk/guidance/content-design/what-is-content-design)
- [Manual updates](https://www.gov.uk/guidance/content-design/updates)

HMRC manuals
- [HMRC manual](https://www.gov.uk/hmrc-internal-manuals/pensions-tax-manual)
- [HMRC manual section](https://www.gov.uk/hmrc-internal-manuals/pensions-tax-manual/ptm000001)
- [HMRC manual updates](https://www.gov.uk/hmrc-internal-manuals/pensions-tax-manual/updates)

## Visual changes

None

## Prerequisites
- ~[Conditionally load components](https://github.com/alphagov/government-frontend/pull/2782)~
- ~[Move text direction styles](https://github.com/alphagov/government-frontend/pull/2777)~
- ~[Turn digests back on in test environment](https://github.com/alphagov/government-frontend/pull/2767)~
- ~[Add Govspeak component](https://github.com/alphagov/government-frontend/pull/2765)~
- ~[Add missing govuk-link link formatting](https://github.com/alphagov/government-frontend/pull/2761)~
- ~[Move organisation-links helper alongside corporate information page view styles](https://github.com/alphagov/government-frontend/pull/2760)~
- ~[Move service manual guide modules alongside respective view styles](https://github.com/alphagov/government-frontend/pull/2759)~
- ~[Replace white-links helper with Design System mixin](https://github.com/alphagov/government-frontend/pull/2756)~
- ~[Remove unused helpers](https://github.com/alphagov/government-frontend/pull/2751)~
- ~[Replace consultation view styles with Design System styles](https://github.com/alphagov/government-frontend/pull/2750)~
- ~[Extract published dates button group shared styles](https://github.com/alphagov/government-frontend/pull/2745)~
- ~[Remove unused view styles](https://github.com/alphagov/government-frontend/pull/2744)~

## Anything else
- https://github.com/alphagov/govuk_publishing_components/pull/3014
- https://github.com/alphagov/frontend/pull/3342
- https://github.com/alphagov/smart-answers/pull/6213
- [RFC #149](https://github.com/alphagov/govuk-rfcs/pull/152)