### PR TITLE
(397) Render worldwide organisation pages in government frontend

### DIFF
--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -58,3 +58,20 @@
     }
   }
 }
+
+.corporate-information__sub-navigation {
+  li {
+    @media (min-width: 1px) { // target modern browsers
+      list-style: none;
+      padding-left: $govuk-gutter-half;
+
+      &:before {
+        content: "-";
+        position: relative;
+        float: left;
+        width: $govuk-gutter-half;
+        margin-left: $govuk-gutter-half * -1;
+      }
+    }
+  }
+}

--- a/app/presenters/worldwide_office_presenter.rb
+++ b/app/presenters/worldwide_office_presenter.rb
@@ -1,8 +1,6 @@
 class WorldwideOfficePresenter < ContentItemPresenter
-  DEFAULT_ORGANISATION_LOGO = "single-identity".freeze
-
   include ContentItem::ContentsList
-  include ActionView::Helpers::UrlHelper
+  include WorldwideOrganisation::Branding
 
   def body
     content_item.dig("details", "access_and_opening_times")
@@ -14,54 +12,21 @@ class WorldwideOfficePresenter < ContentItemPresenter
     WorldwideOrganisation::LinkedContactPresenter.new(contact)
   end
 
-  def world_location_links
-    return if world_locations.empty?
-
-    links = world_locations.map do |location|
-      link_to(location["title"], WorldLocationBasePath.for(location), class: "govuk-link")
-    end
-
-    links.to_sentence.html_safe
-  end
-
-  def sponsoring_organisation_links
-    return if sponsoring_organisations.empty?
-
-    links = sponsoring_organisations.map do |organisation|
-      link_to(organisation["title"], organisation["base_path"], class: "sponsoring-organisation govuk-link")
-    end
-
-    links.to_sentence.html_safe
-  end
-
-  def organisation_logo
-    first_sponsoring_organisation = sponsoring_organisations&.first
-
-    {
-      name: title,
-      url: worldwide_organisation["base_path"],
-      crest: first_sponsoring_organisation&.dig("details", "logo", "crest") || DEFAULT_ORGANISATION_LOGO,
-      brand: first_sponsoring_organisation&.dig("details", "brand") || DEFAULT_ORGANISATION_LOGO,
-    }
-  end
-
   def show_default_breadcrumbs?
     false
   end
 
-private
-
   def worldwide_organisation
-    content_item.dig("links", "worldwide_organisation")&.first
+    return unless content_item.dig("links", "worldwide_organisation")
+
+    WorldwideOrganisationPresenter.new(content_item.dig("links", "worldwide_organisation").first, requested_path, view_context)
   end
 
   def sponsoring_organisations
-    worldwide_organisation&.dig("links", "sponsoring_organisations") || []
+    worldwide_organisation&.sponsoring_organisations
   end
 
-  def world_locations
-    worldwide_organisation&.dig("links", "world_locations") || []
-  end
+private
 
   def show_contents_list?
     true

--- a/app/presenters/worldwide_organisation/branding.rb
+++ b/app/presenters/worldwide_organisation/branding.rb
@@ -1,0 +1,17 @@
+module WorldwideOrganisation
+  module Branding
+    DEFAULT_ORGANISATION_LOGO = "single-identity".freeze
+
+    def organisation_logo
+      link_to_organisation = defined?(worldwide_organisation) && worldwide_organisation
+
+      sponsoring_organisation = sponsoring_organisations&.first
+      {
+        name: content_item["title"],
+        url: link_to_organisation ? worldwide_organisation.base_path : nil,
+        crest: sponsoring_organisation&.dig("details", "logo", "crest") || DEFAULT_ORGANISATION_LOGO,
+        brand: sponsoring_organisation&.dig("details", "brand") || DEFAULT_ORGANISATION_LOGO,
+      }
+    end
+  end
+end

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -1,4 +1,6 @@
 class WorldwideOrganisationPresenter < ContentItemPresenter
+  include ContentItem::Body
+
   def show_default_breadcrumbs?
     false
   end

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -16,8 +16,13 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
   def world_location_links
     return if world_locations.empty?
 
+    world_location_name_translations = content_item.dig("details", "world_location_names")
+
     links = world_locations.map do |location|
-      link_to(location["title"], WorldLocationBasePath.for(location), class: "govuk-link")
+      world_location_translation = world_location_name_translations.find do |translation|
+        translation["content_id"] == location["content_id"]
+      end
+      link_to(world_location_translation["name"], WorldLocationBasePath.for(location), class: "govuk-link")
     end
 
     links.to_sentence.html_safe

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -8,4 +8,40 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
   def social_media_accounts
     content_item.dig("details", "social_media_links") || []
   end
+
+  def show_our_people_section?
+    person_in_primary_role || people_in_non_primary_roles.any?
+  end
+
+  def person_in_primary_role
+    return unless content_item["links"]["primary_role_person"]
+
+    person = content_item.dig("links", "primary_role_person").first
+    current_roles = person.dig("links", "role_appointments").select { |role_app| role_app.dig("details", "current") }
+
+    {
+      name: person["title"],
+      href: person["web_url"],
+      image_url: person["details"]["image"]["url"],
+      image_alt: person["details"]["image"]["alt_text"],
+      description: current_roles.map { |role_app| role_app.dig("links", "role").first["title"] }.join,
+    }
+  end
+
+  def people_in_non_primary_roles
+    secondary_role_person = content_item["links"]["secondary_role_person"] || []
+    office_staff = content_item["links"]["office_staff"] || []
+    people = secondary_role_person + office_staff
+    return [] unless people.any?
+
+    people.map do |person|
+      current_roles = person.dig("links", "role_appointments").select { |role_app| role_app.dig("details", "current") }
+
+      {
+        name: person["title"],
+        href: person["web_url"],
+        description: current_roles.map { |role_app| role_app.dig("links", "role").first["title"] }.join,
+      }
+    end
+  end
 end

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -1,5 +1,27 @@
 class WorldwideOrganisationPresenter < ContentItemPresenter
   include ContentItem::Body
+  include WorldwideOrganisation::Branding
+  include ActionView::Helpers::UrlHelper
+
+  def sponsoring_organisation_links
+    return if sponsoring_organisations.empty?
+
+    links = sponsoring_organisations.map do |organisation|
+      link_to(organisation["title"], organisation["base_path"], class: "sponsoring-organisation govuk-link")
+    end
+
+    links.to_sentence.html_safe
+  end
+
+  def world_location_links
+    return if world_locations.empty?
+
+    links = world_locations.map do |location|
+      link_to(location["title"], WorldLocationBasePath.for(location), class: "govuk-link")
+    end
+
+    links.to_sentence.html_safe
+  end
 
   def show_default_breadcrumbs?
     false
@@ -66,5 +88,15 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
 
   def secondary_corporate_information
     content_item.dig("details", "secondary_corporate_information_pages").to_s
