### PR TITLE
Fix phase banner left/right spacing on some pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,18 +6,12 @@
 
 <% content_for :body do %>
   <div id="wrapper" class="<%= wrapper_class %>">
-    <% if @content_item.show_phase_banner? || @content_item.service_manual? %>
+    <% if @content_item.show_phase_banner? %>
+      <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase %>
+    <% end %>
+    <% if @content_item.service_manual? %>
       <div class="govuk-width-container">
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full">
-            <% if @content_item.show_phase_banner? %>
-              <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase %>
-            <% end %>
-            <% if @content_item.service_manual? %>
-              <%= render_phase_label @content_item, content_for(:phase_message) %>
-            <% end %>
-          </div>
-        </div>
+        <%= render_phase_label @content_item, content_for(:phase_message) %>
       </div>
     <% end %>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Fixes a problem with unneeded left/right padding around the phase banner.

- below the tablet breakpoint (around 1020px) the phase banner at the top of some pages was being padded left and right, which indented it from the rest of the page
- caused by the govuk-frontend grid wrapping classes, which were unnecessary
- some wrapping divs moved instead to support the phase label, which is similar but does require additional wrapping elements
- also remove some unnecessary logic

Example pages:

- https://www.gov.uk/hmrc-internal-manuals/air-passenger-duty/updates (phase banner with problem)
- https://www.gov.uk/service-manual (phase label, should be unaffected)
- https://www.gov.uk/world/organisations/british-consulate-general-barcelona/office/british-consulate-general-barcelona (also rendered by `government-frontend`, no phase banner or phase label, should be unaffected)

## Why

## Visual changes

Desktop - no change.

Tablet - change:

Before | After
------ | ------
![Screenshot 2023-11-14 at 13 30 12](https://github.com/alphagov/government-frontend/assets/861310/8d0fffb0-2efc-491a-9271-4f5ed136eb71) | ![Screenshot 2023-11-14 at 13 30 23](https://github.com/alphagov/government-frontend/assets/861310/72493d6d-8666-4edc-852d-60817589c012)

Mobile - change:

Before | After
------- | -------
![Screenshot 2023-11-14 at 13 31 54](https://github.com/alphagov/government-frontend/assets/861310/3ff81acf-8c28-4638-8498-f271360015a8) | ![Screenshot 2023-11-14 at 13 32 05](https://github.com/alphagov/government-frontend/assets/861310/d393e862-f96a-4d2a-a021-a9072d7fe522)

