### PR TITLE
Adding '/media/*path' route

### DIFF
--- a/app/controllers/asset_manager_redirect_controller.rb
+++ b/app/controllers/asset_manager_redirect_controller.rb
@@ -1,5 +1,15 @@
 class AssetManagerRedirectController < ApplicationController
-  def show
+  def redirect_government_uploads_path
+    redirect
+  end
+
+  def redirect_media_path
+    redirect
+  end
+
+private
+
+  def redirect
     asset_url = Plek.new.external_url_for("assets")
     expires_in 1.day, public: true
     redirect_to(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,8 @@ Rails.application.routes.draw do
     GovukHealthcheck::RailsCache,
   )
 
-  get "/government/uploads/*path" => "asset_manager_redirect#show", format: false
+  get "/government/uploads/*path" => "asset_manager_redirect#redirect_government_uploads_path", format: false
+  get "/media/*path" => "asset_manager_redirect#redirect_media_path", format: false
 
   get "/service-manual/search",
       to: redirect { |_, request|

--- a/test/controllers/asset_manager_redirect_controller_test.rb
+++ b/test/controllers/asset_manager_redirect_controller_test.rb
@@ -3,22 +3,36 @@ require "test_helper"
 class AssetManagerRedirectControllerTest < ActionController::TestCase
   test "sets the cache-control max-age to 1 day" do
     request.host = "some-host.com"
-    get :show, params: { path: "asset.txt" }
+    get :redirect_government_uploads_path, params: { path: "asset.txt" }
 
     assert_equal @response.headers["Cache-Control"], "max-age=86400, public"
   end
 
-  test "redirects asset requests to the assets hostname" do
-    get :show, params: { path: "asset.txt" }
+  test "redirects asset requests from 'government/upload' path to the assets hostname" do
+    get :redirect_government_uploads_path, params: { path: "asset.txt" }
 
     assert_redirected_to "http://assets.test.gov.uk/government/uploads/asset.txt"
   end
 
-  test "redirects to assets hostname respect the draft stack" do
+  test "redirects asset requests from '/media' path to the assets hostname" do
+    get :redirect_media_path, params: { path: "filename/asset.txt" }
+
+    assert_redirected_to "http://assets.test.gov.uk/media/filename/asset.txt"
+  end
+
+  test "redirects to assets hostname respect the draft stack for legacy path" do
     ClimateControl.modify PLEK_HOSTNAME_PREFIX: "draft-" do
-      get :show, params: { path: "asset.txt" }
+      get :redirect_government_uploads_path, params: { path: "asset.txt" }
 
       assert_redirected_to "http://draft-assets.test.gov.uk/government/uploads/asset.txt"
+    end
+  end
+
+  test "redirects to assets hostname respect the draft stack for modern path" do
+    ClimateControl.modify PLEK_HOSTNAME_PREFIX: "draft-" do
+      get :redirect_media_path, params: { path: "filename/asset.txt" }
+
+      assert_redirected_to "http://draft-assets.test.gov.uk/media/filename/asset.txt"
     end
   end
 end

--- a/test/integration/asset_manager_redirect_test.rb
+++ b/test/integration/asset_manager_redirect_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class AssetManagerRedirectTest < ActionDispatch::IntegrationTest
+  test "should redirect to asset path for '/government/uploads/*path'" do
+    get "/government/uploads/system/uploads/attachment_data/file/1234567/example.pdf"
+    assert_redirected_to "http://assets.test.gov.uk/government/uploads/system/uploads/attachment_data/file/1234567/example.pdf"
+  end
+
+  test "should redirect to asset path for '/media/*path'" do
+    get "/media/1234567/example.pdf"
+    assert_redirected_to "http://assets.test.gov.uk/media/1234567/example.pdf"
+  end
+end


### PR DESCRIPTION
This is to allow request from `gov.uk` domain for `/media` path to be routed to 'asset' domain.

This is a proposed fix to work for modern url for assets for csv previews. Currently only legacy url paths work correctly for csv previews.

Currently csv previews only work for assets with legacy url path which contains `/government/uploads.` This is because when a request comes from 'www.gov.uk' domain for legacy asset path( /government/uploads ), it gets routed to government-frontend app which then redirects it to asset-path and the request works.

We want csv previews to work with modern asset url path `/media/:id/:filename`. Hence this PR adds the '/media/*path' route which will allow to request to get routed correctly to asset-domain as like legacy url path.

examples:
When we `View Online` a csv attachment then the preview url for modern url path looks like : `https://www.gov.uk/media/645231afc33b460012f5e5b4/January_2023_Payments_over__25000_Attorney_General_s_Office__AGO___Government_Legal_Department__GLD__HM_Crown_Prosecution_Service_Inspectorate__HMCPSI_.csv/preview`. This should work and for this to work the request should get routed correctly to 'asset' domain.
Currently, only legacy paths : `https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/1154423/January_2023_Payments_over__25000_Attorney_General_s_Office__AGO___Government_Legal_Department__GLD__HM_Crown_Prosecution_Service_Inspectorate__HMCPSI_.csv/preview` because of the logic in government-frontend which allows a request with path containing '/government/uploads' to be redirected to assets domain.

This PR is coupled with: https://github.com/alphagov/special-route-publisher/pull/287

[trello](https://trello.com/b/zKiroi2H/govuk-asset-management-in-whitehall)