### PR TITLE
Add scroll tracking to guide pages

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -21,12 +21,22 @@
       "/apply-to-come-to-the-uk",
     ]
 
+    ga4_scroll_track_headings_paths = [
+      "/skilled-worker-visa/your-partner-and-children",
+      "/penalty-points-endorsements/endorsement-codes-and-penalty-points",
+      "/universal-credit/other-financial-support",
+    ]
+
     full_url = [@content_item.base_path, @content_item.part_slug].compact.join('/')
   %>
   <% if scroll_track_headings_paths.include?(full_url) %>
     <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker" data-track-type="headings"/>
   <% elsif scroll_track_percent_paths.include?(@content_item.base_path) %>
     <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker"/>
+  <% end %>
+
+  <% if ga4_scroll_track_headings_paths.include?(full_url) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker" data-ga4-track-type="headings"/>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds heading scroll tracking to the following guide pages:

- https://www.gov.uk/skilled-worker-visa/your-partner-and-children
- https://www.gov.uk/penalty-points-endorsements/endorsement-codes-and-penalty-points
- https://www.gov.uk/universal-credit/other-financial-support

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/Revzr3iF/611-scroll-tracking-heading-type-guidance
