### PR TITLE
Add GA4 tracking to content navigation components

### DIFF
--- a/app/views/components/_contents_list_with_body.html.erb
+++ b/app/views/components/_contents_list_with_body.html.erb
@@ -8,7 +8,7 @@
   <div id="contents" class="app-c-contents-list-with-body"<%= sticky_attr %>>
     <% if contents.any? %>
       <div class="responsive-bottom-margin">
-        <%= render 'govuk_publishing_components/components/contents_list', contents: contents %>
+        <%= render 'govuk_publishing_components/components/contents_list', contents: contents, ga4_tracking: true %>
       </div>
     <% end %>
     <%= block %>

--- a/app/views/components/_published_dates.html.erb
+++ b/app/views/components/_published_dates.html.erb
@@ -24,7 +24,11 @@
       class="app-c-published-dates__toggle govuk-link"
       data-controls="full-history"
       data-expanded="false"
-      data-toggled-text="&#45;&nbsp;<%= t('components.published_dates.hide_all_updates', locale: :en) %>">&#43;&nbsp;<%= t('components.published_dates.show_all_updates', locale: :en) %></a>
+      data-toggled-text="&#45;&nbsp;<%= t('components.published_dates.hide_all_updates', locale: :en) %>"
+      data-module="ga4-event-tracker"
+      data-ga4-event="<%= {event_name: "select_content", type: "content", section: "Footer"}.to_json %>"
+      data-ga4-expandable
+      >&#43;&nbsp;<%= t('components.published_dates.show_all_updates', locale: :en) %></a>
       <div class="app-c-published-dates__change-history js-hidden" id="full-history">
         <ol class="app-c-published-dates__list">
           <% history.each do |change| %>

--- a/app/views/content_items/field_of_operation.html.erb
+++ b/app/views/content_items/field_of_operation.html.erb
@@ -14,7 +14,8 @@
     <% if @content_item.contents.present? %>
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/contents_list", {
-          contents: @content_item.contents
+          contents: @content_item.contents,
+          ga4_tracking: true
         } %>
       </div>
     <% end %>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -69,7 +69,11 @@
       <% end %>
 
       <% if @content_item.show_guide_navigation? %>
-        <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
+        <%
+          previous_and_next_with_ga4_tracking = { ga4_tracking: true }
+          previous_and_next_with_ga4_tracking.merge!(@content_item.previous_and_next_navigation) # @content_item is frozen so we make a new hash
+        %>
+        <%= render 'govuk_publishing_components/components/previous_and_next_navigation', previous_and_next_with_ga4_tracking %>
 
         <div class="responsive-bottom-margin">
           <a href="<%= @content_item.print_link %>" class="govuk-link govuk-link--no-visited-state govuk-body"><%= t("multi_page.print_entire_guide") %></a>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -48,7 +48,7 @@
         href: "#guide-contents"
       } %>
       <aside class="part-navigation-container" role="complementary">
-        <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("guide.pages_in_guide") }, contents: @content_item.part_link_elements, underline_links: true %>
+        <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("guide.pages_in_guide") }, contents: @content_item.part_link_elements, underline_links: true, ga4_tracking: true %>
       </aside>
     <% end %>
   </div>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -76,7 +76,17 @@
         <%= render 'govuk_publishing_components/components/previous_and_next_navigation', previous_and_next_with_ga4_tracking %>
 
         <div class="responsive-bottom-margin">
-          <a href="<%= @content_item.print_link %>" class="govuk-link govuk-link--no-visited-state govuk-body"><%= t("multi_page.print_entire_guide") %></a>
+          <a href="<%= @content_item.print_link %>"
+            class="govuk-link govuk-link--no-visited-state govuk-body"
+            data-module="ga4-link-tracker"
+            data-ga4-link="<%= {
+              event_name: "navigation",
+              type: "content",
+              section: "Footer",
+              text: t("multi_page.print_entire_guide", locale: :en)
+            }.to_json %>">
+            <%= t("multi_page.print_entire_guide") %>
+          </a>
         </div>
       <% end %>
     <% end %>

--- a/app/views/content_items/guide_single.html.erb
+++ b/app/views/content_items/guide_single.html.erb
@@ -21,7 +21,7 @@
 
     <% if @content_item.show_guide_navigation? %>
       <aside class="part-navigation-container" role="complementary">
