### PR TITLE
Change font size of second H1 on guide pages

### DIFF
--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -6,7 +6,6 @@
 
     @include govuk-media-query($from: tablet) {
       margin-top: 0;
-      margin-bottom: 0;
       padding-bottom: govuk-spacing(3);
     }
 

--- a/app/assets/stylesheets/views/_guide.scss
+++ b/app/assets/stylesheets/views/_guide.scss
@@ -10,18 +10,4 @@
     margin-left: 1.5em;
     padding-left: .3em;
   }
-
-  // FIXME: Remove when typography improvements made to
-  //        govspeak component
-  //
-  // Distinguish between part titles (27px) and h2s
-  // within content of part by reducing font-size
-  //
-  // Override h2 sizes to match layout used by alphagov/frontend
-  // https://github.com/alphagov/static/blob/f44470edc4e4159ea37481985c641034741623ac/app/assets/stylesheets/helpers/_text.scss#L38
-  .govuk-govspeak {
-    h2 {
-      @include govuk-font(24, $weight: bold);
-    }
-  }
 }

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -56,9 +56,7 @@
   <div class="govuk-grid-column-two-thirds" id="guide-contents">
     <% if @content_item.has_parts? %>
       <% if @content_item.show_guide_navigation? %>
-        <h1 class="part-title">
-          <%= @content_item.current_part_title %>
-        </h1>
+        <%= render 'govuk_publishing_components/components/heading', heading_level: 1, font_size: 'l', margin_bottom: 6, text: @content_item.current_part_title %>
       <% end %>
       <%
         disable_youtube_expansions = true


### PR DESCRIPTION
## What

Change the font size of the heading on guide pages by using a heading component with the font size `govuk-heading-l`.

## Why

This type of page features a title (rendered by the application) and a body of HTML that is saved to the content item in Whitehall and then rendered using Govspeak. This was leading to an accessibility issue where the page had two differently styled H1s. If we wanted to ensure that the page had one H1 then all the content that is rendered in the guides would need to be re-edited to update the heading levels. In addition we would need to ensure that future guides used this offset of headings. The solution that has the least amount of overhead (and would also ensure this issue does not crop up again for new pages) was to change the stying of the second H1 to resemble the first H1. Having two H1s on the page is acceptable if they both resemble H1s and do not differ in styling.

## Visual DIfferences

### Before

![Screenshot 2023-06-26 at 11 17 48](https://github.com/alphagov/government-frontend/assets/3727504/9e5e639f-5f67-487b-b88a-fc3ea7579c18)

### After

![Screenshot 2023-06-26 at 11 17 57](https://github.com/alphagov/government-frontend/assets/3727504/83f8a849-c554-4bd3-b565-7aed9f0c7113)


[Related Trello Card
](https://trello.com/c/c1iqDv2I/1737-two-h1s-on-the-same-page-that-look-like-different-levels-2-m)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
