### PR TITLE
Change GA4 type for show/hide updates accordions

### DIFF
--- a/app/views/components/_published_dates.html.erb
+++ b/app/views/components/_published_dates.html.erb
@@ -26,7 +26,7 @@
       data-expanded="false"
       data-toggled-text="&#45;&nbsp;<%= t('components.published_dates.hide_all_updates', locale: :en) %>"
       data-module="ga4-event-tracker"
-      data-ga4-event="<%= {event_name: "select_content", type: "content", section: "Footer"}.to_json %>"
+      data-ga4-event="<%= {event_name: "select_content", type: "content history", section: "Footer"}.to_json %>"
       data-ga4-expandable
       >&#43;&nbsp;<%= t('components.published_dates.show_all_updates', locale: :en) %></a>
       <div class="app-c-published-dates__change-history js-hidden" id="full-history">

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -111,7 +111,7 @@
               data-toggled-text="- Hide all page updates (<%= @content_item.previous_changes.length %>)"
               data-expanded="false"
               data-module="ga4-event-tracker"
-              data-ga4-event="<%= {event_name: "select_content", type: "content", section: "Footer"}.to_json %>"
+              data-ga4-event="<%= {event_name: "select_content", type: "content history", section: "Footer"}.to_json %>"
               data-ga4-expandable
               role="button"
               aria-controls="full-history"

--- a/test/components/published_dates_test.rb
+++ b/test/components/published_dates_test.rb
@@ -101,7 +101,7 @@ class PublishedDatesTest < ComponentTestCase
 
     expected_ga4_json = {
       "event_name": "select_content",
-      "type": "content",
+      "type": "content history",
       "section": "Footer",
     }.to_json
 


### PR DESCRIPTION
## What
Changes the GA4 `type` from `content` to `content history` on `show/hide updates` accordions

## Why
https://trello.com/c/KdNfD2FM/682-change-see-updates-show-hide-all-updates-selectcontent-event-types-to-content-history

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
