### PR TITLE
Remove unicorn config

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,2 +1,0 @@
-require "govuk_app_config/govuk_unicorn"
-GovukUnicorn.configure(self)


### PR DESCRIPTION
Unicorn has been replaced by Puma as the web server so the config can be removed.

See:
1. https://github.com/alphagov/govuk_app_config/pull/286/commits/71f4f2fa3871721e5c8140bcf73d683e09d8d7b2
2. https://github.com/alphagov/government-frontend/pull/2776

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
