### PR TITLE
Change GA4 type on service manual contents list

### DIFF
--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -68,8 +68,8 @@
             data-ga4-track-links-only
             data-ga4-set-indexes
             data-ga4-link="<%= {
-              event_name: "navigation",
-              type: "content",
+              event_name: "select_content",
+              type: "contents list",
               section: "Page contents:"
             }.to_json %>">
           <% @content_item.header_links.each do |header_link| %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Change the GA4 type on the contents list on pages like https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction#make-non-digital-parts-of-your-service-accessible to 'select content'.

## Why
These are in-page navigation events.

## Visual changes
None.

Trello card: https://trello.com/c/kPQBqdSw/675-change-contents-navigation-selectcontent-event-types-to-contents-list
