### PR TITLE
Fix bug in rendering travel advice with no parts

### DIFF
--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -27,6 +27,10 @@ class TravelAdvicePresenter < ContentItemPresenter
     }
   end
 
+  def body_for_metadata
+    current_part || ""
+  end
+
   def title_and_context
     {
       context: I18n.t("travel_advice.context"),

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -8,7 +8,7 @@
     schema: :article,
     canonical_url: @content_item.canonical_url,
     title: @content_item.page_title,
-    body: @content_item.current_part_body
+    body: @content_item.body_for_metadata
   ) %>
 <% end %>
 
@@ -27,33 +27,35 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="part-title">
-      <%= @content_item.current_part_title %>
-    </h1>
+  <% unless @content_item.parts.empty? %>
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="part-title">
+        <%= @content_item.current_part_title %>
+      </h1>
 
-    <% if @content_item.no_part_slug_provided? %>
-      <%= render 'shared/travel_advice_first_part', content_item: @content_item %>
-    <% end %>
-
-    <div data-module="gem-track-click"
-      data-track-category="SummaryTravelAdviceWarning"
-      data-track-action="callOutBoxClicked"
-      data-track-links-only
-      data-limit-to-element-class="call-to-action">
-      <%= render 'govuk_publishing_components/components/govspeak', {
-        direction: page_text_direction,
-      } do %>
-        <%= raw(@content_item.current_part_body) %>
+      <% if @content_item.no_part_slug_provided? %>
+        <%= render 'shared/travel_advice_first_part', content_item: @content_item %>
       <% end %>
-    </div>
 
-    <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
+      <div data-module="gem-track-click"
+        data-track-category="SummaryTravelAdviceWarning"
+        data-track-action="callOutBoxClicked"
+        data-track-links-only
+        data-limit-to-element-class="call-to-action">
+        <%= render 'govuk_publishing_components/components/govspeak', {
+          direction: page_text_direction,
+        } do %>
+          <%= raw(@content_item.current_part_body) %>
+        <% end %>
+      </div>
 
-    <div class="responsive-bottom-margin">
-      <a href="<%= @content_item.print_link %>" class="govuk-link govuk-link--no-visited-state govuk-body"><%= t("multi_page.print_entire_guide") %></a>
+      <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
+
+      <div class="responsive-bottom-margin">
+        <a href="<%= @content_item.print_link %>" class="govuk-link govuk-link--no-visited-state govuk-body"><%= t("multi_page.print_entire_guide") %></a>
+      </div>
     </div>
-  </div>
+  <% end %>
   <%= render 'shared/sidebar_navigation' %>
 </div>
 

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -1,14 +1,17 @@
 require "test_helper"
 
 class TravelAdviceTest < ActionDispatch::IntegrationTest
-  test "random but valid items do not error" do
-    setup_and_visit_random_content_item
+  test "can render all valid examples" do
+    GovukSchemas::Example.find_all("travel_advice").each do |content_item|
+      setup_and_visit_content_item_by_example(content_item)
+
+      assert page.has_css?("title", visible: false, text: content_item["title"])
+    end
   end
 
   test "travel advice header and navigation" do
     setup_and_visit_content_item("full-country")
 
-    assert page.has_css?("title", visible: false, text: @content_item["title"])
     assert_has_component_title(@content_item["details"]["country"]["name"])
 
     assert page.has_css?("a[href=\"#{@content_item['details']['email_signup_link']}\"]", text: "Get email alerts")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -164,15 +164,18 @@ class ActionDispatch::IntegrationTest
   def setup_and_visit_content_item(name, overrides = {}, parameter_string = "")
     @content_item = get_content_example(name).tap do |item|
       content_item = item.deep_merge(overrides)
-      stub_content_store_has_item(content_item["base_path"], content_item.to_json)
-      visit_with_cachebust("#{content_item['base_path']}#{parameter_string}")
+      setup_and_visit_content_item_by_example(content_item, parameter_string)
     end
   end
 
   def setup_and_visit_content_item_with_params(name, parameter_string = "")
     @content_item = get_content_example(name)
-    stub_content_store_has_item(@content_item["base_path"], @content_item.to_json)
-    visit_with_cachebust("#{@content_item['base_path']}#{parameter_string}")
+    setup_and_visit_content_item_by_example(@content_item, parameter_string)
+  end
+
+  def setup_and_visit_content_item_by_example(content_item, parameter_string = "")
+    stub_content_store_has_item(content_item["base_path"], content_item.to_json)
+    visit_with_cachebust("#{content_item['base_path']}#{parameter_string}")
   end
 
   def setup_and_visit_html_publication(name, parameter_string = "")


### PR DESCRIPTION
We had a flakey test which was failing since it was randomly selecting a travel advice example (from content schemas) to test against, and one of these example schemas actually isn't able to be rendered at the moment. This was actually highlighting a bug whereby travel advice content items with no parts errored upon rendering, since the rendering code always assumes there are parts. 

While it looks like we have no live travel advice content items with no parts, it's permitted by the schema where a parts field is [required](https://github.com/alphagov/publishing-api/blob/main/content_schemas/formats/travel_advice.jsonnet) but there's nothing stopping it from being an empty array. It's also permitted by the publishing application - I tested in integration and nothing stopped me from removing all parts, but the resultant page resulted in rendering errors. So we should handle this case in our rendering, since it is entirely possible to publish such a piece of travel advice in our system. 

This PR also ensures that we always test all example schemas each test run, to avoid introducing behaviour that breaks rendering for a certain case, and this not being immediately exposed.

[Trello](https://trello.com/c/k6tNo7ug/1849-fix-flakey-travel-advice-test-in-government-frontend)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
