### PR TITLE
Add missing `govuk-link` link formatting

### DIFF
--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -48,7 +48,7 @@ class SpecialistDocumentPresenter < ContentItemPresenter
 
   def finder_link
     if finder && statutory_instrument?
-      view_context.link_to("See all #{finder['title']}", finder["base_path"])
+      view_context.link_to("See all #{finder['title']}", finder["base_path"], class: "govuk-link")
     end
   end
 


### PR DESCRIPTION
## What

Add missing `govuk-link` link formatting.

See https://www.gov.uk/eu-withdrawal-act-2018-statutory-instruments/the-drivers-hours-and-tachographs-amendment-regulations-2021

## Why

Consistent link appearance.

## Visual changes

### Before

<img src="https://user-images.githubusercontent.com/87758239/236171190-fa97aca9-cb22-4a41-af28-6556939bfd3d.png" alt width=400>

### After

<img src="https://user-images.githubusercontent.com/87758239/236171149-9c691c21-08b0-47b5-a88e-9cda743c2184.png" alt width=400>