### PR TITLE
Enable taxonomy email signup for document collection

### DIFF
--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -63,6 +63,10 @@ class DocumentCollectionPresenter < ContentItemPresenter
     )
   end
 
+  def taxonomy_topic_email_override_base_path
+    content_item.dig("links", "taxonomy_topic_email_override", 0, "base_path")
+  end
+
 private
 
   def group_documents(group)

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -22,7 +22,11 @@
 </div>
 
 <%= render 'shared/publisher_metadata_with_logo' %>
-<%= render 'shared/single_page_notification_button', content_item: @content_item, skip_account: "true" %>
+<% if @content_item.taxonomy_topic_email_override_base_path.present? %>
+  <%= render 'shared/taxon_signup_link', base_path: @content_item.taxonomy_topic_email_override_base_path %>
+<% else %>
+  <%= render 'shared/single_page_notification_button', content_item: @content_item %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/shared/_taxon_signup_link.html.erb
+++ b/app/views/shared/_taxon_signup_link.html.erb
@@ -1,0 +1,17 @@
+<div
+  data-module="ga4-link-tracker"
+  data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Top" }'
+  data-ga4-track-links-only
+>
+  <%= render "govuk_publishing_components/components/signup_link", {
+    link_text: "Get emails about this topic",
+    link_href: "/email-signup/?link=#{base_path}",
+    data: {
+      "module": "gem-track-click",
+      "track-category": "emailAlertLinkClicked",
+      "track-action": base_path,
+      "track-label": ""
+    },
+    margin_bottom: 6
+  } %>
+</div>

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -158,4 +158,10 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item("document_collection")
     assert page.has_css?(".gem-c-single-page-notification-button")
   end
+
+  test "renders with the taxonomy subscription button" do
+    setup_and_visit_content_item_with_taxonomy_topic_email_override("document_collection")
+    assert page.has_css?(".gem-c-signup-link")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -195,6 +195,16 @@ class ActionDispatch::IntegrationTest
     end
   end
 
+  def setup_and_visit_content_item_with_taxonomy_topic_email_override(name)
+    @content_item = get_content_example(name).tap do |item|
+      item["links"]["taxonomy_topic_email_override"] = [{
+        "base_path": "test",
+      }]
+      stub_content_store_has_item(item["base_path"], item.to_json)
+      visit_with_cachebust(item["base_path"])
+    end
+  end
+
   def setup_and_visit_notification_exempt_page(name)
     @content_item = get_content_example(name).tap do |item|
       item["content_id"] = ContentItem::SinglePageNotificationButton::EXEMPTION_LIST[0]


### PR DESCRIPTION
Allow users to sign up to a mapped taxonomy topic email subscription from some document collection pages if `taxonomy_topic_email_override` is present.

Trello card: https://trello.com/c/uvbb9UYR/1893-document-collection-template-uses-different-email-signup-component-if-taxonomytopicemailoverride-is-present-l

Without `taxonomy_topic_email_override` 
<img width="802" alt="Screenshot 2023-08-23 at 15 25 33" src="https://github.com/alphagov/government-frontend/assets/96050928/d5a18c77-1454-461d-8fe2-bf5b56851a54">

With `taxonomy_topic_email_override`
<img width="817" alt="Screenshot 2023-08-23 at 16 23 47" src="https://github.com/alphagov/government-frontend/assets/96050928/1d5945c6-2245-4d0e-a1b6-78aeb3a6825a">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
