### PR TITLE
Add ga4 tracking to single page notification button

### DIFF
--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -14,7 +14,22 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo', content_item: @content_item %>
-<%= render 'shared/single_page_notification_button', content_item: @content_item %>
+<%= render 'shared/single_page_notification_button',
+  content_item: @content_item,
+  ga4_data_attributes: {
+    module: "ga4-link-tracker",
+    ga4_link: {
+      event_name: "navigation",
+      type: "subscribe",
+      index: {
+        index_link: 1
+      },
+      index_total: 2,
+      section: "Top"
+    }
+  }
+%>
+
 <%= render 'shared/history_notice', content_item: @content_item %>
 <% if @content_item.withdrawn? %>
   <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -68,7 +68,21 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
-<%= render 'shared/single_page_notification_button', content_item: @content_item %>
+<%= render 'shared/single_page_notification_button',
+  content_item: @content_item,
+  ga4_data_attributes: {
+    module: "ga4-link-tracker",
+    ga4_link: {
+      event_name: "navigation",
+      type: "subscribe",
+      index: {
+        index_link: 1
+      },
+      index_total: 2,
+      section: "Top"
+    }
+  }
+%>
 
 <%= render 'shared/history_notice', content_item: @content_item %>
 <% if @content_item.withdrawn? %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -31,7 +31,21 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
-<%= render 'shared/single_page_notification_button', content_item: @content_item %>
+<%= render 'shared/single_page_notification_button',
+  content_item: @content_item,
+  ga4_data_attributes: {
+    module: "ga4-link-tracker",
+    ga4_link: {
+      event_name: "navigation",
+      type: "subscribe",
+      index: {
+        index_link: 1
+      },
+      index_total: 2,
+      section: "Top"
+    }
+  }
+%>
 
 <%= render 'shared/history_notice', content_item: @content_item %>
 

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -13,6 +13,18 @@
     js_enhancement: @has_govuk_account,
     button_location: "bottom",
     margin_bottom: 3,
+    ga4_data_attributes: {
+      module: "ga4-link-tracker",
+      ga4_link: {
+        event_name: "navigation",
+        type: "subscribe",
+        index: {
+          index_link: 2
+        },
+        index_total: 2,
+        section: "Footer"
+      }
+  }
   } if @content_item.has_single_page_notifications? %>
   <%= render "govuk_publishing_components/components/print_link", {
     margin_top: 0,

--- a/app/views/shared/_single_page_notification_button.html.erb
+++ b/app/views/shared/_single_page_notification_button.html.erb
@@ -1,6 +1,7 @@
 <%= render 'govuk_publishing_components/components/single_page_notification_button', {
   base_path: @content_item.base_path,
   js_enhancement: @has_govuk_account,
+  ga4_data_attributes: ga4_data_attributes ||= nil,
   margin_bottom: 6,
   button_location: "top",
 } if @content_item.has_single_page_notifications? %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
This PR adds GA4 tracking to the `Get emails about this page` button (see screenshot below).

![image](https://github.com/alphagov/government-frontend/assets/110391449/abfc5499-f23b-4ad8-96e5-f5d522eb7ccb)

This code is dependant on [PR #3443](https://github.com/alphagov/govuk_publishing_components/pull/3443).

## Why
Part of the GA4 migration.

[Trello card](https://trello.com/c/iP21pmuk/565-subscribe-get-emails-about-this-page-stop-getting-emails-about-this-page-button)