### PR TITLE
Remove org changing banner for DIT and BEIS

### DIFF
--- a/app/presenters/corporate_information_page_presenter.rb
+++ b/app/presenters/corporate_information_page_presenter.rb
@@ -5,11 +5,6 @@ class CorporateInformationPagePresenter < ContentItemPresenter
   include ContentItem::OrganisationBranding
   include ContentItem::CorporateInformationGroups
 
-  ORG_CHANGING_BANNER_BASE_PATHS = %w[
-    /government/organisations/department-for-business-energy-and-industrial-strategy/about
-    /government/organisations/department-for-international-trade/about
-  ].freeze
-
   def page_title
     page_title = super
     page_title += " - #{default_organisation['title']}" if default_organisation
@@ -25,10 +20,6 @@ class CorporateInformationPagePresenter < ContentItemPresenter
 
   def contents_items
     super + extra_headings
-  end
-
-  def show_organisation_changing_banner?
-    ORG_CHANGING_BANNER_BASE_PATHS.include?(base_path)
   end
 
 private

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -4,15 +4,6 @@
   ) %>
 <% end %>
 
-<% if @content_item.show_organisation_changing_banner? %>
-  <div class="govuk-width-container govuk-!-margin-top-8">
-    <%= render "govuk_publishing_components/components/notice", {
-      title: sanitize('This organisation is changing. Read about <a href="https://www.gov.uk/government/publications/making-government-deliver-for-the-british-people/making-government-deliver-for-the-british-people-html">recent government updates</a>.'),
-      margin_bottom: 3,
-    } %>
-  </div>
-<% end %>
-
 <% @additional_body = capture do %>
   <% if @content_item.corporate_information? %>
     <%= @content_item.corporate_information_heading_tag %>

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -77,15 +77,5 @@ class CorporateInformationPagePresenterTest
       assert presented_item.further_information.include?(information_charter["base_path"])
       assert presented_item.further_information.include?(information_charter["title"])
     end
-
-    test "returns true for about pages that require a banner" do
-      presented_item = presented_item(schema_name, "base_path" => "/government/organisations/department-for-business-energy-and-industrial-strategy/about")
-      assert presented_item.show_organisation_changing_banner?
-    end
-
-    test "returns false for about pages that don't require a banner" do
-      presented_item = presented_item(schema_name, "base_path" => "/government/organisations/a-random-org/about")
-      assert_not presented_item.show_organisation_changing_banner?
-    end
   end
 end


### PR DESCRIPTION
This was asked by content.

DIT and BEIS have now closed which means we can remove the transitory banners on the org about pages and the accompanying code. We've already removed DCMS's banner prior to this [1].

Trello:
https://trello.com/c/ZATeFciM/5-remove-temporary-banner-for-certain-org-about-pages

[1]: https://github.com/alphagov/government-frontend/pull/2726

## Before

<img width="1366" alt="Screenshot 2023-05-12 at 10 36 34" src="https://github.com/alphagov/government-frontend/assets/24479188/7dae61a7-645a-44c6-b587-a2d4e2e7b65b">
<img width="1477" alt="Screenshot 2023-05-12 at 12 13 02" src="https://github.com/alphagov/government-frontend/assets/24479188/73138237-845a-4542-9ecb-05c0baed0d1d">


## After

<img width="1219" alt="Screenshot 2023-05-12 at 10 36 26" src="https://github.com/alphagov/government-frontend/assets/24479188/9b54d226-43d5-4238-8b8d-725679dc1ccc">
<img width="1421" alt="Screenshot 2023-05-12 at 10 37 09" src="https://github.com/alphagov/government-frontend/assets/24479188/57bc071d-a763-43fa-8518-5326f1da974f">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
