### PR TITLE
Fix styling for external links in attachment metadata

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,3 +54,11 @@ $govuk-include-default-font-face: false;
     text-align: start;
   }
 }
+
+// TEMP: Fix metadata styling issue for attachments with external links
+.gem-c-attachment__metadata {
+  span.gem-c-attachment__attribute {
+    word-break: break-word;
+    word-wrap: break-word;
+  }
+}


### PR DESCRIPTION
## What
Fixes a styling issue where long strings of text for external links do not wrap onto a new line.

## Why
The long string of text was not contained and overlapped with other elements on the page.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
