### PR TITLE
Fixed typo in 1 Horse Guards Road description

### DIFF
--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -17,7 +17,7 @@ module PublishStaticPages
     {
       content_id: "7be62825-1538-4ff5-aa29-cd09350349f2",
       title: "History of 1 Horse Guards Road",
-      descriotion: "The history of 1 Horse Guards Road.",
+      description: "The history of 1 Horse Guards Road.",
       template: "histories/1_horse_guards_road",
       base_path: "/government/history/1-horse-guards-road",
     },


### PR DESCRIPTION
I noticed that a meta tag description wasn't appearing for the History of 1 Horse Guards Road page in internal search. I think it could be because of a typo in the word 'description' in this file, so I've updated it.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