-        <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("guide.pages_in_guide") }, contents: @content_item.part_link_elements, underline_links: true %>
+        <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("guide.pages_in_guide") }, contents: @content_item.part_link_elements, underline_links: true, ga4_tracking: true %>
       </aside>
     <% end %>
   </div>

--- a/app/views/content_items/hmrc_manual_section.html.erb
+++ b/app/views/content_items/hmrc_manual_section.html.erb
@@ -25,6 +25,10 @@
   <% end %>
 
   <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/previous_and_next_navigation", @content_item.previous_and_next_links %>
+        <%
+          previous_and_next_with_ga4_tracking = { ga4_tracking: true }
+          previous_and_next_with_ga4_tracking.merge!(@content_item.previous_and_next_links) # @content_item is frozen so we make a new hash
+        %>
+    <%= render "govuk_publishing_components/components/previous_and_next_navigation", previous_and_next_with_ga4_tracking %>
   </div>
 <% end %>

--- a/app/views/content_items/how_government_works.html.erb
+++ b/app/views/content_items/how_government_works.html.erb
@@ -61,7 +61,8 @@
               href: "#history-uk-government",
               text: "History of government",
             }
-          ]
+          ],
+          ga4_tracking: true
         } %>
       </div>
 

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -58,7 +58,7 @@
   <div class="govuk-grid-row">
     <% if @content_item.contents.any? %>
       <div class="govuk-grid-column-one-quarter-from-desktop contents-list-container">
-        <%= render 'govuk_publishing_components/components/contents_list', contents: @content_item.contents, format_numbers: true %>
+        <%= render 'govuk_publishing_components/components/contents_list', contents: @content_item.contents, format_numbers: true, ga4_tracking: true %>
 
         <%= render 'govuk_publishing_components/components/print_link', {
           margin_top: 0,

--- a/app/views/content_items/manuals/_header.html.erb
+++ b/app/views/content_items/manuals/_header.html.erb
@@ -24,6 +24,7 @@
 
 
     <%
+      # The metadata component on this page receives ga4_tracking: true as it has a 'See all updates' link.
       metadata_with_ga4_tracking = { ga4_tracking: true }
       metadata_with_ga4_tracking.merge!(content_item.manual_metadata) # @content_item is frozen so we make a new hash
     %>

--- a/app/views/content_items/manuals/_header.html.erb
+++ b/app/views/content_items/manuals/_header.html.erb
@@ -22,7 +22,12 @@
       margin_bottom: margin_bottom,
     } %>
 
-    <%= render 'govuk_publishing_components/components/metadata', content_item.manual_metadata %>
+
+    <%
+      metadata_with_ga4_tracking = { ga4_tracking: true }
+      metadata_with_ga4_tracking.merge!(content_item.manual_metadata) # @content_item is frozen so we make a new hash
+    %>
+    <%= render 'govuk_publishing_components/components/metadata', metadata_with_ga4_tracking %>
 
     <div class="in-manual-search">
       <form action="/search/all" >

--- a/app/views/content_items/manuals/_manual_section_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_section_layout.html.erb
@@ -4,7 +4,7 @@
   <div id="manuals-frontend" class="manuals-frontend-body">
     <% if show_contents %>
       <%= render "govuk_publishing_components/components/contents_list", {
-        aria: { label: t("manuals.pages_in_manual_section") }, contents: @content_item.contents, underline_links: true
+        aria: { label: t("manuals.pages_in_manual_section") }, contents: @content_item.contents, underline_links: true, ga4_tracking: true
       } %>
     <% end %>
 

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -63,7 +63,15 @@
             margin_bottom: 1,
           } %>
         </div>
-        <ul class="govuk-list app-page-contents__list">
+        <ul class="govuk-list app-page-contents__list"
+            data-module="ga4-link-tracker"
+            data-ga4-track-links-only
+            data-ga4-set-indexes
+            data-ga4-link="<%= {
+              event_name: "navigation",
+              type: "content",
+              section: "Page contents:"
+            }.to_json %>">
           <% @content_item.header_links.each do |header_link| %>
             <li class="govuk-body-s">
               <%= link_to(header_link[:title], header_link[:href], class: 'govuk-link') %>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -62,12 +62,17 @@
       %>
       <%= render 'govuk_publishing_components/components/previous_and_next_navigation', previous_and_next_with_ga4_tracking %>
 
