### PR TITLE
Do not show breadcrumbs for worldwide organisation and office pages

### DIFF
--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -1,10 +1,6 @@
 .worldwide-organisation-header {
   margin-top: $govuk-gutter-half;
   margin-bottom: $govuk-gutter-half;
-
-  @include govuk-media-query($from: tablet) {
-    margin-top: govuk-spacing(8);
-  }
 }
 
 .js-enabled {

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -74,8 +74,6 @@ private
     ]
 
     if valid_page_ids.include?(page_id)
-      @do_not_show_breadcrumbs = true
-
       render template: "histories/#{page_id}"
     else
       render plain: "Not found", status: :not_found
@@ -89,17 +87,6 @@ private
   def show_service_manual_page
     slimmer_template(service_manual_layout)
     configure_header_search
-
-    has_custom_breadcrumbs = %w[
-      service_manual_guide
-      service_manual_service_standard
-      service_manual_topic
-      service_manual_homepage
-      service_manual_service_toolkit
-    ]
-
-    @do_not_show_breadcrumbs =
-      has_custom_breadcrumbs.include?(@content_item.document_type)
 
     with_locale do
       render content_item_template

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -111,6 +111,10 @@ class ContentItemPresenter
     view_context.request.path =~ /^\/hmrc-internal-manuals\/.*\/updates$/ && content_item["schema_name"] == "hmrc_manual"
   end
 
+  def show_default_breadcrumbs?
+    true
+  end
+
 private
 
   def voting_is_open?

--- a/app/presenters/history_presenter.rb
+++ b/app/presenters/history_presenter.rb
@@ -1,2 +1,5 @@
 class HistoryPresenter < ContentItemPresenter
+  def show_default_breadcrumbs?
+    false
+  end
 end

--- a/app/presenters/service_manual_homepage_presenter.rb
+++ b/app/presenters/service_manual_homepage_presenter.rb
@@ -11,6 +11,10 @@ class ServiceManualHomepagePresenter < ServiceManualPresenter
     "beta"
   end
 
+  def show_default_breadcrumbs?
+    false
+  end
+
 private
 
   def unsorted_topics

--- a/app/presenters/service_manual_presenter.rb
+++ b/app/presenters/service_manual_presenter.rb
@@ -18,4 +18,8 @@ class ServiceManualPresenter < ContentItemPresenter
   def show_phase_banner?
     false
   end
+
+  def show_default_breadcrumbs?
+    false
+  end
 end

--- a/app/presenters/service_manual_service_standard_presenter.rb
+++ b/app/presenters/service_manual_service_standard_presenter.rb
@@ -20,6 +20,10 @@ class ServiceManualServiceStandardPresenter < ServiceManualPresenter
     "/email-signup?link=#{content_item['base_path']}"
   end
 
+  def show_default_breadcrumbs?
+    false
+  end
+
 private
 
   def points_attributes

--- a/app/presenters/service_manual_service_toolkit_presenter.rb
+++ b/app/presenters/service_manual_service_toolkit_presenter.rb
@@ -6,4 +6,8 @@ class ServiceManualServiceToolkitPresenter < ServiceManualPresenter
   def collections
     details.fetch("collections", [])
   end
+
+  def show_default_breadcrumbs?
+    false
+  end
 end

--- a/app/presenters/service_manual_topic_presenter.rb
+++ b/app/presenters/service_manual_topic_presenter.rb
@@ -75,6 +75,10 @@ class ServiceManualTopicPresenter < ServiceManualPresenter
     end
   end
 
+  def show_default_breadcrumbs?
+    false
+  end
+
 private
 
   def accordion_section_links(links)

--- a/app/presenters/worldwide_office_presenter.rb
+++ b/app/presenters/worldwide_office_presenter.rb
@@ -45,6 +45,10 @@ class WorldwideOfficePresenter < ContentItemPresenter
     }
   end
 
+  def show_default_breadcrumbs?
+    false
+  end
+
 private
 
   def worldwide_organisation

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -1,2 +1,5 @@
 class WorldwideOrganisationPresenter < ContentItemPresenter
+  def show_default_breadcrumbs?
+    false
+  end
 end

