### PR TITLE
[DO NOT MERGE] Change GA4 type from 'content' to 'print page' on print links

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -95,7 +95,7 @@
             data-module="ga4-link-tracker"
             data-ga4-link="<%= {
               event_name: "navigation",
-              type: "content",
+              type: "print page",
               section: "Footer",
               text: t("multi_page.print_entire_guide", locale: :en)
             }.to_json %>">

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -66,7 +66,7 @@
           data-module="ga4-link-tracker"
           data-ga4-link="<%= {
             event_name: "navigation",
-            type: "content",
+            type: "print page",
             section: "Footer",
             text: t("multi_page.print_entire_guide", locale: :en)
           }.to_json %>"><%= t("multi_page.print_entire_guide") %></a>

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -174,7 +174,7 @@ class GuideTest < ActionDispatch::IntegrationTest
 
     expected_ga4_json = {
       event_name: "navigation",
-      type: "content",
+      type: "print page",
       section: "Footer",
       text: "View a printable version of the whole guide",
     }.to_json

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -75,7 +75,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
 
     expected_ga4_json = {
       event_name: "navigation",
-      type: "content",
+      type: "print page",
       section: "Footer",
       text: "View a printable version of the whole guide",
     }.to_json


### PR DESCRIPTION
## What

- Changes the GA4 `type` on certain print links from `content` to `print page`
- Has a do not merge as this will be auto deployed so I'll need to check with the PAs first

## Why

https://trello.com/c/999SSkPq/681-change-view-a-printable-version-navigation-event-types-to-print-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
