### PR TITLE
Don't show "Part of:" tag when sponsoring organisations are absent

### DIFF
--- a/app/views/content_items/worldwide_organisation/_header.html.erb
+++ b/app/views/content_items/worldwide_organisation/_header.html.erb
@@ -20,8 +20,11 @@
             <dt><%= t('worldwide_organisation.location') %>:</dt>
             <dd data-module="hide-other-links"><%= worldwide_organisation.world_location_links %></dd>
           <% end %>
-          <dt><%= t('worldwide_organisation.part_of') %>:</dt>
-          <dd lang="en"><%= worldwide_organisation&.sponsoring_organisation_links %></dd>
+
+          <% if worldwide_organisation&.sponsoring_organisation_links.present? %>
+            <dt><%= t('worldwide_organisation.part_of') %>:</dt>
+            <dd lang="en"><%= worldwide_organisation&.sponsoring_organisation_links %></dd>
+          <% end %>
         </dl>
       </div>
     </div>

--- a/test/integration/worldwide_corporate_information_page_test.rb
+++ b/test/integration/worldwide_corporate_information_page_test.rb
@@ -48,10 +48,26 @@ class WorldwideCorporateInformationPageTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item("worldwide_corporate_information_page")
 
     within find(".worldwide-organisation-header__metadata", match: :first) do
+      assert page.has_content? "Location:"
       assert page.has_link? "Philippines", href: "/world/philippines/news"
       assert page.has_link? "Palau", href: "/world/palau/news"
 
+      assert page.has_content? "Part of:"
       assert page.has_link? "Foreign, Commonwealth & Development Office", href: "/government/organisations/foreign-commonwealth-development-office"
+    end
+  end
+
+  test "omits the world locations and sponsoring organisations when they are absent" do
+    content_item = get_content_example("worldwide_corporate_information_page")
+    content_item["links"]["worldwide_organisation"][0]["links"]["sponsoring_organisations"] = nil
+    content_item["links"]["worldwide_organisation"][0]["links"]["world_locations"] = nil
+
+    stub_content_store_has_item(content_item["base_path"], content_item.to_json)
+    visit_with_cachebust(content_item["base_path"])
+
+    within find(".worldwide-organisation-header__metadata", match: :first) do
+      assert_not page.has_content? "Location:"
+      assert_not page.has_content? "Part of:"
     end
   end
 

--- a/test/integration/worldwide_office_test.rb
+++ b/test/integration/worldwide_office_test.rb
@@ -85,10 +85,26 @@ class WorldwideOfficeTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item("worldwide_office")
 
     within find(".worldwide-organisation-header__metadata", match: :first) do
+      assert page.has_content? "Location:"
       assert page.has_link? "Philippines", href: "/world/philippines/news"
       assert page.has_link? "Palau", href: "/world/palau/news"
 
+      assert page.has_content? "Part of:"
       assert page.has_link? "Foreign, Commonwealth & Development Office", href: "/government/organisations/foreign-commonwealth-development-office"
+    end
+  end
+
+  test "omits the world locations and sponsoring organisations when they are absent" do
+    content_item = get_content_example("worldwide_office")
+    content_item["links"]["worldwide_organisation"][0]["links"]["sponsoring_organisations"] = nil
+    content_item["links"]["worldwide_organisation"][0]["links"]["world_locations"] = nil
+
+    stub_content_store_has_item(content_item["base_path"], content_item.to_json)
+    visit_with_cachebust(content_item["base_path"])
+
+    within find(".worldwide-organisation-header__metadata", match: :first) do
+      assert_not page.has_content? "Location:"
+      assert_not page.has_content? "Part of:"
     end
   end
 end

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -129,4 +129,31 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
     )
     assert_not page.has_text?("Contact us")
   end
+
+  test "includes the world locations and sponsoring organisations" do
+    setup_and_visit_content_item("worldwide_organisation")
+
+    within find(".worldwide-organisation-header__metadata", match: :first) do
+      assert page.has_content? "Location:"
+      assert page.has_link? "India with translation", href: "/world/india/news"
+      assert page.has_link? "Another location with translation", href: "/world/another-location/news"
+
+      assert page.has_content? "Part of:"
+      assert page.has_link? "Foreign, Commonwealth & Development Office", href: "/government/organisations/foreign-commonwealth-development-office"
+    end
+  end
+
+  test "omits the world locations and sponsoring organisations when they are absent" do
+    content_item = get_content_example("worldwide_organisation")
+    content_item["links"]["sponsoring_organisations"] = nil
+    content_item["links"]["world_locations"] = nil
+
+    stub_content_store_has_item(content_item["base_path"], content_item.to_json)
+    visit_with_cachebust(content_item["base_path"])
+
+    within find(".worldwide-organisation-header__metadata", match: :first) do
+      assert_not page.has_content? "Location:"
+      assert_not page.has_content? "Part of:"
+    end
+  end
 end


### PR DESCRIPTION
Currently, when sponsoring organisations are absent for a worldwide organisation (this isn't true for any currently, but can be), we still show the "Part of:" description in the header.

This makes it conditional on the presence of the sponsoring organisations, and adds some additional testing around this.

|Before|After|
|-|-|
|<img width="1007" alt="image" src="https://github.com/alphagov/government-frontend/assets/47089130/6344afa8-c25c-4420-af00-4024bd6c8a0c">|<img width="1031" alt="image" src="https://github.com/alphagov/government-frontend/assets/47089130/c9d09169-2f11-422b-bd4a-00d6b5a6b41c">|


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
