### PR TITLE
Ensure `nil` sponsoring organisations are handled appropriately

### DIFF
--- a/app/presenters/worldwide_office_presenter.rb
+++ b/app/presenters/worldwide_office_presenter.rb
@@ -14,10 +14,6 @@ class WorldwideOfficePresenter < ContentItemPresenter
     WorldwideOrganisation::LinkedContactPresenter.new(contact)
   end
 
-  def worldwide_organisation
-    content_item.dig("links", "worldwide_organisation")&.first
-  end
-
   def world_location_links
     return if world_locations.empty?
 
@@ -44,12 +40,16 @@ class WorldwideOfficePresenter < ContentItemPresenter
     {
       name: title,
       url: worldwide_organisation["base_path"],
-      crest: first_sponsoring_organisation.dig("details", "logo", "crest") || DEFAULT_ORGANISATION_LOGO,
-      brand: first_sponsoring_organisation.dig("details", "brand") || DEFAULT_ORGANISATION_LOGO,
+      crest: first_sponsoring_organisation&.dig("details", "logo", "crest") || DEFAULT_ORGANISATION_LOGO,
+      brand: first_sponsoring_organisation&.dig("details", "brand") || DEFAULT_ORGANISATION_LOGO,
     }
   end
 
 private
+
+  def worldwide_organisation
+    content_item.dig("links", "worldwide_organisation")&.first
+  end
 
   def sponsoring_organisations
     worldwide_organisation&.dig("links", "sponsoring_organisations") || []

--- a/test/presenters/worldwide_office_presenter_test.rb
+++ b/test/presenters/worldwide_office_presenter_test.rb
@@ -73,6 +73,16 @@ class WorldwideOfficePresenterTest < PresenterTestCase
     assert_equal expected, presented.organisation_logo
   end
 
+  test "#sponsoring_organisation_logo returns default values when the sponsoring organisations are nil" do
+    without_sponsoring_organisations = schema_item
+    without_sponsoring_organisations["links"]["worldwide_organisation"][0]["links"].delete("sponsoring_organisations")
+
+    presented = create_presenter(WorldwideOfficePresenter, content_item: without_sponsoring_organisations)
+
+    expected = { name: "British Embassy Manila", url: "/world/organisations/british-embassy-manila", crest: "single-identity", brand: "single-identity" }
+    assert_equal expected, presented.organisation_logo
+  end
+
 private
 
   def first_sponsoring_organisation(item)


### PR DESCRIPTION
https://trello.com/c/sLMFQp5N

As part of moving the rendering of the Worldwide Office pages to
government-frontend, we republished all of the Worldwide Organisations.

However, there was an issue where some Organisations were not republished. This
meant that we saw errors in production where we were trying to access the
details of a sponsoring organisation which was nil.

This makes sure that we are correctly handling the case where there are no
sponsoring organisations linked to the office's organisation.

`worldwide_organisation` is made private as it's not referred to outside of
this class.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