-
-
       <div class="responsive-bottom-margin">
-        <a href="<%= @content_item.print_link %>" class="govuk-link govuk-link--no-visited-state govuk-body"><%= t("multi_page.print_entire_guide") %></a>
+        <a href="<%= @content_item.print_link %>"
+          class="govuk-link govuk-link--no-visited-state govuk-body"
+          data-module="ga4-link-tracker"
+          data-ga4-link="<%= {
+            event_name: "navigation",
+            type: "content",
+            section: "Footer",
+            text: t("multi_page.print_entire_guide", locale: :en)
+          }.to_json %>"><%= t("multi_page.print_entire_guide") %></a>
       </div>
-    </div>
   <% end %>
   <%= render 'shared/sidebar_navigation' %>
 </div>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -56,7 +56,13 @@
         <% end %>
       </div>
 
-      <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
+      <%
+        previous_and_next_with_ga4_tracking = { ga4_tracking: true }
+        previous_and_next_with_ga4_tracking.merge!(@content_item.previous_and_next_navigation) # @content_item is frozen so we make a new hash
+      %>
+      <%= render 'govuk_publishing_components/components/previous_and_next_navigation', previous_and_next_with_ga4_tracking %>
+
+
 
       <div class="responsive-bottom-margin">
         <a href="<%= @content_item.print_link %>" class="govuk-link govuk-link--no-visited-state govuk-body"><%= t("multi_page.print_entire_guide") %></a>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -17,7 +17,7 @@
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
 
     <aside class="part-navigation-container" role="complementary">
-      <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("travel_advice.pages") }, contents: @content_item.part_link_elements, underline_links: true %>
+      <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("travel_advice.pages") }, contents: @content_item.part_link_elements, underline_links: true, ga4_tracking: true %>
 
       <div 
         data-module="ga4-link-tracker"

--- a/app/views/content_items/worldwide_office.html.erb
+++ b/app/views/content_items/worldwide_office.html.erb
@@ -6,7 +6,8 @@
   <div class="govuk-grid-column-one-third">
     <%= render "govuk_publishing_components/components/contents_list",
                contents: @content_item.contents,
-               underline_links: true
+               underline_links: true,
+               ga4_tracking: true
     %>
   </div>
 

--- a/app/views/histories/10_downing_street.html.erb
+++ b/app/views/histories/10_downing_street.html.erb
@@ -69,7 +69,8 @@
           href: "#larry-chief-mouser",
           text: "Larry, Chief Mouser to the Cabinet&nbsp;Office".html_safe,
         },
-      ]
+      ],
+      ga4_tracking: true
     } %>
   </nav>
 

--- a/app/views/histories/11_downing_street.html.erb
+++ b/app/views/histories/11_downing_street.html.erb
@@ -61,7 +61,8 @@
           href: "#sir-john-soane",
           text: "Sir John Soane",
         },
-      ]
+      ],
+      ga4_tracking: true
     } %>
   </nav>
 

--- a/app/views/histories/1_horse_guards_road.html.erb
+++ b/app/views/histories/1_horse_guards_road.html.erb
@@ -40,7 +40,8 @@
           href: "#the-cabinet-war-rooms",
           text: "The Cabinet War Rooms",
         },
-      ]
+      ],
+      ga4_tracking: true
     } %>
   </nav>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/histories/king_charles_street.html.erb
+++ b/app/views/histories/king_charles_street.html.erb
@@ -33,7 +33,8 @@
           href: "#fine-rooms",
           text: "Fine Rooms",
         },
-      ]
+      ],
+      ga4_tracking: true
     } %>
   </nav>
 

--- a/app/views/histories/lancaster_house.html.erb
+++ b/app/views/histories/lancaster_house.html.erb
@@ -73,7 +73,8 @@
           href: "#contact-details",
           text: "Contact details",
         },
-      ]
+      ],
+      ga4_tracking: true
     } %>
   </nav>
 

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -1,6 +1,7 @@
 <%
   metadata_component_options = @content_item.publisher_metadata
   metadata_component_options[:margin_bottom] = 3 if @notification_button_visible
+  metadata_component_options[:ga4_tracking] = true
 %>
 <div class="govuk-grid-row">
   <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if @content_item.try(:logo) %>">

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -1,6 +1,7 @@
 <%
   metadata_component_options = @content_item.publisher_metadata
   metadata_component_options[:margin_bottom] = 3 if @notification_button_visible
