### PR TITLE
Remove old GA4 code

### DIFF
--- a/app/presenters/service_manual_topic_presenter.rb
+++ b/app/presenters/service_manual_topic_presenter.rb
@@ -50,17 +50,8 @@ class ServiceManualTopicPresenter < ServiceManualPresenter
     # This method returns the content in the required shape from the hash
     # supplied by the `groups` method.
 
-    groups.each.with_index(1).map do |section, index|
+    groups.each.map do |section|
       {
-        data_attributes: {
-          ga4: {
-            event_name: "select_content",
-            type: "accordion",
-            text: section.name,
-            index:,
-            index_total: groups.length,
-          },
-        },
         heading: {
           text: section.name,
         },

--- a/test/presenters/service_manual_topic_presenter_test.rb
+++ b/test/presenters/service_manual_topic_presenter_test.rb
@@ -33,15 +33,6 @@ class ServiceManualTopicPresenterTest < PresenterTestCase
   test "returns accordion content data" do
     accordion_content = presented_item.accordion_content
     first_accordion_section = {
-      data_attributes: {
-        ga4: {
-          event_name: "select_content",
-          type: "accordion",
-          text: "Group 1",
-          index: 1,
-          index_total: 2,
-        },
-      },
       heading: { text: "Group 1" },
       summary: { text: "The first group" },
       content: { html: "<ul class=\"govuk-list\">\n<li><a class=\"govuk-link\" href=\"/service-manual/user-centred-design/accessibility\">Accessibility</a></li>\n<li><a class=\"govuk-link\" href=\"/service-manual/user-centred-design/resources/patterns/addresses\">Addresses</a></li>\n</ul>" },


### PR DESCRIPTION
This is no longer needed, as the GA4 data attributes are handled within the component (and `data-ga4` was the old name for the attribute)

Example page: https://www.gov.uk/service-manual/helping-people-to-use-your-service

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
