### PR TITLE
Add Govspeak component

### DIFF
--- a/app/views/content_items/field_of_operation.html.erb
+++ b/app/views/content_items/field_of_operation.html.erb
@@ -25,6 +25,9 @@
             text: t("fatality_notice.field_of_operation"),
             margin_bottom: 2,
           } %>
+        <% end %>
+        <%= render 'govuk_publishing_components/components/govspeak', {
+        } do %>
           <%= @content_item.description %>
         <% end %>
         <div class="govuk-!-margin-top-7 govuk-!-padding-bottom-3">

--- a/app/views/content_items/field_of_operation.html.erb
+++ b/app/views/content_items/field_of_operation.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/title", @content_item.title_and_context %>
     </div>
-    <div class="govuk-grid-column-one-third govuk-!-padding-top-8 govuk-!-padding-left-0 govuk-!-padding-bottom-8">
+    <div class="govuk-grid-column-one-third govuk-!-margin-top-8 govuk-!-margin-bottom-8">
       <%= render "govuk_publishing_components/components/organisation_logo", {
         organisation: @content_item.organisation
       } %>
@@ -23,7 +23,7 @@
         <% unless @content_item.description.blank? %>
           <%= render "govuk_publishing_components/components/heading", {
             text: t("fatality_notice.field_of_operation"),
-            margin_bottom: 2,
+            margin_bottom: 4,
           } %>
         <% end %>
         <%= render 'govuk_publishing_components/components/govspeak', {
@@ -39,7 +39,7 @@
             } %>
             <ul class="govuk-list">
               <% @content_item.fatality_notices.each do |fatality_notice| %>
-                <li class="fatality-notice govuk-!-padding-top-2 govuk-!-padding-bottom-3">
+                <li class="fatality-notice govuk-!-padding-bottom-3">
                   <% unless fatality_notice.roll_call_introduction.blank? %>
                   <p class="govuk-body">
                     <%= fatality_notice.roll_call_introduction %>


### PR DESCRIPTION
## What

https://trello.com/c/fc41oyEK/1923-enable-individual-loading-of-stylesheets-in-government-frontend

- Add [Govspeak component](https://components.publishing.service.gov.uk/component-guide/govspeak) for description content as a pre-requisite to implementing the AssetHelper to load component and view style sheets only required on the page being viewed
- Some minor style improvements (see visual changes below).

## Why

So Govspeak component styles will be automatically loaded on **field of operation** document types and no need to explicitly add the styles with the `add_gem_component_stylesheet` helper and to make it easier when implementing the helper.

## Visual changes

### Before (mobile)
<img src="https://user-images.githubusercontent.com/87758239/235894393-acb56876-6d03-4e94-b1c6-5c65c2caba98.png" width=400>

### After (mobile)
<img src="https://user-images.githubusercontent.com/87758239/235894349-700939c1-e883-4fd9-a148-a4815454686b.png" width=400>

### Before (desktop)
<img src="https://user-images.githubusercontent.com/87758239/235894655-ca91f532-0b2b-49ab-b4c1-ed6244a2e023.png" width=600>

### After (desktop)
<img src="https://user-images.githubusercontent.com/87758239/235894628-322afa6a-160a-4087-91d2-a98ad5933c47.png" width=600>

## Anything else

- https://github.com/alphagov/govuk_publishing_components/pull/3014
- https://github.com/alphagov/frontend/pull/3342
- https://github.com/alphagov/smart-answers/pull/6213
- [RFC #149](https://github.com/alphagov/govuk-rfcs/pull/152)