+  end
+
+  def sponsoring_organisations
+    content_item.dig("links", "sponsoring_organisations") || []
+  end
+
+private
+
+  def world_locations
+    content_item.dig("links", "world_locations") || []
   end
 end

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -2,4 +2,8 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
   def show_default_breadcrumbs?
     false
   end
+
+  def social_media_accounts
+    content_item.dig("details", "social_media_links") || []
+  end
 end

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -44,4 +44,27 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
       }
     end
   end
+
+  def show_corporate_info_section?
+    corporate_information_pages.any? || secondary_corporate_information.present?
+  end
+
+  def corporate_information_pages
+    cips = content_item.dig("links", "corporate_information_pages")
+    return [] if cips.blank?
+
+    ordered_cips = content_item.dig("details", "ordered_corporate_information_pages")
+    return [] if ordered_cips.blank?
+
+    ordered_cips.map do |cip|
+      {
+        text: cip["title"],
+        url: cips.find { |cp| cp["content_id"] == cip["content_id"] }["web_url"],
+      }
+    end
+  end
+
+  def secondary_corporate_information
+    content_item.dig("details", "secondary_corporate_information_pages").to_s
+  end
 end

--- a/app/views/content_items/worldwide_office.html.erb
+++ b/app/views/content_items/worldwide_office.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "content_items/worldwide_organisation/header", locals: {
-  link_to_organisation: true,
+  worldwide_organisation: @content_item.worldwide_organisation,
 } %>
 
 <article class="govuk-grid-row">

--- a/app/views/content_items/worldwide_organisation.html.erb
+++ b/app/views/content_items/worldwide_organisation.html.erb
@@ -71,6 +71,38 @@
   </section>
 <% end %>
 
+<% if @content_item.main_office %>
+  <section id="contact-us">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("worldwide_organisation.headings.contact_us"),
+      border_top: 5,
+      padding: true,
+    } %>
+
+    <hr class="govuk-section-break govuk-section-break--visible">
+
+    <div class="govuk-!-padding-top-6 govuk-!-padding-bottom-6 govuk-clearfix">
+      <%= render partial: "content_items/worldwide_organisation/contact", locals: {
+        contact: @content_item.main_office.contact,
+      } %>
+
+      <% if @content_item.main_office.has_access_and_opening_times? %>
+        <%= link_to "Access and opening times", @content_item.main_office.public_url, class: "govuk-link", lang: "en" %>
+      <% end %>
+    </div>
+
+    <% @content_item.home_page_offices.each do |contact| %>
+      <hr class="govuk-section-break govuk-section-break--visible">
+
+      <div class="govuk-!-padding-top-6 govuk-!-padding-bottom-6 govuk-clearfix">
+        <%= render partial: "content_items/worldwide_organisation/contact", locals: {
+          contact: contact,
+        } %>
+      </div>
+    <% end %>
+  </section>
+<% end %>
+
 <% if @content_item.show_corporate_info_section? %>
   <section class="corporate-information" id="corporate-info">
     <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/content_items/worldwide_organisation.html.erb
+++ b/app/views/content_items/worldwide_organisation.html.erb
@@ -15,4 +15,22 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
   </div>
+
+  <% if @content_item.social_media_accounts.any? %>
+    <aside class="social-media-links govuk-grid-column-one-third">
+      <div class="content">
+        <h2 class="govuk-heading-s"><%= t("worldwide_organisation.headings.follow_us") %></h2>
+        <%= render "govuk_publishing_components/components/share_links", {
+          track_as_follow: true,
+          links: @content_item.social_media_accounts.map do |account|
+            {
+              href: account["href"],
+              text: account["title"],
+              icon: account["service_type"],
+            }
+          end
+        } %>
+      </div>
+    </aside>
+  <% end %>
 </section>

--- a/app/views/content_items/worldwide_organisation.html.erb
+++ b/app/views/content_items/worldwide_organisation.html.erb
@@ -40,3 +40,44 @@
     </aside>
   <% end %>
 </section>
+
+<% if @content_item.show_our_people_section? %>
+  <section class="govuk-grid-row" id="people">
+    <div class="govuk-grid-column-full">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("worldwide_organisation.headings.our_people"),
+        border_top: 5,
+        padding: true,
+      } %>
+    </div>
+
+    <% if @content_item.person_in_primary_role %>
+      <div class="govuk-grid-column-one-quarter">
+        <%= render "govuk_publishing_components/components/image_card", {
+          href: @content_item.person_in_primary_role[:href],
+          image_src: @content_item.person_in_primary_role[:image_url],
+          image_alt: @content_item.person_in_primary_role[:image_alt],
+          heading_text: @content_item.person_in_primary_role[:name],
+          heading_level: 3,
+          description: @content_item.person_in_primary_role[:description]
+        } %>
+      </div>
+    <% end %>
+
+    <div class="govuk-grid-column-three-quarters">
+      <ul class="govuk-list govuk-grid-row">
+        <% @content_item.people_in_non_primary_roles.each.with_index do |person, i| %>
+          <% extra_class = (i + 1) % 4 == 0 ? " clear-column" : "" %>
+          <li class="govuk-grid-column-one-third<%= extra_class %>">
+            <%= render "govuk_publishing_components/components/image_card", {
+              href: person[:href],
+              heading_text: person[:name],
+              heading_level: 3,
+              description: person[:description]
+            } %>
+          <% end %>
+        </li>
+      </ul>
+    </div>
+  </section>
+<% end %>

--- a/app/views/content_items/worldwide_organisation.html.erb
+++ b/app/views/content_items/worldwide_organisation.html.erb
@@ -1,15 +1,4 @@
-<header class="worldwide-organisation-header govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds worldwide-organisation-header__logo">
-    <%= render 'govuk_publishing_components/components/organisation_logo', {
-      organisation: {
-        name: @content_item.title,
-        crest: "single-identity",
-      },
-      heading_level: 1,
-      inline: true,
-    } %>
-  </div>
-</header>
+<%= render partial: "content_items/worldwide_organisation/header", locals: { worldwide_organisation: @content_item } %>
 
 <section class="govuk-grid-row" id="about-us">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/worldwide_organisation.html.erb
+++ b/app/views/content_items/worldwide_organisation.html.erb
@@ -81,3 +81,29 @@
     </div>
   </section>
 <% end %>
+
+<% if @content_item.show_corporate_info_section? %>
+  <section class="corporate-information" id="corporate-info">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t('worldwide_organisation.headings.corporate_information'),
+      border_top: 5,
+      padding: true
+    } %>
+
+    <% if @content_item.corporate_information_pages.any? %>
+      <nav class="group corporate-information__sub-navigation" role="navigation">
+        <ul class="govuk-list">
+          <% @content_item.corporate_information_pages.each do |cip| %>
+            <li lang="<%= @content_item.locale %>"><%= link_to cip[:text], cip[:url], class: "govuk-link" %></li>
+          <% end %>
+        </ul>
+      </nav>
+    <% end %>
+
+    <% if @content_item.secondary_corporate_information.present? %>
+      <p class="govuk-body">
+        <%= @content_item.secondary_corporate_information.html_safe %>
+      </p>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/content_items/worldwide_organisation.html.erb
+++ b/app/views/content_items/worldwide_organisation.html.erb
@@ -87,7 +87,7 @@
       } %>
 
       <% if @content_item.main_office.has_access_and_opening_times? %>
