### PR TITLE
Add the GA4 form tracker to /service-manual search

### DIFF
--- a/app/views/content_items/service_manual_homepage.html.erb
+++ b/app/views/content_items/service_manual_homepage.html.erb
@@ -20,7 +20,14 @@
           <p class="govuk-body-lead app-hero-lead app-hero__body--inverse govuk-!-padding-bottom-1">
             Helping teams to create and run great public services that meet the <%= link_to 'Service Standard', '/service-manual/service-standard', class: 'govuk-link govuk-link--inverse' %>.
           </p>
-          <form action="/search" method="get" role="search">
+          <form
+            action="/search"
+            method="get"
+            role="search"
+            data-module="ga4-form-tracker"
+            data-ga4-form-include-text
+            data-ga4-form-no-answer-undefined
+            data-ga4-form='{"event_name": "search", "type": "content", "url": "/search/all", "section": "Service Manual", "action": "search"}' >
             <input type="hidden" name="filter_manual" value="/service-manual">
             <%= render "govuk_publishing_components/components/search", {
               label_text: "Search the service manual",

--- a/test/integration/service_manual_homepage_test.rb
+++ b/test/integration/service_manual_homepage_test.rb
@@ -50,4 +50,13 @@ class ServiceManualHomepageTest < ActionDispatch::IntegrationTest
 
     assert page.has_link? "communities of practice", href: "/service-manual/communities"
   end
+
+  test "the homepage includes GA4 form tracking on the search form" do
+    setup_and_visit_content_item("service_manual_homepage")
+
+    assert page.has_selector?("[data-module='ga4-form-tracker']")
+    assert page.has_selector?("[data-ga4-form='{\"event_name\": \"search\", \"type\": \"content\", \"url\": \"/search/all\", \"section\": \"Service Manual\", \"action\": \"search\"}']")
+    assert page.has_selector?("[data-ga4-form-include-text]")
+    assert page.has_selector?("[data-ga4-form-no-answer-undefined]")
+  end
 end


### PR DESCRIPTION
## What
Adds the GA4 form tracker to /service-manual search form

## Why
https://trello.com/c/mpoui5h3/726-add-search-tracking-to-https-wwwgovuk-service-manual


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
