### PR TITLE
Consultation template improvements

### DIFF
--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -154,43 +154,40 @@
     <% if @content_item.ways_to_respond? %>
       <div id="ways-to-respond" class="consultation-ways-to-respond">
         <%= render 'govuk_publishing_components/components/heading', text: t("consultation.ways_to_respond"), mobile_top_margin: true %>
-          <% @ways_to_respond_body = capture do %>
-            <% if @content_item.respond_online_url %>
-              <div class="call-to-action">
-                <p><%= link_to t("consultation.respond_online"), @content_item.respond_online_url %></p>
-              </div>
-
-              <% if @content_item.email || @content_item.postal_address %>
-                <p>or</p>
-              <% end %>
-            <% end %>
-
-            <% if @content_item.response_form? %>
-              <p>
-                <%= t("consultation.complete_a") %> <%= link_to 'response form', @content_item.attachment_url %> <%= t("consultation.and") %>
-                <%= t("consultation.either") if @content_item.email && @content_item.postal_address %>
-              </p>
-            <% end %>
-
-            <% if @content_item.email %>
-              <h3><%= t("consultation.email_to") %></h3>
-              <p><%= mail_to @content_item.email, @content_item.email %></p>
-            <% end %>
-
-            <% if @content_item.postal_address %>
-              <h3><%= t("consultation.write_to") %></h3>
-              <div class="contact">
-                <div class="content">
-                  <%= simple_format(@content_item.postal_address) %>
-                </div>
-              </div>
-            <% end %>
-          <% end %>
 
         <%= render 'govuk_publishing_components/components/govspeak', {
           direction: page_text_direction,
         } do %>
-          <%= raw(@ways_to_respond_body) %>
+          <% if @content_item.respond_online_url %>
+            <div class="call-to-action">
+              <p><%= link_to t("consultation.respond_online"), @content_item.respond_online_url %></p>
+            </div>
+
+            <% if @content_item.email || @content_item.postal_address %>
+              <p><%= t("consultation.or") %></p>
+            <% end %>
+          <% end %>
+
+          <% if @content_item.response_form? %>
+            <p>
+              <%= t("consultation.complete_a") %> <%= link_to 'response form', @content_item.attachment_url %> <%= t("consultation.and") %>
+              <%= t("consultation.either") if @content_item.email && @content_item.postal_address %>
+            </p>
+          <% end %>
+
+          <% if @content_item.email %>
+            <h3><%= t("consultation.email_to") %></h3>
+            <p><%= mail_to @content_item.email, @content_item.email %></p>
+          <% end %>
+
+          <% if @content_item.postal_address %>
+            <h3><%= t("consultation.write_to") %></h3>
+            <div class="contact">
+              <div class="content">
+                <%= simple_format(@content_item.postal_address) %>
+              </div>
+            </div>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -30,7 +30,7 @@
 
     <% if @content_item.unopened? %>
       <% content_item_unopened = capture do %>
-        <%= raw(t("consultation.opens")) %>
+        <%= t("consultation.opens") %>
         <%= @content_item.opening_date_midnight? ? t("consultation.on") : t("consultation.at") %>
         <time datetime="<%= @content_item.opening_date_time %>"><%= @content_item.opening_date %></time>
       <% end %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -41,16 +41,16 @@
 
     <% elsif @content_item.pending_final_outcome? %>
       <% content_item_final_outcome = capture do %>
-        <%= raw(t("consultation.visit_soon")) %>
+        <%= t("consultation.visit_soon") %>
       <% end %>
       <%= render 'govuk_publishing_components/components/notice',
-        title: 'We are analysing your feedback',
+        title: t("consultation.analysing_feedback"),
         description_text: content_item_final_outcome,
         margin_bottom:(0 unless @content_item.add_margin?)
       %>
 
     <% elsif @content_item.final_outcome? %>
-      <%= render 'govuk_publishing_components/components/notice', title: 'This consultation has concluded' %>
+      <%= render 'govuk_publishing_components/components/notice', title: t("consultation.concluded") %>
 
       <%= render "attachments",
           title: t("consultation.download_outcome"),

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -19,12 +19,14 @@ ar:
     share_links:
       share_this_page: شارك هذه الصفحة
   consultation:
+    analysing_feedback:
     and: و
     another_website_html: عُقدت هذه الاستشارة %{closed} على <a href="%{url}">موقع ويب آخر</a>
     at: في
     closes: موعد الإغلاق
     closes_at: تُغلق هذه الاستشارة تغلق في
     complete_a: إكمال
+    concluded:
     description: وصف الاستشارة
     detail_of_feedback_received: تفاصيل التعليق المستلم
     detail_of_outcome: تفاصيل النتيجة
@@ -37,6 +39,7 @@ ar:
     not_open_yet: هذه الاستشارة لم تُفتح بعد
     'on':
     opens: تفتح هذه الاستشارة
+    or:
     original_consultation: الاستشارة الأصلية
     ran_from: أجريت هذه الاستشارة من
     respond_online: الرد عبر الإنترنت

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -19,12 +19,14 @@ az:
     share_links:
       share_this_page: Bu səhifəni paylaşın
   consultation:
+    analysing_feedback:
     and: və
     another_website_html: Bu məsləhətləşmə %{closed} başqa <a href="%{url}">vebsaytda həyata keçirilir</a>
     at: "(vaxtı göstərir)"
     closes: O, saat ...də (da) bağlanır
     closes_at: Məsləhətləşmə saat ...də (da) bağlanır
     complete_a: "...tamamlayın"
+    concluded:
     description: Məsləhətləşmənin təsviri
     detail_of_feedback_received: Alınmış rəyin təfərrüatları
     detail_of_outcome: Nəticənin təfərrüatları
@@ -37,6 +39,7 @@ az:
     not_open_yet: Bu məsləhətləşmə hələ açıq deyildir
     'on':
     opens: Bu məsləhətləşmə açılır
+    or:
     original_consultation: İlkin məsləhətləşmə
     ran_from: Bu məsləhətləşmə başlayır
     respond_online: Onlayn cavab verin

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -19,12 +19,14 @@ be:
     share_links:
       share_this_page: Падзяліцца гэтай старонкай
   consultation:
+    analysing_feedback:
     and: і
     another_website_html: Гэта кансультацыя %{closed}  праводзілася на <a href="%{url}">іншым сайце</a>
     at: на
     closes: Ён зачыняецца ў
     closes_at: Кансультацыі завяршаюцца ў
     complete_a: Скончыць
+    concluded:
     description: Апісанне кансультацыі
     detail_of_feedback_received: Падрабязная інфармацыя аб атрыманых водгуках
     detail_of_outcome: Дэталізацыя вынікаў
@@ -37,6 +39,7 @@ be:
     not_open_yet: Гэта кансультацыя яшчэ не адкрыта
     'on':
     opens: Гэта кансультацыя адкрываецца
+    or:
     original_consultation: Арыгінальная кансультацыя
     ran_from: Кансультацыя доўжылася з
     respond_online: Адказаць анлайн

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -19,12 +19,14 @@ bg:
     share_links:
       share_this_page: Споделяне на тази страница
   consultation:
+    analysing_feedback:
     and: и
     another_website_html: Тази консултация %{closed} се намира на <a href="%{url}">друг уебсайт</a>
     at: на
     closes: Закрива се в
     closes_at: Тази консултация се закрива в
     complete_a: Попълнете
+    concluded:
     description: Решение за консултация
     detail_of_feedback_received: Подробности за получената обратна връзка
     detail_of_outcome: Подробности за резултата
@@ -37,6 +39,7 @@ bg:
     not_open_yet: Тази консултация все още не е открита
     'on':
     opens: Тази консултация се отваря
+    or:
     original_consultation: Първоначална консултация
     ran_from: Тази консултация се управлява от
     respond_online: Отговор онлайн

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -19,12 +19,14 @@ bn:
     share_links:
       share_this_page: এই পেজটি শেয়ার করুন
   consultation:
+    analysing_feedback:
     and: এবং
     another_website_html: এই পরামর্শটি %{closed} <a href="%{url}">আরেকটি ওয়েবসাইটে</a> অনুষ্ঠিত হয়
     at: এ
     closes: এটি বন্ধ হচ্ছে
     closes_at: এই পরামর্শটি বন্ধ হচ্ছে
     complete_a: একটি সম্পন্ন করুন
