### PR TITLE
Flatten GA4 attributes

### DIFF
--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -92,9 +92,7 @@
           ga4_event: {
             event_name: 'print_page',
             type: 'print page',
-            index: {
-              index_link: 1,
-            },
+            index_link: 1,
             index_total: 2,
             section: 'Content',
           },

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -29,9 +29,7 @@
         ga4_event: {
           event_name: 'print_page',
           type: 'print page',
-          index: {
-            index_link: 1,
-          },
+          index_link: 1,
           index_total: 2,
           section: 'Content',
         },
@@ -62,9 +60,7 @@
         ga4_event: {
           event_name: 'print_page',
           type: 'print page',
-          index: {
-            index_link: 2,
-          },
+          index_link: 2,
           index_total: 2,
           section: 'Footer',
         },

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -70,9 +70,7 @@
             ga4_event: {
               event_name: 'print_page',
               type: 'print page',
-              index: {
-                index_link: 1,
-              },
+              index_link: 1,
               index_total: 1,
               section: 'Content',
             },

--- a/app/views/content_items/manuals/_manual_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_layout.html.erb
@@ -23,13 +23,11 @@
         ga4_event: {
           event_name: 'print_page',
           type: 'print page',
-          index: {
-            index_link: 1,
-          },
+          index_link: 1,
           index_total: 1,
           section: 'Footer',
         },
       },
-    } %>    
+    } %>
   </div>
 <% end %>

--- a/app/views/content_items/manuals/_manual_section_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_section_layout.html.erb
@@ -40,9 +40,7 @@
         ga4_event: {
           event_name: 'print_page',
           type: 'print page',
-          index: {
-            index_link: 1,
-          },
+          index_link: 1,
           index_total: 1,
           section: 'Footer',
         },

--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -65,9 +65,7 @@
     ga4_event: {
       event_name: 'print_page',
       type: 'print page',
-      index: {
-        index_link: 1,
-      },
+      index_link: 1,
       index_total: 1,
       section: 'Footer',
     },

--- a/app/views/content_items/travel_advice.html+print.erb
+++ b/app/views/content_items/travel_advice.html+print.erb
@@ -28,9 +28,7 @@
         ga4_event: {
           event_name: 'print_page',
           type: 'print page',
-          index: {
-            index_link: 1,
-          },
+          index_link: 1,
           index_total: 2,
           section: 'Content',
         },
@@ -62,9 +60,7 @@
         ga4_event: {
           event_name: 'print_page',
           type: 'print page',
-          index: {
-            index_link: 2,
-          },
+          index_link: 2,
           index_total: 2,
           section: 'Footer',
         },

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -19,18 +19,18 @@
    <%= render "govuk_publishing_components/components/govspeak", {
     } do %>
        <% @content_item.alert_status.each do |text| %>
-        <%= render "govuk_publishing_components/components/warning_text", 
-          text: text 
-        %> 
+        <%= render "govuk_publishing_components/components/warning_text",
+          text: text
+        %>
       <% end %>
     <% end %>
 
     <aside class="part-navigation-container" role="complementary">
       <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("travel_advice.pages") }, contents: @content_item.part_link_elements, underline_links: true, ga4_tracking: true %>
 
-      <div 
+      <div
         data-module="ga4-link-tracker"
-        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Top" }'
+        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
         data-ga4-track-links-only
       >
         <%= render 'govuk_publishing_components/components/subscription_links',
@@ -46,7 +46,7 @@
   <% unless @content_item.parts.empty? %>
     <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
       <%= render 'govuk_publishing_components/components/heading', heading_level: 1, font_size: 'l', margin_bottom: 6, text: @content_item.current_part_title %>
-      
+
       <% if @content_item.no_part_slug_provided? %>
         <%= render 'shared/travel_advice_first_part', content_item: @content_item %>
       <% end %>

--- a/app/views/shared/_document_collections_email_signup.html.erb
+++ b/app/views/shared/_document_collections_email_signup.html.erb
@@ -1,7 +1,7 @@
 <% if @content_item.taxonomy_topic_email_override_base_path.present? %>
   <div
     data-module="ga4-link-tracker"
-    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Top" }'
+    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
     data-ga4-track-links-only
   >
     <%= render "govuk_publishing_components/components/signup_link", {

--- a/app/views/shared/_email_signup.html.erb
+++ b/app/views/shared/_email_signup.html.erb
@@ -6,10 +6,10 @@
     id: "related-subscriptions",
   } %>
 
-  <div 
-    class="related-item__subscription-link" 
+  <div
+    class="related-item__subscription-link"
     data-module="ga4-link-tracker"
-    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Sidebar" }'
+    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Sidebar" }'
     data-ga4-track-links-only
   >
     <%= render "govuk_publishing_components/components/subscription_links", {

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -20,9 +20,7 @@
       ga4_link: {
         event_name: "navigation",
         type: "subscribe",
-        index: {
-          index_link: 2
-        },
+        index_link: 2,
         index_total: 2,
         section: "Footer"
       }
@@ -36,9 +34,7 @@
       ga4_event: {
         event_name: 'print_page',
         type: 'print page',
-        index: {
-          index_link: 2,
-        },
+        index_link: 2,
         index_total: 2,
         section: 'Footer',
       },

--- a/app/views/shared/_single_page_notification_button.html.erb
+++ b/app/views/shared/_single_page_notification_button.html.erb
@@ -4,9 +4,7 @@
     ga4_link: {
       event_name: "navigation",
       type: "subscribe",
-      index: {
-        index_link: 1
-      },
+      index_link: 1,
       index_total: 2,
       section: "Top"
     }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -283,7 +283,7 @@ class ActionDispatch::IntegrationTest
     {
       "event_name" => "navigation",
       "type" => "subscribe",
-      "index" => { "index_link" => index_link },
+      "index_link" => index_link,
       "index_total" => 2,
       "section" => section,
       "url" => "/email/subscriptions/single-page/new",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- we no longer need to nest GA4 attributes attached to elements, notably the index attributes
- these attributes when collected by trackers are automatically nested based on the structure of the GA4 schema, held in the gem
- flattening them here saves code and complexity

## Visual changes
None.

Trello card: https://trello.com/c/IseA05Fd/644-remove-nesting-of-ga4-attributes