-        <%= link_to "Access and opening times", @content_item.main_office.public_url, class: "govuk-link", lang: "en" %>
+        <%= link_to t("contact.access_and_opening_times"), @content_item.main_office.public_url, class: "govuk-link", lang: @content_item.locale %>
       <% end %>
     </div>
 

--- a/app/views/content_items/worldwide_organisation.html.erb
+++ b/app/views/content_items/worldwide_organisation.html.erb
@@ -14,6 +14,12 @@
 <section class="govuk-grid-row" id="about-us">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
+
+    <div class="body">
+      <%= render "govuk_publishing_components/components/govspeak", {} do
+        raw(@content_item.body)
+      end %>
+    </div>
   </div>
 
   <% if @content_item.social_media_accounts.any? %>

--- a/app/views/content_items/worldwide_organisation/_contact.html.erb
+++ b/app/views/content_items/worldwide_organisation/_contact.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag(:div, class: "worldwide-organisation-contact-section", lang: local_assigns[:lang] ? lang : nil) do %>
   <% unless local_assigns[:hide_title] %>
     <%= render "govuk_publishing_components/components/heading", {
-      text: contact["title"],
+      text: contact.title,
       heading_level: 3,
       font_size: "s",
       margin_bottom: 2,

--- a/app/views/content_items/worldwide_organisation/_header.html.erb
+++ b/app/views/content_items/worldwide_organisation/_header.html.erb
@@ -8,6 +8,11 @@
   </div>
 
   <div class="govuk-grid-column-one-third govuk-!-padding-top-2">
+    <% if @content_item.available_translations.length > 1 %>
+      <%= render 'govuk_publishing_components/components/translation_nav',
+        translations: @content_item.available_translations %>
+    <% end %>
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full worldwide-organisation-header__metadata">
         <dl>

--- a/app/views/content_items/worldwide_organisation/_header.html.erb
+++ b/app/views/content_items/worldwide_organisation/_header.html.erb
@@ -11,12 +11,12 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full worldwide-organisation-header__metadata">
         <dl>
-          <% if @content_item.world_location_links.present? %>
+          <% if worldwide_organisation&.world_location_links.present? %>
             <dt><%= t('worldwide_organisation.location') %>:</dt>
-            <dd data-module="hide-other-links"><%= @content_item.world_location_links %></dd>
+            <dd data-module="hide-other-links"><%= worldwide_organisation.world_location_links %></dd>
           <% end %>
           <dt><%= t('worldwide_organisation.part_of') %>:</dt>
-          <dd lang="en"><%= @content_item.sponsoring_organisation_links %></dd>
+          <dd lang="en"><%= worldwide_organisation&.sponsoring_organisation_links %></dd>
         </dl>
       </div>
     </div>

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -199,3 +199,8 @@ worldwide_office: '/world/organisations/british-consulate-general-barcelona/offi
 worldwide_office_without_access_details: '/world/organisations/british-consulate-general-alexandria/office/consulate-general-alexandria'
 worldwide_office_with_many_locations: '/world/organisations/british-embassy-paris/office/british-embassy'
 worldwide_office_with_non_default_logo: '/world/organisations/department-for-business-and-trade-ecuador/office/uk-trade-investment-ecuador'
+
+worldwide_organisation: '/world/organisations/british-embassy-madrid'
+worldwide_organisation_translation: '/world/organisations/british-embassy-madrid.es'
+worldwide_organisation_with_secondary_corporate_info_pages: '/world/organisations/british-deputy-high-commission-hyderabad'
+worldwide_organisation_without_corporate_info_pages: '/world/organisations/department-for-business-and-trade-germany'

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -45,6 +45,7 @@ ar:
     ways_to_respond: طرق الرد
     write_to: 'قم بمراسلة:'
   contact:
+    access_and_opening_times: أوقات الوصول والفتح
     contact_form: نموذج الاتصال
     email: البريد الإلكتروني
     find_call_charges: تعرف على رسوم المكالمات

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -45,6 +45,7 @@ az:
     ways_to_respond: Cavab vermək üçün yollar
     write_to: 'Yazın:'
   contact:
+    access_and_opening_times: Giriş və iş vaxtı
     contact_form: Əlaqə saxlamaq üçün forma
     email: E-poçt
     find_call_charges: Telefon danışıqlarının xərci barədə öyrənin

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -45,6 +45,7 @@ be:
     ways_to_respond: Спосабы рэагавання
     write_to: 'Пішыце па адрасе:'
   contact:
+    access_and_opening_times: Доступ і час працы
     contact_form: Кантактная форма
     email: Электронная пошта
     find_call_charges: Даведайцеся пра кошт званкоў

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -45,6 +45,7 @@ bg:
     ways_to_respond: Начини за отговор
     write_to: 'Пишете до:'
   contact:
+    access_and_opening_times: Часове за достъп и отваряне
     contact_form: Формуляр за контакт
     email: Имейл
     find_call_charges: Научете повече за телефонните такси

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -45,6 +45,7 @@ bn:
     ways_to_respond: উত্তর দেওয়ার উপায়
     write_to: 'যার কাছে লিখবেন:'
   contact:
+    access_and_opening_times: প্রবেশ ও খোলার সময়
     contact_form: যোগাযোগের ফর্ম
     email: ইমেইল
     find_call_charges: কল চার্জগুলো সম্পর্কে খুঁজে দেখুন

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -45,6 +45,7 @@ cs:
     ways_to_respond: Způsoby reakce
     write_to: 'Napište na adresu:'
   contact:
+    access_and_opening_times: Přístup a otevírací doba
     contact_form: Kontaktní formulář
     email: E-mail
     find_call_charges: Informace o poplatcích za volání

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -45,6 +45,7 @@ cy:
     ways_to_respond: Ffyrdd o ymateb
     write_to: 'Ysgrifennu at:'
   contact:
+    access_and_opening_times: Mynediad ac amseroedd agor
     contact_form: Ffurflen gysylltu
     email: E-bost
     find_call_charges: Dysgwch am ffioedd ffonio

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -45,6 +45,7 @@ da:
     ways_to_respond: Måder at reagere på
     write_to: 'Skriv til:'
   contact:
+    access_and_opening_times: Adgang til kontoret og åbningstider
     contact_form: Kontaktformular
     email: E-mail
     find_call_charges: Få mere at vide om opkaldsgebyrer

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -45,6 +45,7 @@ de:
     ways_to_respond: Möglichkeiten, um zu antworten
     write_to: 'Schreiben Sie an:'
   contact:
+    access_and_opening_times: Zugang und Öffnungszeiten
     contact_form: Kontaktformular
     email: Email
     find_call_charges: Erkundigen Sie sich über Telefongebühren

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -45,6 +45,7 @@ dr:
     ways_to_respond: طریقه هایی پاسخ دهی
     write_to: 'نوشته کنید به:'
   contact:
+    access_and_opening_times: زمان باز کردن و دسترسی
     contact_form: فورم تماس
     email: ایمل
     find_call_charges: از هزینه هایی تماس مطلع شوید

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -45,6 +45,7 @@ el:
     ways_to_respond: Τρόποι απάντησης
     write_to: 'Γράψτε στην διεύθυνση:'
   contact:
+    access_and_opening_times: Πρόσβαση και ώρες λειτουργίας
     contact_form: Φόρμα επικοινωνίας
     email: Email
     find_call_charges: Ενημερωθείτε για τις χρεώσεις κλήσεων

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
     ways_to_respond: Ways to respond
     write_to: 'Write to:'
   contact:
+    access_and_opening_times: Access and opening times
     contact_form: Contact form
     email: Email
     find_call_charges: Find out about call charges

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -45,6 +45,7 @@ es-419:
     ways_to_respond: Formas de responder
     write_to: 'Escriba a:'
   contact:
+    access_and_opening_times: Acceso y horarios de aperturaAcceso y inicio
     contact_form: Formulario de contacto
     email: Email
     find_call_charges: Conozca las tarifas de las llamadas

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -45,6 +45,7 @@ es:
     ways_to_respond: Formas de responder
     write_to: 'Escribir a:'
   contact:
+    access_and_opening_times: Horarios de acceso y apertura
     contact_form: Formulario de contacto
     email: Correo electrónico
     find_call_charges: Más información sobre los cargos por llamadas

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -45,6 +45,7 @@ et:
     ways_to_respond: Vastamise viisid
     write_to: 'Kirja adressaat:'
   contact:
+    access_and_opening_times: Juurdepääs ja lahtiolekuajad
     contact_form: Kontaktivorm
     email: E-post
     find_call_charges: Uuri kõnetasude kohta

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -45,6 +45,7 @@ fa:
     ways_to_respond: راه‌های پاسخ
     write_to: 'پیام دهید به:'
   contact:
+    access_and_opening_times: دفعات دسترسی و باز شدن
     contact_form: فرم تماس
     email: ایمیل
     find_call_charges: از هزینه‌های تماس مطلع شوید

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -45,6 +45,7 @@ fi:
     ways_to_respond: Tapoja vastata
     write_to: 'Kirjoittaa:'
   contact:
+    access_and_opening_times: Pääsy ja aukioloajat
     contact_form: Yhteydenottolomake
     email: Sähköposti
     find_call_charges: Ota selvää puheluhinnoista

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -45,6 +45,7 @@ fr:
     ways_to_respond: Moyens de répondre
     write_to: 'Écrire à :'
   contact:
+    access_and_opening_times: Horaires d'accès et d'ouverture
     contact_form: Formulaire de contact
     email: Courriel
     find_call_charges: Consultez les tarifs des appels

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -45,6 +45,7 @@ gd:
     ways_to_respond: Bealaí chun freagra a thabhairt
     write_to: 'Scríobh chuig:'
   contact:
+    access_and_opening_times: Uaireanta rochtana agus oscailte
     contact_form: Foirm teagmhála
     email: R-phost
     find_call_charges: Faigh amach faoin méid cumarsáide

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -45,6 +45,7 @@ gu:
     ways_to_respond: પ્રતિભાવ આપવાની રીતો
     write_to: 'ને લખો:'
   contact:
+    access_and_opening_times: 'એક્સેસ અને ઓપનિંગ સમય '
     contact_form: સંપર્ક પત્રક
     email: ઈમેલ
     find_call_charges: કૉલ ચાર્જિસ અંગે શોધો

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -45,6 +45,7 @@ he:
     ways_to_respond: דרכים להגיב
     write_to: 'כתוב ל:'
   contact:
+    access_and_opening_times: זמני גישה ופתיחה
     contact_form: טופס יצירת קשר
     email: דואר אלקטרוני
     find_call_charges: למידע נוסף על חיובי שיחות

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -45,6 +45,7 @@ hi:
     ways_to_respond: जवाब देने के तरीके
     write_to: 'इसे लिखें:'
   contact:
+    access_and_opening_times: एक्सेस और खुलने का समय
     contact_form: संपर्क प्रपत्र
     email: ईमेल
     find_call_charges: कॉल शुल्क के बारे में जानें

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -45,6 +45,7 @@ hr:
     ways_to_respond: Načini reagiranja
     write_to: 'Pišite na:'
   contact:
+    access_and_opening_times: Vrijeme pristupa i otvaranje
     contact_form: Kontakt obrazac
     email: E-pošta
     find_call_charges: Saznajte o cijenama poziva

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -45,6 +45,7 @@ hu:
     ways_to_respond: Válaszadási lehetőségek
     write_to: 'Levélírás a következőnek:'
   contact:
+    access_and_opening_times: Hozzáférési és nyitási idők
     contact_form: Kapcsolatfelvételi űrlap
     email: E-mail
     find_call_charges: Tudjon meg többet a hívás költségeiről

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -45,6 +45,7 @@ hy:
     ways_to_respond: Պատասխանելու եղանակներ
     write_to: Գրել՝
   contact:
+    access_and_opening_times: Մուտք և հասանելիության ժամեր
     contact_form: Կոնտակտային ձև
     email: Էլ․ փոստ
     find_call_charges: Տեղեկանալ զանգերի վճարների մասին

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -45,6 +45,7 @@ id:
     ways_to_respond: Cara merespons
     write_to: 'Tulis kepada:'
   contact:
+    access_and_opening_times: Waktu akses dan buka
     contact_form: Formulir kontak
     email: Email
     find_call_charges: Cari tahu tentang biaya panggilan

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -45,6 +45,7 @@ is:
     ways_to_respond: Leiðir til að svara
     write_to: 'Skrifa til:'
   contact:
+    access_and_opening_times: Aðgengi og opnunartímar
     contact_form: Eyðublað til að hafa samband
     email: Tölvupóstfang
     find_call_charges: Komast að hvað símtöl kosta

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -45,6 +45,7 @@ it:
     ways_to_respond: Modi di rispondere
     write_to: 'Scrivi a:'
   contact:
+    access_and_opening_times: Orari di accesso e di apertura
     contact_form: Modulo di contatto
     email: E-mail
     find_call_charges: Scopri i costi delle chiamate

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -45,6 +45,7 @@ ja:
     ways_to_respond: 対応方法
     write_to: 書き込み先：
   contact:
+    access_and_opening_times: アクセスと利用時間
     contact_form: お問い合わせフォーム
     email: Eメール
     find_call_charges: 通話料金について調べる

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -45,6 +45,7 @@ ka:
     ways_to_respond: პასუხის გზები
     write_to: 'მიწერეთ:'
   contact:
+    access_and_opening_times: ხელმისაწვდომობა და გახსნის დროები
     contact_form: საკონტაქტო ფორმა
     email: ელ.ფოსტა
     find_call_charges: გაიგეთ ზარის ფასების შესახებ

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -45,6 +45,7 @@ kk:
     ways_to_respond: Жауап беру жолдары
     write_to: 'Мынаған жазу:'
   contact:
+    access_and_opening_times: Кіру және ашу уақыттары
     contact_form: Байланысу формасы
     email: Электрондық пошта
     find_call_charges: Барлық алынатын ақылар туралы мәлімет алу

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -45,6 +45,7 @@ ko:
     ways_to_respond: 응답 방법
     write_to: '다음에 작성:'
   contact:
+    access_and_opening_times: 액세스 및 공개 시간
     contact_form: 콘택트 폼
     email: 이메일
     find_call_charges: 통화비에 대해 알아보기

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -45,6 +45,7 @@ lt:
     ways_to_respond: Kaip pateikti atsakymą
     write_to: 'Parašyti:'
   contact:
+    access_and_opening_times: Prieiga ir  pradžios laikas
     contact_form: Parašykite mums
     email: El. paštas
     find_call_charges: Sužinokite visą informaciją apie skambučiams taikomus mokesčius

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -45,6 +45,7 @@ lv:
     ways_to_respond: Veidi, kā atbildēt
     write_to: 'Rakstīt uz:'
   contact:
+    access_and_opening_times: Piekļuves un atvēršanas laiks
     contact_form: Saziņas forma
     email: E-pasts
     find_call_charges: Informācija par maksu par zvaniem

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -45,6 +45,7 @@ ms:
     ways_to_respond: Cara untuk menjawab
     write_to: 'Tulis kepada:'
   contact:
+    access_and_opening_times: Akses dan waktu pembukaan
     contact_form: Borang hubungan
     email: E-mel
     find_call_charges: Ketahui tentang caj panggilan

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -45,6 +45,7 @@ mt:
     ways_to_respond: Metodi kif twieġeb
     write_to: 'Ikteb lil:'
   contact:
+    access_and_opening_times: Aċċess u ħinijiet tal-ftuħ
     contact_form: Formola ta' kuntatt
     email: Imejl
     find_call_charges: Kun af dwar tariffi tat-telefonata

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -45,6 +45,7 @@ ne:
     ways_to_respond: प्रतिक्रिया दिने तरिका
     write_to: 'मा लेख्नुहोस्:'
   contact:
+    access_and_opening_times: पहुँच र खुल्ने समय
     contact_form: सम्पर्क फारम
     email: इमेल
     find_call_charges: कल शुल्कको बारेमा जानकारी पाउनुहोस्

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -45,6 +45,7 @@ nl:
     ways_to_respond: Manieren om te reageren
     write_to: 'Schrijf naar:'
   contact:
+    access_and_opening_times: Toegang en openingstijden
     contact_form: Contactformulier
     email: E-mail
     find_call_charges: Informatie over gesprekskosten

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -45,6 +45,7 @@
     ways_to_respond: Måter å svare på
     write_to: 'Skriv til:'
   contact:
+    access_and_opening_times: Tilgang og åpningstider
     contact_form: Kontaktskjema
     email: E-post
     find_call_charges: Finn ut om samtalekostnader

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -45,6 +45,7 @@ pa-pk:
     ways_to_respond: جواب دین دے طریقے
     write_to: اینوں لکھو
   contact:
+    access_and_opening_times: پہنچ تے کُھلن دا ویلہ
     contact_form: رابطے دا فارم
     email: ای میل
     find_call_charges: سارے خرچے دے بارے جانو

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -45,6 +45,7 @@ pa:
     ways_to_respond: ਜਵਾਬ ਦੇਣ ਦੇ ਤਰੀਕੇ
     write_to: 'ਨੂੰ ਲਿਖੋ:'
   contact:
+    access_and_opening_times: ਪਹੁੰਚ ਅਤੇ ਖੋਲ੍ਹਣ ਦੇ ਸਮੇਂ
     contact_form: ਸੰਪਰਕ ਫਾਰਮ
     email: ਈ - ਮੇਲ
     find_call_charges: ਕਾਲ ਖਰਚਿਆਂ ਬਾਰੇ ਜਾਣੋ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -45,6 +45,7 @@ pl:
     ways_to_respond: Sposoby wysłania odpowiedzi
     write_to: 'Napisz do:'
   contact:
+    access_and_opening_times: Czas dostępu i otwarcia
     contact_form: Formularz kontaktowy
     email: Wiadomość e-mail
     find_call_charges: Dowiedz się o opłatach za połączenia

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -45,6 +45,7 @@ ps:
     ways_to_respond: د ځواب ویلو لارې
     write_to: 'ته یې ولیکئ:'
   contact:
+    access_and_opening_times: د لاسرسي او خلاصیدو وختونه
     contact_form: د اړیکې فورمه
     email: بریښنالیک
     find_call_charges: د تلیفون لګښتونو په اړه معلومات ترلاسه کړئ

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -45,6 +45,7 @@ pt:
     ways_to_respond: Formas de resposta
     write_to: 'Escreva para:'
   contact:
+    access_and_opening_times: Horários de acesso e abertura
     contact_form: Formulário de contacto
     email: E-mail
     find_call_charges: Saiba quais são as tarifas para as chamadas

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -45,6 +45,7 @@ ro:
     ways_to_respond: Modalități de a răspunde
     write_to: 'Scrieți la:'
   contact:
+    access_and_opening_times: Orele de acces și deschidere
     contact_form: Formular de contact
     email: E-mail
     find_call_charges: Aflați mai multe despre taxele apelurilor

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -45,6 +45,7 @@ ru:
     ways_to_respond: Как получить ответ
     write_to: 'Пишите на:'
   contact:
+    access_and_opening_times: Время доступа и открытия
     contact_form: Форма обратной связи
     email: Электронная почта
     find_call_charges: Узнайте о стоимости звонков

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -45,6 +45,7 @@ si:
     ways_to_respond: ප්රතිචාර දැක්විමේ ක්‍රම
     write_to: 'ලියන්න:'
   contact:
+    access_and_opening_times: පිවිසුම සහ විවෘත කරන වේලාවන්
     contact_form: සබඳතා ආකෘතිය
     email: විද්‍යුත් තැපෑල
     find_call_charges: ඇමතුම් ගාස්තු ගැන සොයා බලන්න

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -45,6 +45,7 @@ sk:
     ways_to_respond: Spôsoby reakcie
     write_to: 'Napíšte na adresu:'
   contact:
+    access_and_opening_times: Prístup a otváracie hodiny
     contact_form: Kontaktný formulár
     email: E-mail
     find_call_charges: Zistite informácie o poplatkoch za hovory

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -45,6 +45,7 @@ sl:
     ways_to_respond: Načini odziva
     write_to: 'Pišite na:'
   contact:
+    access_and_opening_times: Dostop do pisarne in odpiralni čas
     contact_form: Dostop in odpiralni čas
     email: E-pošta
     find_call_charges: Izvedite več o cenah klicev

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -45,6 +45,7 @@ so:
     ways_to_respond: Hababka loo jawaabo
     write_to: 'Loogu qoro:'
   contact:
+    access_and_opening_times: Wakhtiyada galitaanka iyo furitaanka
     contact_form: Foomka lagala xidhiidhayo
     email: Iimaylka
     find_call_charges: Loo raadiyo maxsuulada kasoo baxa wicitaanka

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -45,6 +45,7 @@ sq:
     ways_to_respond: Mënyrat për tu përgjigjur
     write_to: 'Shkruaj tek:'
   contact:
+    access_and_opening_times: Orari i hyrjes dhe hapjes
     contact_form: Formular kontakti
     email: Email
     find_call_charges: Mësoni për tarifat e thirrjeve

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -45,6 +45,7 @@ sr:
     ways_to_respond: Mogućnosti odgovora
     write_to: 'Pišite na:'
   contact:
+    access_and_opening_times: Pristup i radno vreme
     contact_form: Kontakt obrazac
     email: E-adresa
     find_call_charges: Informišite se o ceni poziva

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -45,6 +45,7 @@ sv:
     ways_to_respond: Sätt att svara
     write_to: 'Skriv till:'
   contact:
+    access_and_opening_times: Tillgång och öppettider
     contact_form: Kontaktformulär
     email: E-post
     find_call_charges: Ta reda på hur man tar ut samtalsavgifter

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -45,6 +45,7 @@ sw:
     ways_to_respond: Njia za kujibu
     write_to: 'Andika barua kwa:'
   contact:
+    access_and_opening_times: Saa za upatikanaji na kufunguliwa
     contact_form: Fomu ya mawasiliano
     email: Barua pepe
     find_call_charges: Pata maelezo kuhusu gharama za kupiga simu

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -45,6 +45,7 @@ ta:
     ways_to_respond: பதிலளிக்கும் வழிகள்
     write_to: 'எங்களுக்கு எழுதுங்கள்:'
   contact:
+    access_and_opening_times: அணுகுதல் மற்றும் திறக்கும் நேரங்கள்
     contact_form: தொடர்பு படிவம்
     email: மின்னஞ்சல்
     find_call_charges: அழைப்புக் கட்டணம் குறித்துத் தெரிந்துகொள்ளுங்கள்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -45,6 +45,7 @@ th:
     ways_to_respond: วิธีการตอบกลับ
     write_to: 'เขียนข้อความถึง:'
   contact:
+    access_and_opening_times: การเข้าถึงและเวลาเปิดทำการ
     contact_form: แบบฟอร์มการติดต่อ
     email: อีเมล
     find_call_charges: ดูข้อมูลเกี่ยวกับค่าโทรศัพท์

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -45,6 +45,7 @@ tk:
     ways_to_respond: Jogap bermegiň görnüşleri
     write_to: 'Ýazyň:'
   contact:
+    access_and_opening_times: Giriş we açyk wagtlary
     contact_form: Habarlaşmak üçin forma
     email: E-poçta
     find_call_charges: Jaň etmegiň talaplary bilen tanyşyň

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -45,6 +45,7 @@ tr:
     ways_to_respond: Yanıtlama şekilleri
     write_to: 'Şuraya yaz:'
   contact:
+    access_and_opening_times: Giriş ve açılma saatleri
     contact_form: İrtibat formu
     email: E-posta
     find_call_charges: Tüm arama ücretlerini öğren

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -45,6 +45,7 @@ uk:
     ways_to_respond: Способи реагування
     write_to: 'Написати:'
   contact:
+    access_and_opening_times: Доступ і час відкриття
     contact_form: Форма зв'язку
     email: Електронна пошта
     find_call_charges: Дізнатися про тарифи на дзвінки

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -45,6 +45,7 @@ ur:
     ways_to_respond: جواب دینے کے طریقے
     write_to: 'لکھیں بنام:'
   contact:
+    access_and_opening_times: رسائی اور کھولنے کے اوقات
     contact_form: رابطے کا فارم
     email: ای میل
     find_call_charges: کال کے چارجز کے بارے میں جانیں

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -45,6 +45,7 @@ uz:
     ways_to_respond: Жавоб бериш усули
     write_to: 'Ёзиш:'
   contact:
+    access_and_opening_times: Кириш ва очилиш вақти
     contact_form: Алоқа шакли
     email: Электрон почта
     find_call_charges: Қўнғироқлар нархи ҳақида билиб олиш

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -45,6 +45,7 @@ vi:
     ways_to_respond: Cách trả lời
     write_to: 'Gửi thư đến:'
   contact:
+    access_and_opening_times: Thời gian làm việc và mở cửa
     contact_form: Biểu mẫu liên hệ
     email: Email
     find_call_charges: Tìm hiểu về phí cuộc gọi

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -45,6 +45,7 @@ yi:
     ways_to_respond:
     write_to:
   contact:
+    access_and_opening_times:
     contact_form:
     email:
     find_call_charges:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -45,6 +45,7 @@ zh-hk:
     ways_to_respond: 回應方式
     write_to: 致函：
   contact:
+    access_and_opening_times: 訪問及開放時間
     contact_form: 聯絡資料表
     email: 電子郵件
     find_call_charges: 了解通話費用之狀況

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -45,6 +45,7 @@ zh-tw:
     ways_to_respond: 回覆方式
     write_to: 發送至：
   contact:
+    access_and_opening_times: 訪問與開啟時間
     contact_form: 聯繫表
     email: 電子郵件
     find_call_charges: 了解通話費用

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -45,6 +45,7 @@ zh:
     ways_to_respond: 回复方法
     write_to: 收件人：
   contact:
+    access_and_opening_times: 访问和打开次数
     contact_form: 联系表单
     email: 电子邮箱
     find_call_charges: 查看电话费

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -93,4 +93,33 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
     assert page.has_text?("English")
     assert page.has_link?("Deutsch", href: "/world/uk-embassy-in-country.de")
   end
+
+  test "renders the main office contact with a link to the office page" do
+    setup_and_visit_content_item("worldwide_organisation")
+
+    within("#contact-us") do
+      assert page.has_text?("Contact us")
+      assert page.has_content?("Torre Emperador Castellana")
+      assert page.has_link?("Access and opening times", href: "https://www.integration.publishing.service.gov.uk/world/organisations/british-embassy-madrid/office/british-embassy")
+    end
+  end
+
+  test "renders the home page offices without a link to the office page" do
+    setup_and_visit_content_item("worldwide_organisation")
+
+    within("#contact-us") do
+      assert page.has_content?("Department for Business and Trade Dusseldorf")
+      assert_not page.has_link?("Access and opening times", href: "https://www.integration.publishing.service.gov.uk/world/organisations/department-for-business-and-trade-germany/office/uk-trade-investment-duesseldorf")
+    end
+  end
+
+  test "does not render the contacts section if there is no main office" do
+    setup_and_visit_content_item(
+      "worldwide_organisation",
+      {
+        "links" => { "main_office" => nil },
+      },
+    )
+    assert_not page.has_text?("Contact us")
+  end
 end

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -100,7 +100,7 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
     within("#contact-us") do
       assert page.has_text?("Contact us")
       assert page.has_content?("Torre Emperador Castellana")
-      assert page.has_link?("Access and opening times", href: "https://www.integration.publishing.service.gov.uk/world/organisations/british-embassy-madrid/office/british-embassy")
+      assert page.has_link?(I18n.t("contact.access_and_opening_times"), href: "https://www.integration.publishing.service.gov.uk/world/organisations/british-embassy-madrid/office/british-embassy")
     end
   end
 
@@ -109,7 +109,7 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
 
     within("#contact-us") do
       assert page.has_content?("Department for Business and Trade Dusseldorf")
-      assert_not page.has_link?("Access and opening times", href: "https://www.integration.publishing.service.gov.uk/world/organisations/department-for-business-and-trade-germany/office/uk-trade-investment-duesseldorf")
+      assert_not page.has_link?(I18n.t("contact.access_and_opening_times"), href: "https://www.integration.publishing.service.gov.uk/world/organisations/department-for-business-and-trade-germany/office/uk-trade-investment-duesseldorf")
     end
   end
 

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -42,4 +42,25 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
     )
     assert_not page.has_text?("Our people")
   end