+    concluded:
     description: পরামর্শের বর্ণনা
     detail_of_feedback_received: ফিডব্যাকের বিস্তারিত গৃহীত হয়েছে
     detail_of_outcome: ফলাফলের বিস্তারিত
@@ -37,6 +39,7 @@ bn:
     not_open_yet: এই পরামর্শটি এখনও চালু হয়নি
     'on':
     opens: এই পরামর্শটি চালু হচ্ছে
+    or:
     original_consultation: মূল পরামর্শ
     ran_from: এই পরামর্শটি যেখান থেকে চলেছে
     respond_online: অনলাইনে উত্তর দিন

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -19,12 +19,14 @@ cs:
     share_links:
       share_this_page: Sdílet tuto stránku
   consultation:
+    analysing_feedback:
     and: a
     another_website_html: Tato konzultace %{closed} se konala na <a href="%{url}">jiné webové stránce</a>
     at: na
     closes: Uzavírá se v
     closes_at: Tato konzultace končí v
     complete_a: Dokončete
+    concluded:
     description: Popis konzultace
     detail_of_feedback_received: Podrobnosti o obdržené zpětné vazbě
     detail_of_outcome: Podrobnosti o výsledku
@@ -37,6 +39,7 @@ cs:
     not_open_yet: Tato konzultace ještě není otevřena
     'on':
     opens: Tato konzultace zahajuje
+    or:
     original_consultation: Původní konzultace
     ran_from: Tato konzultace probíhala od
     respond_online: Reagovat online

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -19,12 +19,14 @@ cy:
     share_links:
       share_this_page: Rhannu'r dudalen hon
   consultation:
+    analysing_feedback:
     and: a
     another_website_html: Cynhaliwyd yr ymgynghoriad hwn %{closed} ar <a href="%{url}">wefan arall</a>
     at: am
     closes: Mae'n cau am
     closes_at: Mae'r ymgynghoriad hwn yn cau am
     complete_a: Cwblhau
+    concluded:
     description: Disgrifiad o'r ymgynghoriad
     detail_of_feedback_received: Manylion am yr adborth a gafwyd
     detail_of_outcome: Manylion am y canlyniad
@@ -37,6 +39,7 @@ cy:
     not_open_yet: Nid yw'r ymgynghoriad hwn wedi agor eto
     'on':
     opens: Mae'r ymgynghoriad hwn yn agor
+    or:
     original_consultation: Ymgynghoriad gwreiddiol
     ran_from: Roedd yr ymgynghoriad hwn yn rhedeg o
     respond_online: Ymateb ar-lein

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -19,12 +19,14 @@ da:
     share_links:
       share_this_page: Del denne side
   consultation:
+    analysing_feedback:
     and: og
     another_website_html: Denne konsultation %{closed} blev afholdt på <a href="%{url}">en anden hjemmeside</a>
     at: på
     closes: Den lukker kl.
     closes_at: Denne konsultation lukker kl.
     complete_a: Fuldfør en
+    concluded:
     description: Konsultationsbeskrivelse
     detail_of_feedback_received: Nærmere oplysninger om modtaget feedback
     detail_of_outcome: Nærmere oplysninger om resultatet
@@ -37,6 +39,7 @@ da:
     not_open_yet: Denne høring er ikke åben endnu
     'on':
     opens: Denne konsultation åbner
+    or:
     original_consultation: original konsultation
     ran_from: Denne konsultation løb fra
     respond_online: Svar online

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -19,12 +19,14 @@ de:
     share_links:
       share_this_page: Diese Seite teilen
   consultation:
+    analysing_feedback:
     and: und
     another_website_html: Diese Anhörung %{closed} fand auf einer <a href="%{url}">anderen Website</a> statt
     at: um
     closes: Sie schließt um
     closes_at: Diese Anhörung endet um
     complete_a: Vervollständigen einer
+    concluded:
     description: Beschreibung der Anhörung
     detail_of_feedback_received: Einzelheiten zur erhaltenen Rückmeldung
     detail_of_outcome: Einzelheiten zum Ergebnis
@@ -37,6 +39,7 @@ de:
     not_open_yet: Diese Anhörung ist noch nicht eröffnet
     'on':
     opens: Diese Anhörung wird eröffnet
+    or:
     original_consultation: Originale Anhörung
     ran_from: Diese Anhörung lief ab
     respond_online: Online antworten

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -19,12 +19,14 @@ dr:
     share_links:
       share_this_page: این صفحه را به اشتراک بگذارید
   consultation:
+    analysing_feedback:
     and: و
     another_website_html: این مشاوره%{closed}برگزار میشود در<a href="%{url}">ویبسایت دیگر</a>
     at: در
     closes: این بسته میشود در
     closes_at: این مشاوره بسته میشود در
     complete_a: تکمیل نمایید یک
+    concluded:
     description: شرح مشاوره
     detail_of_feedback_received: جزیٔیات فیدبک دریافت شده
     detail_of_outcome: جزیٔیات نتیجه
@@ -37,6 +39,7 @@ dr:
     not_open_yet: مشاوره تا هنوز شروع نشده است
     'on':
     opens: مشاوره شروع میشود
+    or:
     original_consultation: مشاورهء اصلی
     ran_from: این مشاوره اجرا میشود از
     respond_online: بصورت آنلاین پاسخ دهید

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -19,12 +19,14 @@ el:
     share_links:
       share_this_page: Κοινοποιήστε αυτή τη σελίδα
   consultation:
+    analysing_feedback:
     and: και
     another_website_html: Αυτή η διαβούλευση %{closed} πραγματοποιήθηκε σε <a href="%{url}">άλλο ιστότοπο</a>
     at: στο
     closes: Κλείνει στο
     closes_at: Αυτή η διαβούλευση κλείνει στις
     complete_a: Συμπληρώστε ένα
+    concluded:
     description: Περιγραφή διαβούλευσης
     detail_of_feedback_received: Λεπτομέρειες για τα σχόλια που ελήφθησαν
     detail_of_outcome: Λεπτομέρεια του αποτελέσματος
@@ -37,6 +39,7 @@ el:
     not_open_yet: Αυτή η διαβούλευση δεν είναι ακόμη ανοιχτή
     'on':
     opens: Αυτή η διαβούλευση ανοίγει
+    or:
     original_consultation: Αρχική διαβούλευση
     ran_from: Αυτή η διαβούλευση ξεκίνησε από
     respond_online: Απαντήστε online

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,12 +19,14 @@ en:
     share_links:
       share_this_page: Share this page
   consultation:
+    analysing_feedback: We are analysing your feedback
     and: and
     another_website_html: This consultation %{closed} held on <a href="%{url}">another website</a>
     at: at
     closes: It closes at
     closes_at: This consultation closes at
     complete_a: Complete a
+    concluded: This consultation has concluded
     description: Consultation description
     detail_of_feedback_received: Detail of feedback received
     detail_of_outcome: Detail of outcome
@@ -36,6 +38,7 @@ en:
     is_being: is being
     not_open_yet: This consultation isn't open yet
     'on': 'on'
+    'or': 'or'
     opens: This consultation opens
     original_consultation: Original consultation
     ran_from: This consultation ran from

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -19,12 +19,14 @@ es-419:
     share_links:
       share_this_page: Compartir esta página
   consultation:
+    analysing_feedback:
     and: "y"
     another_website_html: Esta consulta %{closed} realizada en <a href="%{url}">otro sitio web</a>
     at: en
     closes: Se cierra a
     closes_at: Esta consulta se cierra a las
     complete_a: Completar un
+    concluded:
     description: Descripción de la consulta
     detail_of_feedback_received: Detalle de los comentarios recibidos
     detail_of_outcome: Detalle del resultado
@@ -37,6 +39,7 @@ es-419:
     not_open_yet: Esta consulta aún no está abierta
     'on':
     opens: Esta consulta abre
+    or:
     original_consultation: Consulta inicial
     ran_from: Esta consulta se llevó a cabo desde
     respond_online: Responder en línea

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -19,12 +19,14 @@ es:
     share_links:
       share_this_page: Compartir esta página
   consultation:
+    analysing_feedback:
     and: "y"
     another_website_html: Esta consulta %{closed} se realizó en <a href='%{url}'>otro sitio web</a>
     at: en
     closes: Cierra a las
     closes_at: Esta consulta se cierra a las
     complete_a: Complete un/a
+    concluded:
     description: Descripción de la consulta
     detail_of_feedback_received: Detalle de los comentarios recibidos
     detail_of_outcome: Detalle del resultado
