### PR TITLE
Render RTL text for worldwide organisation pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,7 +33,8 @@ $govuk-include-default-font-face: false;
 .news-article,
 .publication,
 .speech,
-.worldwide-organisation {
+.worldwide-organisation,
+.worldwide-corporate-information-page {
   .direction-rtl & {
     direction: rtl;
     text-align: start;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,7 +32,8 @@ $govuk-include-default-font-face: false;
 .html-publication,
 .news-article,
 .publication,
-.speech {
+.speech,
+.worldwide-organisation {
   .direction-rtl & {
     direction: rtl;
     text-align: start;

--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -68,6 +68,7 @@
     @media (min-width: 1px) { // target modern browsers
       list-style: none;
       padding-left: $govuk-gutter-half;
+      @include govuk-responsive-padding(1, "top");
 
       &:before {
         content: "-";

--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -60,6 +60,10 @@
 }
 
 .corporate-information__sub-navigation {
+  ul {
+    padding-inline-start: 0;
+  }
+
   li {
     @media (min-width: 1px) { // target modern browsers
       list-style: none;

--- a/test/integration/worldwide_corporate_information_page_test.rb
+++ b/test/integration/worldwide_corporate_information_page_test.rb
@@ -13,6 +13,13 @@ class WorldwideCorporateInformationPageTest < ActionDispatch::IntegrationTest
     assert page.has_no_selector?(".govuk-breadcrumbs")
   end
 
+  test "renders rtl text direction when the locale is a rtl language" do
+    I18n.stubs(:locale).returns(:ar)
+    setup_and_visit_content_item("worldwide_corporate_information_page")
+
+    assert page.has_css?("#wrapper.direction-rtl"), "has .direction-rtl class on #wrapper element"
+  end
+
   test "includes the body and contents" do
     setup_and_visit_content_item("worldwide_corporate_information_page")
 

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -13,6 +13,13 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
     assert page.has_no_selector?(".govuk-breadcrumbs")
   end
 
+  test "renders rtl text direction when the locale is a rtl language" do
+    I18n.stubs(:locale).returns(:ar)
+    setup_and_visit_content_item("worldwide_organisation")
+
+    assert page.has_css?("#wrapper.direction-rtl"), "has .direction-rtl class on #wrapper element"
+  end
+
   test "renders the body content" do
     setup_and_visit_content_item("worldwide_organisation")
     assert page.has_selector?("#about-us")


### PR DESCRIPTION
https://trello.com/c/ImE91AWP

### Render RTL text for worldwide organisation pages
The worldwide organisation pages need the `direction-rtl` class in order to
correctly render languages with RTL writing systems like Arabic.

The groundwork is already in place for this, we simply need to include the page
type in `application.css`.

Visually, the page is now the same as it was in Whitehall (before the rendering
was moved over), except for the social media logos, which are now on the right.
This change is enabled by the components library and is desirable.

The `padding-inline-start` change ensures that the list of corporate
information pages does not have additional padding when rendered RTL.

### Add padding above links to corporate information pages
This padding is present in Whitehall.

### Render RTL text for worldwide corporate informaiton pages
The worldwide corporate informaiton pages need the `direction-rtl` class in
order to correctly render languages with RTL writing systems like Arabic.

The groundwork is already in place for this, we simply need to include the page
type in `application.css`.


||Whitehall|Gov frontend (this PR)|
|-|-|-|
|WW Org|![image](https://github.com/alphagov/government-frontend/assets/47089130/3d23343a-84ce-41d5-89ac-7e581cbb18fa)|![image](https://github.com/alphagov/government-frontend/assets/47089130/248de181-47d2-4a22-a57c-c54aa6f06cc0)|
|CIP|![image](https://github.com/alphagov/government-frontend/assets/47089130/b7b4b4d2-6d07-4b0e-867b-f0f524d05c3c)|![image](https://github.com/alphagov/government-frontend/assets/47089130/1ef574e8-d8df-43ea-9171-dbc927887e66)|


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
