### PR TITLE
Remove Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3090}


### PR DESCRIPTION
As we're now using Puma it's unlikely that the Procfile is needed for Heroku.

Our apps are crashing https://government-frontend-pr-2775.herokuapp.com/

as it's using the Procfile to call `bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3090}` but we've dropped Unicorn https://github.com/alphagov/govuk_app_config/commit/71f4f2fa3871721e5c8140bcf73d683e09d8d7b2 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