@@ -37,6 +39,7 @@ es:
     not_open_yet: Esta consulta no está abierta todavía
     'on':
     opens: Se abre esta consulta
+    or:
     original_consultation: Consulta original
     ran_from: Esta consulta fue de
     respond_online: Responda en línea

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -19,12 +19,14 @@ et:
     share_links:
       share_this_page: Jaga seda lehte
   consultation:
+    analysing_feedback:
     and: ja
     another_website_html: See konsultatsioon %{closed} toimus <a href="%{url}">teisel veebisaidil</a>
     at: kl
     closes: See lõpeb kl
     closes_at: See konsultatsioon lõpeb kell
     complete_a: Täitke
+    concluded:
     description: Konsultatsiooni kirjeldus
     detail_of_feedback_received: Tagasiside üksikasjad saadud
     detail_of_outcome: Tulemuse üksikasjad
@@ -37,6 +39,7 @@ et:
     not_open_yet: See konsultatsioon pole veel alanud
     'on':
     opens: See konsultatsioon algab
+    or:
     original_consultation: Algne konsultatsioon
     ran_from: See konsultatsioon kestis
     respond_online: Vastake võrgus

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -19,12 +19,14 @@ fa:
     share_links:
       share_this_page: اشتراک‌گذاری این صفحه
   consultation:
+    analysing_feedback:
     and: و
     another_website_html: این مشاوره %{closed} در <a href="%{url}">وب‌سات دیگر برگزار شد</a>
     at: در
     closes: بسته می‌شود در
     closes_at: این مشاوره بسته می‌شود در
     complete_a: تکمیل کنید یک
+    concluded:
     description: توضیحات مشاوره
     detail_of_feedback_received: جزئیات بازخورد دریافت‌شده
     detail_of_outcome: جزئیات نتیجه
@@ -37,6 +39,7 @@ fa:
     not_open_yet: این مشاوره هنوز باز نشده است
     'on':
     opens: این مشاوره باز می‌شود
+    or:
     original_consultation: مشاوره اصلی
     ran_from: این مشاوره در حال اجرا است از
     respond_online: آنلاین پاسخ دهید

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -19,12 +19,14 @@ fi:
     share_links:
       share_this_page: Jaa tämä sivu
   consultation:
+    analysing_feedback:
     and: ja
     another_website_html: Tämä kuuleminen %{closed} järjestettiin toisella <a href="%{url}">averkkosivustolla</a>
     at: klo
     closes: Se sulkeutuu klo
     closes_at: Tämä kuuleminen päättyy klo
     complete_a: Täytä
+    concluded:
     description: Konsultaation kuvaus
     detail_of_feedback_received: Yksityiskohta saadusta palautteesta
     detail_of_outcome: Yksityiskohta lopputuloksesta
@@ -37,6 +39,7 @@ fi:
     not_open_yet: Tämä kuuleminen ei ole vielä auki
     'on':
     opens: Tämä kuuleminen avautuu
+    or:
     original_consultation: Alkuperäinen kuuleminen
     ran_from: Tämä kuuleminen kesti
     respond_online: Vastaa verkossa

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -19,12 +19,14 @@ fr:
     share_links:
       share_this_page: Partagez cette page
   consultation:
+    analysing_feedback:
     and: et
     another_website_html: Cette consultation %{closed} s'est tenue sur <a href="%{url}">un autre site Web</a>
     at: à
     closes: Elle s'achève à
     closes_at: Cette consultation s'achève à
     complete_a: Remplissez un
+    concluded:
     description: Description de la consultation
     detail_of_feedback_received: Détail des commentaires reçus
     detail_of_outcome: Détail du résultat
@@ -37,6 +39,7 @@ fr:
     not_open_yet: Cette consultation n'a pas encore débuté.
     'on':
     opens: Cette consultation a débuté.
+    or:
     original_consultation: Consultation originale
     ran_from: Cette consultation s'est tenue du
     respond_online: Répondre en ligne

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -19,12 +19,14 @@ gd:
     share_links:
       share_this_page: Comhroinn an leathanach seo
   consultation:
+    analysing_feedback:
     and: agus
     another_website_html: Tionóladh an comhairliúchán %{closed} seo ar <a href="%{url}">suíomh Gréasáin eile</a>
     at: ag an seoladh
     closes: Críochnaíonn sé ag
     closes_at: Críochnaíonn an suirbhé seo ag
     complete_a: Comhlánaigh a
+    concluded:
     description: Cur síos ar an bpróiseas comhairliúcháin
     detail_of_feedback_received: Sonraí faoi na breathnuithe a fuarthas
     detail_of_outcome: Sonraigh an toradh
@@ -37,6 +39,7 @@ gd:
     not_open_yet: Níl an teaglaim seo oscailte fós
     'on':
     opens: Tá an chuid seo den chomhairliúchán oscailte
+    or:
     original_consultation: Comhairliúchán bunaidh
     ran_from: Rinneadh an comhairliúchán seo ó
     respond_online: Tabhair freagra ar líne

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -19,12 +19,14 @@ gu:
     share_links:
       share_this_page: આ પેજ શેર કરો
   consultation:
+    analysing_feedback:
     and: અને
     another_website_html: આ પરામર્શ %{closed} ના રોજ <a href="%{url}">અન્ય વેબસાઇટ</a> પર આયોજિત કરેલ છે
     at: ખાતે
     closes: તે સમાપ્ત થાય છે
     closes_at: આ પરામર્શ ના રોજ સમાપ્ત થાય છે
     complete_a: પૂર્ણ કરો
+    concluded:
     description: પરામર્શ વર્ણન
     detail_of_feedback_received: પ્રાપ્ત ફીડબૅકની વિગતો
     detail_of_outcome: પરિણામોની વિગતો
@@ -37,6 +39,7 @@ gu:
     not_open_yet: આ પરામર્શ હજુ સુધી શરૂ થયેલ નથી
     'on':
     opens: આ પરામર્શ શરૂ થાય છે
+    or:
     original_consultation: મૂળ પરામર્શ
     ran_from: આ પરામર્શ થી ચાલુ
     respond_online: ઓનલાઇન પ્રતિભાવ આપો

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -19,12 +19,14 @@ he:
     share_links:
       share_this_page: שתף דף זה
   consultation:
+    analysing_feedback:
     and: ו
     another_website_html: דיון זה %{closed} התקיים ב <a href="%{url}">אתר אחר</a>
     at: ב-
     closes: הוא נסגר ב
     closes_at: דיון זו נסגר ב
     complete_a: השלם
+    concluded:
     description: תיאור הדיון
     detail_of_feedback_received: פירוט המשוב שהתקבל
     detail_of_outcome: פירוט התוצאה
@@ -37,6 +39,7 @@ he:
     not_open_yet: הדיון הזה עדיין לא פתוח
     'on':
     opens: דיון זה נפתח
+    or:
     original_consultation: דיון מקורי
     ran_from: דיון זו נערך מ-
     respond_online: להגיב באינטרנט

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -19,12 +19,14 @@ hi:
     share_links:
       share_this_page: यह पेज शेयर करें
   consultation:
+    analysing_feedback:
     and: और
     another_website_html: यह परामर्श %{closed} <a href="%{url}">एक अन्य वेबसाइट</a>पर आयोजित किया गया
     at: पर
     closes: यह बंद होता है
     closes_at: यह परामर्श पर बंद होता है
     complete_a: पूरा करें
+    concluded:
     description: परामर्श का विवरण
     detail_of_feedback_received: प्राप्त फीडबैक का विवरण
     detail_of_outcome: परिणाम का विवरण
@@ -37,6 +39,7 @@ hi:
     not_open_yet: यह परामर्श अभी तक खोला नहीं गया है
     'on':
     opens: यह परामर्श खुलता है
+    or:
     original_consultation: असली परामर्श
     ran_from: यह परामर्श चला था
     respond_online: ऑनलाइन जवाब दें

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -19,12 +19,14 @@ hr:
     share_links:
       share_this_page: Podijelite ovu stranicu
   consultation:
+    analysing_feedback:
     and: i
     another_website_html: Ovo savjetovanje %{closed} održano je na <ahref="%{url}">drugoj web stranici</a>
     at: u
     closes: Zatvara se u
     closes_at: Ovo savjetovanje završava se u
     complete_a: 'Dovršite '
+    concluded:
     description: Opis konzultacija
     detail_of_feedback_received: Detalji primljene povratne informacije
     detail_of_outcome: Detalji ishoda
