### PR TITLE
Add cost of living user research banner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,7 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/components/govspeak-html-publication";
 @import "govuk_publishing_components/components/image-card";
 @import "govuk_publishing_components/components/inset-text";
+@import "govuk_publishing_components/components/intervention";
 @import "govuk_publishing_components/components/inverse-header";
 @import "govuk_publishing_components/components/lead-paragraph";
 @import "govuk_publishing_components/components/metadata";

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -38,3 +38,7 @@
   max-width: 30em;
   padding-top: govuk-spacing(2);
 }
+
+.gem-c-intervention {
+  margin-top: govuk-spacing(4);
+}

--- a/app/presenters/content_item/research_banner.rb
+++ b/app/presenters/content_item/research_banner.rb
@@ -1,0 +1,26 @@
+module ContentItem
+  module ResearchBanner
+    USER_RESEARCH_SURVEY_URL = "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6".freeze
+    SURVEY_URL_MAPPINGS = {
+      "/cost-of-living" => USER_RESEARCH_SURVEY_URL,
+      "/guidance/cost-of-living-payment" => USER_RESEARCH_SURVEY_URL,
+      "/cost-living-help-local-council" => USER_RESEARCH_SURVEY_URL,
+      "/benefits-calculators" => USER_RESEARCH_SURVEY_URL,
+      "/the-warm-home-discount-scheme" => USER_RESEARCH_SURVEY_URL,
+      "/universal-credit" => USER_RESEARCH_SURVEY_URL,
+      "/universal-credit/eligibility" => USER_RESEARCH_SURVEY_URL,
+      "/universal-credit/what-youll-get" => USER_RESEARCH_SURVEY_URL,
+      "/universal-credit/how-to-claim" => USER_RESEARCH_SURVEY_URL,
+      "/universal-credit/other-financial-support" => USER_RESEARCH_SURVEY_URL,
+      "/universal-credit/contact-universal-credit" => USER_RESEARCH_SURVEY_URL,
+      "/new-state-pension/what-youll-get" => USER_RESEARCH_SURVEY_URL,
+      "/get-help-energy-bills" => USER_RESEARCH_SURVEY_URL,
+      "/get-help-energy-bills/getting-discount-energy-bill" => USER_RESEARCH_SURVEY_URL,
+      "/pension-credit" => USER_RESEARCH_SURVEY_URL,
+    }.freeze
+
+    def survey_url
+      SURVEY_URL_MAPPINGS[requested_path]
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,5 +1,6 @@
 class ContentItemPresenter
   include ContentItem::Withdrawable
+  include ContentItem::ResearchBanner
 
   attr_reader :content_item,
               :requested_path,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,6 +64,14 @@
     <% end %>
 
     <%= yield :header %>
+    <% if @content_item.survey_url %>
+      <%= render "govuk_publishing_components/components/intervention", {
+        suggestion_text: "Help make GOV.UK better",
+        suggestion_link_text: "Take part in user research",
+        suggestion_link_url: @content_item.survey_url,
+        new_tab: true,
+      } %>
+    <% end %>
 
     <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">
       <%= yield :main %>

--- a/test/integration/research_banner_test.rb
+++ b/test/integration/research_banner_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class ResearchBannerTest < ActionDispatch::IntegrationTest
+  test "Cost of living survey banner is displayed on pages of interest" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+
+    pages_of_interest = %w[
+      /cost-of-living
+      /guidance/cost-of-living-payment
+      /cost-living-help-local-council
+      /benefits-calculators
+      /the-warm-home-discount-scheme
+      /universal-credit
+      /universal-credit/eligibility
+      /universal-credit/what-youll-get
+      /universal-credit/how-to-claim
+      /universal-credit/other-financial-support
+      /universal-credit/contact-universal-credit
+      /new-state-pension/what-youll-get
+      /get-help-energy-bills
+      /get-help-energy-bills/getting-discount-energy-bill
+      /pension-credit
+    ]
+
+    pages_of_interest.each do |path|
+      guide["base_path"] = path
+      stub_content_store_has_item(guide["base_path"], guide.to_json)
+      visit path
+
+      assert page.has_css?(".gem-c-intervention")
+      assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6")
+    end
+  end
+
+  test "Cost of living recruitment banner is not displayed on all pages" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    guide["base_path"] = "/universal-credit/changes-of-circumstances"
+    stub_content_store_has_item(guide["base_path"], guide.to_json)
+    visit "/universal-credit/changes-of-circumstances"
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/XS2YWV/")
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Add a GOV.UK user research banner for Cost of Living

Paths affected:
      /cost-living-help-local-council
      /benefits-calculators
      /the-warm-home-discount-scheme
      /universal-credit
      /universal-credit/eligibility
      /universal-credit/what-youll-get
      /universal-credit/how-to-claim
      /universal-credit/other-financial-support
      /universal-credit/contact-universal-credit
      /new-state-pension/what-youll-get
      /get-help-energy-bills
      /get-help-energy-bills/getting-discount-energy-bill
      /pension-credit

[Trello card](https://trello.com/c/1O3pEivw/1777-govuk-user-research-banner-requests-for-col-tree-testing-study-1m)

Before:
<img width="1001" alt="Screenshot 2023-04-13 at 15 56 31" src="https://user-images.githubusercontent.com/96050928/231800292-67a43a36-9c11-4b51-aeb1-13645b190d2a.png">

After:
<img width="1047" alt="Screenshot 2023-04-13 at 15 55 17" src="https://user-images.githubusercontent.com/96050928/231800328-a38eabff-375e-4b3b-b0dc-27d8295db8ef.png">


