### PR TITLE
Remove GA4 tracking on 'print this page' buttons

### DIFF
--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -86,16 +86,6 @@
       <%= render "govuk_publishing_components/components/print_link", {
         margin_top: 0,
         margin_bottom: 6,
-        data_attributes: {
-          module: "ga4-event-tracker",
-          ga4_event: {
-            event_name: 'print_page',
-            type: 'print page',
-            index_link: 1,
-            index_total: 2,
-            section: 'Content',
-          },
-        },
       } %>
 
       <%= render 'govuk_publishing_components/components/govspeak', {} do %>

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -22,17 +22,9 @@
 
     <%= render 'govuk_publishing_components/components/print_link', {
       data_attributes: {
-        module: "ga4-event-tracker",
         "track-category": "printButton",
         "track-action": "clicked",
         "track-label": t("components.print_link.text"),
-        ga4_event: {
-          event_name: 'print_page',
-          type: 'print page',
-          index_link: 1,
-          index_total: 2,
-          section: 'Content',
-        },
       },
       margin_bottom: 8,
       text: t("components.print_link.text"),
@@ -53,17 +45,9 @@
 
     <%= render 'govuk_publishing_components/components/print_link', {
       data_attributes: {
-        module: "ga4-event-tracker",
         "track-category": "printButton",
         "track-action": "clicked",
         "track-label": t("components.print_link.text"),
-        ga4_event: {
-          event_name: 'print_page',
-          type: 'print page',
-          index_link: 2,
-          index_total: 2,
-          section: 'Footer',
-        },
       },
       text: t("components.print_link.text")
     } %>

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -64,16 +64,6 @@
         <%= render 'govuk_publishing_components/components/print_link', {
           margin_top: 0,
           margin_bottom: 6,
-          data_attributes: {
-            module: "ga4-event-tracker",
-            ga4_event: {
-              event_name: 'print_page',
-              type: 'print page',
-              index_link: 1,
-              index_total: 1,
-              section: 'Content',
-            },
-          },
         } %>
       </div>
     <% end %>

--- a/app/views/content_items/manuals/_manual_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_layout.html.erb
@@ -17,17 +17,6 @@
 
     <%= yield %>
 
-    <%= render 'govuk_publishing_components/components/print_link', {
-      data_attributes: {
-        module: "ga4-event-tracker",
-        ga4_event: {
-          event_name: 'print_page',
-          type: 'print page',
-          index_link: 1,
-          index_total: 1,
-          section: 'Footer',
-        },
-      },
-    } %>
+    <%= render 'govuk_publishing_components/components/print_link' %>
   </div>
 <% end %>

--- a/app/views/content_items/manuals/_manual_section_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_section_layout.html.erb
@@ -34,17 +34,6 @@
       </div>
     </div>
 
-    <%= render 'govuk_publishing_components/components/print_link', {
-      data_attributes: {
-        module: "ga4-event-tracker",
-        ga4_event: {
-          event_name: 'print_page',
-          type: 'print page',
-          index_link: 1,
-          index_total: 1,
-          section: 'Footer',
-        },
-      },
-    } %>
+    <%= render 'govuk_publishing_components/components/print_link' %>
   </div>
 <% end %>

--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -58,15 +58,4 @@
   </div>
 </div>
 
-<%= render 'govuk_publishing_components/components/print_link', {
-  data_attributes: {
-    module: "ga4-event-tracker",
-    ga4_event: {
-      event_name: 'print_page',
-      type: 'print page',
-      index_link: 1,
-      index_total: 1,
-      section: 'Footer',
-    },
-  },
-} %>
+<%= render 'govuk_publishing_components/components/print_link' %>

--- a/app/views/content_items/travel_advice.html+print.erb
+++ b/app/views/content_items/travel_advice.html+print.erb
@@ -21,17 +21,9 @@
 
     <%= render 'govuk_publishing_components/components/print_link', {
       data_attributes: {
-        module: "ga4-event-tracker",
         "track-category": "printButton",
         "track-action": "clicked",
         "track-label": t("components.print_link.text"),
-        ga4_event: {
-          event_name: 'print_page',
-          type: 'print page',
-          index_link: 1,
-          index_total: 2,
-          section: 'Content',
-        },
       },
       margin_bottom: 8,
       text: t("components.print_link.text"),
@@ -53,17 +45,9 @@
 
     <%= render 'govuk_publishing_components/components/print_link', {
       data_attributes: {
-        module: "ga4-event-tracker",
         "track-category": "printButton",
         "track-action": "clicked",
         "track-label": t("components.print_link.text"),
-        ga4_event: {
-          event_name: 'print_page',
-          type: 'print page',
-          index_link: 2,
-          index_total: 2,
-          section: 'Footer',
-        },
       },
       text: t("components.print_link.text")
     } %>

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -29,16 +29,6 @@
   <%= render "govuk_publishing_components/components/print_link", {
     margin_top: 0,
     margin_bottom: 8,
-    data_attributes: {
-      module: "ga4-event-tracker",
-      ga4_event: {
-        event_name: 'print_page',
-        type: 'print page',
-        index_link: 2,
-        index_total: 2,
-        section: 'Footer',
-      },
-    },
   } %>
 </div>
 


### PR DESCRIPTION
## What
Removes GA4 tracking on 'print page' buttons

## Why
- We now have a tracker that tracks the browser's print dialog, so we remove this tracking to prevent duplicate print events.
- https://trello.com/c/8tv1YU8b/718-print-page-button-click-triggers-a-browser-print-event-duplicate-printpage-tracking

## Pages affected
(Taken from #2513 )

- detailed guides ([example detailed guide](http://127.0.0.1:3090/guidance/register-a-trust-as-a-trustee))
- guides ([example guide](http://127.0.0.1:3090/change-address-driving-licence/print))
- HMRC manuals ([example manual](http://127.0.0.1:3090/hmrc-internal-manuals/employment-income-manual) and [example manual section](http://127.0.0.1:3090/hmrc-internal-manuals/employment-income-manual/eim00100) and [example updates page](http://127.0.0.1:3090/hmrc-internal-manuals/trust-registration-service-manual/updates))
- HTML publication ([example HTML publication](http://127.0.0.1:3090/government/publications/budget-2016-documents/budget-2016))
- manuals ([example manual section](http://127.0.0.1:3090/guidance/the-highway-code/general-rules-techniques-and-advice-for-all-drivers-and-riders-103-to-158) and [example manual](http://127.0.0.1:3090/guidance/academy-trust-handbook))
- travel advice ([example travel advice](http://127.0.0.1:3090/foreign-travel-advice/usa/print))

