### PR TITLE
Remove GA4 link tracking from certain 'See all updates' links

### DIFF
--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -1,8 +1,6 @@
 <%
   metadata_component_options = @content_item.publisher_metadata
   metadata_component_options[:margin_bottom] = 3 if @notification_button_visible
-  # The metadata component on this page receives ga4_tracking: true as it has a 'See all updates' link.
-  metadata_component_options[:ga4_tracking] = true
 %>
 <div class="govuk-grid-row">
   <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if @content_item.try(:logo) %>">


### PR DESCRIPTION
## What

Most of the 'See all updates' links trigger a `select_content` event when clicked, as they open an accordion and jump to the accordion heading on the page instead of navigating to a new link. Therefore with the `ga4_tracking: true` flag, they were sending a link click (`navigation`) event and a `select_content` event on click. I've removed `ga4_tracking: true`, so that it will only send a `select_content` event on click.

## Why

https://trello.com/c/6Yq0OIER/667-see-all-updates-click-coming-through-as-navigation-as-well-as-selectcontent-event-on-some-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
