### PR TITLE
Add End Of Life research banner

### DIFF
--- a/app/presenters/content_item/research_banner.rb
+++ b/app/presenters/content_item/research_banner.rb
@@ -1,7 +1,11 @@
 module ContentItem
   module ResearchBanner
+    END_OF_LIFE_SURVEY_URL = "https://forms.office.com/e/a0WvT73tCV".freeze
     USER_RESEARCH_SURVEY_URL = "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6".freeze
+
     SURVEY_URL_MAPPINGS = {
+      "/benefits-end-of-life" => END_OF_LIFE_SURVEY_URL,
+      "/pip/claiming-if-you-might-have-12-months-or-less-to-live" => END_OF_LIFE_SURVEY_URL,
       "/cost-of-living" => USER_RESEARCH_SURVEY_URL,
       "/guidance/cost-of-living-payment" => USER_RESEARCH_SURVEY_URL,
       "/cost-living-help-local-council" => USER_RESEARCH_SURVEY_URL,

--- a/test/integration/research_banner_test.rb
+++ b/test/integration/research_banner_test.rb
@@ -4,7 +4,7 @@ class ResearchBannerTest < ActionDispatch::IntegrationTest
   test "Cost of living survey banner is displayed on pages of interest" do
     guide = GovukSchemas::Example.find("guide", example_name: "guide")
 
-    pages_of_interest = %w[
+    cost_living_banner_pages = %w[
       /cost-of-living
       /guidance/cost-of-living-payment
       /cost-living-help-local-council
@@ -22,7 +22,7 @@ class ResearchBannerTest < ActionDispatch::IntegrationTest
       /pension-credit
     ]
 
-    pages_of_interest.each do |path|
+    cost_living_banner_pages.each do |path|
       guide["base_path"] = path
       stub_content_store_has_item(guide["base_path"], guide.to_json)
       visit path
@@ -39,6 +39,34 @@ class ResearchBannerTest < ActionDispatch::IntegrationTest
     visit "/universal-credit/changes-of-circumstances"
 
     assert_not page.has_css?(".gem-c-intervention")
-    assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/XS2YWV/")
+    assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6")
+  end
+
+  test "EOL banner is on the Get benefits if you're nearing the end of life page" do
+    answer = GovukSchemas::Example.find("answer", example_name: "answer")
+    answer["base_path"] = "/benefits-end-of-life"
+    stub_content_store_has_item(answer["base_path"], answer.to_json)
+    visit answer["base_path"]
+
+    assert page.has_css?(".gem-c-intervention")
+  end
+
+  test "EOL banner is on the Personal Independence Payment (PIP) page" do
+    answer = GovukSchemas::Example.find("guide", example_name: "guide")
+    answer["base_path"] = "/pip/claiming-if-you-might-have-12-months-or-less-to-live"
+    stub_content_store_has_item(answer["base_path"], answer.to_json)
+    visit answer["base_path"]
+
+    assert page.has_css?(".gem-c-intervention")
+  end
+
+  test "EOL banner is not on other pages" do
+    schema = GovukSchemas::Schema.find(frontend_schema: "detailed_guide")
+    random_content = GovukSchemas::RandomExample.new(schema:).payload
+    stub_content_store_has_item(random_content["base_path"], random_content.to_json)
+    visit random_content["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://forms.office.com/e/a0WvT73tCV")
   end
 end


### PR DESCRIPTION
Piggy backing off of work to add the Cost of living survey banner. The two pages are different content types so need specific tests.

## Preview links

* https://government-frontend-pr-2775.herokuapp.com/benefits-end-of-life
* https://government-frontend-pr-2775.herokuapp.com/pip/claiming-if-you-might-have-12-months-or-less-to-live

[Trello](https://trello.com/c/vhN2QSQf/1806-add-end-of-life-survey-banner-s)

## Before

![www gov uk_benefits-end-of-life](https://github.com/alphagov/government-frontend/assets/424772/e8e5df8a-c1a3-482f-8ccf-902712511079)
![www gov uk_pip_claiming-if-you-might-have-12-months-or-less-to-live](https://github.com/alphagov/government-frontend/assets/424772/3595a6e8-4a0a-40ab-8df9-cfffd4cbef33)

## After

![government-frontend dev gov uk_benefits-end-of-life](https://github.com/alphagov/government-frontend/assets/424772/872867ce-ea59-4624-bf41-b03b15d2d67e)
![government-frontend dev gov uk_pip_claiming-if-you-might-have-12-months-or-less-to-live](https://github.com/alphagov/government-frontend/assets/424772/ddc33b29-854d-4d06-8e15-5092b7c7b73f)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
