### PR TITLE
Reflect travel advice alert status from travel advice publisher on the advice page

### DIFF
--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -84,7 +84,7 @@ class TravelAdvicePresenter < ContentItemPresenter
     alert_statuses = content_item["details"]["alert_status"] || []
     alert_statuses.map do |alert|
       if allowed_statuses.include?(alert)
-        I18n.t("travel_advice.alert_status.#{alert}_html").html_safe
+        I18n.t("travel_advice.alert_status.#{alert}_html", country: country_name).html_safe
       end
     end
   end

--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -82,14 +82,11 @@ class TravelAdvicePresenter < ContentItemPresenter
       avoid_all_travel_to_whole_country
     ]
     alert_statuses = content_item["details"]["alert_status"] || []
-    alert_statuses = alert_statuses.map do |alert|
+    alert_statuses.map do |alert|
       if allowed_statuses.include?(alert)
-        copy = I18n.t("travel_advice.alert_status.#{alert}_html").html_safe
-        view_context.tag.p(copy)
+        I18n.t("travel_advice.alert_status.#{alert}_html").html_safe
       end
     end
-
-    alert_statuses.join("").html_safe
   end
 
   def atom_change_description

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -16,6 +16,12 @@
   <div class="govuk-grid-column-two-thirds travel-advice__header">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
 
+    <% @content_item.alert_status.each do |text| %>
+      <%= render "govuk_publishing_components/components/warning_text", 
+        text: text 
+      %> 
+    <% end %>
+
     <aside class="part-navigation-container" role="complementary">
       <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("travel_advice.pages") }, contents: @content_item.part_link_elements, underline_links: true, ga4_tracking: true %>
 

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -16,10 +16,13 @@
   <div class="govuk-grid-column-two-thirds travel-advice__header">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
 
-    <% @content_item.alert_status.each do |text| %>
-      <%= render "govuk_publishing_components/components/warning_text", 
-        text: text 
-      %> 
+   <%= render "govuk_publishing_components/components/govspeak", {
+    } do %>
+       <% @content_item.alert_status.each do |text| %>
+        <%= render "govuk_publishing_components/components/warning_text", 
+          text: text 
+        %> 
+      <% end %>
     <% end %>
 
     <aside class="part-navigation-container" role="complementary">

--- a/app/views/shared/_travel_advice_first_part.html.erb
+++ b/app/views/shared/_travel_advice_first_part.html.erb
@@ -1,13 +1,3 @@
-<% if content_item.alert_status.present? %>
-  <%= render 'govuk_publishing_components/components/govspeak', {
-    direction: page_text_direction,
-  } do %>
-    <div class="help-notice">
-      <%= raw(content_item.alert_status) %>
-    </div>
-  <% end %>
-<% end %>
-
 <%= render 'govuk_publishing_components/components/metadata', content_item.metadata %>
 <% if content_item.map %>
   <figure class="map">

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -5,5 +5,4 @@ data:
 ignore_unused:
   - 'content_item.schema_name.*.{one,other,zero,few,many,two}'
   - 'corporate_information_page.*'
-  - 'travel_advice.alert_status.*'
   - 'publication.documents.other'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -525,10 +525,10 @@ en:
       short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all but essential travel to parts of %{country}.
-      avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all but essential travel to %{country}.
-      avoid_all_travel_to_parts_html: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all travel to parts of %{country}.
-      avoid_all_travel_to_whole_country_html: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all travel to %{country}.
+      avoid_all_but_essential_travel_to_parts_html: <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advises against all but essential travel to parts of %{country}.
+      avoid_all_but_essential_travel_to_whole_country_html: <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advises against all but essential travel to %{country}.
+      avoid_all_travel_to_parts_html: <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advises against all travel to parts of %{country}.
+      avoid_all_travel_to_whole_country_html: <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advises against all travel to %{country}.
     context: Foreign travel advice
     pages: Travel advice pages
     still_current_at: Still current at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -525,10 +525,10 @@ en:
       short_ordinal: "%e %B %Y"
   travel_advice:
     alert_status:
