### PR TITLE
Add GA4 event tracker to service manual guide

### DIFF
--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -110,6 +110,9 @@
               data-controls="full-history"
               data-toggled-text="- Hide all page updates (<%= @content_item.previous_changes.length %>)"
               data-expanded="false"
+              data-module="ga4-event-tracker"
+              data-ga4-event="<%= {event_name: "select_content", type: "content", section: "Footer"}.to_json %>"
+              data-ga4-expandable
               role="button"
               aria-controls="full-history"
               aria-expanded="false"


### PR DESCRIPTION
## What
- Adds the GA4 event tracker to this page's "+ Show all page updates (3)" element: http://127.0.0.1:3090/service-manual/design/introduction-designing-government-services

<img width="339" alt="image" src="https://github.com/alphagov/government-frontend/assets/8880610/c2108d2a-70e9-4aa9-a20c-b169374cbdb5">


## Why
- It was missed while adding GA4 tracking to content navigation
- Trello card: https://trello.com/c/C9M2EJQu/553-content-navigation-chapter-headings-next-previous-view-a-printable-version-navigation-and-show-hide-updates-interaction#comment-64c3b662087abc05326982a8
- This is an example of a page with this tracking already on it https://www.gov.uk/guidance/cost-of-living-payment

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
