### PR TITLE
AB test - replace some content on UTR page

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -24,31 +24,7 @@ class ContentItemsController < ApplicationController
   def show
     load_content_item
 
-    # TEMPORARY (author: richard.towers, expected end date: November 30 2023)
-    # Content specific AB test for the Find your UTR number page
-    placeholder = "{{ab_test_find_utr_number_video_links}}"
-    if @content_item.base_path == "/find-utr-number" && @content_item.body.include?(placeholder)
-      ab_test = GovukAbTesting::AbTest.new(
-        "find_utr_number_video_links",
-        dimension: 61, # https://docs.google.com/spreadsheets/d/1h4vGXzIbhOWwUzourPLIc8WM-iU1b6WYOVDOZxmU1Uo/edit#gid=254065189&range=69:69
-        allowed_variants: %w[A B Z],
-        control_variant: "Z",
-      )
-      @requested_variant = ab_test.requested_variant(request.headers)
-      @requested_variant.configure_response(response)
-
-      replacement = case @requested_variant.variant_name
-                    when "A"
-                      I18n.t("ab_tests.find_utr_number_video_links.A")
-                    when "B"
-                      I18n.t("ab_tests.find_utr_number_video_links.B")
-                    else
-                      I18n.t("ab_tests.find_utr_number_video_links.Z")
-                    end
-      @content_item.body.sub!(placeholder, replacement)
-    end
-    # /TEMPORARY
-
+    temporary_ab_test_find_utr_page
     set_expiry
 
     if is_service_manual?
@@ -291,4 +267,31 @@ private
 
     @content_item.csp_connect_src
   end
+
+  # TEMPORARY (author: richard.towers, expected end date: February 2024)
+  # Content specific AB test for the Find your UTR number page
+  def temporary_ab_test_find_utr_page
+    placeholder = "{{ab_test_find_utr_number_video_links}}"
+    if @content_item.base_path == "/find-utr-number" && @content_item.body.include?(placeholder)
+      ab_test = GovukAbTesting::AbTest.new(
+        "find_utr_number_video_links",
+        dimension: 61, # https://docs.google.com/spreadsheets/d/1h4vGXzIbhOWwUzourPLIc8WM-iU1b6WYOVDOZxmU1Uo/edit#gid=254065189&range=69:69
+        allowed_variants: %w[A B Z],
+        control_variant: "Z",
+      )
+      @requested_variant = ab_test.requested_variant(request.headers)
+      @requested_variant.configure_response(response)
+
+      replacement = case @requested_variant.variant_name
+                    when "A"
+                      I18n.t("ab_tests.find_utr_number_video_links.A")
+                    when "B"
+                      I18n.t("ab_tests.find_utr_number_video_links.B")
+                    else
+                      I18n.t("ab_tests.find_utr_number_video_links.Z")
+                    end
+      @content_item.body.sub!(placeholder, replacement)
+    end
+  end
+  # /TEMPORARY
 end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -29,7 +29,7 @@ class ContentItemsController < ApplicationController
     if @content_item.base_path == "/find-utr-number"
       ab_test = GovukAbTesting::AbTest.new(
         "find_utr_number_video_links",
-        dimension: 300, # TODO: which dimension should we use?
+        dimension: 61, # https://docs.google.com/spreadsheets/d/1h4vGXzIbhOWwUzourPLIc8WM-iU1b6WYOVDOZxmU1Uo/edit#gid=254065189&range=69:69
         allowed_variants: %w[A B Z],
         control_variant: "Z",
       )

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -26,7 +26,8 @@ class ContentItemsController < ApplicationController
 
     # TEMPORARY (author: richard.towers, expected end date: November 30 2023)
     # Content specific AB test for the Find your UTR number page
