### PR TITLE
Move single page notification button tracking code

### DIFF
--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -14,21 +14,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo', content_item: @content_item %>
-<%= render 'shared/single_page_notification_button',
-  content_item: @content_item,
-  ga4_data_attributes: {
-    module: "ga4-link-tracker",
-    ga4_link: {
-      event_name: "navigation",
-      type: "subscribe",
-      index: {
-        index_link: 1
-      },
-      index_total: 2,
-      section: "Top"
-    }
-  }
-%>
+<%= render 'shared/single_page_notification_button', content_item: @content_item %>
 
 <%= render 'shared/history_notice', content_item: @content_item %>
 <% if @content_item.withdrawn? %>

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -68,22 +68,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
-<%= render 'shared/single_page_notification_button',
-  content_item: @content_item,
-  ga4_data_attributes: {
-    module: "ga4-link-tracker",
-    ga4_link: {
-      event_name: "navigation",
-      type: "subscribe",
-      index: {
-        index_link: 1
-      },
-      index_total: 2,
-      section: "Top"
-    }
-  }
-%>
-
+<%= render 'shared/single_page_notification_button', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 <% if @content_item.withdrawn? %>
   <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -31,22 +31,7 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
-<%= render 'shared/single_page_notification_button',
-  content_item: @content_item,
-  ga4_data_attributes: {
-    module: "ga4-link-tracker",
-    ga4_link: {
-      event_name: "navigation",
-      type: "subscribe",
-      index: {
-        index_link: 1
-      },
-      index_total: 2,
-      section: "Top"
-    }
-  }
-%>
-
+<%= render 'shared/single_page_notification_button', content_item: @content_item %>
 <%= render 'shared/history_notice', content_item: @content_item %>
 
 <% if @content_item.withdrawn? %>

--- a/app/views/shared/_single_page_notification_button.html.erb
+++ b/app/views/shared/_single_page_notification_button.html.erb
@@ -1,7 +1,24 @@
+<%
+  default_ga4_data_attributes = {
+    module: "ga4-link-tracker",
+    ga4_link: {
+      event_name: "navigation",
+      type: "subscribe",
+      index: {
+        index_link: 1
+      },
+      index_total: 2,
+      section: "Top"
+    }
+  }
+%>
+
+<% ga4_data_attributes = ga4_data_attributes || default_ga4_data_attributes %>
+
 <%= render 'govuk_publishing_components/components/single_page_notification_button', {
   base_path: @content_item.base_path,
   js_enhancement: @has_govuk_account,
-  ga4_data_attributes: ga4_data_attributes ||= nil,
+  ga4_data_attributes: ga4_data_attributes,
   margin_bottom: 6,
   button_location: "top",
 } if @content_item.has_single_page_notifications? %>

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -162,6 +162,16 @@ class ConsultationTest < ActionDispatch::IntegrationTest
   test "renders with the single page notification button" do
     setup_and_visit_content_item("open_consultation")
     assert page.has_css?(".gem-c-single-page-notification-button")
+
+    buttons = page.find_all(:button)
+
+    expected_tracking_top = single_page_notification_button_ga_tracking(1, "Top")
+    actual_tracking_top = JSON.parse(buttons.first["data-ga4-link"])
+    assert_equal expected_tracking_top, actual_tracking_top
+
+    expected_tracking_bottom = single_page_notification_button_ga_tracking(2, "Footer")
+    actual_tracking_bottom = JSON.parse(buttons.last["data-ga4-link"])
+    assert_equal expected_tracking_bottom, actual_tracking_bottom
   end
 
   test "does not render the single page notification button on exempt pages" do

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -90,6 +90,16 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
   test "renders with the single page notification button" do
     setup_and_visit_content_item("detailed_guide")
     assert page.has_css?(".gem-c-single-page-notification-button")
+
+    buttons = page.find_all(:button)
+
+    expected_tracking_top = single_page_notification_button_ga_tracking(1, "Top")
+    actual_tracking_top = JSON.parse(buttons.first["data-ga4-link"])
+    assert_equal expected_tracking_top, actual_tracking_top
+
+    expected_tracking_bottom = single_page_notification_button_ga_tracking(2, "Footer")
+    actual_tracking_bottom = JSON.parse(buttons.last["data-ga4-link"])
+    assert_equal expected_tracking_bottom, actual_tracking_bottom
   end
 
   test "does not render the single page notification button on exempt pages" do

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -95,6 +95,16 @@ class PublicationTest < ActionDispatch::IntegrationTest
   test "renders with the single page notification button" do
     setup_and_visit_content_item("publication")
     assert page.has_css?(".gem-c-single-page-notification-button")
+
+    buttons = page.find_all(:button)
+
+    expected_tracking_top = single_page_notification_button_ga_tracking(1, "Top")
+    actual_tracking_top = JSON.parse(buttons.first["data-ga4-link"])
+    assert_equal expected_tracking_top, actual_tracking_top
+
+    expected_tracking_bottom = single_page_notification_button_ga_tracking(2, "Footer")
+    actual_tracking_bottom = JSON.parse(buttons.last["data-ga4-link"])
+    assert_equal expected_tracking_bottom, actual_tracking_bottom
   end
 
   test "does not render the single page notification button on exempt pages" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -268,4 +268,15 @@ class ActionDispatch::IntegrationTest
 
     schemas.detect { |schema| schema["@type"] == schema_name }
   end
+
+  def single_page_notification_button_ga_tracking(index_link, section)
+    {
+      "event_name" => "navigation",
+      "type" => "subscribe",
+      "index" => { "index_link" => index_link },
+      "index_total" => 2,
+      "section" => section,
+      "url" => "/email/subscriptions/single-page/new",
+    }
+  end
 end


### PR DESCRIPTION
Small refactor of the code added https://github.com/alphagov/government-frontend/pull/2818 with additional test coverage.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
