### PR TITLE
Remove ga4_tracking: true component options

### DIFF
--- a/app/helpers/service_manual_phase_label_helper.rb
+++ b/app/helpers/service_manual_phase_label_helper.rb
@@ -3,7 +3,6 @@ module ServiceManualPhaseLabelHelper
     if presented_object.respond_to?(:phase) && %w[alpha beta].include?(presented_object.phase)
       render "govuk_publishing_components/components/phase_banner",
              phase: presented_object.phase,
-             ga4_tracking: true,
              message:
     end
   end

--- a/app/views/components/_contents_list_with_body.html.erb
+++ b/app/views/components/_contents_list_with_body.html.erb
@@ -8,7 +8,7 @@
   <div id="contents" class="app-c-contents-list-with-body"<%= sticky_attr %>>
     <% if contents.any? %>
       <div class="responsive-bottom-margin">
-        <%= render 'govuk_publishing_components/components/contents_list', contents: contents, ga4_tracking: true %>
+        <%= render 'govuk_publishing_components/components/contents_list', contents: contents %>
       </div>
     <% end %>
     <%= block %>

--- a/app/views/content_items/call_for_evidence.html.erb
+++ b/app/views/content_items/call_for_evidence.html.erb
@@ -25,7 +25,6 @@
       <%= render "govuk_publishing_components/components/devolved_nations", {
         national_applicability: @content_item.national_applicability,
         type: @content_item.schema_name,
-        ga4_tracking: true,
       } %>
     <% end %>
 

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -26,7 +26,6 @@
       <%= render "govuk_publishing_components/components/devolved_nations", {
         national_applicability: @content_item.national_applicability,
         type: @content_item.schema_name,
-        ga4_tracking: true,
       } %>
     <% end %>
 

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -79,7 +79,6 @@
       <%= render "govuk_publishing_components/components/devolved_nations", {
         national_applicability: @content_item.national_applicability,
         type: @content_item.schema_name,
-        ga4_tracking: true,
       } %>
     <% end %>
 

--- a/app/views/content_items/field_of_operation.html.erb
+++ b/app/views/content_items/field_of_operation.html.erb
@@ -15,7 +15,6 @@
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/contents_list", {
           contents: @content_item.contents,
-          ga4_tracking: true
         } %>
       </div>
     <% end %>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -48,7 +48,7 @@
         href: "#guide-contents"
       } %>
       <aside class="part-navigation-container" role="complementary">
-        <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("guide.pages_in_guide") }, contents: @content_item.part_link_elements, underline_links: true, ga4_tracking: true %>
+        <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("guide.pages_in_guide") }, contents: @content_item.part_link_elements, underline_links: true %>
       </aside>
     <% end %>
   </div>
@@ -73,11 +73,7 @@
       <% end %>
 
       <% if @content_item.show_guide_navigation? %>
-        <%
-          previous_and_next_with_ga4_tracking = { ga4_tracking: true }
-          previous_and_next_with_ga4_tracking.merge!(@content_item.previous_and_next_navigation) # @content_item is frozen so we make a new hash
-        %>
-        <%= render 'govuk_publishing_components/components/previous_and_next_navigation', previous_and_next_with_ga4_tracking %>
+        <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
 
         <div class="responsive-bottom-margin">
           <a href="<%= @content_item.print_link %>"

--- a/app/views/content_items/guide_single.html.erb
+++ b/app/views/content_items/guide_single.html.erb
@@ -21,7 +21,7 @@
 
     <% if @content_item.show_guide_navigation? %>
       <aside class="part-navigation-container" role="complementary">
-        <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("guide.pages_in_guide") }, contents: @content_item.part_link_elements, underline_links: true, ga4_tracking: true %>
+        <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("guide.pages_in_guide") }, contents: @content_item.part_link_elements, underline_links: true %>
       </aside>
     <% end %>
   </div>

--- a/app/views/content_items/hmrc_manual_section.html.erb
+++ b/app/views/content_items/hmrc_manual_section.html.erb
@@ -5,7 +5,7 @@
     heading_level: 1,
     margin_bottom: 6,
     green_background: true,
-    type: I18n.t("manuals.hmrc_manual_type"),    
+    type: I18n.t("manuals.hmrc_manual_type"),
   } %>
 <% end %>
 
@@ -25,10 +25,6 @@
   <% end %>
 
   <div class="govuk-grid-column-full">
