### PR TITLE
Use Time.zone.parse instead of Date.parse in ManualUpdatesPresenter

### DIFF
--- a/app/presenters/content_item/manual_updates.rb
+++ b/app/presenters/content_item/manual_updates.rb
@@ -28,7 +28,7 @@ module ContentItem
     end
 
     def updated_at(published_at)
-      Date.parse(published_at)
+      Time.zone.parse(published_at).to_date
     end
 
     def group_updates_by_year(updates)

--- a/test/presenters/content_item/manual_updates_test.rb
+++ b/test/presenters/content_item/manual_updates_test.rb
@@ -22,7 +22,7 @@ class ContentItemManualUpdatesTest < ActiveSupport::TestCase
               "base_path" => "/guidance/content-design/content-policy",
               "title" => "Content policy",
               "change_note" => "New section added.",
-              "published_at" => "2014-10-06T23:49:25Z",
+              "published_at" => "2014-10-06T22:49:25Z",
             },
             {
               "base_path" => "/guidance/content-design/user-needs",
@@ -34,7 +34,7 @@ class ContentItemManualUpdatesTest < ActiveSupport::TestCase
               "base_path" => "/guidance/content-design/random-section",
               "title" => "Random section",
               "change_note" => "New section added.",
-              "published_at" => "2013-11-06T10:49:25Z",
+              "published_at" => "2013-09-06T23:49:25Z",
             },
           ],
         },
@@ -88,7 +88,7 @@ class ContentItemManualUpdatesTest < ActiveSupport::TestCase
         2013,
         [
           [
-            "6 November 2013 <span class=\"govuk-visually-hidden\">#{I18n.t('manuals.updates_amendments')}</span>",
+            "7 September 2013 <span class=\"govuk-visually-hidden\">#{I18n.t('manuals.updates_amendments')}</span>",
             {
               (fourth_note["base_path"]).to_s => [fourth_note],
             },


### PR DESCRIPTION
## Description

At the moment, it uses Date.parse which doesn't account for the difference in timing between the timestamp (UTC) and local time (BST).

This causes issues with some updates being a day off if they were published between 00.00 & 00.59.

Time.zone.parse parses the date correctly into the "London" timezone. We still need to convert it back into a date though as it groups on year, then by identical dates, so all updates for a day are grouped.

## Screenshots

### Before 

<img width="808" alt="image" src="https://github.com/alphagov/government-frontend/assets/42515961/c952ea91-897d-4b7c-8fd0-846bd8af9c3d">


### After 

<img width="551" alt="image" src="https://github.com/alphagov/government-frontend/assets/42515961/cbd3755f-43cc-470e-86b7-246972bff325">

## Trello card

https://trello.com/c/idVD4RQT/1794-update-history-shows-the-wrong-date

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
