### PR TITLE
Adjust manuals search tracking

### DIFF
--- a/app/views/content_items/manuals/_header.html.erb
+++ b/app/views/content_items/manuals/_header.html.erb
@@ -32,6 +32,7 @@
       <%
         form_data = {
           module: "ga4-form-tracker",
+          ga4_form_include_text: "",
           ga4_form: {
             event_name: "search",
             type: "content",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- include a parameter on the form so that responses are also collected by the form tracker
- PII is automatically redacted by the form tracker in this situation

See [related PR](https://github.com/alphagov/government-frontend/pull/2942) for example URLs.

## Why
We want to capture form queries.

## Visual changes
None.

Trello card: https://trello.com/c/zZGLn0tw/694-search-enhancement-add-search-form-tracking-to-manual-manualsection-and-hmrcmanualsection-pages