@@ -37,6 +39,7 @@ hr:
     not_open_yet: Ovo savjetovanje još nije otvoreno
     'on':
     opens: Ovo savjetovanje se otvara
+    or:
     original_consultation: Originalno savjetovanje
     ran_from: Ovo savjetovanje je trajalo od
     respond_online: Odgovorite na mreži

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -19,12 +19,14 @@ hu:
     share_links:
       share_this_page: Oldal megosztása
   consultation:
+    analysing_feedback:
     and: és
     another_website_html: A konzultáció %{closed} egy <a href="%{url}">másik weboldalon kerül megrendezésre</a>
     at: 'itt:'
     closes: 'Lezárul ekkor:'
     closes_at: 'A konzultáció lezárul ekkor:'
     complete_a: 'A következő befejezése:'
+    concluded:
     description: Konzultáció leírása
     detail_of_feedback_received: A kapott visszajelzés részletei
     detail_of_outcome: Kimenetel részletei
@@ -37,6 +39,7 @@ hu:
     not_open_yet: A konzultáció még nem nyitott
     'on':
     opens: A konzultáció megnyílik
+    or:
     original_consultation: Eredeti konzultáció
     ran_from: 'A konzultáció kezdőidőpontja:'
     respond_online: Válasz online

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -19,12 +19,14 @@ hy:
     share_links:
       share_this_page: Կիսվել այս էջով
   consultation:
+    analysing_feedback:
     and: և
     another_website_html: Այս խորհրդակցությունը %{closed} անցկացվել է <a href="%{url}">մեկ այլ</a>
     at: վեբ կայքում՝
     closes: Այն ավարտվում է
     closes_at: Այս խորհրդակցությունն ավարտվում է
     complete_a: Իրականացնել
+    concluded:
     description: Խորհրդակցության նկարագրություն
     detail_of_feedback_received: Ստացված արձագանքի մանրամասներ
     detail_of_outcome: Արդյունքի վերաբերյալ մանրամասներ
@@ -37,6 +39,7 @@ hy:
     not_open_yet: Այս խորհրդակցությունը դեռևս չի սկսվել
     'on':
     opens: Այս խորհրդակցությունը կսկսվի
+    or:
     original_consultation: Սկզբնական խորհրդակցություն
     ran_from: Այս խորհրդակցությունն իրականացվել է
     respond_online: Պատասխանել առցանց

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -19,12 +19,14 @@ id:
     share_links:
       share_this_page: Bagikan halaman ini
   consultation:
+    analysing_feedback:
     and: dan
     another_website_html: Konsultasi ini %{closed} diadakan di <a href="%{url}">situs web lain</a>
     at: pada
     closes: Tutup pada
     closes_at: Konsultasi ini ditutup pada
     complete_a: Selesaikan
+    concluded:
     description: Deskripsi konsultasi
     detail_of_feedback_received: Detail umpan balik yang diterima
     detail_of_outcome: Detail hasil
@@ -37,6 +39,7 @@ id:
     not_open_yet: Konsultasi ini belum dibuka
     'on':
     opens: Konsultasi ini sudah dibuka
+    or:
     original_consultation: Konsultasi asli
     ran_from: Konsultasi ini berlangsung dari
     respond_online: Respons online

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -19,12 +19,14 @@ is:
     share_links:
       share_this_page: Deila þessari síðu
   consultation:
+    analysing_feedback:
     and: og
     another_website_html: Þessi ráðgjöf %{closed} var haldin á <a href="%{url}">annarri vefsíðu</a>
     at: þann
     closes: Henni lýkur
     closes_at: Þessari ráðgjöf lýkur
     complete_a: Ljúka
+    concluded:
     description: Lýsing á ráðgjöf
     detail_of_feedback_received: Nánari upplýsingar um fengna endurgjöf
     detail_of_outcome: Nánari upplýsingar um útkomu
@@ -37,6 +39,7 @@ is:
     not_open_yet: Þessi ráðgjöf er ekki enn opin
     'on':
     opens: Þessi ráðgjöf opnar
+    or:
     original_consultation: Upprunaleg ráðgjöf
     ran_from: Þessi ráðgjöf stóð yfir frá
     respond_online: Svara á netinu

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -19,12 +19,14 @@ it:
     share_links:
       share_this_page: Condividi questa pagina
   consultation:
+    analysing_feedback:
     and: e
     another_website_html: Questa consultazione %{closed} tenuta su <a href=”%{url}”>un altro sito web</a>
     at: in
     closes: Si chiude alle
     closes_at: Questa consultazione si chiude alle
     complete_a: Completa un
+    concluded:
     description: Descrizione della consultazione
     detail_of_feedback_received: Dettagli del feedback ricevuto
     detail_of_outcome: Dettagli dell’esito
@@ -37,6 +39,7 @@ it:
     not_open_yet: Questa consultazione non è ancora aperta
     'on':
     opens: Questa consultazione si apre
+    or:
     original_consultation: Consultazione originale
     ran_from: Questa consultazione è partita da
     respond_online: Rispondi online

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,12 +19,14 @@ ja:
     share_links:
       share_this_page: このページを共有
   consultation:
+    analysing_feedback:
     and: および
     another_website_html: この審議％{closed}は、<ahref = "％{url}">別のウェブサイト</a>で行われました
     at: 時間：
     closes: 終了時間：
     closes_at: 審議終了時間：
     complete_a: 次を完成させる：
+    concluded:
     description: 審議内容
     detail_of_feedback_received: 受け取ったフィードバックの詳細
     detail_of_outcome: 結果の詳細
@@ -37,6 +39,7 @@ ja:
     not_open_yet: この審議はまだ開かれていません
     'on':
     opens: この審議が始まります
+    or:
     original_consultation: 当初の審議
     ran_from: この審議が始まった時間：
     respond_online: オンラインで返信する

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -19,12 +19,14 @@ ka:
     share_links:
       share_this_page: ამ გვერდის გაზიარება
   consultation:
+    analysing_feedback:
     and: და
     another_website_html: ეს კონსულტაცია %{closed} ჩატარდა <a href="%{url}">სხვა ვებგვერდზე</a>
     at: ზე
     closes: იხურება
     closes_at: ეს კონსულტაცია იხურება
     complete_a: დასრულება
+    concluded:
     description: კონსულტაციის აღწერილობა
     detail_of_feedback_received: ფიდბეკის დეტალი მიღებულია
     detail_of_outcome: შედეგის დეტალი
@@ -37,6 +39,7 @@ ka:
     not_open_yet: ეს კონსულტაცია ჯერ არ გახსნილა
     'on':
     opens: ეს კონსულტაცია იხსნება
+    or:
     original_consultation: ორიგინალი კონსულტაცია
     ran_from: ეს კონსულტაცია ამოიწურა
     respond_online: ონლაინ პასუხი

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -19,12 +19,14 @@ kk:
     share_links:
       share_this_page: Осы бетпен бөлісу
   consultation:
+    analysing_feedback:
     and: және
     another_website_html: Бұл кеңес %{closed} <a href="%{url}">басқа веб-сайтта өтті</a>
     at: мына уақытта
     closes: Ол мына уақытта жабылды
     closes_at: Бұл кеңес мына уақытта жабылады
     complete_a: Аяқтау
+    concluded:
     description: Кеңес сипаттамасы
     detail_of_feedback_received: Алынған пікір мәліметі
     detail_of_outcome: Нәтиже мәліметі
@@ -37,6 +39,7 @@ kk:
     not_open_yet: Бұл кеңес әлі ашылмаған
     'on':
     opens: Бұл кеңес ашылды
+    or:
     original_consultation: Бастапқы кеңес
     ran_from: Бұл кеңес мына жерден басталады
     respond_online: Онлайн жауап беру

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -19,12 +19,14 @@ ko:
     share_links:
       share_this_page: 이 페이지 공유하기
   consultation:
+    analysing_feedback:
     and: 그리고
     another_website_html: 이 상담 %{closed} 은 <a href="%{url}">다른 웹사이트</a>에서 진행되었습니다
     at: 때
     closes: 종결 시점
     closes_at: 이 상담은 다음 시점에 종결됩니다
     complete_a: 완료 시점
+    concluded:
     description: 상담 설명
     detail_of_feedback_received: 받은 피드백의 세부 내용
     detail_of_outcome: 결과의 세부 내용
@@ -37,6 +39,7 @@ ko:
     not_open_yet: 이 상담이 아직 공개되지 않았습니다
     'on':
     opens: 이 상담이 공개되었습니다
