### PR TITLE
Add data-ga4-form-no-answer-undefined to search form

### DIFF
--- a/app/views/content_items/manuals/_header.html.erb
+++ b/app/views/content_items/manuals/_header.html.erb
@@ -32,6 +32,7 @@
       <%
         form_data = {
           module: "ga4-form-tracker",
+          ga4_form_no_answer_undefined: "",
           ga4_form_include_text: "",
           ga4_form: {
             event_name: "search",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Add data-ga4-form-no-answer-undefined to search form

## Why

Requested by PAs: https://trello.com/c/WtvEWiS3/592-placeholder-replace-no-answer-given-with-undefined-on-homepage-search-event
