### PR TITLE
Remove travel advice summary from tests

### DIFF
--- a/test/integration/travel_advice_print_test.rb
+++ b/test/integration/travel_advice_print_test.rb
@@ -13,18 +13,12 @@ class TravelAdvicePrint < ActionDispatch::IntegrationTest
 
   test "it renders the summary and all parts in the print view" do
     setup_and_visit_travel_advice_print("full-country")
-    parts = @content_item["details"]["parts"]
 
     assert_has_component_metadata_pair("Still current at", Time.zone.today.strftime("%-d %B %Y"))
     assert_has_component_metadata_pair("Updated", Date.parse(@content_item["details"]["reviewed_at"]).strftime("%-d %B %Y"))
 
     within ".gem-c-metadata" do
       assert page.has_content?(@content_item["details"]["change_description"].gsub("Latest update: ", "").strip)
-    end
-
-    assert page.has_css?(".part-title", text: "Summary")
-    parts.each do |part|
-      assert page.has_css?("h1", text: part["title"])
     end
 
     assert page.has_content?("Summary – the main opposition party has called for mass protests against the government in Tirana on 18 February 2017")


### PR DESCRIPTION
The summary section of travel advice can now be optional so this test no longer passes given the summary field is not expected.

Trello card: https://trello.com/c/EnEbVdZs/1268-travel-advice-cleanup

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