+    or:
     original_consultation: 기존 상담
     ran_from: 상담 실행 장소
     respond_online: 온라인으로 응답하기

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -19,12 +19,14 @@ lt:
     share_links:
       share_this_page: Bendrinti šį puslapį
   consultation:
+    analysing_feedback:
     and: ir
     another_website_html: Ši konsultacija %{closed} teikiama <a href="%{url}">kitoje interneto svetainėje</a>
     at: laiku
     closes: Ji baigiasi
     closes_at: Ši konsultacija baigiasi
     complete_a: Užpildyti
+    concluded:
     description: Konsultacijos aprašas
     detail_of_feedback_received: Informacija apie gautus atsiliepimus
     detail_of_outcome: Informaciją apie rezultatą
@@ -37,6 +39,7 @@ lt:
     not_open_yet: Ši konsultacija dar neprasidėjo
     'on':
     opens: Ši konsultacija prasideda
+    or:
     original_consultation: Pirminė konsultacija
     ran_from: Ši konsultacija tęsėsi nuo
     respond_online: Atsakyti internetu

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -19,12 +19,14 @@ lv:
     share_links:
       share_this_page: Kopīgot šo lapu
   consultation:
+    analysing_feedback:
     and: un
     another_website_html: Šī konsultācija %{closed} notika <a href="%{url}">citā tīmekļa vietnē</a>
     at: 'šajā laikā:'
     closes: Slēgšanas laiks ir
     closes_at: Šīs konsultācijas slēgšanas laiks ir
     complete_a: Pabeigt
+    concluded:
     description: Konsultācijas apraksts
     detail_of_feedback_received: Atsauksmes informācija saņemta
     detail_of_outcome: Rezultāta informācija
@@ -37,6 +39,7 @@ lv:
     not_open_yet: Šī konsultācija vēl nav atvērta
     'on':
     opens: Šī konsultācija tiek atvērta
+    or:
     original_consultation: Oriģinālā konsultācija
     ran_from: Šī konsultācija
     respond_online: Atbildēt tiešsaistē

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -19,12 +19,14 @@ ms:
     share_links:
       share_this_page: Kongsi laman ini
   consultation:
+    analysing_feedback:
     and: dan
     another_website_html: Perundingan ini %{closed} telah diadakan di <a href="%{url}">laman web lain</a>
     at: di
     closes: Ditutup pada
     closes_at: Perundingan ini ditutup pada
     complete_a: Lengkapkan
+    concluded:
     description: Huraian perundingan
     detail_of_feedback_received: Butiran maklum balas diterima
     detail_of_outcome: Butiran hasil
@@ -37,6 +39,7 @@ ms:
     not_open_yet: Perundingan ini masih belum dibuka
     'on':
     opens: Perundingan ini dibuka
+    or:
     original_consultation: Perundingan asal
     ran_from: Perundingan ini berjalan dari
     respond_online: Jawab dalam talian

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -19,12 +19,14 @@ mt:
     share_links:
       share_this_page: Aqsam din il-paġna ma'
   consultation:
+    analysing_feedback:
     and: u
     another_website_html: Din il-konsultazzjoni %{closed} tinsab fuq  <a href="%{url}">websajt oħra</a>
     at: fi
     closes: Din tagħlaq fil
     closes_at: Din il-konsultazzjoni tagħlaq nhar
     complete_a: Lesti
+    concluded:
     description: Deskrizzjoni tal-konsultazzjoni
     detail_of_feedback_received: Dettall tal-feedback li rċevejna
     detail_of_outcome: Detall dwar ir-riżultat
@@ -37,6 +39,7 @@ mt:
     not_open_yet: Din il-konsultazzjoni għada m'hijiex miftuħa
     'on':
     opens: Din il-konsultazzjoni tiftaħ
+    or:
     original_consultation: Konsultazzjoni oriġinali
     ran_from: Din il-konsultazzjoni bdiet minn
     respond_online: Irrispondi onlajn

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -19,12 +19,14 @@ ne:
     share_links:
       share_this_page: यो पृष्ठ साझा गर्नुहोस्
   consultation:
+    analysing_feedback:
     and: र
     another_website_html: यो परामर्श %{बन्द} <a href="%{url}">अर्को वेबसाइट</a> मा आयोजित
     at: मा
     closes: मा बन्द हुन्छ
     closes_at: यो परामर्श मा बन्द हुन्छ
     complete_a: एउटा पूरा गर्नु
+    concluded:
     description: परामर्श विवरण
     detail_of_feedback_received: प्रतिक्रियाको विवरण प्राप्त भयो
     detail_of_outcome: परिणामको विवरण
@@ -37,6 +39,7 @@ ne:
     not_open_yet: यो परामर्श अझै खुलेको छैन
     'on':
     opens: यो परामर्श खुल्छ
+    or:
     original_consultation: मूल परामर्श
     ran_from: यो परामर्श बाट चलेको हो
     respond_online: अनलाइन प्रतिक्रिया

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -19,12 +19,14 @@ nl:
     share_links:
       share_this_page: Deel deze pagina
   consultation:
+    analysing_feedback:
     and: en
     another_website_html: Dit overleg %{closed} werd gehouden op <a href="%{url}">een andere website</a>
     at: om
     closes: Het is afgelopen om
     closes_at: Deze raadpleging sluit op
     complete_a: Vul een
+    concluded:
     description: Beschrijving van de raadpleging
     detail_of_feedback_received: Detail van ontvangen feedback
     detail_of_outcome: Detail van het resultaat
@@ -37,6 +39,7 @@ nl:
     not_open_yet: Deze raadpleging is nog niet geopend
     'on':
     opens: Deze raadpleging wordt geopend
+    or:
     original_consultation: Oorspronkelijke raadpleging
     ran_from: Deze raadpleging liep van
     respond_online: Reageer online

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -19,12 +19,14 @@
     share_links:
       share_this_page: Del denne siden
   consultation:
+    analysing_feedback:
     and: og
     another_website_html: Denne konsultasjonen %{closed} ble avholdt på <a href="%{url}">et annet nettsted</a>
     at: på
     closes: Den avsluttes klokken
     closes_at: Denne konsultasjonen avsluttes klokken
     complete_a: Fullfør en
+    concluded:
     description: Konsultasjonsbeskrivelse
     detail_of_feedback_received: Detalj av mottatt tilbakemelding
     detail_of_outcome: Detalj av resultatet
@@ -37,6 +39,7 @@
     not_open_yet: Denne konsultasjonen er ikke åpen ennå
     'on':
     opens: Denne konsultasjonen åpner
+    or:
     original_consultation: Opprinnelig konsultasjon
     ran_from: Denne konsultasjonen varte fra
     respond_online: Svar online

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -19,12 +19,14 @@ pa-pk:
     share_links:
       share_this_page: ایہ ورقہ تقسیم کرو
   consultation:
+    analysing_feedback:
     and: ہور
     another_website_html: ایہ مشورہ  {closed} %ایندے تے وقوعہ ہویا <a href="%{url}">دُوسری ویب سائٹ</a>
     at: ایندے تے
     closes: ایہ ایندے تے بند ہوندا اے
     closes_at: ایہ مشاورت ایندے تے بند ہوندی اے
     complete_a: اک پُورا کرو
+    concluded:
     description: مشاورت دی وضاحت
     detail_of_feedback_received: موصول شُدہ جواب دی تفصیل
     detail_of_outcome: نتیجے دی تفصیل
@@ -37,6 +39,7 @@ pa-pk:
     not_open_yet: ایہ مشاورت ہلے نئیں کُھلی
     'on':
     opens: ایہ مشاورت کُھل گئی اے
+    or:
     original_consultation: اصلی مشاورت
     ran_from: ایہ مشاورت داچلایا ہویا فارم اے
     respond_online: آن لائن جاب دیوؤ

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -19,12 +19,14 @@ pa:
     share_links:
       share_this_page: ਇਸ ਪੇਜ ਨੂੰ ਸ਼ੇਅਰ ਕਰੋ
   consultation:
