### PR TITLE
Text algin right table headers for RTL content items

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,6 +36,10 @@ $govuk-include-default-font-face: false;
   .direction-rtl & {
     direction: rtl;
     text-align: start;
+
+    table th {
+      text-align: start;
+    }
   }
 }
 


### PR DESCRIPTION
## Description

We've had a zendesk ticket come in https://govuk.zendesk.com/agent/tickets/5368540 which has reported an issue with table headings in RTL languages. While the body of the table renders RTL the headers don't.

I've updated the stylesheets to ensure that TH elements use `text-align: start;` which resolves the issue.


### Before

<img width="579" alt="image" src="https://github.com/alphagov/government-frontend/assets/42515961/4e06b51c-a61e-43b6-a0b3-74f9863da9de">

### After

<img width="708" alt="image" src="https://github.com/alphagov/government-frontend/assets/42515961/319710c7-0cef-4ae1-9f80-bd3322551d6a">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
