### PR TITLE
Enable GA4 tracking on intervention component

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,10 +36,11 @@
           suggestion_link_text: "Take part in user research",
           suggestion_link_url: @content_item.benefits_recruitment_survey_url,
           new_tab: true,
+          ga4_tracking: true,
         } %>
       </div>
     <% end %>
-    
+
     <%= yield :header %>
 
     <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Enable tracking on the intervention component.

## Why
Part of the GA4 migration. This should be turned on when this component is used, but we're exploring alternatives (like enabling tracking by default) so developers don't have to remember to do this.

## Visual changes
None.

Trello card: https://trello.com/c/X9VRm9yV/721-add-tracking-to-intervention-component