+
+  test "renders the navigational corporate information pages" do
+    setup_and_visit_content_item("worldwide_organisation")
+    assert page.has_link?("Complaints procedure", href: "https://www.integration.publishing.service.gov.uk/world/organisations/british-deputy-high-commission-hyderabad/about/complaints-procedure")
+  end
+
+  test "renders the secondary corporate information pages" do
+    setup_and_visit_content_item("worldwide_organisation")
+    assert page.has_link?("Personal information charter", href: "https://www.integration.publishing.service.gov.uk/world/organisations/british-deputy-high-commission-hyderabad/about/personal-information-charter")
+  end
+
+  test "doesn't render the corporate pages section if there are no pages to show" do
+    setup_and_visit_content_item(
+      "worldwide_organisation",
+      {
+        "links" => { "corporate_information_pages" => nil },
+        "details" => { "secondary_corporate_information_pages" => "" },
+      },
+    )
+    assert_not page.has_text?("Corporate information")
+  end
 end

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -12,4 +12,10 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
 
     assert page.has_no_selector?(".govuk-breadcrumbs")
   end
+
+  test "renders the body content" do
+    setup_and_visit_content_item("worldwide_organisation")
+    assert page.has_selector?("#about-us")
+    assert page.has_text?("Find out more on our UK and India")
+  end
 end

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -63,4 +63,34 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
     )
     assert_not page.has_text?("Corporate information")
   end