--- a/app/views/content_items/worldwide_organisation/_header.html.erb
+++ b/app/views/content_items/worldwide_organisation/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="worldwide-organisation-header govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds logo">
+  <div class="govuk-grid-column-two-thirds worldwide-organisation-header__logo">
     <%= render "govuk_publishing_components/components/organisation_logo", {
       organisation: @content_item.organisation_logo,
       heading_level: 1,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
       </div>
     <% end %>
 
-    <% unless @do_not_show_breadcrumbs %>
+    <% if @content_item.show_default_breadcrumbs? %>
       <% if @content_item.try(:back_link) %>
         <%= render 'govuk_publishing_components/components/back_link', href: @content_item.back_link %>
       <% else %>

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -195,3 +195,7 @@ working_group_7: '/government/groups/veterans-welfare-service'
 working_group_8: '/government/groups/uk-national-screening-committee-uk-nsc'
 working_group_9: '/government/groups/uk-council-for-child-internet-safety-ukccis'
 
+worldwide_office: '/world/organisations/british-consulate-general-barcelona/office/british-consulate-general-barcelona'
+worldwide_office_without_access_details: '/world/organisations/british-consulate-general-alexandria/office/consulate-general-alexandria'
+worldwide_office_with_many_locations: '/world/organisations/british-embassy-paris/office/british-embassy'
+worldwide_office_with_non_default_logo: '/world/organisations/department-for-business-and-trade-ecuador/office/uk-trade-investment-ecuador'

--- a/test/integration/worldwide_office_test.rb
+++ b/test/integration/worldwide_office_test.rb
@@ -13,6 +13,12 @@ class WorldwideOfficeTest < ActionDispatch::IntegrationTest
     assert page.has_selector?("h2", text: "Consular section")
   end
 
+  test "omits breadcrumbs" do
+    setup_and_visit_content_item("worldwide_office")
+
+    assert page.has_no_selector?(".govuk-breadcrumbs")
+  end
+
   test "includes access details and contents" do
     setup_and_visit_content_item("worldwide_office")
 

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -6,4 +6,10 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
     assert_has_component_title(@content_item["title"])
     assert page.has_text?(@content_item["description"])
   end
+
+  test "omits breadcrumbs" do
+    setup_and_visit_content_item("worldwide_organisation")
+
+    assert page.has_no_selector?(".govuk-breadcrumbs")
+  end
 end


### PR DESCRIPTION
https://trello.com/c/MIgcASTq

### Refactor how we define which pages show default breadcrumbs
Currently, we are maintaining multiple lists of which content items should not
show breadcrumbs in the `ContentItemsController`.

This moves the logic that determines whether a page shows
breadcrumbs into the derived classes of `ContentItemPresenter`.

### Do not show breadcrumbs for worldwide organisation and office pages

We don't want to show breadcrumbs on the worldwide organisation and office
pages.

### Add worldwide office examples to the development controller

### Fix spacing above logo
We updated the class names for the styling of this page, but missed the logo
class.

### Breadcrumbs removed
|This PR|Prod|
|-|-|
|https://government-frontend-pr-2812.herokuapp.com/world/organisations/british-embassy-paris/office/british-embassy|https://www.gov.uk/world/organisations/british-embassy-paris/office/british-embassy|

### Breadcrumbs the same (history pages)
|This PR|Prod|
|-|-|
|https://government-frontend-pr-2812.herokuapp.com/government/history/10-downing-street|https://www.gov.uk/government/history/10-downing-street|
|https://government-frontend-pr-2812.herokuapp.com/government/history/11-downing-street|https://www.gov.uk/government/history/11-downing-street|
|https://government-frontend-pr-2812.herokuapp.com/government/history/1-horse-guards-road|https://www.gov.uk/government/history/1-horse-guards-road|
|https://government-frontend-pr-2812.herokuapp.com/government/history/king-charles-street|https://www.gov.uk/government/history/king-charles-street|
|https://government-frontend-pr-2812.herokuapp.com/government/history/lancaster-house|https://www.gov.uk/government/history/lancaster-house|
|https://government-frontend-pr-2812.herokuapp.com/government/history|https://www.gov.uk/government/history|

### Breadcrumbs the same (service manual pages)
||This PR|Prod|
|-|-|-|
|Topic|https://government-frontend-pr-2812.herokuapp.com/service-manual/helping-people-to-use-your-service|https://www.gov.uk/service-manual/helping-people-to-use-your-service|
|Guide|https://government-frontend-pr-2812.herokuapp.com/service-manual/design/introduction-designing-government-services|https://www.gov.uk/service-manual/design/introduction-designing-government-services|
|Homepage|https://government-frontend-pr-2812.herokuapp.com/service-manual|https://www.gov.uk/service-manual|
|Service standard|https://government-frontend-pr-2812.herokuapp.com/service-manual/service-standard|https://www.gov.uk/service-manual/service-standard|
|Toolkit|https://government-frontend-pr-2812.herokuapp.com/service-toolkit|https://www.gov.uk/service-toolkit|

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
