### PR TITLE
Add AB test meta tag to /find-utr-number page

### DIFF
--- a/app/views/content_items/answer.html.erb
+++ b/app/views/content_items/answer.html.erb
@@ -16,6 +16,8 @@
   <% elsif scroll_track_percent_paths.include?(@content_item.base_path) %>
     <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker"/>
   <% end %>
+
+  <%= @requested_variant.analytics_meta_tag.html_safe if @requested_variant.present? %>
 <% end %>
 
 <%= render 'content_items/body_with_related_links' %>


### PR DESCRIPTION
If our AB test is active (see ContentItemsController#temporary_ab_test_find_utr_page) then @requested_variant will be set, and we should use it to add the required <meta> tag to the page.

Technically this code will work for any Answer that sets a @requested_variant field, but I think that's probably okay / what people would want in that situation anyway.