### PR TITLE
Add User Research Banner To Cold Weather Payment Pages

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -18,6 +18,24 @@ class ContentItemPresenter
 
   attr_accessor :include_collections_in_other_publisher_metadata
 
+  COLD_SURVEY_URL = "https://forms.office.com/pages/responsepage.aspx?id=lY2s6r7DX0av4Th52NzAlAT5pt_hKLdInpMo5L74aZNUMzgzVUhaSDRSNVg0UVpVOTNLWFFZUlcyRy4u".freeze
+  COLD_SURVEY_URL_MAPPINGS = {
+    "/cold-weather-payment" => COLD_SURVEY_URL,
+    "/cold-weather-payment/eligibility" => COLD_SURVEY_URL,
+    "/cold-weather-payment/what-you-need-to-do" => COLD_SURVEY_URL,
+    "/cold-weather-payment/when-youll-get-paid" => COLD_SURVEY_URL,
+    "/cold-weather-payment/further-information" => COLD_SURVEY_URL,
+  }.freeze
+
+  def recruitment_survey_url
+    user_research_test_url
+  end
+
+  def user_research_test_url
+    key = content_item["base_path"]
+    COLD_SURVEY_URL_MAPPINGS[key]
+  end
+
   def initialize(content_item, requested_path, view_context)
     @content_item = content_item
     @requested_path = requested_path

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,17 @@
       <% end %>
     <% end %>
 
+    <% if @content_item.recruitment_survey_url %>
+      <div class="govuk-!-static-margin-top-4">
+        <%= render "govuk_publishing_components/components/intervention", {
+          suggestion_text: "Help improve a new GOV.UK tool",
+          suggestion_link_text: "Sign up to take part in user research",
+          suggestion_link_url: @content_item.recruitment_survey_url,
+          new_tab: true,
+        } %>
+      </div>
+    <% end %>
+
     <%= yield :header %>
 
     <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">

--- a/test/integration/recruitment_banner_test.rb 
+++ b/test/integration/recruitment_banner_test.rb 
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "User research banner is displayed on pages of interest" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+
+    pages_of_interest =
+      [
+        "/cold-weather-payment",
+        "/cold-weather-payment/eligibility",
+        "/cold-weather-payment/what-you-need-to-do",
+        "/cold-weather-payment/when-youll-get-paid",
+        "/cold-weather-payment/further-information",
+      ]
+
+    pages_of_interest.each do |path|
+      guide["base_path"] = path
+      stub_content_store_has_item(guide["base_path"], guide.to_json)
+      visit guide["base_path"]
+
+      assert page.has_css?(".gem-c-intervention")
+      assert page.has_link?("Take part in user research", href: "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=Content_History&utm_source=Hold_gov_to_account&utm_medium=gov.uk&t=GDS&id=16")
+    end
+  end
+
+  test "User research banner is not displayed on all pages" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    guide["base_path"] = "/nothing-to-see-here"
+    stub_content_store_has_item(guide["base_path"], guide.to_json)
+    visit guide["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Sign up to take part in user research", href: "https://gov.uk")
+  end
+end


### PR DESCRIPTION
Will appear on following pages:

- [/cold-weather-payment](https://www.gov.uk/cold-weather-payment)
- [/cold-weather-payment/eligibility](https://www.gov.uk/cold-weather-payment/eligibility)
- [/cold-weather-payment/what-you-need-to-do](https://www.gov.uk/cold-weather-payment/what-you-need-to-do)
- [/cold-weather-payment/when-youll-get-paid](https://www.gov.uk/cold-weather-payment/when-youll-get-paid)
- [/cold-weather-payment/further-information](https://www.gov.uk/cold-weather-payment/further-information)

## Visual Differences

### Before

![Screenshot 2023-11-24 at 11 01 18](https://github.com/alphagov/government-frontend/assets/3727504/121783c3-7dd7-4d3b-b566-95293520bc88)

### After

![Screenshot 2023-11-24 at 11 01 09](https://github.com/alphagov/government-frontend/assets/3727504/73159ccb-0056-4935-9977-38acba7f7101)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

[Relevant Trello Card](https://trello.com/c/8yCpIpn9/2250-user-research-banner-requests-dwp-cold-weather-payment-set-up-m)