-        <%
-          previous_and_next_with_ga4_tracking = { ga4_tracking: true }
-          previous_and_next_with_ga4_tracking.merge!(@content_item.previous_and_next_links) # @content_item is frozen so we make a new hash
-        %>
-    <%= render "govuk_publishing_components/components/previous_and_next_navigation", previous_and_next_with_ga4_tracking %>
+    <%= render "govuk_publishing_components/components/previous_and_next_navigation", @content_item.previous_and_next_links %>
   </div>
 <% end %>

--- a/app/views/content_items/how_government_works.html.erb
+++ b/app/views/content_items/how_government_works.html.erb
@@ -62,7 +62,6 @@
               text: "History of government",
             }
           ],
-          ga4_tracking: true
         } %>
       </div>
 

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -52,7 +52,6 @@
   <%= render "govuk_publishing_components/components/devolved_nations", {
     national_applicability: @content_item.national_applicability,
     type: @content_item.schema_name,
-    ga4_tracking: true,
   } %>
 <% end %>
 
@@ -60,7 +59,7 @@
   <div class="govuk-grid-row">
     <% if @content_item.contents.any? %>
       <div class="govuk-grid-column-one-quarter-from-desktop contents-list-container">
-        <%= render 'govuk_publishing_components/components/contents_list', contents: @content_item.contents, format_numbers: true, ga4_tracking: true %>
+        <%= render 'govuk_publishing_components/components/contents_list', contents: @content_item.contents, format_numbers: true %>
 
         <%= render 'govuk_publishing_components/components/print_link', {
           margin_top: 0,

--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -56,7 +56,6 @@
         %>
 
         <%= render "govuk_publishing_components/components/accordion", {
-          ga4_tracking: true,
           anchor_navigation: true,
           items: items,
         } %>

--- a/app/views/content_items/manuals/_header.html.erb
+++ b/app/views/content_items/manuals/_header.html.erb
@@ -21,12 +21,7 @@
       margin_bottom: margin_bottom,
     } %>
 
-    <%
-      # The metadata component on this page receives ga4_tracking: true as it has a 'See all updates' link.
-      metadata_with_ga4_tracking = { ga4_tracking: true }
-      metadata_with_ga4_tracking.merge!(content_item.manual_metadata) # @content_item is frozen so we make a new hash
-    %>
-    <%= render 'govuk_publishing_components/components/metadata', metadata_with_ga4_tracking %>
+    <%= render 'govuk_publishing_components/components/metadata', content_item.manual_metadata %>
 
     <div class="in-manual-search">
       <%

--- a/app/views/content_items/manuals/_manual_section_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_section_layout.html.erb
@@ -4,7 +4,7 @@
   <div id="manuals-frontend" class="manuals-frontend-body">
     <% if show_contents %>
       <%= render "govuk_publishing_components/components/contents_list", {
-        aria: { label: t("manuals.pages_in_manual_section") }, contents: @content_item.contents, underline_links: true, ga4_tracking: true
+        aria: { label: t("manuals.pages_in_manual_section") }, contents: @content_item.contents, underline_links: true
       } %>
     <% end %>
 

--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -20,7 +20,6 @@
 
           <%= render "govuk_publishing_components/components/accordion", {
             heading_level: 3,
-            ga4_tracking: true,
             items: updates_by_year.each.with_index(1).map do |updated_documents, index|
               accordion_content = capture do %>
                 <% change_notes = updated_documents.last %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -45,7 +45,6 @@
         <%= render "govuk_publishing_components/components/devolved_nations", {
           national_applicability: @content_item.national_applicability,
           type: @content_item.schema_name,
-          ga4_tracking: true,
         } %>
       <% end %>
 

--- a/app/views/content_items/service_manual_topic.html.erb
+++ b/app/views/content_items/service_manual_topic.html.erb
@@ -28,7 +28,6 @@
       <% if @content_item.display_as_accordion? %>
         <% items = @content_item.accordion_content %>
         <%= render "govuk_publishing_components/components/accordion", {
-          ga4_tracking: true,
           items: items,
         } %>
       <% else %>

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -44,6 +44,6 @@
     <% end %>
   </div>
   <div class="govuk-grid-column-one-third">
-    <%= render 'govuk_publishing_components/components/related_navigation', content_item: @content_item.content_item.parsed_content, context: :sidebar, ga4_tracking: true %>
+    <%= render 'govuk_publishing_components/components/related_navigation', content_item: @content_item.content_item.parsed_content, context: :sidebar %>
   </div>
 </div>

--- a/app/views/content_items/travel_advice.html.erb
+++ b/app/views/content_items/travel_advice.html.erb
@@ -26,7 +26,7 @@
     <% end %>
 
     <aside class="part-navigation-container" role="complementary">
-      <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("travel_advice.pages") }, contents: @content_item.part_link_elements, underline_links: true, ga4_tracking: true %>
+      <%= render "govuk_publishing_components/components/contents_list", aria: { label: t("travel_advice.pages") }, contents: @content_item.part_link_elements, underline_links: true %>
 
       <div
         data-module="ga4-link-tracker"
