### PR TITLE
Add rendering of Field of operation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Not all schemas that this app can handle are rendered by it in production.
 | Document collection | [View on GOV.UK](https://www.gov.uk/government/collections/statutory-guidance-schools) | Migrated |
 | Fatality notice | [View on GOV.UK](https://www.gov.uk/government/fatalities/corporal-lee-churcher-dies-in-iraq) | Migrated |
 | Fields of operation | [View on Gov.UK](https://www.gov.uk/government/fields-of-operation) | Migrated |
+| Field of operation | [View on GOV.UK](https://www.gov.uk/government/fields-of-operation/iraq) | Migrated |
 | Help page | [View on GOV.UK](https://www.gov.uk/help/about-govuk) | Migrated |
 | HTML Publication | [View on GOV.UK](https://www.gov.uk/government/publications/budget-2016-documents/budget-2016)| Migrated |
 | Guide | [View on GOV.UK](https://www.gov.uk/log-in-register-hmrc-online-services)| Migrated |

--- a/app/presenters/field_of_operation_presenter.rb
+++ b/app/presenters/field_of_operation_presenter.rb
@@ -1,0 +1,53 @@
+class FieldOfOperationPresenter < ContentItemPresenter
+  include ContentItem::TitleAndContext
+
+  FatalityNotice = Struct.new(:roll_call_introduction, :casualties, :title, :base_path)
+
+  def title_and_context
+    super.tap do |t|
+      t[:context] = I18n.t("field_of_operation.context")
+      t[:title] = "#{I18n.t('field_of_operation.title')} #{@content_item['title']}"
+      t.delete(:average_title_length)
+    end
+  end
+
+  def organisation
+    org = @content_item.dig("links", "primary_publishing_organisation", 0)
+    logo = org.dig("details", "logo")
+
+    {
+      name: logo["formatted_title"].html_safe,
+      url: org["base_path"],
+      brand: org.dig("details", "brand"),
+      crest: logo["crest"],
+    }
+  end
+
+  def description
+    description = @content_item["description"]
+
+    description.html_safe if description.present?
+  end
+
+  def fatality_notices
+    notices = @content_item.dig("links", "fatality_notices")
+    return [] unless notices
+
+    notices.map do |notice|
+      FatalityNotice.new(
+        notice.dig("details", "roll_call_introduction"),
+        notice.dig("details", "casualties"),
+        notice["title"],
+        notice["base_path"],
+      )
+    end
+  end
+
+  def contents
+    contents = []
+    contents << { href: "#field-of-operation", text: "Field of operation" } if description.present?
+    contents << { href: "#fatalities", text: "Fatalities" } if fatality_notices.present?
+
+    contents
+  end
+end

--- a/app/views/content_items/field_of_operation.html.erb
+++ b/app/views/content_items/field_of_operation.html.erb
@@ -1,0 +1,65 @@
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/title", @content_item.title_and_context %>
+    </div>
+    <div class="govuk-grid-column-one-third govuk-!-padding-top-8 govuk-!-padding-left-0 govuk-!-padding-bottom-8">
+      <%= render "govuk_publishing_components/components/organisation_logo", {
+        organisation: @content_item.organisation
+      } %>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <% if @content_item.contents.present? %>
+      <div class="govuk-grid-column-one-third">
+        <%= render "govuk_publishing_components/components/contents_list", {
+          contents: @content_item.contents
+        } %>
+      </div>
+    <% end %>
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-7">
+      <section id="field-of-operation">
+        <% unless @content_item.description.blank? %>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t("fatality_notice.field_of_operation"),
+            margin_bottom: 2,
+          } %>
+          <%= @content_item.description %>
+        <% end %>
+        <div class="govuk-!-margin-top-7 govuk-!-padding-bottom-3">
+          <% if @content_item.fatality_notices.any? %>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Fatalities",
+              id: "fatalities",
+              margin_bottom: 4,
+            } %>
+            <ul class="govuk-list">
+              <% @content_item.fatality_notices.each do |fatality_notice| %>
+                <li class="fatality-notice govuk-!-padding-top-2 govuk-!-padding-bottom-3">
+                  <% unless fatality_notice.roll_call_introduction.blank? %>
+                  <p class="govuk-body">
+                    <%= fatality_notice.roll_call_introduction %>
+                  </p>
+                  <% end %>
+                  <ul class="govuk-list govuk-list--spaced govuk-!-padding-left-4">
+                    <% if fatality_notice.casualties.present? %>
+                      <% fatality_notice.casualties.each do |casualty| %>
+                        <li class="govuk-list--bullet"><%= link_to casualty, fatality_notice.base_path, class: "govuk-link" %></li>
+                      <% end %>
+                    <% else %>
+                      <li class="govuk-list--bullet"><%= link_to fatality_notice.title, fatality_notice.base_path, class: "govuk-link" %></li>
+                    <% end %>
+                  </ul>
+                  <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-2">
+                </li>
+              <% end %>
+            </ul>
+          <% else %>
+            <p class="govuk-body"><%= t("fatality_notice.none_added") %></p>
+          <% end %>
+        </div>
+      </section>
+    </div>
+  </div>
+</div>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -590,7 +590,11 @@ ar:
   fatality_notice:
     alt_text: شعار وزارة الدفاع
     field_of_operation: ساحة العمليات
+    none_added:
     operations_in: العمليات الدائرة في %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -779,7 +783,7 @@ ar:
     release_date: تاريخ الإصدار
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: ينصح <abbr title="Foreign and Commonwealth Office">FCO</abbr> بعدم السفر إلى بعض أجزاء البلد إلا للضرورة.

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -590,7 +590,7 @@ ar:
   fatality_notice:
     alt_text: شعار وزارة الدفاع
     field_of_operation: ساحة العمليات
-    none_added:
+    none_added: لم تتم إضافة أي إشعارات حول الوفيات في ساحة العمليات هذه حتى الآن.
     operations_in: العمليات الدائرة في %{location}
   field_of_operation:
     context:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -294,7 +294,7 @@ az:
   fatality_notice:
     alt_text: Müdafiə nazirliyinin emblemi
     field_of_operation: Əməliyyat sahəsi
-    none_added:
+    none_added: Bu iş sahəsi üzrə hələ heç bir ölüm hadisəsi bildirişləri əlavə edilməyib.
     operations_in: "%{location}-də olan əməliyyatlar"
   field_of_operation:
     context:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -294,7 +294,11 @@ az:
   fatality_notice:
     alt_text: Müdafiə nazirliyinin emblemi
     field_of_operation: Əməliyyat sahəsi
+    none_added:
     operations_in: "%{location}-də olan əməliyyatlar"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ az:
     release_date: Buraxılış tarixi
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ölkənin bölgələrinə zəruri səyahət istisna olmaqla heç birini məsləhət görmürlər.

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -442,7 +442,7 @@ be:
   fatality_notice:
     alt_text: Герб Міністэрства абароны
     field_of_operation: Сфера дзейнасці
-    none_added:
+    none_added: Для гэтага аперацыйнага поля яшчэ не было дададзена ніякіх паведамленняў аб смерцi.
     operations_in: Дзейнасць у %{location}
   field_of_operation:
     context:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -442,7 +442,11 @@ be:
   fatality_notice:
     alt_text: Герб Міністэрства абароны
     field_of_operation: Сфера дзейнасці
+    none_added:
     operations_in: Дзейнасць у %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -629,7 +633,7 @@ be:
     release_date: Дата рэлізу
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: Міністэрства замежных спраў і па справах Садружнасці <abbr title="Foreign and Commonwealth Office">FCO</abbr> раяць устрымацца ад усіх падарожжаў, апроч самых патрэбных, у некаторыя раёны краіны.

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -294,7 +294,7 @@ bg:
   fatality_notice:
     alt_text: Герб на Министерството на отбраната
     field_of_operation: Област на действие
-    none_added:
+    none_added: Все още няма добавени съобщения за смъртни случаи в тази област на дейност.
     operations_in: Операции в %{location}
   field_of_operation:
     context:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -294,7 +294,11 @@ bg:
   fatality_notice:
     alt_text: Герб на Министерството на отбраната
     field_of_operation: Област на действие
+    none_added:
     operations_in: Операции в %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ bg:
     release_date: Дата на издаване
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> препоръчва да не се пътува до някои части на страната, освен ако това не е необходимо.

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -294,7 +294,7 @@ bn:
   fatality_notice:
     alt_text: প্রতিরক্ষা মন্ত্রণালয়ের ক্রেস্ট
     field_of_operation: কার্যক্রমের ক্ষেত্র
-    none_added:
+    none_added: এখনও এই পরিচালনার ফিল্ডের জন্য কোনো বিপর্যয়ের বিজ্ঞপ্তি যোগ করা হয়নি।
     operations_in: "%{location}-এ পরিচালনা"
   field_of_operation:
     context:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -294,7 +294,11 @@ bn:
   fatality_notice:
     alt_text: প্রতিরক্ষা মন্ত্রণালয়ের ক্রেস্ট
     field_of_operation: কার্যক্রমের ক্ষেত্র
+    none_added:
     operations_in: "%{location}-এ পরিচালনা"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ bn:
     release_date: প্রকাশের তারিখ
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> দেশের কিছু অংশে শুধু প্রয়োজনীয় ভ্রমণ ছাড়া সকল ধরনের ভ্রমণের বিরুদ্ধে পরামর্শ দিয়েছে।

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -368,7 +368,7 @@ cs:
   fatality_notice:
     alt_text: Ministerstvo obrany
     field_of_operation: Oblast provozu
-    none_added:
+    none_added: Pro tuto oblast činnosti zatím nebyla přidána žádná oznámení o úmrtí.
     operations_in: Operace v %{location}
   field_of_operation:
     context:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -368,7 +368,11 @@ cs:
   fatality_notice:
     alt_text: Ministerstvo obrany
     field_of_operation: Oblast provozu
+    none_added:
     operations_in: Operace v %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -554,7 +558,7 @@ cs:
     release_date: Datum vydání
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">Úřad pro zahraniční věci, společenství národů a rozvoj</abbr> nedoporučuje cestovat do některých částí země, s výjimkou nezbytných.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -590,7 +590,11 @@ cy:
   fatality_notice:
     alt_text: Arwyddlun y Weinyddiaeth Amddiffyn
     field_of_operation: Maes gweithredu
+    none_added:
     operations_in: Gweithrediadau yn %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -779,7 +783,7 @@ cy:
     release_date: Dyddiad rhyddhau
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: Mae'r <abbr title="Foreign and Commonwealth Office">Swyddfa Dramor, y Gymanwlad a Datblygu</abbr> yn cynghori yn erbyn pob taith, oni fo'n hanfodol, i rannau o'r wlad.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -590,7 +590,7 @@ cy:
   fatality_notice:
     alt_text: Arwyddlun y Weinyddiaeth Amddiffyn
     field_of_operation: Maes gweithredu
-    none_added:
+    none_added: Does dim hysbysiadau o farwolaethau wedi'u hychwanegu ar gyfer y maes gweithredu hwn eto.
     operations_in: Gweithrediadau yn %{location}
   field_of_operation:
     context:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -306,7 +306,11 @@ da:
   fatality_notice:
     alt_text: Forsvarsministeriets kam
     field_of_operation: Operationsområde
+    none_added:
     operations_in: Handlinger i %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -491,7 +495,7 @@ da:
     release_date: Udgivelsesdato
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: Den <abbr title="Foreign and Commonwealth Office">FCO</abbr> fraråde alle, men væsentlige rejser til dele af landet.

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -306,7 +306,7 @@ da:
   fatality_notice:
     alt_text: Forsvarsministeriets kam
     field_of_operation: Operationsområde
-    none_added:
+    none_added: Der er ikke tilføjet nogen dødsfald for dette operationsområde endnu.
     operations_in: Handlinger i %{location}
   field_of_operation:
     context:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -294,7 +294,7 @@ de:
   fatality_notice:
     alt_text: Wappen des Verteidigungsministeriums
     field_of_operation: Tätigkeitsbereich
-    none_added:
+    none_added: Für dieses Einsatzgebiet wurden noch keine Meldungen über Todesfälle hinzugefügt.
     operations_in: Tätigkeiten in %{location}
   field_of_operation:
     context:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -294,7 +294,11 @@ de:
   fatality_notice:
     alt_text: Wappen des Verteidigungsministeriums
     field_of_operation: Tätigkeitsbereich
+    none_added:
     operations_in: Tätigkeiten in %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ de:
     release_date: Veröffentlichungsdatum
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: Das <abbr title="Foreign and Commonwealth Office">FCO</abbr> rät von allen Reisen in Teile des Landes ab, die nicht unbedingt erforderlich sind.

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -294,7 +294,11 @@ dr:
   fatality_notice:
     alt_text: وزارت دفاع
     field_of_operation: ساحهء عملیات
+    none_added:
     operations_in: عملیات در%{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -482,7 +486,7 @@ dr:
     release_date: تاریخ انتشار
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: این<abbr title="Foreign and Commonwealth Office">FCO</abbr> در مورد هر گونه سفر ضروری به تمام نقاط کشور توصیه مینماید.

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -294,7 +294,7 @@ dr:
   fatality_notice:
     alt_text: وزارت دفاع
     field_of_operation: ساحهء عملیات
-    none_added:
+    none_added: هنوز هیچ خبر مرگ و میر در این بخش عملیات اضافه نشده است.
     operations_in: عملیات در%{location}
   field_of_operation:
     context:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -294,7 +294,7 @@ el:
   fatality_notice:
     alt_text: Οικόσημο Υπουργείου Άμυνας
     field_of_operation: Πεδίο λειτουργίας
-    none_added:
+    none_added: Δεν έχουν προστεθεί ακόμη ανακοινώσεις θανάτου για αυτό το πεδίο λειτουργίας.
     operations_in: Λειτουργίες στην τοποθεσία %{location}
   field_of_operation:
     context:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -294,7 +294,11 @@ el:
   fatality_notice:
     alt_text: Οικόσημο Υπουργείου Άμυνας
     field_of_operation: Πεδίο λειτουργίας
+    none_added:
     operations_in: Λειτουργίες στην τοποθεσία %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ el:
     release_date: Ημερομηνία κυκλοφορίας
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: Το <abbr title="Foreign and Commonwealth Office">FCO</abbr> σας συμβουλεύει να αποφύγετε τα ταξίδια, πλην των απαραίτητων, σε μέρη της χώρας.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,7 +294,11 @@ en:
   fatality_notice:
     alt_text: Ministry of Defence crest
     field_of_operation: Field of operation
+    none_added:
     operations_in: Operations in %{location}
+  field_of_operation:
+    context: British fatalities
+    title: Operations in
   fields_of_operation:
     context: British fatalities
   get_involved:
@@ -477,6 +481,9 @@ en:
     proposed_date: Proposed release
     reason_for_change: Reason for change
     release_date: Release date
+  time:
+    formats:
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all but essential travel to parts of the country.
@@ -488,9 +495,6 @@ en:
     still_current_at: Still current at
     summary: Summary
     updated: Updated
-  time:
-    formats:
-      short_ordinal: '%e %B %Y'
   unpublishing:
     page_title: No longer available
     summary: The information on this page has been removed because it was published in error.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,7 +294,7 @@ en:
   fatality_notice:
     alt_text: Ministry of Defence crest
     field_of_operation: Field of operation
-    none_added:
+    none_added: There have been no fatality notices added for this field of operation yet.
     operations_in: Operations in %{location}
   field_of_operation:
     context: British fatalities

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -294,7 +294,7 @@ es-419:
   fatality_notice:
     alt_text: Escudo del Ministerio de Defensa
     field_of_operation: Campo de operación
-    none_added:
+    none_added: Todavía no se han añadido avisos de víctimas fatales para esta área de operaciones.
     operations_in: Operaciones en %{location}
   field_of_operation:
     context:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -294,7 +294,11 @@ es-419:
   fatality_notice:
     alt_text: Escudo del Ministerio de Defensa
     field_of_operation: Campo de operación
+    none_added:
     operations_in: Operaciones en %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ es-419:
     release_date: Fecha de publicación
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: El <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconseja todos los viajes que no sean imprescindibles a algunas zonas del país.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -294,7 +294,7 @@ es:
   fatality_notice:
     alt_text: Escudo del Ministerio de Defensa
     field_of_operation: Campo de operación
-    none_added:
+    none_added: Aún no se han agregado los avisos de defunción para este campo de operación.
     operations_in: Operaciones en %{location}
   field_of_operation:
     context:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -294,7 +294,11 @@ es:
   fatality_notice:
     alt_text: Escudo del Ministerio de Defensa
     field_of_operation: Campo de operación
+    none_added:
     operations_in: Operaciones en %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ es:
     release_date: Fecha de lanzamiento
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: La <abbr title="Foreign and Commonwealth Office">FCO</abbr> aconseja que no se viaje a partes del país, salvo viajes esenciales.

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -294,7 +294,11 @@ et:
   fatality_notice:
     alt_text: Kaitseministeeriumi teadus- ja tehnikauuringute komitee
     field_of_operation: Tegevusvaldkond
+    none_added:
     operations_in: Toimingud asukohas %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ et:
     release_date: Väljaande kuupäev
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> soovitab mitte reisida riigi osadesse muidu kui hädavajadusel.

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -294,7 +294,7 @@ et:
   fatality_notice:
     alt_text: Kaitseministeeriumi teadus- ja tehnikauuringute komitee
     field_of_operation: Tegevusvaldkond
-    none_added:
+    none_added: Selle tegevusvaldkonna kohta ei ole surmajuhtumeid veel lisatud.
     operations_in: Toimingud asukohas %{location}
   field_of_operation:
     context:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -294,7 +294,11 @@ fa:
   fatality_notice:
     alt_text: تاج وزارت دفاع
     field_of_operation: زمینه فعالیت
+    none_added:
     operations_in: فعالیت در %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ fa:
     release_date: تاریخ انتشار
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: وزارت امور خارجه بریتانیا <abbr title="Foreign and Commonwealth Office">(FCO)</abbr> توصیه می‌کند از سفرهای غیر ضروری به بخش‌هایی از این کشور خودداری کنید.

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -294,7 +294,7 @@ fa:
   fatality_notice:
     alt_text: تاج وزارت دفاع
     field_of_operation: زمینه فعالیت
-    none_added:
+    none_added: هنوز هیچ اعلامیه مرگ‌و‌میری برای این زمینه فعالیت اضافه نشده است.
     operations_in: فعالیت در %{location}
   field_of_operation:
     context:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -294,7 +294,7 @@ fi:
   fatality_notice:
     alt_text: Puolustusministeriön vaakuna
     field_of_operation: Toiminta -alue
-    none_added:
+    none_added: Kuolemantapauksia ei ole ilmoitettu lisätty tälle toiminta-alueelle.
     operations_in: Toiminnot paikassa %{location}
   field_of_operation:
     context:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -294,7 +294,11 @@ fi:
   fatality_notice:
     alt_text: Puolustusministeriön vaakuna
     field_of_operation: Toiminta -alue
+    none_added:
     operations_in: Toiminnot paikassa %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ fi:
     release_date: Julkaisupäivä
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> kehottaa välttämään kaikkia muita kuin välttämättömiä matkoja osissa maata.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -294,7 +294,7 @@ fr:
   fatality_notice:
     alt_text: Emblème du ministère de la défense
     field_of_operation: Champ d'opération
-    none_added:
+    none_added: Aucun avis de décès n'a encore été ajouté pour ce domaine d'activité.
     operations_in: Opérations à %{location}
   field_of_operation:
     context:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -294,7 +294,11 @@ fr:
   fatality_notice:
     alt_text: Emblème du ministère de la défense
     field_of_operation: Champ d'opération
+    none_added:
     operations_in: Opérations à %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ fr:
     release_date: Date de sortie
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: Le <abbr title="Foreign and Commonwealth Office" >Bureau des affaires étrangères et du Commonwealth (FCO)</abbr> déconseille tout voyage dans certaines parties du pays, à l'exception de ceux qui sont indispensables.

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -442,7 +442,7 @@ gd:
   fatality_notice:
     alt_text: Suaitheantas rialtais Chónaidhme
     field_of_operation: Réimse oibríochta
-    none_added:
+    none_added: Níor cuireadh aon fhógra báis leis an réimse gníomhaíochta seo.
     operations_in: Idirbhearta I %{location}
   field_of_operation:
     context:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -442,7 +442,11 @@ gd:
   fatality_notice:
     alt_text: Suaitheantas rialtais Chónaidhme
     field_of_operation: Réimse oibríochta
+    none_added:
     operations_in: Idirbhearta I %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -629,7 +633,7 @@ gd:
     release_date: Dáta foilsithe
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: Molann an <abbr title="Foreign and Commonwealth Office">FCO</abbr> gach taisteal ach an taisteal is riachtanaí chuig áiteanna áirithe sa tír a sheachaint.

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -294,7 +294,11 @@ gu:
   fatality_notice:
     alt_text: સંરક્ષણ મંત્રાલય ક્રેસ્ટ
     field_of_operation: કામગીરીનું ક્ષેત્ર
+    none_added:
     operations_in: "%{location} માં સંચાલનો"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ gu:
     release_date: રીલીઝ તારીખ
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">વિદેશી - કોમનવેલ્થ અને વિકાસ કચેરી</abbr> જરૂરી મુસાફરી સિવાય દેશના કેટલાક ભાગોમાં પ્રવાસ ન કરવાની સલાહ આપે છે.

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -294,7 +294,7 @@ gu:
   fatality_notice:
     alt_text: સંરક્ષણ મંત્રાલય ક્રેસ્ટ
     field_of_operation: કામગીરીનું ક્ષેત્ર
-    none_added:
+    none_added: આ કામગીરીના ક્ષેત્રમાં હજુ સુધી કોઇ જાનહાનિ સૂચનાઓ ઉમેરાઈ નથી.
     operations_in: "%{location} માં સંચાલનો"
   field_of_operation:
     context:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -294,7 +294,11 @@ he:
   fatality_notice:
     alt_text: סמל משרד הביטחון
     field_of_operation: תחום הפעולה
+    none_added:
     operations_in: פעולות ב- %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ he:
     release_date: תאריך פרסם
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: ' <abbr title="Foreign and Commonwealth Office">FCO</abbr> להמליץ על כל נסיעות מלבד חיוניות לחלקי הארץ.'

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -294,7 +294,7 @@ he:
   fatality_notice:
     alt_text: סמל משרד הביטחון
     field_of_operation: תחום הפעולה
-    none_added:
+    none_added: עדיין לא נוספו הודעות פטירה על תחום פעולה זה.
     operations_in: פעולות ב- %{location}
   field_of_operation:
     context:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -294,7 +294,7 @@ hi:
   fatality_notice:
     alt_text: रक्षा मंत्रालय का क्रेस्ट
     field_of_operation: संचालन का क्षेत्र
-    none_added:
+    none_added: संचालन के इस क्षेत्र में अभी तक कोई घातक नोटिस नहीं जोड़ा गया है।
     operations_in: "%{location} में संचालन"
   field_of_operation:
     context:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -294,7 +294,11 @@ hi:
   fatality_notice:
     alt_text: रक्षा मंत्रालय का क्रेस्ट
     field_of_operation: संचालन का क्षेत्र
+    none_added:
     operations_in: "%{location} में संचालन"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ hi:
     release_date: जारी करने की तारीख
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> देश के कुछ हिस्सों में अनिवार्य यात्रा को छोड़कर बाकी सबके विरुद्ध सलाह देता है।

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -368,7 +368,7 @@ hr:
   fatality_notice:
     alt_text: Grb Ministarstva obrane
     field_of_operation: Područje djelovanja
-    none_added:
+    none_added: Za ovo područje djelovanja još nema dodanih obavijesti o smrtnim slučajevima.
     operations_in: Operacije u %{location}
   field_of_operation:
     context:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -368,7 +368,11 @@ hr:
   fatality_notice:
     alt_text: Grb Ministarstva obrane
     field_of_operation: Područje djelovanja
+    none_added:
     operations_in: Operacije u %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -554,7 +558,7 @@ hr:
     release_date: Datum izlaska
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> savjetuje protiv svih, osim bitnih putovanja u dijelova zemlje.

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -294,7 +294,7 @@ hu:
   fatality_notice:
     alt_text: A Védelmi Minisztérium címere
     field_of_operation: Működési terület
-    none_added:
+    none_added: Ehhez a működési területhez még nem lettek hozzáadva halálesetekkel kapcsolatos értesítések.
     operations_in: 'Tevékenységek itt: %{location}'
   field_of_operation:
     context:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -294,7 +294,11 @@ hu:
   fatality_notice:
     alt_text: A Védelmi Minisztérium címere
     field_of_operation: Működési terület
+    none_added:
     operations_in: 'Tevékenységek itt: %{location}'
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ hu:
     release_date: Kiadás időpontja
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: A <abbr title="Foreign and Commonwealth Office">FCO</abbr> azt javasolja, hogy az ország bizonyos részeire csak feltétlenül szükséges esetben utazzanak.

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -294,7 +294,7 @@ hy:
   fatality_notice:
     alt_text: Պաշտպանության նախարարության զինանշան
     field_of_operation: Գործունեության ոլորտ
-    none_added:
+    none_added: 'Գործունեության այս ոլորտի համար դժբախտ պատահարի ծանուցումներ դեռևս չեն ավելացվել:'
     operations_in: Գործունեություն % {location}-ում
   field_of_operation:
     context:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -294,7 +294,11 @@ hy:
   fatality_notice:
     alt_text: Պաշտպանության նախարարության զինանշան
     field_of_operation: Գործունեության ոլորտ
+    none_added:
     operations_in: Գործունեություն % {location}-ում
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ hy:
     release_date: Հրապարակման ամսաթիվ
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr>-ը խորհուրդ է տալիս չմեկնել տվյալ երկրի ամբողջ տարածք, բացառությամբ էական նշանակություն ունեցող հատվածների։

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -220,7 +220,7 @@ id:
   fatality_notice:
     alt_text: Lambang Kementerian Pertahanan
     field_of_operation: Bidang operasi
-    none_added:
+    none_added: Belum ada pemberitahuan fatalitas yang ditambahkan untuk bidang operasi ini.
     operations_in: Operasi di %{location}
   field_of_operation:
     context:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -220,7 +220,11 @@ id:
   fatality_notice:
     alt_text: Lambang Kementerian Pertahanan
     field_of_operation: Bidang operasi
+    none_added:
     operations_in: Operasi di %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -404,7 +408,7 @@ id:
     release_date: Tanggal rilis
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> melarang semua perjalanan yang tidak esensial ke bagian-bagian dari negara itu.

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -294,7 +294,11 @@ is:
   fatality_notice:
     alt_text: Skjaldarmerki Varnarmálaráðuneytisins
     field_of_operation: Starfsvið
+    none_added:
     operations_in: Starfsemi á %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ is:
     release_date: Útgáfudagsetning
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ráðleggur gegn öllum ferðalögum til hluta landsins nema þeim allra nauðsynlegustu.

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -294,7 +294,7 @@ is:
   fatality_notice:
     alt_text: Skjaldarmerki Varnarmálaráðuneytisins
     field_of_operation: Starfsvið
-    none_added:
+    none_added: Engum tilkynningum um dauðsföll hefur verið bætt við fyrir þetta starfsvið.
     operations_in: Starfsemi á %{location}
   field_of_operation:
     context:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -294,7 +294,7 @@ it:
   fatality_notice:
     alt_text: Stemma del Ministero della Difesa
     field_of_operation: Campo operativo
-    none_added:
+    none_added: Non sono stati ancora aggiunti avvisi di morte per questo campo di attività.
     operations_in: Operazioni in %{location}
   field_of_operation:
     context:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -294,7 +294,11 @@ it:
   fatality_notice:
     alt_text: Stemma del Ministero della Difesa
     field_of_operation: Campo operativo
+    none_added:
     operations_in: Operazioni in %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ it:
     release_date: Data di rilascio
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: L’<abbr title="Foreign and Commonwealth Office">FCO</abbr> sconsiglia tutti i viaggi tranne quelli essenziali in alcune parti del paese.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -220,7 +220,7 @@ ja:
   fatality_notice:
     alt_text: 国防省の紋章
     field_of_operation: 運用分野
-    none_added:
+    none_added: この活動分野での死亡通知はまだ追加されていません。
     operations_in: "％{location} での操作"
   field_of_operation:
     context:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -220,7 +220,11 @@ ja:
   fatality_notice:
     alt_text: 国防省の紋章
     field_of_operation: 運用分野
+    none_added:
     operations_in: "％{location} での操作"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -404,7 +408,7 @@ ja:
     release_date: 発表日程
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title = "Foreign and Commonwealth Office">FCO</abbr> は、国内一部地域への必要不可欠ものを除くすべての移動を控えるよう勧告しています。

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -294,7 +294,7 @@ ka:
   fatality_notice:
     alt_text: თავდაცვის სამინისტრო
     field_of_operation: ოპერაციის სფერო
-    none_added:
+    none_added: ფატალურობის შეტყობინება ჯერ არ დამატებულა ოპერაციის ამ სფეროში.
     operations_in: ოპერაციები %{location}-ში
   field_of_operation:
     context:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -294,7 +294,11 @@ ka:
   fatality_notice:
     alt_text: თავდაცვის სამინისტრო
     field_of_operation: ოპერაციის სფერო
+    none_added:
     operations_in: ოპერაციები %{location}-ში
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ ka:
     release_date: გამოშვების თარიღი
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> რჩევა ყველას წინააღმდეგ, გარდა ესენციური მოგზაურობებისა ქვეყნის ზოგიერთ ნაწილებში.

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -294,7 +294,11 @@ kk:
   fatality_notice:
     alt_text: Қорғаныс министрлігінің елтаңбасы
     field_of_operation: Жұмыс аймағы
+    none_added:
     operations_in: "%{location} орнындағы жұмыстар"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ kk:
     release_date: Шығарылым күні
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> маңыздысынан басқа елдің барлық аймақтарына барудан бас тартуға кеңес береді.

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -294,7 +294,7 @@ kk:
   fatality_notice:
     alt_text: Қорғаныс министрлігінің елтаңбасы
     field_of_operation: Жұмыс аймағы
-    none_added:
+    none_added: Бұл жұмыс саласы үшін өлім туралы хабарламалар әлі қосылмады.
     operations_in: "%{location} орнындағы жұмыстар"
   field_of_operation:
     context:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -220,7 +220,11 @@ ko:
   fatality_notice:
     alt_text: 국방부 문장
     field_of_operation: 운영 현장
+    none_added:
     operations_in: "%{Location} 내 운영"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -404,7 +408,7 @@ ko:
     release_date: 공개 날짜
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> 는 해당 국가의 각지를 여행하지 말라고 권고합니다.

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -220,7 +220,7 @@ ko:
   fatality_notice:
     alt_text: 국방부 문장
     field_of_operation: 운영 현장
-    none_added:
+    none_added: 이 운영 분야의 사망 통지는 아직 추가되지 않았습니다.
     operations_in: "%{Location} 내 운영"
   field_of_operation:
     context:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -368,7 +368,11 @@ lt:
   fatality_notice:
     alt_text: Apsaugos ministerijos herbas
     field_of_operation: Veiklos sritis
+    none_added:
     operations_in: Veikla vykdoma %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -554,7 +558,7 @@ lt:
     release_date: Paskelbimo data
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> pataria keliauti į skirtingas šalies vietas tik būtinais tikslais.

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -368,7 +368,7 @@ lt:
   fatality_notice:
     alt_text: Apsaugos ministerijos herbas
     field_of_operation: Veiklos sritis
-    none_added:
+    none_added: Šioje srityje kol kas neskelbiamas apie nelaimes.
     operations_in: Veikla vykdoma %{location}
   field_of_operation:
     context:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -294,7 +294,11 @@ lv:
   fatality_notice:
     alt_text: Aizsardzības ministrijas ģerbonis
     field_of_operation: Darbības joma
+    none_added:
     operations_in: 'Darbības šeit: %{location}'
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ lv:
     release_date: Publiskošanas datums
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> iesaka izvairīties no jebkādas ceļošanas, izņemot neatliekamus braucienus uz noteiktām valsts daļām.

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -294,7 +294,7 @@ lv:
   fatality_notice:
     alt_text: Aizsardzības ministrijas ģerbonis
     field_of_operation: Darbības joma
-    none_added:
+    none_added: Šajā darbības jomā vēl nav neviena paziņojuma par bojāgājušajiem.
     operations_in: 'Darbības šeit: %{location}'
   field_of_operation:
     context:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -220,7 +220,7 @@ ms:
   fatality_notice:
     alt_text: Lambang Kementerian Pertahanan
     field_of_operation: Medan operasi
-    none_added:
+    none_added: Belum ada notis kematian yang ditambahkan untuk medan operasi ini.
     operations_in: Operasi di %{location}
   field_of_operation:
     context:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -220,7 +220,11 @@ ms:
   fatality_notice:
     alt_text: Lambang Kementerian Pertahanan
     field_of_operation: Medan operasi
+    none_added:
     operations_in: Operasi di %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -404,7 +408,7 @@ ms:
     release_date: Tarikh hebahan
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> menasihati supaya tidak membuat perjalanan kecuali yang perlu sahaja ke bahagian-bahagian tertentu negara ini.

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -442,7 +442,11 @@ mt:
   fatality_notice:
     alt_text: Il-Ministeru tad-Difiża
     field_of_operation: Qasam tal-operazzjoni
+    none_added:
     operations_in: Operazzjonijiet fil- %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -629,7 +633,7 @@ mt:
     release_date: Data tar-rilaxx
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: Il- <abbr title="Foreign and Commonwealth Office">FCO</abbr> jirrakkomanda li ma jsiru l-ebda vjaġġi ħlief dawk essenzjali.

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -442,7 +442,7 @@ mt:
   fatality_notice:
     alt_text: Il-Ministeru tad-Difiża
     field_of_operation: Qasam tal-operazzjoni
-    none_added:
+    none_added: Ma kien hemm l-ebda avviżi ta' fatalitajiet miżjuda għal din l-operazzjoni.
     operations_in: Operazzjonijiet fil- %{location}
   field_of_operation:
     context:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -294,7 +294,7 @@ ne:
   fatality_notice:
     alt_text: रक्षा मन्त्रालय क्रेस्ट
     field_of_operation: सञ्चालन क्षेत्र
-    none_added:
+    none_added: त्यहाँ सञ्चालन क्षेत्रको लागी अझै सम्म कुनै मृत्यु सूचनाहरु थपिएका छैनन्।
     operations_in: "%{location} मा सञ्चालन"
   field_of_operation:
     context:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -294,7 +294,11 @@ ne:
   fatality_notice:
     alt_text: रक्षा मन्त्रालय क्रेस्ट
     field_of_operation: सञ्चालन क्षेत्र
+    none_added:
     operations_in: "%{location} मा सञ्चालन"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ ne:
     release_date: बिज्ञप्ति मिति
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">विदेश, राष्ट्रमंडल र विकास कार्यालय</abbr> ले जरूरी यात्रा बाहेक देशको केहि भागमा सबै यात्रा बिरूद्ध सल्लाह दिएको छ।

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -294,7 +294,7 @@ nl:
   fatality_notice:
     alt_text: Wapen van het ministerie van Defensie
     field_of_operation: Gebied van operatie
-    none_added:
+    none_added: Er zijn nog geen meldingen van sterfgevallen toegevoegd voor dit werkgebied.
     operations_in: Operaties in %{location}
   field_of_operation:
     context:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -294,7 +294,11 @@ nl:
   fatality_notice:
     alt_text: Wapen van het ministerie van Defensie
     field_of_operation: Gebied van operatie
+    none_added:
     operations_in: Operaties in %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ nl:
     release_date: Publicatiedatum
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: Het <abbr title="Foreign and Commonwealth Office">FCO</abbr> raadt alle, behalve essentiële, reizen naar delen van het land af.

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -294,7 +294,11 @@
   fatality_notice:
     alt_text: Forsvarsdepartementets crest
     field_of_operation: Operasjonsfelt
+    none_added:
     operations_in: Operasjoner i %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@
     release_date: Utgivelsesdato
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> fraråder alle reiser, unntatt viktige reiser, til deler av landet.

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -294,7 +294,7 @@
   fatality_notice:
     alt_text: Forsvarsdepartementets crest
     field_of_operation: Operasjonsfelt
-    none_added:
+    none_added: Det har ikke blitt lagt til noen meldinger om dødsfall for dette operasjonsfeltet ennå.
     operations_in: Operasjoner i %{location}
   field_of_operation:
     context:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -294,7 +294,11 @@ pa-pk:
   fatality_notice:
     alt_text: وزارتِ دفاع کریسٹ
     field_of_operation: عمل کرن دا حلقہ
+    none_added:
     operations_in: ایندے بارے عمل {location}%
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ pa-pk:
     release_date: جاری کرن دی تاریخ
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: ایہ<abbr title="Foreign and Commonwealth Office">FCO</abbr> مُلک دے سارے علاقیاں وچ  ضروری سفر کرن  لئی کیتی گئی نصحیت۔

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -294,7 +294,7 @@ pa-pk:
   fatality_notice:
     alt_text: وزارتِ دفاع کریسٹ
     field_of_operation: عمل کرن دا حلقہ
-    none_added:
+    none_added: موت دی کوئی وی اطلاع شامل نئیں کیتی گئی ایس تھاں تے کم کرن لئی
     operations_in: ایندے بارے عمل {location}%
   field_of_operation:
     context:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -294,7 +294,7 @@ pa:
   fatality_notice:
     alt_text: ਰੱਖਿਆ ਮੰਤਰਾਲਾ ਸਿਖਰ
     field_of_operation: ਕਾਰਜ ਖੇਤਰ
-    none_added:
+    none_added: ਇਸ ਕਾਰਜ ਦੇ ਖੇਤਰ ਵਿੱਚ ਅਜੇ ਤੱਕ ਕੋਈ ਘਾਤਕ ਸੂਚਨਾ ਸ਼ਾਮਲ ਨਹੀਂ ਕੀਤੀ ਗਈ ਹੈ।
     operations_in: "%{location} ਵਿੱਚ ਕਾਰਜ"
   field_of_operation:
     context:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -294,7 +294,11 @@ pa:
   fatality_notice:
     alt_text: ਰੱਖਿਆ ਮੰਤਰਾਲਾ ਸਿਖਰ
     field_of_operation: ਕਾਰਜ ਖੇਤਰ
+    none_added:
     operations_in: "%{location} ਵਿੱਚ ਕਾਰਜ"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ pa:
     release_date: ਰਿਹਾਈ ਤਾਰੀਖ
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ਦੇਸ਼ ਦੇ ਕੁਝ ਹਿੱਸਿਆਂ ਦੀ ਜ਼ਰੂਰੀ ਯਾਤਰਾ ਨੂੰ ਛੱਡ ਕੇ ਬਾਕੀ ਦੇ ਵਿਰੁੱਧ ਸਲਾਹ ਦਿੰਦਾ ਹੈ।

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -442,7 +442,11 @@ pl:
   fatality_notice:
     alt_text: Herb Ministerstwa Obrony
     field_of_operation: Zakres działania
+    none_added:
     operations_in: Działania w %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -629,7 +633,7 @@ pl:
     release_date: Data publikacji
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odradza wszelkie podróże do niektórych części kraju, z wyjątkiem tych niezbędnych.

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -442,7 +442,7 @@ pl:
   fatality_notice:
     alt_text: Herb Ministerstwa Obrony
     field_of_operation: Zakres działania
-    none_added:
+    none_added: Dla tego obszaru nie podano jeszcze żadnych informacji o ofiarach śmiertelnych.
     operations_in: Działania w %{location}
   field_of_operation:
     context:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -294,7 +294,7 @@ ps:
   fatality_notice:
     alt_text: د دفاع وزارت کریسټ
     field_of_operation: د عملیاتو ساحه
-    none_added:
+    none_added: تر دې دمه د عملیاتو ساحې لپاره د مرګ خبرتیاوې ندي اضافه شوي.
     operations_in: په%{location} کې عملیات
   field_of_operation:
     context:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -294,7 +294,11 @@ ps:
   fatality_notice:
     alt_text: د دفاع وزارت کریسټ
     field_of_operation: د عملیاتو ساحه
+    none_added:
     operations_in: په%{location} کې عملیات
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ ps:
     release_date: دخپریدو نیټه
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> د هیواد برخو ته د لازمي سفر پرته ټولو ته مشوره ورکوي.

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -294,7 +294,11 @@ pt:
   fatality_notice:
     alt_text: Brasão do Ministério da Defesa
     field_of_operation: Campo de operação
+    none_added:
     operations_in: Operações em %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ pt:
     release_date: Data de divulgação
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: O <abbr title="Foreign and Commonwealth Office">FCO</abbr> desaconselha todas as viagens, exceto as essenciais, a algumas zonas do país.

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -294,7 +294,7 @@ pt:
   fatality_notice:
     alt_text: Brasão do Ministério da Defesa
     field_of_operation: Campo de operação
-    none_added:
+    none_added: Ainda não foram adicionados avisos de fatalidade para este campo de operação.
     operations_in: Operações em %{location}
   field_of_operation:
     context:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -368,7 +368,7 @@ ro:
   fatality_notice:
     alt_text: Emblema Ministerului Apărării
     field_of_operation: Domeniul de activitate
-    none_added:
+    none_added: Încă nu au fost adăugate notificări de accidente mortale în acest domeniu de activitate.
     operations_in: Operațiuni în %{location}
   field_of_operation:
     context:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -368,7 +368,11 @@ ro:
   fatality_notice:
     alt_text: Emblema Ministerului Apărării
     field_of_operation: Domeniul de activitate
+    none_added:
     operations_in: Operațiuni în %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -554,7 +558,7 @@ ro:
     release_date: Data publicării
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> nu recomandă călătoriile neesențiale în anumite părți ale țării.

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -442,7 +442,11 @@ ru:
   fatality_notice:
     alt_text: Герб Министерства Обороны
     field_of_operation: Сфера деятельности
+    none_added:
     operations_in: Деятельность в  %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -629,7 +633,7 @@ ru:
     release_date: Дата выпуска
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> Все поездки не реккомендуются, за исключением необходимых в части страны.

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -442,7 +442,7 @@ ru:
   fatality_notice:
     alt_text: Герб Министерства Обороны
     field_of_operation: Сфера деятельности
-    none_added:
+    none_added: Уведомления о летальных исходах для этой области операций еще не добавлены.
     operations_in: Деятельность в  %{location}
   field_of_operation:
     context:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -294,7 +294,7 @@ si:
   fatality_notice:
     alt_text: ආරක්ෂක අමාත්යාංශ ලාංඡනය
     field_of_operation: මෙහෙයුම් ක්ෂේත්රය
-    none_added:
+    none_added: මෙම මෙහෙයුම් ක්ෂේත්රයට තවමත් මරණ දැන්වීම් එකතු කර නොමැත.
     operations_in: "%{location} තුළ මෙහෙයුම්"
   field_of_operation:
     context:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -294,7 +294,11 @@ si:
   fatality_notice:
     alt_text: ආරක්ෂක අමාත්යාංශ ලාංඡනය
     field_of_operation: මෙහෙයුම් ක්ෂේත්රය
+    none_added:
     operations_in: "%{location} තුළ මෙහෙයුම්"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ si:
     release_date: නිකුත් කිරීමේ දිනය
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> රටේ කොටස් වලට සියලු සංචාරවලට එරෙහිව උපදෙස් ලබා දෙන නමුත් අත්‍යවශ්‍ය සංවාරයක යෙදිය හැකිය.

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -368,7 +368,7 @@ sk:
   fatality_notice:
     alt_text: Erb ministerstva obrany
     field_of_operation: Oblasť činnosti
-    none_added:
+    none_added: Pre túto oblasť činnosti zatiaľ neboli pridané žiadne oznámenia o úmrtí.
     operations_in: Operácie v %{location}
   field_of_operation:
     context:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -368,7 +368,11 @@ sk:
   fatality_notice:
     alt_text: Erb ministerstva obrany
     field_of_operation: Oblasť činnosti
+    none_added:
     operations_in: Operácie v %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -554,7 +558,7 @@ sk:
     release_date: Dátum vydania
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: Ministerstvo zahraničných vecí a Commonwealthu <abbr title="Foreign and Commonwealth Office">FCO</abbr> neodporúča cestovať do niektorých častí krajiny okrem nevyhnutných prípadov.

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -442,7 +442,7 @@ sl:
   fatality_notice:
     alt_text: Grb Ministrstva za obrambo
     field_of_operation: Področje delovanja
-    none_added:
+    none_added: Za to področje delovanja še ni bilo dodanih obvestil o smrtnih žrtvah.
     operations_in: Dejavni v %{location}
   field_of_operation:
     context:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -442,7 +442,11 @@ sl:
   fatality_notice:
     alt_text: Grb Ministrstva za obrambo
     field_of_operation: Področje delovanja
+    none_added:
     operations_in: Dejavni v %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -629,7 +633,7 @@ sl:
     release_date: Datum objave
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> odsvetuje vsa nenujna potovanja v dele države.

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -294,7 +294,7 @@ so:
   fatality_notice:
     alt_text: Calaamada Wasaarada Difaaca
     field_of_operation: Hawalaha dibadaa
-    none_added:
+    none_added: Ma jiraan wax ogaysiisyada muhiimka ah oo lagu daray goobtan shaqada wali.
     operations_in: Hawalaha %{location}
   field_of_operation:
     context:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -294,7 +294,11 @@ so:
   fatality_notice:
     alt_text: Calaamada Wasaarada Difaaca
     field_of_operation: Hawalaha dibadaa
+    none_added:
     operations_in: Hawalaha %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ so:
     release_date: Taariikhda sii daynta
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> talo dhamaan kasoo wada horjeeda lakin socdaal muhiim ah oo qaybaha dalka oo dhan ah.

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -294,7 +294,11 @@ sq:
   fatality_notice:
     alt_text: Stema e Ministrisë së Mbrojtjes
     field_of_operation: Fusha e operimit
+    none_added:
     operations_in: Operacione në %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ sq:
     release_date: Data e publikimit
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">FCO</abbr> këshillon kundër të gjitha udhëtimeve përveçse thelbësore në pjesë të vendit.

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -294,7 +294,7 @@ sq:
   fatality_notice:
     alt_text: Stema e Ministrisë së Mbrojtjes
     field_of_operation: Fusha e operimit
-    none_added:
+    none_added: Ende nuk është shtuar asnjë njoftim për fatalitet për këtë fushë të funksionimit.
     operations_in: Operacione në %{location}
   field_of_operation:
     context:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -368,7 +368,7 @@ sr:
   fatality_notice:
     alt_text: Grb Ministarstva odbrane
     field_of_operation: Oblast delovanja
-    none_added:
+    none_added: Još nisu dodata obaveštenja o smrtnim slučajevima u ovoj oblasti delovanja.
     operations_in: Delovanje na lokaciji %{location}
   field_of_operation:
     context:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -368,7 +368,11 @@ sr:
   fatality_notice:
     alt_text: Grb Ministarstva odbrane
     field_of_operation: Oblast delovanja
+    none_added:
     operations_in: Delovanje na lokaciji %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -554,7 +558,7 @@ sr:
     release_date: Datum objavljivanja
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ne preporučuje putovanja koja nisu esencijalna za delove zemlje.

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -294,7 +294,7 @@ sv:
   fatality_notice:
     alt_text: Försvarsministeriets vapensköld
     field_of_operation: Verksamhetsområde
-    none_added:
+    none_added: Det har ännu inte lagts till några meddelanden om dödsfall för detta verksamhetsområde.
     operations_in: Verksamhet på %{location}
   field_of_operation:
     context:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -294,7 +294,11 @@ sv:
   fatality_notice:
     alt_text: Försvarsministeriets vapensköld
     field_of_operation: Verksamhetsområde
+    none_added:
     operations_in: Verksamhet på %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ sv:
     release_date: Datum för offentliggörandet
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> avråder från alla utom nödvändiga resor till delar av landet.

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -294,7 +294,7 @@ sw:
   fatality_notice:
     alt_text: Eneo la Wizara ya Ulinzi
     field_of_operation: Sehemu ya kazi
-    none_added:
+    none_added: Bado hakuna notisi za idadi ya vifo zilizowekwa kwenye sehemu hii ya kazi.
     operations_in: Shughuli zinazofanywa katika %{location}
   field_of_operation:
     context:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -294,7 +294,11 @@ sw:
   fatality_notice:
     alt_text: Eneo la Wizara ya Ulinzi
     field_of_operation: Sehemu ya kazi
+    none_added:
     operations_in: Shughuli zinazofanywa katika %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ sw:
     release_date: Tarehe ya kutangazwa
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: Ushauri wa <abbr title="Foreign and Commonwealth Office">FCO</abbr> dhidi ya usafiri wote isipokuwa usafiri muhimu katika sehemu fulani za nchi.

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -294,7 +294,11 @@ ta:
   fatality_notice:
     alt_text: பாதுகாப்பு காவல்துறை அமைச்சர்
     field_of_operation: இயங்குதளம்
+    none_added:
     operations_in: "%{location}-ல் செயல்பாடுகள்"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ ta:
     release_date: வெளியீட்டுத் தேதி
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">அயல்நாடு, காமன்வெல்த் அலுவலகம்</abbr> நாட்டின் பகுதிகளுக்கு அத்தியாவசிய பயணம் செய்வது குறித்து அனைவருக்குமான ஆலோசனை தருகிறது.

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -294,7 +294,7 @@ ta:
   fatality_notice:
     alt_text: பாதுகாப்பு காவல்துறை அமைச்சர்
     field_of_operation: இயங்குதளம்
-    none_added:
+    none_added: இந்த செயல்பாட்டுத் தளத்தில் எந்த உயிரிழப்பு அறிவிப்புகளும் இன்னும் சேர்க்கப்படவில்லை.
     operations_in: "%{location}-ல் செயல்பாடுகள்"
   field_of_operation:
     context:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -220,7 +220,7 @@ th:
   fatality_notice:
     alt_text: ตรากระทรวงกลาโหม
     field_of_operation: พื้นที่ปฏิบัติการ
-    none_added:
+    none_added: ยังไม่มีการแจ้งการเสียชีวิตเพิ่มเติมสำหรับพื้นที่ปฏิบัติการนี้
     operations_in: การดำเนินงานใน %{location}
   field_of_operation:
     context:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -220,7 +220,11 @@ th:
   fatality_notice:
     alt_text: ตรากระทรวงกลาโหม
     field_of_operation: พื้นที่ปฏิบัติการ
+    none_added:
     operations_in: การดำเนินงานใน %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -404,7 +408,7 @@ th:
     release_date: วันเผยแพร่
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ไม่แนะนำให้เดินทางไปยังบางส่วนของประเทศ นอกจากมีเหตุจำเป็น

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -294,7 +294,11 @@ tk:
   fatality_notice:
     alt_text: Goranmak ministrliginiň nyşany
     field_of_operation: Iş meýdany
+    none_added:
     operations_in: "%{location} ýerindäki işler"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ tk:
     release_date: Goýberiliş senesi
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ýurduň käbir ýerlerine zerur syýahatdan başga-da maslahat berýär.

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -294,7 +294,7 @@ tk:
   fatality_notice:
     alt_text: Goranmak ministrliginiň nyşany
     field_of_operation: Iş meýdany
-    none_added:
+    none_added: Bu ugurda entek ölüm howpy barada duýduryş habary ýok.
     operations_in: "%{location} ýerindäki işler"
   field_of_operation:
     context:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -294,7 +294,11 @@ tr:
   fatality_notice:
     alt_text: Savunma Bakanlığı arması
     field_of_operation: Faaliyet alanı
+    none_added:
     operations_in: "%{location} konumundaki faaliyetler"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ tr:
     release_date: Açıklama tarihi
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> ülkenin bazı bölgelerine zorunlu seyahatler haricinde seyahat edilmemesini tavsiye etmektedir.

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -294,7 +294,7 @@ tr:
   fatality_notice:
     alt_text: Savunma Bakanlığı arması
     field_of_operation: Faaliyet alanı
-    none_added:
+    none_added: Henüz bu faaliyet alanına eklenen hiçbir ölüm oranı bildirimi yok.
     operations_in: "%{location} konumundaki faaliyetler"
   field_of_operation:
     context:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -442,7 +442,7 @@ uk:
   fatality_notice:
     alt_text: Герб Міністерства оборони
     field_of_operation: Сфера діяльності
-    none_added:
+    none_added: Поки що не було додано жодних повідомлень про нещасні випадки зі смертельним наслідком в цій сфері діяльності.
     operations_in: Операції в %{location}
   field_of_operation:
     context:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -442,7 +442,11 @@ uk:
   fatality_notice:
     alt_text: Герб Міністерства оборони
     field_of_operation: Сфера діяльності
+    none_added:
     operations_in: Операції в %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -629,7 +633,7 @@ uk:
     release_date: Дата виходу
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: Міністерство закордонних справ<abbr title="Foreign and Commonwealth Office">(FCO)</abbr> забороняє будь-які поїздки, крім необхідних, до певних областей країни.

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -294,7 +294,7 @@ ur:
   fatality_notice:
     alt_text: وزارت دفاع کا کریسنٹ
     field_of_operation: کارروائی کی فیلڈ
-    none_added:
+    none_added: اس کارروائی کی فیلڈ کے لیے ابھی تک کوئی موت کے نوٹسز شامل نہیں کیے گئے۔
     operations_in: "%{location} میں کارروائیاں"
   field_of_operation:
     context:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -294,7 +294,11 @@ ur:
   fatality_notice:
     alt_text: وزارت دفاع کا کریسنٹ
     field_of_operation: کارروائی کی فیلڈ
+    none_added:
     operations_in: "%{location} میں کارروائیاں"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ ur:
     release_date: اجراء کی تاریخ
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> سوائے ملک کے کچھ حصوں میں ضروری سفر کرنے کے ہر قسم کے سفر کے خلاف مشاورت فراہم کرتا ہے۔

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -294,7 +294,11 @@ uz:
   fatality_notice:
     alt_text: Мудофаа вазирлигининг эмблемаси
     field_of_operation: Фаолият соҳаси
+    none_added:
     operations_in: "%{location} да ишлаш"
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ uz:
     release_date: Нашр санаси
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign and Commonwealth Office">Ташқи ишлар ва Ҳамдўстлик ишлари бўйича вазирлиги</abbr> ўта заруратсиз мамлакатнинг муайян минтақаларига сафарларни амалга оширишни тавсия этмайди.

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -294,7 +294,7 @@ uz:
   fatality_notice:
     alt_text: Мудофаа вазирлигининг эмблемаси
     field_of_operation: Фаолият соҳаси
-    none_added:
+    none_added: Ушбу фаолият соҳасида ўлим ҳолатлари ҳақида хабарномалар ҳали қўшилмаган.
     operations_in: "%{location} да ишлаш"
   field_of_operation:
     context:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -220,7 +220,7 @@ vi:
   fatality_notice:
     alt_text: Huy hiệu Bộ trưởng Quốc phòng
     field_of_operation: Lĩnh vực hoạt động
-    none_added:
+    none_added: Chưa có thông báo tử vong nào được thêm vào cho lĩnh vực hoạt động này.
     operations_in: Hoạt động ở %{location}
   field_of_operation:
     context:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -220,7 +220,11 @@ vi:
   fatality_notice:
     alt_text: Huy hiệu Bộ trưởng Quốc phòng
     field_of_operation: Lĩnh vực hoạt động
+    none_added:
     operations_in: Hoạt động ở %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -404,7 +408,7 @@ vi:
     release_date: Ngày phát hành
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">FCO</abbr> khuyến cáo chỉ nên đi đến một số nơi ở quốc gia này khi thật cần thiết.

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -294,7 +294,11 @@ yi:
   fatality_notice:
     alt_text:
     field_of_operation:
+    none_added:
     operations_in:
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -479,7 +483,7 @@ yi:
     release_date:
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -220,7 +220,7 @@ zh-hk:
   fatality_notice:
     alt_text: 國防部徽章
     field_of_operation: 行動領域
-    none_added:
+    none_added: 此運作領域仍未加入任何死亡通知。
     operations_in: 行動位置 %{location}
   field_of_operation:
     context:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -220,7 +220,11 @@ zh-hk:
   fatality_notice:
     alt_text: 國防部徽章
     field_of_operation: 行動領域
+    none_added:
     operations_in: 行動位置 %{location}
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -404,7 +408,7 @@ zh-hk:
     release_date: 發佈日期
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="外交及聯邦事務部">FCO</abbr> 建議，如非必要，請勿前往該國部份地區。

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -220,7 +220,11 @@ zh-tw:
   fatality_notice:
     alt_text: 國防部紋章
     field_of_operation: 經營領域
+    none_added:
     operations_in: 在 %{location} 的領域
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -404,7 +408,7 @@ zh-tw:
     release_date: 發佈日期
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign and Commonwealth Office">外交和英聯邦事務部</abbr> 建議非必要的旅行，不要前往該國部分地區。

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -220,7 +220,7 @@ zh-tw:
   fatality_notice:
     alt_text: 國防部紋章
     field_of_operation: 經營領域
-    none_added:
+    none_added: 尚未為該操作領域新增死亡通知。
     operations_in: 在 %{location} 的領域
   field_of_operation:
     context:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -220,7 +220,7 @@ zh:
   fatality_notice:
     alt_text: 国防部徽章
     field_of_operation: 经营领域
-    none_added:
+    none_added: 目前还没有关于这一经营领域的死亡通知。
     operations_in: 在 %{location} 经营
   field_of_operation:
     context:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -220,7 +220,11 @@ zh:
   fatality_notice:
     alt_text: 国防部徽章
     field_of_operation: 经营领域
+    none_added:
     operations_in: 在 %{location} 经营
+  field_of_operation:
+    context:
+    title:
   fields_of_operation:
     context:
   get_involved:
@@ -404,7 +408,7 @@ zh:
     release_date: 发布日期
   time:
     formats:
-      short_ordinal: '%e %B %Y'
+      short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
       avoid_all_but_essential_travel_to_parts_html: '<abbr title="Foreign and Commonwealth Office">FCO</abbr> 建议除非必要，否则不要前往该国部分地区。  '

--- a/test/presenters/field_of_operation_presenter_test.rb
+++ b/test/presenters/field_of_operation_presenter_test.rb
@@ -1,0 +1,94 @@
+require "presenter_test_helper"
+
+class FieldOfOperationPresenterTest < PresenterTestCase
+  def schema_name
+    "field_of_operation"
+  end
+
+  test "#title_and_context" do
+    expected_title_and_context = {
+      title: "Operations in Iraq",
+      context: "British fatalities",
+      context_locale: :en,
+    }
+    assert_equal expected_title_and_context, presented_item.title_and_context
+  end
+
+  test "it presents a description" do
+    assert_equal "It is with very deep regret that the following fatalities are announced.", presented_item.description
+  end
+
+  test "it presents the organisations object" do
+    expected = {
+      name: "Ministry<br/>of Defence",
+      url: "/government/organisations/ministry-of-defence",
+      brand: "ministry-of-defence",
+      crest: "mod",
+    }
+
+    assert_equal expected, presented_item.organisation
+  end
+
+  test "it presents fatlity notices when they are present" do
+    expected_notices = [
+      FieldOfOperationPresenter::FatalityNotice.new("A fatality sadly occurred on 1 December", nil, "A fatality notice", "/government/fatalities/fatality-notice-one"),
+      FieldOfOperationPresenter::FatalityNotice.new("A fatality sadly occurred on 2 December", nil, "A second fatality notice", "/government/fatalities/fatality-notice-two"),
+    ]
+
+    assert_equal expected_notices, presented_item.fatality_notices
+  end
+
+  test "it presents an ampty array when no fatlity notices are present" do
+    without_fatalities = schema_item
+    without_fatalities["links"].delete("fatality_notices")
+
+    presented = create_presenter(FieldOfOperationPresenter, content_item: without_fatalities)
+
+    assert_equal [], presented.fatality_notices
+  end
+
+  test "it presents contents when fields of operation and fatalities are present" do
+    expected = [
+      { href: "#field-of-operation", text: "Field of operation" },
+      { href: "#fatalities", text: "Fatalities" },
+    ]
+
+    assert_equal expected, presented_item.contents
+  end
+
+  test "it presents contents when only fields of operation are present" do
+    without_fatalities = schema_item
+    without_fatalities["links"].delete("fatality_notices")
+
+    presented = create_presenter(FieldOfOperationPresenter, content_item: without_fatalities)
+
+    expected = [
+      { href: "#field-of-operation", text: "Field of operation" },
+    ]
+
+    assert_equal expected, presented.contents
+  end
+
+  test "it presents contents when only fatalities are present" do
+    without_description = schema_item
+    without_description.delete("description")
+
+    presented = create_presenter(FieldOfOperationPresenter, content_item: without_description)
+
+    expected = [
+      { href: "#fatalities", text: "Fatalities" },
+    ]
+
+    assert_equal expected, presented.contents
+  end
+
+  test "it presents an empty array when neither fatalities nor description are present" do
+    without_description_or_fatalities = schema_item
+    without_description_or_fatalities.delete("description")
+    without_description_or_fatalities["links"].delete("fatality_notices")
+
+    presented = create_presenter(FieldOfOperationPresenter, content_item: without_description_or_fatalities)
+
+    assert_equal [], presented.contents
+  end
+end


### PR DESCRIPTION
This is part of ongoing work to stop Whitehall from rendering anything 

## Whitehall
<img width="1195" alt="Screenshot 2023-04-05 at 11 15 46" src="https://user-images.githubusercontent.com/24547207/230052152-180af40e-c650-4de4-bdf4-5814d56051cd.png">

## Government Frontend
<img width="1171" alt="Screenshot 2023-04-05 at 11 19 51" src="https://user-images.githubusercontent.com/24547207/230053124-0aceffef-a244-486f-ac7e-360756488abe.png">

Trello - https://trello.com/c/alzDKosv/472-add-rendering-of-field-of-operation-pages-to-government-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
