### PR TITLE
Extract published dates button group shared styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -106,4 +106,5 @@ $govuk-include-default-font-face: false;
 @import "views/help-page";
 @import "views/guide";
 @import "views/manual";
+@import "views/published-dates-button-group";
 @import "views/worldwide-organisation";

--- a/app/assets/stylesheets/views/_detailed-guide.scss
+++ b/app/assets/stylesheets/views/_detailed-guide.scss
@@ -21,19 +21,3 @@
     }
   }
 }
-
-.detailed-guide-bottom-button-container {
-  @include govuk-media-query($from: tablet) {
-    display: flex;
-    flex-direction: row;
-  }
-}
-
-.detailed-guide-bottom-button-container form {
-  @include govuk-media-query($until: tablet) {
-    margin-bottom: govuk-spacing(3);
-  }
-  @include govuk-media-query($from: tablet) {
-    margin-right: govuk-spacing(4);
-  }
-}

--- a/app/assets/stylesheets/views/_published-dates-button-group.scss
+++ b/app/assets/stylesheets/views/_published-dates-button-group.scss
@@ -1,0 +1,15 @@
+.published-dates-button-group {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    flex-direction: row;
+  }
+}
+
+.published-dates-button-group form {
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: govuk-spacing(3);
+  }
+  @include govuk-media-query($from: tablet) {
+    margin-right: govuk-spacing(4);
+  }
+}

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -5,7 +5,7 @@
     margin_bottom: 5,
   } %>
 
-<div class="detailed-guide-bottom-button-container">
+<div class="published-dates-button-group">
   <%= render 'govuk_publishing_components/components/single_page_notification_button', {
     base_path: @content_item.base_path,
     js_enhancement: @has_govuk_account,


### PR DESCRIPTION
## What

https://trello.com/c/fc41oyEK/1923-enable-individual-loading-of-stylesheets-in-government-frontend

Extract published dates button group shared styles

## Why

These styles are currently included in `_detailed-guide.scss` but are used by 3 document types:
- Consultation
- Detailed guide
- Publication

This will cause a problem when the AssetHelper is implemented since the complete `_detailed-guide.scss` styles would need to be loaded for the above document types.

## Visual changes

None

## Anything else

- https://github.com/alphagov/govuk_publishing_components/pull/3014
- https://github.com/alphagov/frontend/pull/3342
- https://github.com/alphagov/smart-answers/pull/6213
- [RFC #149](https://github.com/alphagov/govuk-rfcs/pull/152)