### PR TITLE
[DO NOT MERGE BEFORE 23 MAY] Remove cost of living user research banner

### DIFF
--- a/app/presenters/content_item/research_banner.rb
+++ b/app/presenters/content_item/research_banner.rb
@@ -1,26 +1,10 @@
 module ContentItem
   module ResearchBanner
     END_OF_LIFE_SURVEY_URL = "https://forms.office.com/e/a0WvT73tCV".freeze
-    USER_RESEARCH_SURVEY_URL = "https://gdsuserresearch.optimalworkshop.com/treejack/f49b8c01521bf45bd0a519fe02f5f913".freeze
 
     SURVEY_URL_MAPPINGS = {
       "/benefits-end-of-life" => END_OF_LIFE_SURVEY_URL,
       "/pip/claiming-if-you-might-have-12-months-or-less-to-live" => END_OF_LIFE_SURVEY_URL,
-      "/cost-of-living" => USER_RESEARCH_SURVEY_URL,
-      "/guidance/cost-of-living-payment" => USER_RESEARCH_SURVEY_URL,
-      "/cost-living-help-local-council" => USER_RESEARCH_SURVEY_URL,
-      "/benefits-calculators" => USER_RESEARCH_SURVEY_URL,
-      "/the-warm-home-discount-scheme" => USER_RESEARCH_SURVEY_URL,
-      "/universal-credit" => USER_RESEARCH_SURVEY_URL,
-      "/universal-credit/eligibility" => USER_RESEARCH_SURVEY_URL,
-      "/universal-credit/what-youll-get" => USER_RESEARCH_SURVEY_URL,
-      "/universal-credit/how-to-claim" => USER_RESEARCH_SURVEY_URL,
-      "/universal-credit/other-financial-support" => USER_RESEARCH_SURVEY_URL,
-      "/universal-credit/contact-universal-credit" => USER_RESEARCH_SURVEY_URL,
-      "/new-state-pension/what-youll-get" => USER_RESEARCH_SURVEY_URL,
-      "/get-help-energy-bills" => USER_RESEARCH_SURVEY_URL,
-      "/get-help-energy-bills/getting-discount-energy-bill" => USER_RESEARCH_SURVEY_URL,
-      "/pension-credit" => USER_RESEARCH_SURVEY_URL,
     }.freeze
 
     def survey_url

--- a/test/integration/research_banner_test.rb
+++ b/test/integration/research_banner_test.rb
@@ -1,47 +1,6 @@
 require "test_helper"
 
 class ResearchBannerTest < ActionDispatch::IntegrationTest
-  test "Cost of living survey banner is displayed on pages of interest" do
-    guide = GovukSchemas::Example.find("guide", example_name: "guide")
-
-    cost_living_banner_pages = %w[
-      /cost-of-living
-      /guidance/cost-of-living-payment
-      /cost-living-help-local-council
-      /benefits-calculators
-      /the-warm-home-discount-scheme
-      /universal-credit
-      /universal-credit/eligibility
-      /universal-credit/what-youll-get
-      /universal-credit/how-to-claim
-      /universal-credit/other-financial-support
-      /universal-credit/contact-universal-credit
-      /new-state-pension/what-youll-get
-      /get-help-energy-bills
-      /get-help-energy-bills/getting-discount-energy-bill
-      /pension-credit
-    ]
-
-    cost_living_banner_pages.each do |path|
-      guide["base_path"] = path
-      stub_content_store_has_item(guide["base_path"], guide.to_json)
-      visit path
-
-      assert page.has_css?(".gem-c-intervention")
-      assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://gdsuserresearch.optimalworkshop.com/treejack/f49b8c01521bf45bd0a519fe02f5f913")
-    end
-  end
-
-  test "Cost of living recruitment banner is not displayed on all pages" do
-    guide = GovukSchemas::Example.find("guide", example_name: "guide")
-    guide["base_path"] = "/universal-credit/changes-of-circumstances"
-    stub_content_store_has_item(guide["base_path"], guide.to_json)
-    visit "/universal-credit/changes-of-circumstances"
-
-    assert_not page.has_css?(".gem-c-intervention")
-    assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6")
-  end
-
   test "EOL banner is on the Get benefits if you're nearing the end of life page" do
     answer = GovukSchemas::Example.find("answer", example_name: "answer")
     answer["base_path"] = "/benefits-end-of-life"


### PR DESCRIPTION
Trello card: https://trello.com/c/0OnIdenV/1799-take-down-user-research-banner-for-col-m

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Before
![Screenshot 2023-05-18 at 16 59 12](https://github.com/alphagov/government-frontend/assets/96050928/650d878f-3004-4fdb-9cbc-997ee6865e43)

After

![Screenshot 2023-05-18 at 16 58 52](https://github.com/alphagov/government-frontend/assets/96050928/e80699bd-50a4-47b2-9959-e57b2aa44b3f)

