### PR TITLE
Use `pry-byebug` for debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,13 +23,13 @@ gem "uglifier"
 group :development, :test do
   gem "govuk_schemas"
   gem "govuk_test"
+  gem "pry-byebug"
   gem "rubocop-govuk"
 end
 
 group :development do
   gem "better_errors"
   gem "binding_of_caller"
-  gem "pry"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
       msgpack (~> 1.2)
     brakeman (5.3.1)
     builder (3.2.4)
+    byebug (11.1.3)
     capybara (3.39.0)
       addressable
       matrix
@@ -229,6 +230,9 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     public_suffix (5.0.1)
     puma (6.2.2)
       nio4r (~> 2.0)
@@ -412,7 +416,7 @@ DEPENDENCIES
   minitest-reporters
   mocha
   plek
-  pry
+  pry-byebug
   rails (= 7.0.4.3)
   rails-controller-testing
   rails-i18n


### PR DESCRIPTION
This swaps `pry` for `pry-byebug` so that we can use step-by-step debugging actions.

It also moves the debugging Gem into the `development` and `test` group so that we can debug when running the tests.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