+
+  test "does not render the translations when there are no translations" do
+    setup_and_visit_content_item("worldwide_organisation")
+
+    assert_not page.has_text?("English")
+  end
+
+  test "renders the translations when there are translations" do
+    setup_and_visit_content_item(
+      "worldwide_organisation",
+      {
+        "links" => {
+          "available_translations" =>
+            [
+              {
+                "locale": "en",
+                "base_path": "/world/uk-embassy-in-country",
+              },
+              {
+                "locale": "de",
+                "base_path": "/world/uk-embassy-in-country.de",
+              },
+            ],
+        },
+      },
+    )
+
+    assert page.has_text?("English")
+    assert page.has_link?("Deutsch", href: "/world/uk-embassy-in-country.de")
+  end
 end

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -18,4 +18,28 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
     assert page.has_selector?("#about-us")
     assert page.has_text?("Find out more on our UK and India")
   end
+
+  test "renders the person in the primary role" do
+    setup_and_visit_content_item("worldwide_organisation")
+    assert page.has_link?("Karen Pierce DCMG", href: "https://www.integration.publishing.service.gov.uk/government/people/karen-pierce")
+    assert page.has_css?("img[src=\"https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/583/s216_UKMissionGeneva__HMA_Karen_Pierce_-_uploaded.jpg\"]")
+  end
+
+  test "renders people in secondary and office roles" do
+    setup_and_visit_content_item("worldwide_organisation")
+    assert page.has_link?("Justin Sosne", href: "https://www.integration.publishing.service.gov.uk/government/people/justin-sosne")
+    assert page.has_link?("Rachel Galloway", href: "https://www.integration.publishing.service.gov.uk/government/people/rachel-galloway")
+  end
+
+  test "doesn't render the people section if there are no appointed people" do
+    setup_and_visit_content_item(
+      "worldwide_organisation",
+      { "links" => {
+        "primary_role_person" => nil,
+        "secondary_role_person" => nil,
+        "office_staff" => nil,
+      } },
+    )
+    assert_not page.has_text?("Our people")
+  end
 end

