### PR TITLE
Turn digests back on in test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,13 +45,6 @@ Rails.application.configure do
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true
 
-  # TODO: Re-enable tests to run against compiled assets with digests
-  #       Add a performant assets compilation step before tests run
-  # Don't depend on precompiled JS assets. We are not currently precompiling
-  # javascript before tests run. Meaning failing JS will not be detected
-  # in integration tests.
-  config.assets.digest = false
-
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 end


### PR DESCRIPTION
## What

https://trello.com/c/fc41oyEK/1923-enable-individual-loading-of-stylesheets-in-government-frontend.

Turn digests back on (remove `config.assets.digest = false`) in test environment as a pre-requisite to implementing the AssetHelper to load component and view style sheets only required on the page being viewed.

## Why

The default `config.assets.digest` was changed here: https://github.com/alphagov/government-frontend/commit/a806be8eb76bab3ec592671c43f623af7b05dee1 due to an issue loading Axe core in integration tests (with a comment to re-enable the option).

I've discovered an issue running some tests when individual style sheets are loaded with the GOV.UK Publishing Components [AssetHelper module](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/set-up-individual-component-css-loading.md).

```
test_guides_with_no_parts_in_a_step_by_step_with_hide_chapter_navigation_do_not_error
ERROR (4.82s)
Minitest::UnexpectedError: ActionController::RoutingError: No route matches [GET] 
"/govuk_publishing_components/components/_step-by-step-nav-related.css"
```

- The issue only affects `_step-by-step-nav-related.css`. All other CSS files are loaded correctly
- When digests are disabled `_step-by-step-nav-related.css` seems to be incorrectly identified as having a digest as documented here: https://github.com/rails/sprockets/issues/749
- The suffix `-related` is stripped from the stylesheet path, which seems to cause an issue with `step-by-step-nav.css`.
- It only seems to happen when you have more than two style sheets with the same name and one has a suffix e.g. 

```
@import "components/step-by-step-nav-related";
@import "components/step-by-step-nav";
```

- The error only occurs when that suffix is 7 or more characters (you do not see this with `_attachment-link.css`).

With digests re-enabled I've seen no issues running component guide accessibility tests locally -

### Notice
<img src="https://github.com/alphagov/government-frontend/assets/87758239/e30b5525-0558-44e1-ae39-5e19848ce479" width=600>

### Banner
<img src="https://github.com/alphagov/government-frontend/assets/87758239/7c9ebaa7-3b66-45ff-8178-5fb5b029723b" width=600>

## Visual changes

None.