@@ -63,11 +63,7 @@
         <% end %>
       </div>
 
-      <%
-        previous_and_next_with_ga4_tracking = { ga4_tracking: true }
-        previous_and_next_with_ga4_tracking.merge!(@content_item.previous_and_next_navigation) # @content_item is frozen so we make a new hash
-      %>
-      <%= render 'govuk_publishing_components/components/previous_and_next_navigation', previous_and_next_with_ga4_tracking %>
+      <%= render 'govuk_publishing_components/components/previous_and_next_navigation', @content_item.previous_and_next_navigation %>
 
       <div class="responsive-bottom-margin">
         <a href="<%= @content_item.print_link %>"

--- a/app/views/content_items/worldwide_office.html.erb
+++ b/app/views/content_items/worldwide_office.html.erb
@@ -5,9 +5,8 @@
 <article class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
     <%= render "govuk_publishing_components/components/contents_list",
-               contents: @content_item.contents,
-               underline_links: true,
-               ga4_tracking: true
+      contents: @content_item.contents,
+      underline_links: true
     %>
   </div>
 

--- a/app/views/histories/10_downing_street.html.erb
+++ b/app/views/histories/10_downing_street.html.erb
@@ -70,7 +70,6 @@
           text: "Larry, Chief Mouser to the Cabinet&nbsp;Office".html_safe,
         },
       ],
-      ga4_tracking: true
     } %>
   </nav>
 

--- a/app/views/histories/11_downing_street.html.erb
+++ b/app/views/histories/11_downing_street.html.erb
@@ -62,7 +62,6 @@
           text: "Sir John Soane",
         },
       ],
-      ga4_tracking: true
     } %>
   </nav>
 

--- a/app/views/histories/1_horse_guards_road.html.erb
+++ b/app/views/histories/1_horse_guards_road.html.erb
@@ -41,7 +41,6 @@
           text: "The Cabinet War Rooms",
         },
       ],
-      ga4_tracking: true
     } %>
   </nav>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/histories/king_charles_street.html.erb
+++ b/app/views/histories/king_charles_street.html.erb
@@ -34,7 +34,6 @@
           text: "Fine Rooms",
         },
       ],
-      ga4_tracking: true
     } %>
   </nav>
 

--- a/app/views/histories/lancaster_house.html.erb
+++ b/app/views/histories/lancaster_house.html.erb
@@ -74,7 +74,6 @@
           text: "Contact details",
         },
       ],
-      ga4_tracking: true
     } %>
   </nav>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
             <% if @content_item.show_phase_banner? %>
-              <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase, ga4_tracking: true %>
+              <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase %>
             <% end %>
             <% if @content_item.service_manual? %>
               <%= render_phase_label @content_item, content_for(:phase_message) %>
@@ -25,7 +25,7 @@
       <% if @content_item.try(:back_link) %>
         <%= render 'govuk_publishing_components/components/back_link', href: @content_item.back_link %>
       <% else %>
-        <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.parsed_content_item, ga4_tracking: true %>
+        <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.parsed_content_item %>
       <% end %>
     <% end %>
 

--- a/app/views/shared/_footer_navigation.html.erb
+++ b/app/views/shared/_footer_navigation.html.erb
@@ -1,5 +1,5 @@
 <% @contextual_footer = capture do %>
-  <%= render 'govuk_publishing_components/components/contextual_footer', content_item: @content_item.content_item.parsed_content, ga4_tracking: true %>
+  <%= render 'govuk_publishing_components/components/contextual_footer', content_item: @content_item.content_item.parsed_content %>
 <% end %>
 
 <% if @contextual_footer.present? %>

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -1,7 +1,5 @@
-<%
-  content_item = @content_item.content_item.parsed_content
-%>
+<% content_item = @content_item.content_item.parsed_content %>
 
 <div class="govuk-grid-column-one-third">
-  <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item, ga4_tracking: true %>
+  <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
 </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Removes all instances of `ga4_tracking: true` in calls to components.

- all components that previously accepted this option now have GA4 tracking enabled by default, so these options are no longer needed
- no tracking should change as a result of this change
- this change was made in components gem v `35.22.0`

## Why
We're moving to an 'opt out' model of component inclusion, to future proof tracking as the site changes and components are added and removed.

## Visual changes
None.

Trello card: https://trello.com/c/Xwp7dgJN/294-tracking-auditing-tracking-by-default
