### PR TITLE
Mark Worldwide Offices as migrated in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Not all schemas that this app can handle are rendered by it in production.
 | Topical event about page | [View on GOV.UK](https://www.gov.uk/government/topical-events/2014-overseas-territories-joint-ministerial-council/about) | Migrated |
 | Travel advice | [View on GOV.UK](https://www.gov.uk/foreign-travel-advice/nepal) | Migrated |
 | Working group | [View on GOV.UK](https://www.gov.uk/government/groups/abstraction-reform) | Migrated |
-| Worldwide Office | | Rendered by Whitehall |
-| Worldwide Organisation | | Rendered by Whitehall |
+| Worldwide office | [View on GOV.UK](https://www.gov.uk/world/organisations/british-embassy-paris/office/british-embassy) | Migrated |
+| Worldwide organisation | | Rendered by Whitehall |
 
 ## Technical documentation
 


### PR DESCRIPTION
Now that we have migrated Worldwide Offices across from Whitehall, we can mark them as "migrated" and provide an example.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