--- a/test/presenters/worldwide_office_presenter_test.rb
+++ b/test/presenters/worldwide_office_presenter_test.rb
@@ -17,39 +17,6 @@ class WorldwideOfficePresenterTest < PresenterTestCase
     assert presented_item.contact.is_a?(WorldwideOrganisation::LinkedContactPresenter)
   end
 
-  test "#world_location_links returns the world locations as a joined sentence of links" do
-    expected_links =
-      "<a class=\"govuk-link\" href=\"/world/philippines/news\">Philippines</a> and "\
-      "<a class=\"govuk-link\" href=\"/world/palau/news\">Palau</a>"
-
-    assert_equal expected_links, presented_item.world_location_links
-  end
-
-  test "#world_location_links returns nil when world locations are empty" do
-    without_world_locations = schema_item
-    without_world_locations["links"]["worldwide_organisation"][0]["links"].delete("world_locations")
-
-    presented = create_presenter(WorldwideOfficePresenter, content_item: without_world_locations)
-
-    assert_nil presented.world_location_links
-  end
-
-  test "#sponsoring_organisation_links returns the sponsoring organisations as sentence of links" do
-    expected_links =
-      "<a class=\"sponsoring-organisation govuk-link\" href=\"/government/organisations/foreign-commonwealth-development-office\">Foreign, Commonwealth &amp; Development Office</a>"
-
-    assert_equal expected_links, presented_item.sponsoring_organisation_links
-  end
-
-  test "#sponsoring_organisation_links returns nil when sponsoring organisations are empty" do
-    without_sponsoring_organisations = schema_item
-    without_sponsoring_organisations["links"]["worldwide_organisation"][0]["links"].delete("sponsoring_organisations")
-
-    presented = create_presenter(WorldwideOfficePresenter, content_item: without_sponsoring_organisations)
-
-    assert_nil presented.sponsoring_organisation_links
-  end
-
   test "#sponsoring_organisation_logo returns the logo details of the item" do
     with_non_default_crest = schema_item
     sponsoring_organisation = first_sponsoring_organisation(with_non_default_crest)

