### PR TITLE
[WIP, DO NOT MERGE] Remove published date from mainstream pages tagged to a collection

### DIFF
--- a/app/presenters/content_item/metadata.rb
+++ b/app/presenters/content_item/metadata.rb
@@ -27,5 +27,13 @@ module ContentItem
         see_updates_link: true,
       }
     end
+
+    def publisher_metadata_nodates
+      {
+        from:,
+        see_updates_link: true,
+      }
+    end
+
   end
 end

--- a/app/views/components/_published_dates.html.erb
+++ b/app/views/components/_published_dates.html.erb
@@ -12,9 +12,7 @@
 %>
 <% if published || last_updated %>
 <div class="<%= classes.join(' ') %>" <% if history.any? %>id="full-publication-update-history" data-module="gem-toggle"<% end %> lang="en">
-  <% if published %>
-    <%= t('components.published_dates.published', date: published) %>
-  <% end %>
+
   <% if last_updated %>
     <% if published %><br /><% end %><%= t('components.published_dates.last_updated', date: last_updated) %>
     <% if link_to_history && history.empty? %>

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -1,5 +1,5 @@
 <%
-  metadata_component_options = @content_item.publisher_metadata
+  metadata_component_options = @content_item.publisher_metadata_nodates
   metadata_component_options[:margin_bottom] = 3 if @notification_button_visible
 %>
 <div class="govuk-grid-row">


### PR DESCRIPTION
Mainstream content tagged to a document collection shows misleading data about when it was last updated underneath the link on the collection page. Often, this is the date the page was created and this is misleading for users as they may think the content is out of date.

We need to either show the correct "last updated" data or not show anything.

Example page https://www.gov.uk/government/collections/how-hmrc-resolves-civil-tax-disputes

[Trello Ticket](https://trello.com/c/P4zeXabu/1757-document-collections-are-showing-misleading-last-updated-data-for-mainstream-content-m)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
