### PR TITLE
Conditionally load components

### DIFF
--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -15,7 +15,9 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
-<%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% if @content_item.withdrawn? %>
+  <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -20,10 +20,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/devolved_nations", {
-      national_applicability: @content_item.national_applicability || {},
-      type: @content_item.schema_name
-    } %>
+    <% if @content_item.national_applicability.present? %>
+      <%= render "govuk_publishing_components/components/devolved_nations", {
+        national_applicability: @content_item.national_applicability,
+        type: @content_item.schema_name
+      } %>
+    <% end %>
+
     <% if @content_item.unopened? %>
       <% content_item_unopened = capture do %>
         <%= raw(t("consultation.opens")) %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -16,8 +16,9 @@
 <%= render 'shared/publisher_metadata_with_logo', content_item: @content_item %>
 <%= render 'shared/single_page_notification_button', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component %>
-
+<% if @content_item.withdrawn? %>
+  <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @content_item.national_applicability.present? %>

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -34,7 +34,9 @@
     <%= render 'shared/translations' %>
     <div class="govuk-grid-column-two-thirds">
       <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
-      <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+      <% if @content_item.withdrawn? %>
+        <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -71,8 +71,9 @@
 <%= render 'shared/single_page_notification_button', content_item: @content_item %>
 
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
-
+<% if @content_item.withdrawn? %>
+  <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @content_item.national_applicability.present? %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -75,10 +75,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/devolved_nations", {
-      national_applicability: @content_item.national_applicability || {},
-      type: @content_item.schema_name
-    } %>
+    <% if @content_item.national_applicability.present? %>
+      <%= render "govuk_publishing_components/components/devolved_nations", {
+        national_applicability: @content_item.national_applicability,
+        type: @content_item.schema_name
+      } %>
+    <% end %>
 
     <%= render "components/contents_list_with_body", contents: @content_item.contents do %>
       <%= render "govuk_publishing_components/components/print_link", {

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -14,7 +14,9 @@
   <%= render 'shared/translations', content_item: @content_item %>
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
-    <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+    <% if @content_item.withdrawn? %>
+      <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+    <% end %>
     <%= render 'shared/history_notice', content_item: @content_item %>
   </div>
 </div>

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -15,8 +15,9 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
-<%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
-
+<% if @content_item.withdrawn? %>
+  <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="content-bottom-margin">

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -44,10 +44,12 @@
 
 <%= render 'shared/history_notice', content_item: @content_item %>
 <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
-<%= render "govuk_publishing_components/components/devolved_nations", {
-  national_applicability: @content_item.national_applicability || {},
-  type: @content_item.schema_name
-} %>
+<% if @content_item.national_applicability.present? %>
+  <%= render "govuk_publishing_components/components/devolved_nations", {
+    national_applicability: @content_item.national_applicability,
+    type: @content_item.schema_name
+  } %>
+<% end %>
 
 <div id="contents">
   <div class="govuk-grid-row">

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -43,7 +43,9 @@
 <% end %>
 
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% if @content_item.withdrawn? %>
+  <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% end %>
 <% if @content_item.national_applicability.present? %>
   <%= render "govuk_publishing_components/components/devolved_nations", {
     national_applicability: @content_item.national_applicability,

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -16,7 +16,9 @@
 
 <%= render 'shared/publisher_metadata_with_logo' %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% if @content_item.withdrawn? %>
+  <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds ">

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -35,7 +35,9 @@
 
 <%= render 'shared/history_notice', content_item: @content_item %>
 
-<%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% if @content_item.withdrawn? %>
+  <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -40,10 +40,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="responsive-bottom-margin">
-      <%= render "govuk_publishing_components/components/devolved_nations", {
-        national_applicability: @content_item.national_applicability || {},
-        type: @content_item.schema_name
-      } %>
+      <% if @content_item.national_applicability.present? %>
+        <%= render "govuk_publishing_components/components/devolved_nations", {
+          national_applicability: @content_item.national_applicability,
+          type: @content_item.schema_name
+        } %>
+      <% end %>
+
       <div class="responsive-bottom-margin">
         <%= render "attachments",
           title: t("publication.documents", count: 5), # This should always be pluralised.

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -16,7 +16,9 @@
 
 <%= render 'shared/publisher_metadata_with_logo' %>
 <%= render 'shared/history_notice', content_item: @content_item %>
-<%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% if @content_item.withdrawn? %>
+  <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -14,7 +14,9 @@
   <%= render 'shared/translations', content_item: @content_item %>
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
-    <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+    <% if @content_item.withdrawn? %>
+      <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
+    <% end %>
     <%= render 'shared/history_notice', content_item: @content_item %>
   </div>
 </div>


### PR DESCRIPTION
## What

https://trello.com/c/fc41oyEK/1923-enable-individual-loading-of-stylesheets-in-government-frontend

- Conditionally load [Devolved Nations](https://components.publishing.service.gov.uk/component-guide/devolved_nations) component 
- Conditionally load [Notice](https://components.publishing.service.gov.uk/component-guide/notice) component on Detailed Guide

Pre-requisites to implementing the AssetHelper to load component and view style sheets only required on the page being viewed.

**Review URL(s):**
- [Waste exemption: NWFD 2 temporary storage at the place of production](https://government-frontend-pr-2782.herokuapp.com/guidance/waste-exemption-nwfd-2-temporary-storage-at-the-place-of-production--2) (no devolved nations component)
- [Living safely with respiratory infections, including COVID-19](https://government-frontend-pr-2782.herokuapp.com/guidance/living-safely-with-respiratory-infections-including-covid-19) (include devolved nations component)
- [Rates and thresholds for employers 2023 to 2024](https://government-frontend-pr-2782.herokuapp.com/guidance/rates-and-thresholds-for-employers-2023-to-2024) (no notice component)
- [About the Document Checking Service pilot scheme
](https://government-frontend-pr-2782.herokuapp.com/guidance/apply-for-the-document-checking-service-pilot-scheme) (include notice component)

## Why

So less stylesheets are loaded and to help keep [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link) header size low as possible.

## Visual changes

None

## Anything else
- https://github.com/alphagov/govuk_publishing_components/pull/3014
- https://github.com/alphagov/frontend/pull/3342
- https://github.com/alphagov/smart-answers/pull/6213
- [RFC #149](https://github.com/alphagov/govuk-rfcs/pull/152)