### PR TITLE
Improve spacing on the Worldwide Office pages

### DIFF
--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -1,6 +1,10 @@
 .worldwide-organisation-header {
   margin-top: $govuk-gutter-half;
   margin-bottom: $govuk-gutter-half;
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(8);
+  }
 }
 
 .js-enabled {
@@ -39,6 +43,7 @@
     dd {
       display: block;
       line-height: 1.5em;
+      margin: 0;
     }
   }
 }


### PR DESCRIPTION
- Remove the margin from the `dd` elements in the header metadata section. In Whitehall (which previously rendered these pages), this was applied globally.
- Add top padding to the header section. As breadcrumbs are now shown where they weren't in Whitehall, this section looks a little squashed.

|Before|After|
|-|-|
|![image](https://github.com/alphagov/government-frontend/assets/47089130/8aa681a5-2594-4aa0-8aee-edcc8470304d)|<img width="1175" alt="image" src="https://github.com/alphagov/government-frontend/assets/47089130/9af51c78-06a5-4441-9026-3edccccf06cf">|

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
