### PR TITLE
Fix Related content section

### DIFF
--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -72,6 +72,7 @@
           }.to_json %>"><%= t("multi_page.print_entire_guide") %></a>
       </div>
   <% end %>
+  </div>
   <%= render 'shared/sidebar_navigation' %>
 </div>
 


### PR DESCRIPTION
Missing a closing div tag for some reason.

There is also an issue with header spacing which we'll address in another PR as that's a wider issue.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Before

<img width="1134" alt="Screenshot 2023-08-03 at 3 37 53 pm" src="https://github.com/alphagov/government-frontend/assets/424772/ddafeb47-7d4d-4977-af9f-a81995173cca">

## After

<img width="1134" alt="Screenshot 2023-08-03 at 3 37 58 pm" src="https://github.com/alphagov/government-frontend/assets/424772/50be00c4-a327-4ad1-9c87-ca1b8f2023fb">
