### PR TITLE
Enable GA4 tracking on the phase & devolved nations banners

### DIFF
--- a/app/helpers/service_manual_phase_label_helper.rb
+++ b/app/helpers/service_manual_phase_label_helper.rb
@@ -3,6 +3,7 @@ module ServiceManualPhaseLabelHelper
     if presented_object.respond_to?(:phase) && %w[alpha beta].include?(presented_object.phase)
       render "govuk_publishing_components/components/phase_banner",
              phase: presented_object.phase,
+             ga4_tracking: true,
              message:
     end
   end

--- a/app/views/content_items/call_for_evidence.html.erb
+++ b/app/views/content_items/call_for_evidence.html.erb
@@ -24,7 +24,8 @@
     <% if @content_item.national_applicability.present? %>
       <%= render "govuk_publishing_components/components/devolved_nations", {
         national_applicability: @content_item.national_applicability,
-        type: @content_item.schema_name
+        type: @content_item.schema_name,
+        ga4_tracking: true,
       } %>
     <% end %>
 

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -25,7 +25,8 @@
     <% if @content_item.national_applicability.present? %>
       <%= render "govuk_publishing_components/components/devolved_nations", {
         national_applicability: @content_item.national_applicability,
-        type: @content_item.schema_name
+        type: @content_item.schema_name,
+        ga4_tracking: true,
       } %>
     <% end %>
 

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -78,7 +78,8 @@
     <% if @content_item.national_applicability.present? %>
       <%= render "govuk_publishing_components/components/devolved_nations", {
         national_applicability: @content_item.national_applicability,
-        type: @content_item.schema_name
+        type: @content_item.schema_name,
+        ga4_tracking: true,
       } %>
     <% end %>
 

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -50,7 +50,8 @@
 <% if @content_item.national_applicability.present? %>
   <%= render "govuk_publishing_components/components/devolved_nations", {
     national_applicability: @content_item.national_applicability,
-    type: @content_item.schema_name
+    type: @content_item.schema_name,
+    ga4_tracking: true,
   } %>
 <% end %>
 

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -44,7 +44,8 @@
       <% if @content_item.national_applicability.present? %>
         <%= render "govuk_publishing_components/components/devolved_nations", {
           national_applicability: @content_item.national_applicability,
-          type: @content_item.schema_name
+          type: @content_item.schema_name,
+          ga4_tracking: true,
         } %>
       <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
             <% if @content_item.show_phase_banner? %>
-              <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase %>
+              <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase, ga4_tracking: true %>
             <% end %>
             <% if @content_item.service_manual? %>
               <%= render_phase_label @content_item, content_for(:phase_message) %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
