### PR TITLE
Render Worldwide Corporate Information Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Not all schemas that this app can handle are rendered by it in production.
 | Topical event about page | [View on GOV.UK](https://www.gov.uk/government/topical-events/2014-overseas-territories-joint-ministerial-council/about) | Migrated |
 | Travel advice | [View on GOV.UK](https://www.gov.uk/foreign-travel-advice/nepal) | Migrated |
 | Working group | [View on GOV.UK](https://www.gov.uk/government/groups/abstraction-reform) | Migrated |
+| Worldwide corporate information page | | Rendered by Whitehall |
 | Worldwide office | [View on GOV.UK](https://www.gov.uk/world/organisations/british-embassy-paris/office/british-embassy) | Migrated |
 | Worldwide organisation | | Rendered by Whitehall |
 

--- a/app/presenters/worldwide_corporate_information_page_presenter.rb
+++ b/app/presenters/worldwide_corporate_information_page_presenter.rb
@@ -1,0 +1,29 @@
+class WorldwideCorporateInformationPagePresenter < ContentItemPresenter
+  include ContentItem::Body
+  include ContentItem::ContentsList
+  include WorldwideOrganisation::Branding
+
+  def show_default_breadcrumbs?
+    false
+  end
+
+  def worldwide_organisation
+    return unless content_item.dig("links", "worldwide_organisation")
+
+    WorldwideOrganisationPresenter.new(content_item.dig("links", "worldwide_organisation").first, requested_path, view_context)
+  end
+
+  def sponsoring_organisations
+    worldwide_organisation&.sponsoring_organisations
+  end
+
+  def organisation_logo
+    super.merge!(name: worldwide_organisation&.title)
+  end
+
+private
+
+  def show_contents_list?
+    true
+  end
+end

--- a/app/views/content_items/worldwide_corporate_information_page.html.erb
+++ b/app/views/content_items/worldwide_corporate_information_page.html.erb
@@ -1,0 +1,29 @@
+<%= render partial: "content_items/worldwide_organisation/header", locals: {
+  worldwide_organisation: @content_item.worldwide_organisation,
+} %>
+
+<article class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <%= render "govuk_publishing_components/components/contents_list",
+               contents: @content_item.contents,
+               underline_links: true
+    %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: @content_item.title,
+      heading_level: 2,
+      font_size: "xl",
+      margin_bottom: 4,
+    } %>
+
+    <p class="govuk-body-l"><%= @content_item.description %></p>
+
+    <div class="body">
+      <%= render "govuk_publishing_components/components/govspeak", {} do
+        raw(@content_item.body)
+      end %>
+    </div>
+  </div>
+</article>

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -204,3 +204,7 @@ worldwide_organisation: '/world/organisations/british-embassy-madrid'
 worldwide_organisation_translation: '/world/organisations/british-embassy-madrid.es'
 worldwide_organisation_with_secondary_corporate_info_pages: '/world/organisations/british-deputy-high-commission-hyderabad'
 worldwide_organisation_without_corporate_info_pages: '/world/organisations/department-for-business-and-trade-germany'
+
+worldwide_corporate_information_page: '/world/organisations/british-consulate-general-atlanta/about/recruitment'
+worldwide_corporate_information_page_translation: '/world/organisations/british-consulate-general-shanghai/about/recruitment.zh'
+worldwide_corporate_information_page_with_attachments: '/world/organisations/british-embassy-dakar/about/recruitment'

--- a/test/integration/worldwide_corporate_information_page_test.rb
+++ b/test/integration/worldwide_corporate_information_page_test.rb
@@ -1,0 +1,80 @@
+require "test_helper"
+
+class WorldwideCorporateInformationPageTest < ActionDispatch::IntegrationTest
+  test "includes the title of the organisation" do
+    setup_and_visit_content_item("worldwide_corporate_information_page")
+
+    assert page.has_title?("British Embassy Manila")
+  end
+
+  test "omits breadcrumbs" do
+    setup_and_visit_content_item("worldwide_corporate_information_page")
+
+    assert page.has_no_selector?(".govuk-breadcrumbs")
+  end
+
+  test "includes the body and contents" do
+    setup_and_visit_content_item("worldwide_corporate_information_page")
+
+    assert page.has_content? "Contents"
+    assert_has_contents_list([
+      { text: "General information", id: "general-information" },
+      { text: "Current work opportunities", id: "current-work-opportunities" },
+    ])
+    assert page.has_content?("Fair competition is at the centre of recruitment at the British Embassy Manila.")
+  end
+
+  test "includes the description" do
+    setup_and_visit_content_item("worldwide_corporate_information_page")
+
+    assert page.has_content? "The description for the worldwide corporate information page"
+  end
+
+  test "includes the logo and name of the worldwide organisation as a link" do
+    setup_and_visit_content_item("worldwide_corporate_information_page")
+
+    assert_has_component_organisation_logo
+    assert page.has_link? "British Embassy Manila", href: "/world/organisations/british-embassy-manila"
+  end
+
+  test "includes the world locations and sponsoring organisations" do
+    setup_and_visit_content_item("worldwide_corporate_information_page")
+
+    within find(".worldwide-organisation-header__metadata", match: :first) do
+      assert page.has_link? "Philippines", href: "/world/philippines/news"
+      assert page.has_link? "Palau", href: "/world/palau/news"
+
+      assert page.has_link? "Foreign, Commonwealth & Development Office", href: "/government/organisations/foreign-commonwealth-development-office"
+    end
+  end
+
+  test "does not render the translations when there are no translations" do
+    setup_and_visit_content_item("worldwide_corporate_information_page")
+
+    assert_not page.has_text?("English")
+  end
+
+  test "renders the translations when there are translations" do
+    setup_and_visit_content_item(
+      "worldwide_corporate_information_page",
+      {
+        "links" => {
+          "available_translations" =>
+            [
+              {
+                "locale": "en",
+                "base_path": "/world/organisations/british-embassy-madrid/about/recruitment",
+              },
+              {
+                "locale": "es",
+                "base_path": "/world/organisations/british-embassy-madrid/about/recruitment.es",
+              },
+            ],
+        },
+      },
+    )
+
+    assert page.has_text?("English")
+    assert page.has_link?("Español", href: "/world/organisations/british-embassy-madrid/about/recruitment.es")
+  end
+end

--- a/test/presenters/worldwide_corporate_information_page_presenter_test.rb
+++ b/test/presenters/worldwide_corporate_information_page_presenter_test.rb
@@ -1,0 +1,54 @@
+require "presenter_test_helper"
+
+class WorldwideCorporateInformationPagePresenterTest < PresenterTestCase
+  def schema_name
+    "worldwide_corporate_information_page"
+  end
+
+  test "#title returns the title of the schema item" do
+    assert_equal schema_item["title"], presented_item.title
+  end
+
+  test "#body returns the access and opening times of the schema item" do
+    assert_equal schema_item["details"]["body"], presented_item.body
+  end
+
+  test "#sponsoring_organisation_logo returns the logo details of the item" do
+    with_non_default_crest = schema_item
+    sponsoring_organisation = first_sponsoring_organisation(with_non_default_crest)
+    sponsoring_organisation["details"]["logo"]["crest"] = "dbt"
+
+    presented = create_presenter(WorldwideCorporateInformationPagePresenter, content_item: with_non_default_crest)
+
+    expected = { name: "British Embassy Manila", url: "/world/organisations/british-embassy-manila", crest: "dbt", brand: "foreign-commonwealth-development-office" }
+    assert_equal expected, presented.organisation_logo
+  end
+
+  test "#sponsoring_organisation_logo returns default values when the crest and brand of the first sponsoring organisation are blank" do
+    with_empty_logo = schema_item
+    sponsoring_organisation = first_sponsoring_organisation(with_empty_logo)
+    sponsoring_organisation["details"]["logo"]["crest"] = nil
+    sponsoring_organisation["details"]["brand"] = nil
+
+    presented = create_presenter(WorldwideCorporateInformationPagePresenter, content_item: with_empty_logo)
+
+    expected = { name: "British Embassy Manila", url: "/world/organisations/british-embassy-manila", crest: "single-identity", brand: "single-identity" }
+    assert_equal expected, presented.organisation_logo
+  end
+
+  test "#sponsoring_organisation_logo returns default values when the sponsoring organisations are nil" do
+    without_sponsoring_organisations = schema_item
+    without_sponsoring_organisations["links"]["worldwide_organisation"][0]["links"].delete("sponsoring_organisations")
+
+    presented = create_presenter(WorldwideCorporateInformationPagePresenter, content_item: without_sponsoring_organisations)
+
+    expected = { name: "British Embassy Manila", url: "/world/organisations/british-embassy-manila", crest: "single-identity", brand: "single-identity" }
+    assert_equal expected, presented.organisation_logo
+  end
+
+private
+
+  def first_sponsoring_organisation(item)
+    item["links"]["worldwide_organisation"][0]["links"]["sponsoring_organisations"][0]
+  end
+end


### PR DESCRIPTION
> **Warning**
> **Depends on ~~https://github.com/alphagov/publishing-api/pull/2409~~ and ~~https://github.com/alphagov/government-frontend/pull/2804~~**

https://trello.com/c/ATDZQXqq

# Differences from Whitehall
- [As noted in the worldwide office rendering PR](https://github.com/alphagov/government-frontend/pull/2793) and [worldwide organisation PR](https://github.com/alphagov/government-frontend/pull/2804), the location name in the header will now link to the world location news, instead of the world location taxonomy.  
- We lose some additional padding at the bottom of the page, do we want to preserve this?

|This PR|Prod|
|-|-|
|![image](https://github.com/alphagov/government-frontend/assets/47089130/24d8d7bd-f0c6-4b27-9590-d99128f21588)|![image](https://github.com/alphagov/government-frontend/assets/47089130/e346b31e-27cb-4dc6-8309-1186580b40e0)|
|![image](https://github.com/alphagov/government-frontend/assets/47089130/48f4aba4-31b6-496f-a6bb-8b0aca7fcfba)|![image](https://github.com/alphagov/government-frontend/assets/47089130/a06f34b3-047d-4f51-9837-910d3ccb9c96)|
|![image](https://github.com/alphagov/government-frontend/assets/47089130/116cdf17-4c95-4221-86a4-ade8d8ed5130)|![image](https://github.com/alphagov/government-frontend/assets/47089130/c70a92d6-7f5f-4610-947a-dd864cb7f447)|


### Add Worldwide Corporate Information Page to README
The README contains a list of content items and their production status.

Now that the migration of Worldwide Corporate Information Pages is underway, we
can add them in.

### Render Worldwide Corporate Information Pages
We have added a new content item to represent Corporate Information Pages that
are associated with Worldwide Organisations 
(https://github.com/alphagov/publishing-api/pull/2399).

Because the Worldwide Corporate Information Pages have a link to their
Worldwide Organisation, much of the rendering code added for Worldwide Offices
and Worldwide Organisations works with this page.

### Add worldwide corporate information pages to the development controller

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
