### PR TITLE
Add ga4 tracking for email alerts

### DIFF
--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -19,9 +19,16 @@
     <aside class="part-navigation-container" role="complementary">
       <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("travel_advice.pages") }, contents: @content_item.part_link_elements, underline_links: true %>
 
-      <%= render 'govuk_publishing_components/components/subscription_links',
-        email_signup_link: @content_item.email_signup_link,
-        email_signup_link_text: "Get email alerts" %>
+      <div 
+        data-module="ga4-link-tracker"
+        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Top" }'
+        data-ga4-track-links-only
+      >
+        <%= render 'govuk_publishing_components/components/subscription_links',
+          email_signup_link: @content_item.email_signup_link,
+          email_signup_link_text: "Get email alerts"
+        %>
+      </div>
     </aside>
   </div>
 </div>

--- a/app/views/shared/_email_signup.html.erb
+++ b/app/views/shared/_email_signup.html.erb
@@ -6,7 +6,12 @@
     id: "related-subscriptions",
   } %>
 
-  <div class="related-item__subscription-link">
+  <div 
+    class="related-item__subscription-link" 
+    data-module="ga4-link-tracker"
+    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Sidebar" }'
+    data-ga4-track-links-only
+  >
     <%= render "govuk_publishing_components/components/subscription_links", {
       hide_heading: true,
       email_signup_link_text: "Get emails when any guidance within this topic is updated",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

This PR adds GA4 tracking to the `Get email alerts`/`Get emails` link (screenshots below).

`Get email alerts` link at the top of a page:

![image](https://github.com/alphagov/government-frontend/assets/110391449/e5953566-74ca-407e-8a4f-42975c5bc120)

`Get emails` link in a sidebar:

![image](https://github.com/alphagov/government-frontend/assets/110391449/b9cdafce-fbe0-4161-9d39-b30093135b26)

As per the Implementation Guide, it is believed that these links only appear once on each page and therefore the `index_link` and `index_total` properties have been hardcoded to 1.

## Why

Part of the GA4 migration.

[Trello card](https://trello.com/c/Df3jj1HF/567-subscribe-get-email-alerts-link)