### PR TITLE
Filter people roles by organisation

### DIFF
--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -51,7 +51,7 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
       href: person["web_url"],
       image_url: person["details"]["image"]["url"],
       image_alt: person["details"]["image"]["alt_text"],
-      description: current_roles.map { |role_app| role_app.dig("links", "role").first["title"] }.join(", "),
+      description: organisation_roles_for(current_roles),
     }
   end
 
@@ -67,7 +67,7 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
       {
         name: person["title"],
         href: person["web_url"],
-        description: current_roles.map { |role_app| role_app.dig("links", "role").first["title"] }.join(", "),
+        description: organisation_roles_for(current_roles),
       }
     end
   end
@@ -123,6 +123,18 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
   end
 
 private
+
+  def organisation_roles_for(current_appointments)
+    current_appointments
+      .map { |role_appointment| role_appointment.dig("links", "role").first }
+      .select { |role| organisation_role_ids.include?(role["content_id"]) }
+      .map { |role| role["title"] }
+      .compact.join(", ")
+  end
+
+  def organisation_role_ids
+    content_item.dig("links", "roles")&.map { |role| role["content_id"] } || []
+  end
 
   def world_locations
     content_item.dig("links", "world_locations") || []

--- a/test/presenters/worldwide_organisation_presenter_test.rb
+++ b/test/presenters/worldwide_organisation_presenter_test.rb
@@ -6,13 +6,23 @@ class WorldwideOrganisationPresenterTest < PresenterTestCase
   end
 
   test "description of primary_role_person should have spaces between roles" do
-    presenter = create_presenter(WorldwideOrganisationPresenter, content_item: { "links" => { "primary_role_person" => [{ "details" => { "image" => {} }, "links" => { "role_appointments" => [{ "details" => { "current" => true }, "links" => { "role" => [{ "title" => "Example Role 1" }] } }, { "details" => { "current" => true }, "links" => { "role" => [{ "title" => "Example Role 2" }] } }] } }] } })
+    presenter = create_presenter(WorldwideOrganisationPresenter, content_item: { "links" => { "primary_role_person" => [{ "details" => { "image" => {} }, "links" => { "role_appointments" => [{ "details" => { "current" => true }, "links" => { "role" => [{ "content_id" => "1", "title" => "Example Role 1" }] } }, { "details" => { "current" => true }, "links" => { "role" => [{ "content_id" => "2", "title" => "Example Role 2" }] } }] } }], "roles" => [{ "content_id" => "1" }, { "content_id" => "2" }] } })
     assert_equal "Example Role 1, Example Role 2", presenter.person_in_primary_role[:description]
   end
 
+  test "description of primary_role_person should only show roles that are associated with the organisation" do
+    presenter = create_presenter(WorldwideOrganisationPresenter, content_item: { "links" => { "primary_role_person" => [{ "details" => { "image" => {} }, "links" => { "role_appointments" => [{ "details" => { "current" => true }, "links" => { "role" => [{ "content_id" => "1", "title" => "Example Role 1" }] } }, { "details" => { "current" => true }, "links" => { "role" => [{ "content_id" => "2", "title" => "Example Role 2" }] } }] } }], "roles" => [{ "content_id" => "1" }] } })
+    assert_equal "Example Role 1", presenter.person_in_primary_role[:description]
+  end
+
   test "description of people_in_non_primary_roles should have spaces between roles" do
-    presenter = create_presenter(WorldwideOrganisationPresenter, content_item: { "links" => { "secondary_role_person" => [{ "details" => { "image" => {} }, "links" => { "role_appointments" => [{ "details" => { "current" => true }, "links" => { "role" => [{ "title" => "Example Role 1" }] } }, { "details" => { "current" => true }, "links" => { "role" => [{ "title" => "Example Role 2" }] } }] } }] } })
+    presenter = create_presenter(WorldwideOrganisationPresenter, content_item: { "links" => { "secondary_role_person" => [{ "details" => { "image" => {} }, "links" => { "role_appointments" => [{ "details" => { "current" => true }, "links" => { "role" => [{ "content_id" => "1", "title" => "Example Role 1" }] } }, { "details" => { "current" => true }, "links" => { "role" => [{ "content_id" => "2", "title" => "Example Role 2" }] } }] } }], "roles" => [{ "content_id" => "1" }, { "content_id" => "2" }] } })
     assert_equal "Example Role 1, Example Role 2", presenter.people_in_non_primary_roles.first[:description]
+  end
+
+  test "description of people_in_non_primary_roles should only show roles that are associated with the organisation" do
+    presenter = create_presenter(WorldwideOrganisationPresenter, content_item: { "links" => { "secondary_role_person" => [{ "details" => { "image" => {} }, "links" => { "role_appointments" => [{ "details" => { "current" => true }, "links" => { "role" => [{ "content_id" => "1", "title" => "Example Role 1" }] } }, { "details" => { "current" => true }, "links" => { "role" => [{ "content_id" => "2", "title" => "Example Role 2" }] } }] } }], "roles" => [{ "content_id" => "1" }] } })
+    assert_equal "Example Role 1", presenter.people_in_non_primary_roles.first[:description]
   end
 
   test "#title returns the title" do


### PR DESCRIPTION
> [!WARNING]  
> 🚨 Do not merge! 🚨 
> Depends on https://github.com/alphagov/whitehall/pull/8162 being merged and all worldwide organisations being republished

https://trello.com/c/54I3mDxr

People linked to a worldwide organisation may have multiple roles, some of which are related to other organsaitions. Currently, we are incorrectly displaying these roles on the world wide organisation pages.

This copies the approach taken in alphagov/collections#1719. We link to all roles from the worldwide organisation, then filter out the incorrect ones in the rendering app.

See also https://github.com/alphagov/publishing-api/pull/2478 and https://github.com/alphagov/whitehall/pull/8162.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