+    analysing_feedback:
     and: ਅਤੇ
     another_website_html: ਇਹ ਸਲਾਹ -ਮਸ਼ਵਰਾ %{close} <a href="%{url}"> ਹੋਰ ਵੈਬਸਾਈਟ </a> 'ਤੇ ਆਯੋਜਿਤ ਕੀਤਾ ਗਿਆ
     at: "'ਤੇ"
     closes: "'ਤੇ ਬੰਦ ਹੁੰਦਾ ਹੈ"
     closes_at: ਇਹ ਸਲਾਹ -ਮਸ਼ਵਰਾ ਇੱਥੇ ਬੰਦ ਹੁੰਦਾ ਹੈ
     complete_a: ਪੂਰਾ ਕਰੋ
+    concluded:
     description: ਸਲਾਹ ਮਸ਼ਵਰਾ
     detail_of_feedback_received: ਪ੍ਰਾਪਤ ਫੀਡਬੈਕ ਦਾ ਵੇਰਵਾ
     detail_of_outcome: ਨਤੀਜਿਆਂ ਦਾ ਵੇਰਵਾ
@@ -37,6 +39,7 @@ pa:
     not_open_yet: ਇਹ ਸਲਾਹ -ਮਸ਼ਵਰਾ ਅਜੇ ਖੁੱਲ੍ਹਾ ਨਹੀਂ ਹੈ
     'on':
     opens: ਇਹ ਸਲਾਹ ਮਸ਼ਵਰਾ ਖੁੱਲਦਾ ਹੈ
+    or:
     original_consultation: ਮੂਲ ਸਲਾਹ
     ran_from: ਇਹ ਸਲਾਹ -ਮਸ਼ਵਰਾ ਇਸ ਤੋਂ ਚੱਲਿਆ
     respond_online: ਆਨਲਾਈਨ ਜਵਾਬ ਦਿਓ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -19,12 +19,14 @@ pl:
     share_links:
       share_this_page: Udostępnij tę stronę
   consultation:
+    analysing_feedback:
     and: i
     another_website_html: Te konsultacje %{closed} odbyły się na <a href="%{url}">innej stronie internetowej</a>
     at: o
     closes: Kończy się o
     closes_at: Te konsultacje kończą się o
     complete_a: Wypełnij
+    concluded:
     description: Opis konsultacji
     detail_of_feedback_received: Szczegóły dotyczące otrzymanych informacji zwrotnych
     detail_of_outcome: Szczegóły dotyczące wyniku
@@ -37,6 +39,7 @@ pl:
     not_open_yet: Te konsultacje jeszcze się nie rozpoczęły
     'on':
     opens: Konsultacje rozpoczynają się
+    or:
     original_consultation: Pierwotne konsultacje
     ran_from: Te konsultacje trwały od
     respond_online: Odpowiedz online

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -19,12 +19,14 @@ ps:
     share_links:
       share_this_page: دا پاه شریکه کړئ
   consultation:
+    analysing_feedback:
     and: او
     another_website_html: دا مشوره <a href="%{url}">په بله ویبپا ڼه  کې %{closed}ترسره شوه</a>
     at: په
     closes: په کې بندیږي
     closes_at: دا مشوره په پای کې پای ته رسیږي
     complete_a: بشپړ کړئ
+    concluded:
     description: د مشورې توضیحات
     detail_of_feedback_received: د ترلاسه شوي نظریاتو تفصیل
     detail_of_outcome: د پایلې تفصیل
@@ -37,6 +39,7 @@ ps:
     not_open_yet: دا مشوره لاهم خلاص نده
     'on':
     opens: دا مشوره خلاصیږي
+    or:
     original_consultation: اصلي مشوره
     ran_from: دا مشوره له دې ځایه روانه وه
     respond_online: آنلاین ځواب ورکړئ

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -19,12 +19,14 @@ pt:
     share_links:
       share_this_page: Partilhar esta página
   consultation:
+    analysing_feedback:
     and: e
     another_website_html: Esta consulta %{closed} foi realizada <a href="%{url}">noutro site</a>
     at: às
     closes: Encerra às
     closes_at: Esta consulta encerra às
     complete_a: Preencha um
+    concluded:
     description: Descrição da consulta
     detail_of_feedback_received: Detalhes do feedback recebido
     detail_of_outcome: Detalhes do resultado
@@ -37,6 +39,7 @@ pt:
     not_open_yet: Esta consulta ainda não está aberta
     'on':
     opens: Esta consulta abre
+    or:
     original_consultation: Consulta original
     ran_from: Esta consulta decorreu de
     respond_online: Responder online

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -19,12 +19,14 @@ ro:
     share_links:
       share_this_page: Distribuiți această pagină
   consultation:
+    analysing_feedback:
     and: și
     another_website_html: Această consultație %{closed} s-a ținut pe <a href="%{url}">un alt website</a>
     at: la
     closes: Se închide la
     closes_at: Această consultație se închide la
     complete_a: Finalizați o
+    concluded:
     description: Descrierea consultației
     detail_of_feedback_received: Detaliile feedbackului primit
     detail_of_outcome: Detaliile rezultatului
@@ -37,6 +39,7 @@ ro:
     not_open_yet: Această consultație nu este deschisă încă
     'on':
     opens: Această consultație se deschide
+    or:
     original_consultation: Consultație originală
     ran_from: Această consultație a început la
     respond_online: Răspundeți online

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -19,12 +19,14 @@ ru:
     share_links:
       share_this_page: 'Поделиться данной страницей '
   consultation:
+    analysing_feedback:
     and: и
     another_website_html: Консультация %{closed} проведенная на <a href="%{url}">другой Веб-сайт</a>
     at: на
     closes: Она закрывается на
     closes_at: Данная консультация закрывается на
     complete_a: Заполните
+    concluded:
     description: Описание консультации
     detail_of_feedback_received: Детали, полученного отзыва
     detail_of_outcome: Детали результата
@@ -37,6 +39,7 @@ ru:
     not_open_yet: Консультация еще не открыта
     'on':
     opens: Консультация открывается
+    or:
     original_consultation: Оригинальная консультация
     ran_from: Обычная консультация
     respond_online: Он-лайн ответ

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -19,12 +19,14 @@ si:
     share_links:
       share_this_page: මෙම පිටුව බෙදාගන්න
   consultation:
+    analysing_feedback:
     and: සහ
     another_website_html: මෙම උපදේශනය %{closed} <a href="%{url}">වෙනත් වෙබ් අඩවියක</a> පවත් වනු ලැබේ
     at: දී
     closes: එය වසන වේලාව
     closes_at: මෙම උපදේශනය වසන වේලාව
     complete_a: එකක් සම්පූර්ණ කරන්න
+    concluded:
     description: උපදේශන විස්තරය
     detail_of_feedback_received: ලැබුණු ප්‍රතිපෝෂණ පිළිබඳ විස්තර
     detail_of_outcome: ප්රතිඵලය පිළිබඳ විස්තර
@@ -37,6 +39,7 @@ si:
     not_open_yet: මෙම උපදේශනය තවමත් විවෘත කර නැත
     'on':
     opens: මෙම උපදේශනය විවෘත වේ
+    or:
     original_consultation: මුල් උපදේශනය
     ran_from: මෙම උපදේශනය ක්‍රියාත්මක වුනේ
     respond_online: මාර්ගගතව ප්රතිචාර දක්වන්න

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -19,12 +19,14 @@ sk:
     share_links:
       share_this_page: Zdieľať túto stránku
   consultation:
+    analysing_feedback:
     and: a
     another_website_html: Táto konzultácia %{closed} sa konala na <a href="%{url}">inej webovej stránke</a>
     at: na
     closes: Zatvára sa o
     closes_at: Táto konzultácia sa končí o
     complete_a: Dokončite
+    concluded:
     description: Popis konzultácie
     detail_of_feedback_received: Podrobnosti o prijatej spätnej väzbe
     detail_of_outcome: Podrobnosti o výsledku
@@ -37,6 +39,7 @@ sk:
     not_open_yet: Táto konzultácia ešte nie je otvorená
     'on':
     opens: Táto konzultácia sa začína
+    or:
     original_consultation: Pôvodná konzultácia
     ran_from: Táto konzultácia prebiehala od
     respond_online: Odpovedať online

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -19,12 +19,14 @@ sl:
     share_links:
       share_this_page: Deli to stran
   consultation:
+    analysing_feedback:
     and: in
     another_website_html: To posvetovanje %{closed} poteka na <a href="%{url}">drugi spletni strani</a>
     at: na
     closes: Zapre se ob
     closes_at: To posvetovanje se zapre ob
     complete_a: 'Izpolnite '
+    concluded:
     description: Opis posvetovanja
     detail_of_feedback_received: Podrobnosti o povratnih informacijah
     detail_of_outcome: Podrobnosti o rezultatu
