### PR TITLE
[PRODUCTION CONFIG] Update Webchat urls for HMPO contact page 

### DIFF
--- a/lib/webchat.yaml
+++ b/lib/webchat.yaml
@@ -1,5 +1,5 @@
 - base_path: /government/organisations/hm-passport-office/contact/hm-passport-office-webchat
-  open_url: https://omni.eckoh.uk/v03.5/launcherV3.php?p=HMPO&d=717&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Chat&s=https://omni.eckoh.uk/v03.5&u=&wo=&uh=&pid=2&iif=0
-  availability_url: https://omni.eckoh.uk/v03.5/providers/HMPO/api/availability.php
-  csp_connect_src: https://omni.eckoh.uk
+  open_url: https://d1y02qp19gjy8q.cloudfront.net/open/index.html
+  availability_url: https://d1y02qp19gjy8q.cloudfront.net/availability/18555309
+  csp_connect_src: https://d1y02qp19gjy8q.cloudfront.net
   open_url_redirect: false


### PR DESCRIPTION
**To be deployed: 06/09/2023**

The urls provided are for the production environment. We used test URLs in [1].

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5053254

Trello Card: https://trello.com/c/qkzOuOJc/2155-help-hmpo-set-up-new-webchat-provider

[1]: https://github.com/alphagov/government-frontend/pull/2579

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
