### PR TITLE
Fix misaligned heading and related contents

### DIFF
--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -6,7 +6,7 @@
 
     @include govuk-media-query($from: tablet) {
       margin-top: 0;
-      padding-bottom: govuk-spacing(3);
+      margin-bottom: 0;
     }
 
     border-bottom: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -4,10 +4,6 @@
 .travel-advice {
   @include parts;
 
-  .part-navigation-container {
-    margin-bottom: 0;
-  }
-
   .part-navigation {
     margin-bottom: govuk-spacing(8);
   }

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -63,7 +63,7 @@
     <% end %>
   </div>
 
-  <div class="govuk-grid-column-two-thirds" id="guide-contents">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6" id="guide-contents">
     <% if @content_item.has_parts? %>
       <% if @content_item.show_guide_navigation? %>
         <%= render 'govuk_publishing_components/components/heading', heading_level: 1, font_size: 'l', margin_bottom: 6, text: @content_item.current_part_title %>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -35,7 +35,7 @@
 
 <div class="govuk-grid-row">
   <% unless @content_item.parts.empty? %>
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
       <%= render 'govuk_publishing_components/components/heading', heading_level: 1, font_size: 'l', margin_bottom: 6, text: @content_item.current_part_title %>
       
       <% if @content_item.no_part_slug_provided? %>


### PR DESCRIPTION
Adjustments in previous commits #2837 and #2840 did not account for simultaneously aligning the grey border with the blue border of the related content, and providing space above the secondary heading. This small fix ensures that both columns line up correctly and that the secondary heading can breathe.

Note that this is a quick fix and further work should be done on these pages to consolidate the template.

See Trello for more info:

https://trello.com/c/H9MfuTul/1916-consolidate-traveladvice-and-guide-pages-in-governmentfrontend-l

## BEFORE (TRAVEL GUIDANCE)

![image](https://github.com/alphagov/government-frontend/assets/2166204/9a4dd15c-6d07-47c8-90bb-c4929ebe3479)

## AFTER (TRAVEL GUIDANCE)

![image](https://github.com/alphagov/government-frontend/assets/2166204/1c7cd1ae-9b18-4850-9799-c591b429a3d6)

## BEFORE (GUIDE)

![image](https://github.com/alphagov/government-frontend/assets/2166204/41a7d636-ffb8-4ada-a35b-16d1e74b8f69)

## AFTER (GUIDE)

![image](https://github.com/alphagov/government-frontend/assets/2166204/83ed4cbe-705b-4662-83ac-6e3e975f697b)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