+  # The metadata component on this page receives ga4_tracking: true as it has a 'See all updates' link.
   metadata_component_options[:ga4_tracking] = true
 %>
 <div class="govuk-grid-row">

--- a/test/components/published_dates_test.rb
+++ b/test/components/published_dates_test.rb
@@ -91,4 +91,22 @@ class PublishedDatesTest < ComponentTestCase
     render_component(published: "1st November 2000", margin_bottom: 5)
     assert_select '.app-c-published-dates.govuk-\!-margin-bottom-5'
   end
+
+  test "accordion has GA4 tracking" do
+    render_component(
+      published: "1st November 2000",
+      last_updated: "15th July 2015",
+      history: [display_time: "23 August 2013", note: "Updated with new data"],
+    )
+
+    expected_ga4_json = {
+      "event_name": "select_content",
+      "type": "content",
+      "section": "Footer",
+    }.to_json
+
+    assert_select "a[data-module='ga4-event-tracker']"
+    assert_select "a[data-ga4-expandable='']"
+    assert_select "a[data-ga4-event='#{expected_ga4_json}']"
+  end
 end

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -169,6 +169,19 @@ class GuideTest < ActionDispatch::IntegrationTest
     assert_not page.has_css?(".gem-c-single-page-notification-button")
   end
 
+  test "print link has GA4 tracking" do
+    setup_and_visit_content_item("guide")
+
+    expected_ga4_json = {
+      event_name: "navigation",
+      type: "content",
+      section: "Footer",
+      text: "View a printable version of the whole guide",
+    }.to_json
+
+    assert page.has_css?("a[data-ga4-link='#{expected_ga4_json}']")
+  end
+
   def once_voting_has_closed
     Timecop.freeze(Time.zone.local(2021, 5, 6, 22, 0, 0))
     yield

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -70,6 +70,19 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     assert_not page.has_css?(".gem-c-single-page-notification-button")
   end
 
+  test "print link has GA4 tracking" do
+    setup_and_visit_content_item("full-country-without-summary")
+
+    expected_ga4_json = {
+      event_name: "navigation",
+      type: "content",
+      section: "Footer",
+      text: "View a printable version of the whole guide",
+    }.to_json
+
+    assert page.has_css?("a[data-ga4-link='#{expected_ga4_json}']")
+  end
+
   def setup_and_visit_travel_advice_part(name, part)
     @content_item = get_content_example(name).tap do |item|
       stub_content_store_has_item("#{item['base_path']}/#{part}", item.to_json)


### PR DESCRIPTION
https://trello.com/c/C9M2EJQu/553-content-navigation-chapter-headings-next-previous-view-a-printable-version-navigation-and-show-hide-updates-interaction

## What
- Adds tracking to our content pages as part of the content navigation card. It enables `ga4_tracking: true` on certain components, or adds a GA4 object to the HTML if the HTML is not rendered via `govuk_publishing_components`. 

## Why
This is part of our content navigation GA4 tracking. The elements which are tracked are:
- Contents list links at the top of the page.
- A "See all updates" jump link at the top of the page.
- Previous/Next page links at the bottom of the page.
- "View a printable version of this page" links at the bottom of the page.
- A "+ show updates" / " - hide updates" accordion at the bottom of the page.


I haven't written a lot of tests. This is mainly because we don't usually write tests just for passing `ga4_tracking: true` to a component, and the test pages provided by the `content_schemas` repo dont always have the components we want to test on them anyway. If you'd like to manually check all the tracking is there, here's a list of links + screenshot of what each component looks like: https://gist.github.com/AshGDS/0f3bd5aa6c04cefed2839f4d9b6b7337. You'll need to checkout `main` in `govuk_publishing_components` if [this](https://github.com/alphagov/govuk_publishing_components/pull/3451) hasn't been released. Then change your `Gemfile` in this repo to use your local publishing components, and then run `bundle install` in this repo, and then run this application with `./startup.sh --live`.

I suggest looking at the PR commit by commit, it looks a bit daunting if you look at the `Files changed` tab, but I think it looks a lot simpler if you look at it commit by commit. (I did consider creating separate PRs just before setting this ready for review, but since they share templates it might cause a merge conflict headache if they all get merged at separate times.) Apologies if the PR looks massive.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
