### PR TITLE
Add spacing to WorldWideOrganisation descriptions

### DIFF
--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -51,7 +51,7 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
       href: person["web_url"],
       image_url: person["details"]["image"]["url"],
       image_alt: person["details"]["image"]["alt_text"],
-      description: current_roles.map { |role_app| role_app.dig("links", "role").first["title"] }.join,
+      description: current_roles.map { |role_app| role_app.dig("links", "role").first["title"] }.join(", "),
     }
   end
 
@@ -67,7 +67,7 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
       {
         name: person["title"],
         href: person["web_url"],
-        description: current_roles.map { |role_app| role_app.dig("links", "role").first["title"] }.join,
+        description: current_roles.map { |role_app| role_app.dig("links", "role").first["title"] }.join(", "),
       }
     end
   end

--- a/test/presenters/worldwide_organisation_presenter_test.rb
+++ b/test/presenters/worldwide_organisation_presenter_test.rb
@@ -5,6 +5,16 @@ class WorldwideOrganisationPresenterTest < PresenterTestCase
     "worldwide_organisation"
   end
 
+  test "description of primary_role_person should have spaces between roles" do
+    presenter = create_presenter(WorldwideOrganisationPresenter, content_item: { "links" => { "primary_role_person" => [{ "details" => { "image" => {} }, "links" => { "role_appointments" => [{ "details" => { "current" => true }, "links" => { "role" => [{ "title" => "Example Role 1" }] } }, { "details" => { "current" => true }, "links" => { "role" => [{ "title" => "Example Role 2" }] } }] } }] } })
+    assert_equal "Example Role 1, Example Role 2", presenter.person_in_primary_role[:description]
+  end
+
+  test "description of people_in_non_primary_roles should have spaces between roles" do
+    presenter = create_presenter(WorldwideOrganisationPresenter, content_item: { "links" => { "secondary_role_person" => [{ "details" => { "image" => {} }, "links" => { "role_appointments" => [{ "details" => { "current" => true }, "links" => { "role" => [{ "title" => "Example Role 1" }] } }, { "details" => { "current" => true }, "links" => { "role" => [{ "title" => "Example Role 2" }] } }] } }] } })
+    assert_equal "Example Role 1, Example Role 2", presenter.people_in_non_primary_roles.first[:description]
+  end
+
   test "#title returns the title" do
     assert_equal schema_item["title"], presented_item.title
   end


### PR DESCRIPTION
## What

Adds ", " to a join on the roles of a person in the WorldWideOrganisationPresenter. Adds test cases for spaces being present between roles in the description.

## Why

Fixes an issue where the description of people that was being generated by the WorldWideOrganisationPresenter was not adding spacing between multiple roles. Issue raised in a ticket on Zendesk.

## Visual Differences

### Before

![Screenshot 2023-08-08 at 12 22 49](https://github.com/alphagov/government-frontend/assets/3727504/1f222c88-96a6-403d-a0e9-9905762565d8)

### After

![Screenshot 2023-08-08 at 12 23 36](https://github.com/alphagov/government-frontend/assets/3727504/99ca8feb-81ea-4057-a578-07cef2019fb9)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
