### PR TITLE
Remove RSS from subscription_links

### DIFF
--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -20,8 +20,7 @@
 
       <%= render 'govuk_publishing_components/components/subscription_links',
         email_signup_link: @content_item.email_signup_link,
-        email_signup_link_text: "Get email alerts",
-        feed_link: @content_item.feed_link %>
+        email_signup_link_text: "Get email alerts" %>
     </aside>
   </div>
 </div>

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -12,7 +12,6 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["details"]["country"]["name"])
 
     assert page.has_css?("a[href=\"#{@content_item['details']['email_signup_link']}\"]", text: "Get email alerts")
-    assert page.has_css?("a[href=\"#{@content_item['base_path']}.atom\"]", text: "Subscribe to feed")
 
     assert page.has_css?(".part-navigation-container nav li", count: @content_item["details"]["parts"].size + 1)
     assert page.has_css?(".part-navigation-container nav li", text: "Summary")
@@ -82,7 +81,6 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["details"]["country"]["name"])
 
     assert page.has_css?("a[href=\"#{@content_item['details']['email_signup_link']}\"]", text: "Get email alerts")
-    assert page.has_css?("a[href=\"#{@content_item['base_path']}.atom\"]", text: "Subscribe to feed")
 
     assert page.has_css?(".part-navigation-container nav li", count: @content_item["details"]["parts"].size)
     assert page.has_css?(".part-navigation-container nav li", text: "Safety and security")


### PR DESCRIPTION
## What

Remove link to RSS feed on all instances of the subscription_links component.

## Why

Part of a redesign of the subscription links. Due to decreased usage and problematic emphasis of the RSS feed link, we are going to try removing it on pages of applications that 
Navigation & Presentation team are responsible for.

[Relevant Trello Card](https://trello.com/c/lVsaCSRR/1722-remove-subscribe-to-feed-links-from-the-pages-we-own-m)

## Visual Differences

### Before

![Screenshot 2023-04-26 at 16 41 04](https://user-images.githubusercontent.com/3727504/234628930-4b17a291-f933-4101-9764-330f3a13f046.png)

### After

![Screenshot 2023-04-26 at 16 38 42](https://user-images.githubusercontent.com/3727504/234628903-065aaa3c-13b1-4a3b-88f0-48391f6c7927.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