--- a/test/presenters/worldwide_organisation_presenter_test.rb
+++ b/test/presenters/worldwide_organisation_presenter_test.rb
@@ -9,6 +9,10 @@ class WorldwideOrganisationPresenterTest < PresenterTestCase
     assert_equal schema_item["title"], presented_item.title
   end
 
+  test "#body returns the body" do
+    assert_equal schema_item["details"]["body"], presented_item.body
+  end
+
   test "#social_media_links returns the social media accounts" do
     assert_equal schema_item["details"]["social_media_links"], presented_item.social_media_accounts
   end

--- a/test/presenters/worldwide_organisation_presenter_test.rb
+++ b/test/presenters/worldwide_organisation_presenter_test.rb
@@ -50,4 +50,22 @@ class WorldwideOrganisationPresenterTest < PresenterTestCase
   test "#social_media_links returns the social media accounts" do
     assert_equal schema_item["details"]["social_media_links"], presented_item.social_media_accounts
   end
+
+  test "#main_office returns nil when there is no main office" do
+    without_main_office = schema_item
+    without_main_office["links"].delete("main_office")
+
+    presented = create_presenter(WorldwideOrganisationPresenter, content_item: without_main_office)
+
+    assert_nil presented.main_office
+  end
+
+  test "#home_page_offices returns an empty array when there are no home page offices" do
+    without_home_page_offices = schema_item
+    without_home_page_offices["links"].delete("home_page_offices")
+
+    presented = create_presenter(WorldwideOrganisationPresenter, content_item: without_home_page_offices)
+
+    assert_equal [], presented.home_page_offices
+  end
 end

