### PR TITLE
Enable youtube embeds

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -60,10 +60,16 @@
           <%= @content_item.current_part_title %>
         </h1>
       <% end %>
-
+      <%
+        disable_youtube_expansions = true
+        # This is for the /child-benefit/how-to-claim page
+        if @content_item.content_id == "aed2cee3-7ca8-4f00-ab17-9193fff516ae"
+          disable_youtube_expansions = false
+        end
+      %>
       <%= render "govuk_publishing_components/components/govspeak", {
         direction: page_text_direction,
-        disable_youtube_expansions: true
+        disable_youtube_expansions: disable_youtube_expansions
       } do %>
         <%= raw(@content_item.current_part_body) %>
       <% end %>


### PR DESCRIPTION
This is a temporary hack to allow a single content item (https://www.gov.uk/child-benefit/how-to-claim) to expand a Youtube link into a Youtube embed. 

This was requested by Anna Hepburn (Head of Content) and was agreed with HMRC at senior level.

This hack is logged as tech debt to ensure it is removed when appropriate and if necessary can be replaced with a solution that allows embeds at a publisher controlled level: https://trello.com/c/3rIkaWkA/253-government-frontend-hacked-to-support-youtube-embed

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