-    if @content_item.base_path == "/find-utr-number"
+    placeholder = "{{ab_test_find_utr_number_video_links}}"
+    if @content_item.base_path == "/find-utr-number" && @content_item.body.include?(placeholder)
       ab_test = GovukAbTesting::AbTest.new(
         "find_utr_number_video_links",
         dimension: 61, # https://docs.google.com/spreadsheets/d/1h4vGXzIbhOWwUzourPLIc8WM-iU1b6WYOVDOZxmU1Uo/edit#gid=254065189&range=69:69
@@ -44,7 +45,7 @@ class ContentItemsController < ApplicationController
                     else
                       I18n.t("ab_tests.find_utr_number_video_links.Z")
                     end
-      @content_item.body.sub!("{{ab_test_find_utr_number_video_links}}", replacement)
+      @content_item.body.sub!(placeholder, replacement)
     end
     # /TEMPORARY
 

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -46,7 +46,7 @@ class ContentItemsController < ApplicationController
         # situation. This is not a sustainable way of doing AB tests in the
         # future.
         @content_item.body.sub!(
-          /<li>\s*in\ the\s+<a\ href="[^"]*"><abbr\ title="[^"]+">HMRC<\/abbr>\s+app<\/a>/,
+          /<li>\s*in\ the\s+<a\ href="[^"]*"><abbr\ title="[^"]+">HMRC<\/abbr>\s+app<\/a>\s*<\/li>/,
           '<li>in the <a href="https://www.gov.uk/guidance/download-the-hmrc-app"><abbr title="HM Revenue and Customs">HMRC</abbr> app</a> - watch a <a href="https://www.youtube.com/watch?v=LXw9ily9rTo">video about finding your UTR number in the app</a>',
         )
       end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -47,7 +47,7 @@ class ContentItemsController < ApplicationController
         # future.
         @content_item.body.sub!(
           /<li>\s*in\ the\s+<a\ href="[^"]*"><abbr\ title="[^"]+">HMRC<\/abbr>\s+app<\/a>\s*<\/li>/,
-          '<li>in the <a href="https://www.gov.uk/guidance/download-the-hmrc-app"><abbr title="HM Revenue and Customs">HMRC</abbr> app</a> - watch a <a href="https://www.youtube.com/watch?v=LXw9ily9rTo">video about finding your UTR number in the app</a>',
+          '<li>in the <a href="https://www.gov.uk/guidance/download-the-hmrc-app"><abbr title="HM Revenue and Customs">HMRC</abbr> app</a> - watch a <a href="https://www.youtube.com/watch?v=LXw9ily9rTo">video about finding your UTR number in the app</a></li>',
         )
       end
     end

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1,5 +1,10 @@
 ---
 ar:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -1,5 +1,10 @@
 ---
 az:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -1,5 +1,10 @@
 ---
 be:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -1,5 +1,10 @@
 ---
 bg:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -1,5 +1,10 @@
 ---
 bn:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,5 +1,10 @@
 ---
 cs:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1,5 +1,10 @@
 ---
 cy:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -1,5 +1,10 @@
 ---
 da:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,5 +1,10 @@
 ---
 de:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -1,5 +1,10 @@
 ---
 dr:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -1,5 +1,10 @@
 ---
 el:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,10 @@
 ---
 en:
+  ab_tests:
+    find_utr_number_video_links:
+      A: 'in the <a href="/guidance/download-the-hmrc-app"><abbr title="HM Revenue and Customs">HMRC</abbr> app</a>'
+      B: 'in the <abbr title="HM Revenue and Customs">HMRC</abbr> app - watch a <a href="https://www.youtube.com/watch?v=LXw9ily9rTo">video about finding your UTR number in the app</a>'
+      Z: 'in the <a href="/guidance/download-the-hmrc-app"><abbr title="HM Revenue and Customs">HMRC</abbr> app</a>'
   call_for_evidence:
     and: and
     another_website_html: This call for evidence %{closed} held on <a href="%{url}">another website</a>

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -1,5 +1,10 @@
 ---
 es-419:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,10 @@
 ---
 es:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -1,5 +1,10 @@
 ---
 et:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1,5 +1,10 @@
 ---
 fa:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1,5 +1,10 @@
 ---
 fi:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,5 +1,10 @@
 ---
 fr:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -1,5 +1,10 @@
 ---
 gd:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -1,5 +1,10 @@
 ---
 gu:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1,5 +1,10 @@
 ---
 he:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -1,5 +1,10 @@
 ---
 hi:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -1,5 +1,10 @@
 ---
 hr:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1,5 +1,10 @@
 ---
 hu:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -1,5 +1,10 @@
 ---
 hy:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1,5 +1,10 @@
 ---
 id:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -1,5 +1,10 @@
 ---
 is:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,5 +1,10 @@
 ---
 it:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,10 @@
 ---
 ja:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -1,5 +1,10 @@
 ---
 ka:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -1,5 +1,10 @@
 ---
 kk:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,5 +1,10 @@
 ---
 ko:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -1,5 +1,10 @@
 ---
 lt:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1,5 +1,10 @@
 ---
 lv:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -1,5 +1,10 @@
 ---
 ms:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -1,5 +1,10 @@
 ---
 mt:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -1,5 +1,10 @@
 ---
 ne:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,5 +1,10 @@
 ---
 nl:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -1,5 +1,10 @@
 ---
 'no':
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -1,5 +1,10 @@
 ---
 pa-pk:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -1,5 +1,10 @@
 ---
 pa:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,5 +1,10 @@
 ---
 pl:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -1,5 +1,10 @@
 ---
 ps:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,5 +1,10 @@
 ---
 pt:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,5 +1,10 @@
 ---
 ro:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,5 +1,10 @@
 ---
 ru:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -1,5 +1,10 @@
 ---
 si:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,5 +1,10 @@
 ---
 sk:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -1,5 +1,10 @@
 ---
 sl:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -1,5 +1,10 @@
 ---
 so:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -1,5 +1,10 @@
 ---
 sq:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -1,5 +1,10 @@
 ---
 sr:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,5 +1,10 @@
 ---
 sv:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -1,5 +1,10 @@
 ---
 sw:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -1,5 +1,10 @@
 ---
 ta:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -1,5 +1,10 @@
 ---
 th:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -1,5 +1,10 @@
 ---
 tk:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,5 +1,10 @@
 ---
 tr:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1,5 +1,10 @@
 ---
 uk:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -1,5 +1,10 @@
 ---
 ur:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -1,5 +1,10 @@
 ---
 uz:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1,5 +1,10 @@
 ---
 vi:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -1,5 +1,10 @@
 ---
 yi:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -1,5 +1,10 @@
 ---
 zh-hk:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -1,5 +1,10 @@
 ---
 zh-tw:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1,5 +1,10 @@
 ---
 zh:
+  ab_tests:
+    find_utr_number_video_links:
+      A:
+      B:
+      Z:
   call_for_evidence:
     and:
     another_website_html:

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -368,7 +368,6 @@ class ContentItemsControllerTest < ActionController::TestCase
     content_item = content_store_has_schema_example("answer", "answer")
     content_item["base_path"] = "/find-utr-number"
     content_item["details"]["body"] = "<li>{{ab_test_find_utr_number_video_links}}</li>"
-    content_item["locale"] = "en"
 
     stub_content_store_has_item(content_item["base_path"], content_item)
 
@@ -380,11 +379,25 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_match "<li>#{I18n.t('ab_tests.find_utr_number_video_links.Z')}</li>", response.body
   end
 
+  test "AB test replaces content on the find-utr-number page with variant A" do
+    content_item = content_store_has_schema_example("answer", "answer")
+    content_item["base_path"] = "/find-utr-number"
+    content_item["details"]["body"] = "<li>{{ab_test_find_utr_number_video_links}}</li>"
+
+    stub_content_store_has_item(content_item["base_path"], content_item)
+
+    request.headers["HTTP_GOVUK_ABTEST_FIND_UTR_NUMBER_VIDEO_LINKS"] = "A"
+
+    get :show, params: { path: path_for(content_item) }
+    assert_response :success
+    assert_no_match "{{ab_test_find_utr_number_video_links}}", response.body
+    assert_match "<li>#{I18n.t('ab_tests.find_utr_number_video_links.A')}</li>", response.body
+  end
+
   test "AB test replaces content on the find-utr-number page with variant B" do
     content_item = content_store_has_schema_example("answer", "answer")
     content_item["base_path"] = "/find-utr-number"
     content_item["details"]["body"] = "<li>{{ab_test_find_utr_number_video_links}}</li>"
-    content_item["locale"] = "en"
 
     stub_content_store_has_item(content_item["base_path"], content_item)
 

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -364,19 +364,36 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_equal "true", @response.headers[Slimmer::Headers::REMOVE_SEARCH_HEADER]
   end
 
-  test "AB test replaces content on the find-utr-number page" do
+  test "AB test replaces content on the find-utr-number page with default" do
     content_item = content_store_has_schema_example("answer", "answer")
     content_item["base_path"] = "/find-utr-number"
-    content_item["details"]["body"] = "<li>in the <a href=\"\"><abbr title=\"HM Revenue and Customs\">HMRC</abbr> app</a>\n</li>"
+    content_item["details"]["body"] = "<li>{{ab_test_find_utr_number_video_links}}</li>"
     content_item["locale"] = "en"
 
     stub_content_store_has_item(content_item["base_path"], content_item)
 
-    request.headers["HTTP_GOVUK_ABTEST_FIND_UTR_NUMBER_VIDEO_LINKS"] = "VideoLink"
+    request.headers["HTTP_GOVUK_ABTEST_FIND_UTR_NUMBER_VIDEO_LINKS"] = nil
 
     get :show, params: { path: path_for(content_item) }
     assert_response :success
-    assert_match 'watch a <a href="https://www.youtube.com/watch?v=LXw9ily9rTo">video about finding your UTR number in the app</a>', response.body
+    assert_no_match "{{ab_test_find_utr_number_video_links}}", response.body
+    assert_match "<li>#{I18n.t('ab_tests.find_utr_number_video_links.Z')}</li>", response.body
+  end
+
+  test "AB test replaces content on the find-utr-number page with variant B" do
+    content_item = content_store_has_schema_example("answer", "answer")
+    content_item["base_path"] = "/find-utr-number"
+    content_item["details"]["body"] = "<li>{{ab_test_find_utr_number_video_links}}</li>"
+    content_item["locale"] = "en"
+
+    stub_content_store_has_item(content_item["base_path"], content_item)
+
+    request.headers["HTTP_GOVUK_ABTEST_FIND_UTR_NUMBER_VIDEO_LINKS"] = "B"
+
+    get :show, params: { path: path_for(content_item) }
+    assert_response :success
+    assert_no_match "{{ab_test_find_utr_number_video_links}}", response.body
+    assert_match "<li>#{I18n.t('ab_tests.find_utr_number_video_links.B')}</li>", response.body
   end
 
   def path_for(content_item, locale = nil)

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -364,6 +364,21 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_equal "true", @response.headers[Slimmer::Headers::REMOVE_SEARCH_HEADER]
   end
 
+  test "AB test replaces content on the find-utr-number page" do
+    content_item = content_store_has_schema_example("answer", "answer")
+    content_item["base_path"] = "/find-utr-number"
+    content_item["details"]["body"] = '<li>in the <a href=""><abbr title="HM Revenue and Customs">HMRC</abbr> app</a>'
+    content_item["locale"] = "en"
+
+    stub_content_store_has_item(content_item["base_path"], content_item)
+
+    request.headers["HTTP_GOVUK_ABTEST_FIND_UTR_NUMBER_VIDEO_LINKS"] = "VideoLink"
+
+    get :show, params: { path: path_for(content_item) }
+    assert_response :success
+    assert_match 'watch a <a href="https://www.youtube.com/watch?v=LXw9ily9rTo">video about finding your UTR number in the app</a>', response.body
+  end
+
   def path_for(content_item, locale = nil)
     base_path = content_item["base_path"].sub(/^\//, "")
     base_path.gsub!(/\.#{locale}$/, "") if locale

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -367,7 +367,7 @@ class ContentItemsControllerTest < ActionController::TestCase
   test "AB test replaces content on the find-utr-number page" do
     content_item = content_store_has_schema_example("answer", "answer")
     content_item["base_path"] = "/find-utr-number"
-    content_item["details"]["body"] = '<li>in the <a href=""><abbr title="HM Revenue and Customs">HMRC</abbr> app</a>'
+    content_item["details"]["body"] = "<li>in the <a href=\"\"><abbr title=\"HM Revenue and Customs\">HMRC</abbr> app</a>\n</li>"
     content_item["locale"] = "en"
 
     stub_content_store_has_item(content_item["base_path"], content_item)


### PR DESCRIPTION
https://trello.com/c/jKWA7Nu3/543-ab-test-content-for-find-your-utr-number
    
HMRC would like to see whether a link to a video performs better than
some descriptive help text. We've agreed to run an AB test to compare
these variants.

There's no elegant way to AB test bits of content in GOV.UK, so we've
had to resort to a workaround where we look for a particular replacement
string in the content (in this case `{{ab_test_find_utr_number_video_links}}`)
and replace it with a value from the translations file, depending on which variant
the user should see.

The code will only be executed on the /find-utr-number page, and only if the placeholder
string appears in the content item's body. This will allow us to deploy this code to production,
and treat the introduction of the placeholder string in the content item as the trigger to
start the test. We can try this out in the draft stack in integration and production before
running it in the live content item.

We think this is a pragmatic thing to do as a one off, as
it keeps an immportant stakeholder happy, helps us learn about video
content (which is a strategic priority), and helps us learn about the
use case for content AB tests in mainstream content.
