### PR TITLE
Fix overlapping links on contact section of Worldwide Offices

### DIFF
--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -49,6 +49,11 @@
 }
 
 .worldwide-organisation-contact-section {
+  a {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+  }
+
   address {
     font-style: normal;
 


### PR DESCRIPTION
The narrow column design of the Worldwide Office page means that there is an
issue where long links (that don't contain wrapping characters like `-`) will
overflow.

This is a pre-existing issue from the Whitehall app.

As a quick fix, we can allow wrapping within words. Whilst the break points are
arbitrary, this is preferable to the overlapping we currently see. Both the
`word-wrap` and `overflow-wrap` declarations are needed to support all browsers.

|Before|After|
|-|-|
|<img width="1194" alt="image" src="https://github.com/alphagov/government-frontend/assets/47089130/05a733e2-f0f5-43ef-8226-d1bc4001ef25">|<img width="1070" alt="image" src="https://github.com/alphagov/government-frontend/assets/47089130/d373c713-bb75-4fdd-8f91-c665b8835be0">|

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