--- a/test/presenters/worldwide_organisation_presenter_test.rb
+++ b/test/presenters/worldwide_organisation_presenter_test.rb
@@ -15,8 +15,8 @@ class WorldwideOrganisationPresenterTest < PresenterTestCase
 
   test "#world_location_links returns the world locations as a joined sentence of links" do
     expected_links =
-      "<a class=\"govuk-link\" href=\"/world/india/news\">India</a> and " \
-        "<a class=\"govuk-link\" href=\"/world/another-location/news\">Another location</a>"
+      "<a class=\"govuk-link\" href=\"/world/india/news\">India with translation</a> and " \
+        "<a class=\"govuk-link\" href=\"/world/another-location/news\">Another location with translation</a>"
 
     assert_equal expected_links, presented_item.world_location_links
   end

--- a/test/presenters/worldwide_organisation_presenter_test.rb
+++ b/test/presenters/worldwide_organisation_presenter_test.rb
@@ -13,6 +13,40 @@ class WorldwideOrganisationPresenterTest < PresenterTestCase
     assert_equal schema_item["details"]["body"], presented_item.body
   end
 
+  test "#world_location_links returns the world locations as a joined sentence of links" do
+    expected_links =
+      "<a class=\"govuk-link\" href=\"/world/india/news\">India</a> and " \
+        "<a class=\"govuk-link\" href=\"/world/another-location/news\">Another location</a>"
+
+    assert_equal expected_links, presented_item.world_location_links
+  end
+
+  test "#world_location_links returns nil when world locations are empty" do
+    without_world_locations = schema_item
+    without_world_locations["links"].delete("world_locations")
+
+    presented = create_presenter(WorldwideOrganisationPresenter, content_item: without_world_locations)
+
+    assert_nil presented.world_location_links
+  end
+
+  test "#sponsoring_organisation_links returns the sponsoring organisations as sentence of links" do
+    expected_links =
+      "<a class=\"sponsoring-organisation govuk-link\" href=\"/government/organisations/foreign-commonwealth-development-office\">Foreign, Commonwealth &amp; Development Office</a> and " \
+        "<a class=\"sponsoring-organisation govuk-link\" href=\"/government/organisations/department-for-business-and-trade\">Department for Business and Trade</a>"
+
+    assert_equal expected_links, presented_item.sponsoring_organisation_links
+  end
+
+  test "#sponsoring_organisation_links returns nil when sponsoring organisations are empty" do
+    without_sponsoring_organisations = schema_item
+    without_sponsoring_organisations["links"].delete("sponsoring_organisations")
+
+    presented = create_presenter(WorldwideOrganisationPresenter, content_item: without_sponsoring_organisations)
+
+    assert_nil presented.sponsoring_organisation_links
+  end
+
   test "#social_media_links returns the social media accounts" do
     assert_equal schema_item["details"]["social_media_links"], presented_item.social_media_accounts
   end

--- a/test/presenters/worldwide_organisation_presenter_test.rb
+++ b/test/presenters/worldwide_organisation_presenter_test.rb
@@ -5,7 +5,11 @@ class WorldwideOrganisationPresenterTest < PresenterTestCase
     "worldwide_organisation"
   end
 
-  test "presents the title" do
+  test "#title returns the title" do
     assert_equal schema_item["title"], presented_item.title
+  end
+
+  test "#social_media_links returns the social media accounts" do
+    assert_equal schema_item["details"]["social_media_links"], presented_item.social_media_accounts
   end
 end


### PR DESCRIPTION
This pull request adds rendering the worldwide organisations to government-frontend, trying to keep the contents and the visual aspect as close to whitehall as possible, except where we think we are improving upon it.

## Notable changes

- [As noted in the worldwide office rendering PR](https://github.com/alphagov/government-frontend/pull/2793), the location name in the header will now link to the world location news, instead of the world location taxonomy.  

## Header section

### Before
<img width="977" alt="Screenshot 2023-06-07 at 17 26 24" src="https://github.com/alphagov/government-frontend/assets/579522/c3c8deab-151c-48cd-8bf3-cfef7353dbc8">

### After
<img width="986" alt="Screenshot 2023-06-07 at 17 26 13" src="https://github.com/alphagov/government-frontend/assets/579522/d7e85ec3-f6c1-4f52-a0b3-52886701753b">

## Our people section

### Before
<img width="1001" alt="Screenshot 2023-06-07 at 17 25 22" src="https://github.com/alphagov/government-frontend/assets/579522/96724bee-5e2b-4132-8170-57e5c14c653b">

### After
<img width="987" alt="Screenshot 2023-06-07 at 17 25 28" src="https://github.com/alphagov/government-frontend/assets/579522/e2c75269-c269-4b8b-919f-de6264e9101e">

## Contact us section

### Before
<img width="1012" alt="Screenshot 2023-06-07 at 17 25 46" src="https://github.com/alphagov/government-frontend/assets/579522/1f3a8096-1585-40cd-b240-771f032868c8">

### After
<img width="983" alt="Screenshot 2023-06-07 at 17 25 53" src="https://github.com/alphagov/government-frontend/assets/579522/e6f2a17b-9b2e-4f3b-ba98-2491aaa7114c">

## Corporate information section

### Before
<img width="993" alt="Screenshot 2023-06-07 at 17 24 31" src="https://github.com/alphagov/government-frontend/assets/579522/500c016b-9ee0-4b3a-9097-5f62de0803b5">

### After
<img width="995" alt="Screenshot 2023-06-07 at 17 24 41" src="https://github.com/alphagov/government-frontend/assets/579522/bcbd719a-8bd4-4cd7-b678-400d402044fc">

[Trello card](https://trello.com/c/lzp59ynE/397-add-rendering-of-worldwide-organisation-pages-in-government-frontend)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
