### PR TITLE
Add Brand recruitment banner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,8 @@ $govuk-include-default-font-face: false;
 // Components from govuk_publishing_components gem
 @import "govuk_publishing_components/govuk_frontend_support";
 
+@import "components/intervention";
+
 // government-frontend mixins
 @import "mixins/margins";
 

--- a/app/assets/stylesheets/components/_intervention.scss
+++ b/app/assets/stylesheets/components/_intervention.scss
@@ -1,0 +1,3 @@
+.gem-c-intervention {
+  margin-top: govuk-spacing(4);
+}

--- a/app/presenters/content_item/recruitment_banner.rb
+++ b/app/presenters/content_item/recruitment_banner.rb
@@ -1,0 +1,19 @@
+module ContentItem
+  module RecruitmentBanner
+    BRAND_SURVEY_URL = "https://surveys.publishing.service.gov.uk/s/5G06FO/".freeze
+    SURVEY_URL_MAPPINGS = {
+      "/repaying-your-student-loan" => BRAND_SURVEY_URL,
+      "/student-finance" => BRAND_SURVEY_URL,
+      "/jobseekers-allowance" => BRAND_SURVEY_URL,
+    }.freeze
+
+    def recruitment_survey_url
+      brand_user_research_test_url
+    end
+
+    def brand_user_research_test_url
+      key = content_item["base_path"]
+      SURVEY_URL_MAPPINGS[key]
+    end
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,5 +1,6 @@
 class ContentItemPresenter
   include ContentItem::Withdrawable
+  include ContentItem::RecruitmentBanner
 
   attr_reader :content_item,
               :requested_path,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,14 @@
 
 <% content_for :body do %>
   <div id="wrapper" class="<%= wrapper_class %>">
-    <% if @content_item.show_phase_banner? || @content_item.service_manual? %>
+    <% if @content_item.recruitment_survey_url %>
+      <%= render "govuk_publishing_components/components/intervention", {
+        suggestion_text: "Help improve GOV.UK",
+        suggestion_link_text: "Take part in user research",
+        suggestion_link_url: @content_item.recruitment_survey_url,
+        new_tab: true,
+      } %>
+    <% elsif @content_item.show_phase_banner? || @content_item.service_manual? %>
       <div class="govuk-width-container">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
@@ -28,7 +35,7 @@
         <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.parsed_content_item, ga4_tracking: true %>
       <% end %>
     <% end %>
-    
+
     <%= yield :header %>
 
     <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "Brand user research banner is displayed on pages of interest" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+
+    pages_of_interest =
+      [
+        "/repaying-your-student-loan",
+        "/student-finance",
+        "/jobseekers-allowance",
+      ]
+
+    pages_of_interest.each do |path|
+      guide["base_path"] = path
+      stub_content_store_has_item(guide["base_path"], guide.to_json)
+      visit guide["base_path"]
+
+      assert page.has_css?(".gem-c-intervention")
+      assert page.has_link?("Take part in user research", href: "https://surveys.publishing.service.gov.uk/s/5G06FO/")
+    end
+  end
+
+  test "Brand user research banner is not displayed on all pages" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    guide["base_path"] = "/nothing-to-see-here"
+    stub_content_store_has_item(guide["base_path"], guide.to_json)
+    visit guide["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://surveys.publishing.service.gov.uk/s/5G06FO/")
+  end
+end


### PR DESCRIPTION
The banner will be applied on the following pages:
- [/repaying-your-student-loan](https://www.gov.uk/repaying-your-student-loan)
- [/student-finance](https://www.gov.uk/student-finance)
- [/jobseekers-allowance](https://www.gov.uk/jobseekers-allowance)

Trello card: https://trello.com/c/EVjvHjqE/2090-brand-team-govuk-user-research-banner-request-to-set-up-m

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