@@ -37,6 +39,7 @@ sl:
     not_open_yet: To posvetovanje še ni začeto
     'on':
     opens: Posvetovanje se začne
+    or:
     original_consultation: Izvirno posvetovanje
     ran_from: To posvetovanje je trajalo od
     respond_online: Odgovori na spletu

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -19,12 +19,14 @@ so:
     share_links:
       share_this_page: Lawadaag bogan
   consultation:
+    analysing_feedback:
     and: iyo
     another_website_html: Latalintan %{closed} held on <a href="%{url}">websaayt kale</a>
     at: ee
     closes: U dhaw goobta
     closes_at: Latalintan waxay aad ugu dhawdahay meesha
     complete_a: Dhamaystirka
+    concluded:
     description: Qoraalada latalinta
     detail_of_feedback_received: Faah-faahinta falcelinta la helay
     detail_of_outcome: Faah-faahinta maxsuulka
@@ -37,6 +39,7 @@ so:
     not_open_yet: Latalinta aan wali furnayn
     'on':
     opens: Latalintan waxay furantahay
+    or:
     original_consultation: Latalinta asalka ah
     ran_from: Latalinta waxay ka timid
     respond_online: Jawaab onlaayn ah

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -19,12 +19,14 @@ sq:
     share_links:
       share_this_page: Shpërdaj këtë faqe
   consultation:
+    analysing_feedback:
     and: dhe
     another_website_html: Ky konsultim %{closed} u mbajt <a href="%{url}">uebfaqe tjetër</a>
     at: në
     closes: Mbyllet në
     closes_at: Ky konsultim mbyllet në
     complete_a: Kompleto një
+    concluded:
     description: Përshkrimi i konsultimit
     detail_of_feedback_received: Detajet e reagimit të marrë
     detail_of_outcome: Detajet e rezultatit
@@ -37,6 +39,7 @@ sq:
     not_open_yet: Ky konsultim nuk është hapur ende
     'on':
     opens: Ky konsultim hapet
+    or:
     original_consultation: Konsultimi origjinal
     ran_from: Ky konsultim filloi nga
     respond_online: Përgjigju online

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -19,12 +19,14 @@ sr:
     share_links:
       share_this_page: Podeli ovu stranicu
   consultation:
+    analysing_feedback:
     and: i
     another_website_html: Ove konsultacije %{closed} se održavaju na <a href="%{url}">drugom veb-sajtu</a>
     at: u
     closes: Zatvara se u
     closes_at: Ove konsultacije se zatvaraju u
     complete_a: Popunite
+    concluded:
     description: Opis konsultacija
     detail_of_feedback_received: Detalj dobijenih povratnih informacija
     detail_of_outcome: Detalj ishoda
@@ -37,6 +39,7 @@ sr:
     not_open_yet: Ove konsultacije još nisu otvorene
     'on':
     opens: Ove konsultacije se otvaraju
+    or:
     original_consultation: Prvobitne konsultacije
     ran_from: Ove konsultacije se održavaju od
     respond_online: Odgovori onlajn

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -19,12 +19,14 @@ sv:
     share_links:
       share_this_page: Dela den här sidan
   consultation:
+    analysing_feedback:
     and: och
     another_website_html: Detta samråd %{closed} hölls på <a href="%{url}">en annan webbplats</a>
     at: kl
     closes: Det avslutas kl
     closes_at: Detta samråd avslutas på
     complete_a: Fyll i ett
+    concluded:
     description: Beskrivning av samrådet
     detail_of_feedback_received: Detaljerad information om den mottagna feedbacken
     detail_of_outcome: Detaljerad information om resultatet
@@ -37,6 +39,7 @@ sv:
     not_open_yet: Detta samråd är inte öppet ännu
     'on':
     opens: Detta samråd öppnas
+    or:
     original_consultation: Ursprungligt samråd
     ran_from: Detta samråd pågick från och med
     respond_online: Svara online

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -19,12 +19,14 @@ sw:
     share_links:
       share_this_page: Shiriki ukurasa huu
   consultation:
+    analysing_feedback:
     and: na
     another_website_html: Mashauriano haya %{closed} yalifanywa kwenye <a href="%{url}">tovuti nyingine</a>
     at: saa
     closes: Yatafungwa saa
     closes_at: Mashauriano haya yatafungwa saa
     complete_a: Jaza
+    concluded:
     description: Maelezo ya mashauriano
     detail_of_feedback_received: Maelezo ya maoni yamepokewa
     detail_of_outcome: Maelezo ya matokeo
@@ -37,6 +39,7 @@ sw:
     not_open_yet: Bado mashauriano haya hayajafunguliwa
     'on':
     opens: Mashauriano haya yatafunguliwa
+    or:
     original_consultation: Mashauriano halisi
     ran_from: Mashauriano haya yalifanywa kuanzia
     respond_online: Jibu mtandaoni

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -19,12 +19,14 @@ ta:
     share_links:
       share_this_page: இந்தப் பக்கத்தைப் பகிர்க
   consultation:
+    analysing_feedback:
     and: மற்றும்
     another_website_html: இந்தக் கலந்தாலோசனை %{closed} <a href="%{url}">வேறொரு இணையதளத்தில்</a>நடைபெற்றது
     at: "-இல்"
     closes: இது முடிவடைகிறது
     closes_at: இந்தக் கலந்தாலோசனை முடிவடைகிறது
     complete_a: கலந்தாலோசனை விளக்கத்தை
+    concluded:
     description: நிரப்பவும்
     detail_of_feedback_received: மதிப்புரை விபரம் பெறப்பட்டது
     detail_of_outcome: பயன் விபரம்
@@ -37,6 +39,7 @@ ta:
     not_open_yet: இந்தக் கலந்தாலோசனை இன்னும் திறக்கப்படவில்லை
     'on':
     opens: இந்தக் கலந்தாலோசனை திறக்கிறது
+    or:
     original_consultation: மூலக் கலந்தாலோசனை
     ran_from: "-லிருந்து இந்தக் கலந்தாலோசனை நடந்தது"
     respond_online: இணையத்தில் பதிலளிக்கவும்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -19,12 +19,14 @@ th:
     share_links:
       share_this_page: แชร์หน้านี้
   consultation:
+    analysing_feedback:
     and: และ
     another_website_html: การให้คำปรึกษา %{closed} นี้จัดขึ้นใน <a href="%{url}">เว็บไซต์อื่น</a>
     at: เมื่อ
     closes: ปิดเมื่อ
     closes_at: การให้คำปรึกษานี้ปิดเมื่อ
     complete_a: เสร็จสิ้น
+    concluded:
     description: คำอธิบายการให้คำปรึกษา
     detail_of_feedback_received: รายละเอียดของข้อเสนอแนะที่ได้รับ
     detail_of_outcome: รายละเอียดของผลลัพธ์
@@ -37,6 +39,7 @@ th:
     not_open_yet: ยังไม่เปิดการให้คำปรึกษา
     'on':
     opens: การให้คำปรึกษานี้เปิดแล้ว
+    or:
     original_consultation: การให้คำปรึกษาดั้งเดิม
     ran_from: การให้คำปรึกษานี้เริ่มจาก
     respond_online: ตอบกลับทางออนไลน์

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -19,12 +19,14 @@ tk:
     share_links:
       share_this_page: Bu sahypany paýlaşyň
   consultation:
+    analysing_feedback:
     and: we
     another_website_html: Bu maslahat %{closed} <a href="%{url}">başga websahypa</a> internet sahypasynda görkezilýär
     at: "-da"
     closes: Ol ýapylýar
     closes_at: Bu maslahat ýapylýar
     complete_a: Tamamlaň
+    concluded:
     description: Maslahat berişiň beýany
     detail_of_feedback_received: Alnan seslenmäniň jikme-jikleri
     detail_of_outcome: Netijeleriň jikme-jikleri
@@ -37,6 +39,7 @@ tk:
     not_open_yet: Bu maslahat beriş heniz açylmady
     'on':
     opens: Maslahat beriş açyldy
+    or:
     original_consultation: Hakyky maslahat beriş
     ran_from: Bu maslahat beriş dowam edýär
     respond_online: Onlaýn jogap bermek

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -19,12 +19,14 @@ tr:
     share_links:
       share_this_page: Bu sayfayı paylaş
   consultation:
