### PR TITLE
Fix manuals with inverse metadata component style issue

### DIFF
--- a/app/assets/stylesheets/views/_manual.scss
+++ b/app/assets/stylesheets/views/_manual.scss
@@ -40,6 +40,15 @@
   &.hmrc {
     background: govuk-organisation-colour("hm-revenue-customs");
   }
+
+  .gem-c-metadata--inverse {
+    background: none;
+    padding: 0;
+
+    .gem-c-metadata__list {
+      margin: 0;
+    }
+  }
 }
 
 .section-list {


### PR DESCRIPTION
## What

Fix style issues (incorrect background colour and spacing) on manuals when `inverse` [metadata component](https://components.publishing.service.gov.uk/component-guide/metadata#on_a_dark_background) is included within the header.

## Why

To fix style issues introduced following an update to the `inverse` [metadata component](https://components.publishing.service.gov.uk/component-guide/metadata#on_a_dark_background) https://github.com/alphagov/govuk_publishing_components/pull/3365

## Visuals changes

### Before (Manuals)

![www gov uk_guidance_content-design(iPad Air) (1)](https://github.com/alphagov/government-frontend/assets/87758239/c5cc24f5-3186-4a1f-92e4-01d74cbeeb77)

### After (Manuals)

![government-frontend-pr-2785 herokuapp com_guidance_content-design(iPad Air) (1)](https://github.com/alphagov/government-frontend/assets/87758239/cc376a67-a3ca-4641-8278-c52cd6871410)

### Before (HMRC Manuals)

![www gov uk_hmrc-internal-manuals_capital-gains-manual_cg10100(iPad Air) (1)](https://github.com/alphagov/government-frontend/assets/87758239/8472f581-d349-4517-8809-587c0b100e81)

### After (HMRC Manuals)

![government-frontend-pr-2785 herokuapp com_hmrc-internal-manuals_capital-gains-manual_cg10100(iPad Air) (1)](https://github.com/alphagov/government-frontend/assets/87758239/5b74f81c-8637-4642-834e-24b99e86ab89)

## Anything else
No.