### PR TITLE
Add recruitment banner

### DIFF
--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,0 +1,24 @@
+module ContentItem
+  module RecruitmentBanner
+    SURVEY_URL = "https://surveys.publishing.service.gov.uk/s/SNFVW1/".freeze
+    SURVEY_URL_MAPPINGS = {
+      "/log-in-register-hmrc-online-services" => SURVEY_URL,
+      "/log-in-file-self-assessment-tax-return" => SURVEY_URL,
+      "/self-assessment-tax-returns" => SURVEY_URL,
+      "/pay-self-assessment-tax-bill" => SURVEY_URL,
+      "/contact-hmrc" => SURVEY_URL,
+      "/log-in-register-hmrc-online-services/register" => SURVEY_URL,
+      "/dbs-update-service" => SURVEY_URL,
+      "/government/organisations/hm-revenue-customs/contact/self-assessment" => SURVEY_URL,
+    }.freeze
+
+    def recruitment_survey_url
+      user_research_test_url
+    end
+
+    def user_research_test_url
+      key = content_item["base_path"]
+      SURVEY_URL_MAPPINGS[key]
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,5 +1,6 @@
 class ContentItemPresenter
   include ContentItem::Withdrawable
+  include ContentItem::RecruitmentBanner
 
   attr_reader :content_item,
               :requested_path,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,17 @@
         <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.parsed_content_item, ga4_tracking: true %>
       <% end %>
     <% end %>
+
+    <% if @content_item.recruitment_survey_url %>
+      <div class="govuk-!-static-margin-top-4">
+        <%= render "govuk_publishing_components/components/intervention", {
+          suggestion_text: "Help improve a new GOV.UK tool",
+          suggestion_link_text: "Sign up to take part in user research",
+          suggestion_link_url: @content_item.recruitment_survey_url,
+          new_tab: true,
+        } %>
+      </div>
+    <% end %>
     
     <%= yield :header %>
 

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "User research banner is displayed on pages of interest" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+
+    pages_of_interest =
+      [
+        "/log-in-register-hmrc-online-services",
+        "/log-in-file-self-assessment-tax-return",
+        "/self-assessment-tax-returns",
+        "/pay-self-assessment-tax-bill",
+        "/contact-hmrc",
+        "/log-in-register-hmrc-online-services/register",
+        "/dbs-update-service",
+        "/government/organisations/hm-revenue-customs/contact/self-assessment",
+      ]
+
+    pages_of_interest.each do |path|
+      guide["base_path"] = path
+      stub_content_store_has_item(guide["base_path"], guide.to_json)
+      visit guide["base_path"]
+
+      assert page.has_css?(".gem-c-intervention")
+      assert page.has_link?("Sign up to take part in user research", href: "https://surveys.publishing.service.gov.uk/s/SNFVW1/")
+    end
+  end
+
+  test "User research banner is not displayed on all pages" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    guide["base_path"] = "/nothing-to-see-here"
+    stub_content_store_has_item(guide["base_path"], guide.to_json)
+    visit guide["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Sign up to take part in user research", href: "https://gov.uk")
+  end
+end


### PR DESCRIPTION
The banner will be applied on the following pages:
- [/log-in-register-hmrc-online-services](https://www.gov.uk/log-in-register-hmrc-online-services)
- [/log-in-file-self-assessment-tax-return](https://www.gov.uk/log-in-file-self-assessment-tax-return)
- [/self-assessment-tax-returns](https://www.gov.uk/self-assessment-tax-returns)
- [pay-self-assessment-tax-bill](https://www.gov.uk/pay-self-assessment-tax-bill)
- [/contact-hmrc](https://www.gov.uk/contact-hmrc)
- [/log-in-register-hmrc-online-services/register](https://www.gov.uk/log-in-register-hmrc-online-services/register)
- [/dbs-update-service](https://www.gov.uk/dbs-update-service)
- [/government/organisations/hm-revenue-customs/contact/self-assessment](https://www.gov.uk/government/organisations/hm-revenue-customs/contact/self-assessment)

Before:
<img width="998" alt="Screenshot 2023-09-26 at 09 08 25" src="https://github.com/alphagov/government-frontend/assets/96050928/ec5aa697-d37d-41c5-a0d5-35ef3e3a9b63">

After:
<img width="995" alt="Screenshot 2023-09-26 at 09 07 53" src="https://github.com/alphagov/government-frontend/assets/96050928/699986ab-7330-402c-a7ab-01240fa67d03">


Trello card: 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
