### PR TITLE
Add tracking for email subscriptions completion

### DIFF
--- a/app/helpers/content_items_helper.rb
+++ b/app/helpers/content_items_helper.rb
@@ -1,11 +1,11 @@
 module ContentItemsHelper
-  def email_subscription_success_banner_heading(account_flash)
+  def email_subscription_success_banner_heading(account_flash, locale = nil)
     if account_flash.include?("email-subscription-success")
-      sanitize(t("email.subscribe_title"))
+      sanitize(t("email.subscribe_title", locale:))
     elsif account_flash.include?("email-unsubscribe-success")
-      sanitize(t("email.unsubscribe_title"))
+      sanitize(t("email.unsubscribe_title", locale:))
     elsif account_flash.include?("email-subscription-already-subscribed")
-      sanitize(t("email.already_subscribed_title"))
+      sanitize(t("email.already_subscribed_title", locale:))
     end
   end
 

--- a/app/views/content_items/call_for_evidence.html.erb
+++ b/app/views/content_items/call_for_evidence.html.erb
@@ -4,7 +4,7 @@
   ) %>
 <% end %>
 
-<%= render 'shared/email_subscribe_unsubscribe_flash' %>
+<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title_and_context[:title] } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -4,7 +4,7 @@
   ) %>
 <% end %>
 
-<%= render 'shared/email_subscribe_unsubscribe_flash' %>
+<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title_and_context[:title] } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -55,7 +55,7 @@
   <% end %>
 <% end %>
 
-<%= render 'shared/email_subscribe_unsubscribe_flash' %>
+<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title_and_context[:title] } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -13,7 +13,7 @@
   <% end %>
 <% end %>
 
-<%= render 'shared/email_subscribe_unsubscribe_flash' %>
+<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
+++ b/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
@@ -5,11 +5,27 @@
 <% if show_email_subscription_success_banner?(@account_flash) %>
   <div class="govuk-grid-row govuk-!-margin-top-3">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/success_alert", {
-        message: email_subscription_success_banner_heading(@account_flash),
-        description: banner_description,
-        margin_bottom: 0,
-      } %>
+      <%
+        ga4_data = {
+          event_name: "form_complete",
+          type: "email subscription",
+          text: email_subscription_success_banner_heading(@account_flash, :en),
+          section: local_assigns[:title],
+          action: "complete",
+          tool_name: "Get emails from GOV.UK"
+        }.to_json
+      %>
+      <%= content_tag(:div,
+        data: {
+          module: "ga4-auto-tracker",
+          ga4_auto: ga4_data
+        }) do %>
+        <%= render "govuk_publishing_components/components/success_alert", {
+          message: email_subscription_success_banner_heading(@account_flash),
+          description: banner_description,
+          margin_bottom: 0,
+        } %>
+      <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds GA4 tracking for notifications about subscribing/unsubscribing to emails about some pages, specifically:
- [detailed guides](https://www.gov.uk/guidance/cost-of-living-payment)
- call for evidence
- consultation
- [publications](https://www.gov.uk/government/publications/form-pa14-medical-certificate-probate)

These events are generated using the auto tracker, with attributes in the notification, so it should only fire when the notification is visible.

Detailed guide with the notification looks like this:

![Screenshot 2023-08-17 at 09 27 01](https://github.com/alphagov/government-frontend/assets/861310/a3a4ee11-5b1b-4376-bd8e-eadea5a8f6a8)


## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/TXQOqtZ0/628-email-subscriptions-manage-subscriptions-sign-in-change-unsubscribe-forms
