### PR TITLE
Remove underscores from AB test name

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -274,7 +274,7 @@ private
     placeholder = "{{ab_test_find_utr_number_video_links}}"
     if @content_item.base_path == "/find-utr-number" && @content_item.body.include?(placeholder)
       ab_test = GovukAbTesting::AbTest.new(
-        "find_utr_number_video_links",
+        "FindUtrNumberVideoLinks",
         dimension: 61, # https://docs.google.com/spreadsheets/d/1h4vGXzIbhOWwUzourPLIc8WM-iU1b6WYOVDOZxmU1Uo/edit#gid=254065189&range=69:69
         allowed_variants: %w[A B Z],
         control_variant: "Z",

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -371,7 +371,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
     stub_content_store_has_item(content_item["base_path"], content_item)
 
-    request.headers["HTTP_GOVUK_ABTEST_FIND_UTR_NUMBER_VIDEO_LINKS"] = nil
+    request.headers["HTTP_GOVUK_ABTEST_FINDUTRNUMBERVIDEOLINKS"] = nil
 
     get :show, params: { path: path_for(content_item) }
     assert_response :success
@@ -386,7 +386,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
     stub_content_store_has_item(content_item["base_path"], content_item)
 
-    request.headers["HTTP_GOVUK_ABTEST_FIND_UTR_NUMBER_VIDEO_LINKS"] = "A"
+    request.headers["HTTP_GOVUK_ABTEST_FINDUTRNUMBERVIDEOLINKS"] = "A"
 
     get :show, params: { path: path_for(content_item) }
     assert_response :success
@@ -401,7 +401,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
     stub_content_store_has_item(content_item["base_path"], content_item)
 
-    request.headers["HTTP_GOVUK_ABTEST_FIND_UTR_NUMBER_VIDEO_LINKS"] = "B"
+    request.headers["HTTP_GOVUK_ABTEST_FINDUTRNUMBERVIDEOLINKS"] = "B"
 
     get :show, params: { path: path_for(content_item) }
     assert_response :success


### PR DESCRIPTION
nginx no likey underscores in headers - https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#missing-disappearing-http-headers

This was resulting in the HTTP header that Fastly sets for the AB test being dropped by one of the nginxs which sit in front of rails.