+    analysing_feedback:
     and: ve
     another_website_html: Bu danışma %{closed} başka bir websitesinde<a href="%{url}">gerçekleşti</a>
     at: şurada
     closes: şurada kapanıyor
     closes_at: Bu danışma şurada kapanıyor
     complete_a: Bir danışma
+    concluded:
     description: Açıklaması tamamlayın
     detail_of_feedback_received: Alınan geri bildirimin ayrıntısı
     detail_of_outcome: Sonuç ayrıntısı
@@ -37,6 +39,7 @@ tr:
     not_open_yet: Bu danışma henüz açık değil
     'on':
     opens: Bu danışma açılıyor
+    or:
     original_consultation: Orijinal danışma
     ran_from: Bu danışma şuradan başladı
     respond_online: Çevrimiçi yanıtla

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -19,12 +19,14 @@ uk:
     share_links:
       share_this_page: Поділіться цією сторінкою
   consultation:
+    analysing_feedback:
     and: та
     another_website_html: Ця консультація %{closed} проведена на <a href="%{url}">іншому вебсайті</a>
     at: о
     closes: Вона завершиться о
     closes_at: Ця консультація завершиться о
     complete_a: Заповніть
+    concluded:
     description: Опис консультації
     detail_of_feedback_received: Деталі отриманого відгуку
     detail_of_outcome: Деталі результату
@@ -37,6 +39,7 @@ uk:
     not_open_yet: Ця консультація ще не розпочалася
     'on':
     opens: Ця консультація розпочинається
+    or:
     original_consultation: Первісна консультація
     ran_from: Ця консультація розпочалася з
     respond_online: Відповідати онлайн

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -19,12 +19,14 @@ ur:
     share_links:
       share_this_page: اس صفحے کو شیئر کریں
   consultation:
+    analysing_feedback:
     and: اور
     another_website_html: یہ مشاورت %{closed} <a href="%{url}">ایک اور ویب سائٹ پر ہوئی تھی</a>
     at: پر
     closes: یہ درج ذیل پر بند ہوتی ہے
     closes_at: یہ مشاورت درج ذیل پر بند ہوتی ہے
     complete_a: مکمل کریں
+    concluded:
     description: مشاورت کی تفصیل
     detail_of_feedback_received: وصول کردہ فیڈ بیک کی تفصیل
     detail_of_outcome: نتیجے کی تفصیل
@@ -37,6 +39,7 @@ ur:
     not_open_yet: یہ مشاورت ابھی تک کھلی نہیں ہے
     'on':
     opens: یہ مشاورت درج ذیل پر کھلتی ہے
+    or:
     original_consultation: اصل مشاورت
     ran_from: اس مشاورت میں درج ذیل ختم ہو گیا
     respond_online: آن لائن جواب دیں

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -19,12 +19,14 @@ uz:
     share_links:
       share_this_page: Саҳифа билан бўлишиш
   consultation:
+    analysing_feedback:
     and: ва
     another_website_html: Ушбу маслаҳат %{closed} бошқа <a href="%{url}"> веб-сайтда ўтказилди</a>
     at: да
     closes: да якунланади
     closes_at: Ушбу маслаҳат да якунланади
     complete_a: Якунлаш
+    concluded:
     description: Маслаҳат тавсифи
     detail_of_feedback_received: Батафсил шарҳ олинди
     detail_of_outcome: Натижалар бўйича батафсил маълумот
@@ -37,6 +39,7 @@ uz:
     not_open_yet: Маслаҳат ҳали бошланмади
     'on':
     opens: Маслаҳат бошланмоқда
+    or:
     original_consultation: Дастлабки маслаҳат
     ran_from: Ушбу маслаҳат дан ўтказилган
     respond_online: Онлайн жавоб бериш

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -19,12 +19,14 @@ vi:
     share_links:
       share_this_page: Chia sẻ trang này
   consultation:
+    analysing_feedback:
     and: và
     another_website_html: Buổi tham vấn này %{closed} được tổ chức trên <a href="%{url}">một trang web khác</a>
     at: lúc
     closes: Và kết thúc lúc
     closes_at: Buổi tham vấn này kết thúc lúc
     complete_a: Hoàn thành
+    concluded:
     description: Mô tả buổi tham vấn
     detail_of_feedback_received: Chi tiết phản hồi đã nhận được
     detail_of_outcome: Chi tiết kết quả
@@ -37,6 +39,7 @@ vi:
     not_open_yet: Buổi tham vấn này chưa mở
     'on':
     opens: Buổi tham vấn này đang diễn ra
+    or:
     original_consultation: Buổi tham vấn nguyên bản
     ran_from: Buổi tham vấn này bắt đầu từ
     respond_online: Trả lời trực tuyến

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -19,12 +19,14 @@ yi:
     share_links:
       share_this_page:
   consultation:
+    analysing_feedback:
     and:
     another_website_html:
     at:
     closes:
     closes_at:
     complete_a:
+    concluded:
     description:
     detail_of_feedback_received:
     detail_of_outcome:
@@ -37,6 +39,7 @@ yi:
     not_open_yet:
     'on':
     opens:
+    or:
     original_consultation:
     ran_from:
     respond_online:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -19,12 +19,14 @@ zh-hk:
     share_links:
       share_this_page: 轉載此一頁面
   consultation:
+    analysing_feedback:
     and: 及
     another_website_html: 本次諮詢 %{closed} 在 <a href="%{url}">另一網站舉行</a>
     at: 位於
     closes: 截止日期為
     closes_at: 本次諮詢結束於
     complete_a: 完成一項
+    concluded:
     description: 諮詢詳情
     detail_of_feedback_received: 已收到回饋意見之詳情
     detail_of_outcome: 結果詳情
@@ -37,6 +39,7 @@ zh-hk:
     not_open_yet: 諮詢仍未開始
     'on':
     opens: 本次諮詢開始
+    or:
     original_consultation: 原有諮詢
     ran_from: 本次諮詢開始於
     respond_online: 線上回覆

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -19,12 +19,14 @@ zh-tw:
     share_links:
       share_this_page: 分享此頁面
   consultation:
+    analysing_feedback:
     and: 以及
     another_website_html: 此諮詢 %{closed} 在 <a href="%{url}">另一個網站進</a>
     at: 在
     closes: 截止於
     closes_at: 此諮詢截止於
     complete_a: 完成
+    concluded:
     description: 諮詢說明
     detail_of_feedback_received: 收到的反饋詳情
     detail_of_outcome: 結果詳情
@@ -37,6 +39,7 @@ zh-tw:
     not_open_yet: 諮詢尚未開始
     'on':
     opens: 諮詢開始
+    or:
     original_consultation: 最初諮詢
     ran_from: 此諮詢從
     respond_online: 線上回覆

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -19,12 +19,14 @@ zh:
     share_links:
       share_this_page: 分享本页面
   consultation:
+    analysing_feedback:
     and: 和
     another_website_html: 本咨询 %{closed} 位于 <a href="%{url}">另一个网站</a>
     at: 在
     closes: 它的结束时间
     closes_at: 本咨询的结束时间
     complete_a: 完成
+    concluded:
     description: 咨询描述
     detail_of_feedback_received: 收到的反馈详情
     detail_of_outcome: 结果详情
@@ -37,6 +39,7 @@ zh:
     not_open_yet: 本咨询尚未开始
     'on':
     opens: 本咨询开始
+    or:
     original_consultation: 最初咨询
     ran_from: 本咨询的时间
     respond_online: 在线回复

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -111,14 +111,16 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders public feedback attachments (as-is and directly)" do
+  test "shows pre-rendered public feedback documents" do
     setup_and_visit_content_item("consultation_outcome_with_feedback")
 
     assert page.has_text?("Feedback received")
     within "#feedback-received" do
       assert page.has_text?("Analysis of responses to our consultation on setting the grade standards of new GCSEs in England – part 2")
     end
+  end
 
+  test "renders public feedback document attachments" do
     setup_and_visit_content_item("consultation_outcome_with_featured_attachments")
 
     assert page.has_text?("Feedback received")


### PR DESCRIPTION
This PR originates from feedback provided on https://github.com/alphagov/government-frontend/pull/2828, which replicated behaviour from the consultation template that could be improved. I intend to rebase that PR on top of these changes

This PR addresses a number of issues with the consultation content item template:

- Usage of hardcoded text instead of locale strings
- Unnecessary usage of "raw" function
- Unnecessary instance variable capture
- A confusing test that tested both pre-rendered feedback documents and feedback documents provided as attachments
