### PR TITLE
Consultation presenter improvements

### DIFF
--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -53,19 +53,19 @@ class ConsultationPresenter < ContentItemPresenter
   end
 
   def final_outcome_documents
-    content_item["details"]["final_outcome_documents"].to_a.join("")
+    content_item["details"]["final_outcome_documents"]&.join("")
   end
 
   def final_outcome_attachments
-    content_item["details"]["final_outcome_attachments"].to_a
+    content_item["details"]["final_outcome_attachments"]
   end
 
   def public_feedback_documents
-    content_item["details"]["public_feedback_documents"].to_a.join("")
+    content_item["details"]["public_feedback_documents"]&.join("")
   end
 
   def public_feedback_attachments
-    content_item["details"]["public_feedback_attachments"].to_a
+    content_item["details"]["public_feedback_attachments"] || []
   end
 
   def public_feedback_detail
@@ -73,7 +73,7 @@ class ConsultationPresenter < ContentItemPresenter
   end
 
   def held_on_another_website?
-    content_item["details"].include?("held_on_another_website_url")
+    held_on_another_website_url.present?
   end
 
   def held_on_another_website_url
@@ -81,11 +81,11 @@ class ConsultationPresenter < ContentItemPresenter
   end
 
   def documents
-    content_item["details"]["documents"].to_a.join("")
+    content_item["details"]["documents"]&.join("")
   end
 
   def featured_attachments
-    content_item["details"]["featured_attachments"].to_a
+    content_item["details"]["featured_attachments"]
   end
 
   def ways_to_respond?

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -63,24 +63,27 @@ class ConsultationPresenterTest
     end
 
     test "presents consultation documents" do
-      presented = presented_item("closed_consultation")
       schema = schema_item("closed_consultation")
+      schema["details"]["documents"] = %W[<section>\n<p>a</p>\n</section> <section>\n<p>b</p>\n</section> <section>\n<p>c</p>\n</section>]
+      presented = presented_item("closed_consultation", schema)
 
-      assert_equal schema["details"]["documents"].join(""), presented.documents
+      assert_equal "<section>\n<p>a</p>\n</section><section>\n<p>b</p>\n</section><section>\n<p>c</p>\n</section>", presented.documents
     end
 
     test "presents final outcome documents" do
-      presented = presented_item("consultation_outcome")
       schema = schema_item("consultation_outcome")
+      schema["details"]["final_outcome_documents"] = %W[<section>\n<p>a</p>\n</section> <section>\n<p>b</p>\n</section> <section>\n<p>c</p>\n</section>]
+      presented = presented_item("consultation_outcome", schema)
 
-      assert_equal schema["details"]["final_outcome_documents"].join(""), presented.final_outcome_documents
+      assert_equal "<section>\n<p>a</p>\n</section><section>\n<p>b</p>\n</section><section>\n<p>c</p>\n</section>", presented.final_outcome_documents
     end
 
     test "presents public feedback documents" do
-      presented = presented_item("consultation_outcome_with_feedback")
       schema = schema_item("consultation_outcome_with_feedback")
+      schema["details"]["public_feedback_documents"] = %W[<section>\n<p>a</p>\n</section> <section>\n<p>b</p>\n</section> <section>\n<p>c</p>\n</section>]
+      presented = presented_item("consultation_outcome_with_feedback", schema)
 
-      assert_equal schema["details"]["public_feedback_documents"].join(""), presented.public_feedback_documents
+      assert_equal "<section>\n<p>a</p>\n</section><section>\n<p>b</p>\n</section><section>\n<p>c</p>\n</section>", presented.public_feedback_documents
     end
 
     test "presents URL for consultations held on another website" do


### PR DESCRIPTION
This PR originates from feedback provided on https://github.com/alphagov/government-frontend/pull/2828, which duplicated behaviour from the consultation presenter. I intend to rebase that PR on top of these changes

This PR addresses several issues with the consultation presenter:

- Use of `to_a` to handle possible nil values, rather than handling them explicitly
- Readability improvements to `held_on_another_website?`
- Ensure that we are testing the interface rather than the implementation of document pre-rendering methods
