### PR TITLE
Update Pashto language name

### DIFF
--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -402,7 +402,7 @@ ps:
     pa:
     pa-pk:
     pl:
-    ps: جرمني
+    ps: پښتو
     pt:
     ro:
     ru:


### PR DESCRIPTION
- incorrectly had the pashto word for German instead of Pashto

https://govuk.zendesk.com/agent/tickets/5410354

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
