### PR TITLE
Use heading component with size l on travel advice pages

### DIFF
--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -4,6 +4,10 @@
 .travel-advice {
   @include parts;
 
+  .part-navigation-container {
+    margin-bottom: 0;
+  }
+
   .part-navigation {
     margin-bottom: govuk-spacing(8);
   }

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -36,10 +36,8 @@
 <div class="govuk-grid-row">
   <% unless @content_item.parts.empty? %>
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="part-title">
-        <%= @content_item.current_part_title %>
-      </h1>
-
+      <%= render 'govuk_publishing_components/components/heading', heading_level: 1, font_size: 'l', margin_bottom: 6, text: @content_item.current_part_title %>
+      
       <% if @content_item.no_part_slug_provided? %>
         <%= render 'shared/travel_advice_first_part', content_item: @content_item %>
       <% end %>


### PR DESCRIPTION
## What

Change the font size of the heading on travel advice pages by using a heading component with the font size `govuk-heading-l`.

## Why

This type of page features a title (rendered by the application) and a body of HTML that is saved to the content item in Whitehall and then rendered using Govspeak. This was leading to an accessibility issue where the page had two differently styled H1s. If we wanted to ensure that the page had one H1 then all the content that is rendered in the guides would need to be re-edited to update the heading levels. In addition we would need to ensure that future guides used this offset of headings. The solution that has the least amount of overhead (and would also ensure this issue does not crop up again for new pages) was to change the stying of the second H1 to resemble the first H1. Having two H1s on the page is acceptable if they both resemble H1s and do not differ in styling.

These changes were made already to guide pages (https://github.com/alphagov/government-frontend/pull/2837) but travel advice pages use a copy of the same template, so I missed making the change there. [In the future work should be done](https://trello.com/c/H9MfuTul/479-consolidate-traveladvice-and-guide-pages-in-governmentfrontend) to consolidate the two templates so something like this does not happen again.

## Visual Differences

### Before

![Screenshot 2023-06-28 at 10 23 44](https://github.com/alphagov/government-frontend/assets/3727504/cd5acfbc-8f96-405d-b9fa-fe1998660290)


### After

![Screenshot 2023-06-28 at 10 23 40](https://github.com/alphagov/government-frontend/assets/3727504/e97613b0-21fe-44f4-84d4-2bac1eed5724)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

[Related Trello Card
](https://trello.com/c/c1iqDv2I/1737-two-h1s-on-the-same-page-that-look-like-different-levels-2-m)