-      avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all but essential travel to parts of the country.
-      avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all but essential travel to the whole country.
-      avoid_all_travel_to_parts_html: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all travel to parts of the country.
-      avoid_all_travel_to_whole_country_html: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all travel to the whole country.
+      avoid_all_but_essential_travel_to_parts_html: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all but essential travel to parts of %{country}.
+      avoid_all_but_essential_travel_to_whole_country_html: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all but essential travel to %{country}.
+      avoid_all_travel_to_parts_html: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all travel to parts of %{country}.
+      avoid_all_travel_to_whole_country_html: The <abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr> advise against all travel to %{country}.
     context: Foreign travel advice
     pages: Travel advice pages
     still_current_at: Still current at

--- a/test/presenters/travel_advice_presenter_test.rb
+++ b/test/presenters/travel_advice_presenter_test.rb
@@ -213,8 +213,11 @@ class TravelAdvicePresenterTest
     test "presents alert statuses" do
       example = schema_item("full-country")
       example["details"]["alert_status"] = %w[avoid_all_but_essential_travel_to_parts avoid_all_travel_to_parts]
-      assert present_example(example).alert_status.include?("advise against all but essential travel")
-      assert present_example(example).alert_status.include?("advise against all travel to parts")
+
+      presented = present_example(example)
+
+      assert presented.alert_status.first.include?("advises against all but essential travel to parts of #{presented.country_name}")
+      assert presented.alert_status.last.include?("advises against all travel to parts of #{presented.country_name}")
     end
 
     test "metadata uses today for 'Still current at'" do


### PR DESCRIPTION
## What
Publishers can now set an alert status for a country programmatically instead of including it in the copy content (see screenshot below for the editor options). 

<img width="706" alt="4_alert_status_options" src="https://github.com/alphagov/government-frontend/assets/5007934/6110b095-e923-454c-98b9-bfd7db26c4a6">

This PR:
- Removes legacy code to render travel alerts as part of the govspeak content. To our knowledge this code has never been used as it wasn't possible to set `alert_status` in the editor until recently. Removes formatting from the presenter which was customised for rendering the alerts in govspeak: it used to flatten the array of alert statuses and wrap them each in a paragraph tag. These changes are in readiness for rendering the alerts with warning text.
- Renders alert statuses with warning text component
- Wraps the alert status in govspeak because the alert copy uses the abbreviation markup as recommended by the GOV.UK styleguide. Wrapping the alerts in govspeak applies the govspeak styling for acronyms.
- Runs automated tests to check that the alert statuses are rendering correctly

## Why
This will make it easier for publishers to update the alert status, keep it consistent in implementation, make it more visible for users and improve the semantics of the page.

## Further information
As these alerts will replace the alerts previously set in the body copy, publishers will need to remove any alerts from the body copy when they set the status using the travel advice publisher checkboxes. 

This change means that whilst travel alerts were previously rendered using the govspeak callout component, they will now be rendered using the warning text. The warning text contains visually hidden text to help screen reader users understand the content of the alerts.

Since the editor options were implemented as checkboxes, a publisher could set multiple statuses even though only one status will probably ever be set. The logic should therefore work with up to four options. We might change the options to radios in a further iteration.

## Before
<img width="782" alt="Screenshot 2023-09-13 at 18 23 42" src="https://github.com/alphagov/government-frontend/assets/5007934/7d819672-402e-4345-a37e-c2ec70edcfaa">

## After
<img width="826" alt="Screenshot 2023-09-13 at 18 23 03" src="https://github.com/alphagov/government-frontend/assets/5007934/489c2cfb-e02b-4323-a947-2b83143a35de">



Fixes https://trello.com/c/Y4fruQto/1987-reflect-travel-advice-alert-status-from-travel-advice-publisher-on-the-advice-page-m

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
