### PR TITLE
Fix incorrect test assertion

### DIFF
--- a/test/presenters/how_government_works_presenter_test.rb
+++ b/test/presenters/how_government_works_presenter_test.rb
@@ -12,7 +12,7 @@ class HowGovernmentWorksPresenterTest < PresenterTestCase
 
   test "presents the current prime minister" do
     assert_equal(
-      schema_item("reshuffle-mode-off").dig("links", "current_prime_minister", 0, "title"),
+      schema_item("reshuffle-mode-off").dig("links", "current_prime_minister", 0),
       presented_item("reshuffle-mode-off").prime_minister,
     )
   end


### PR DESCRIPTION
The assertion is passing by coincidence, because the item is nil in the example in publishing-api.

I only noticed it thanks to the deprecation warning from minitest:

```
HowGovernmentWorksPresenterTest
DEPRECATED: Use assert_nil if expecting nil from
test/presenters/how_government_works_presenter_test.rb:14. This will
fail in Minitest 6.
```

I will also open a pull request to add a `current_prime_minister` link to the example, so the test is more meaningful.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
