### PR TITLE
Add scroll tracking to guides and answers

### DIFF
--- a/app/views/content_items/answer.html.erb
+++ b/app/views/content_items/answer.html.erb
@@ -10,11 +10,30 @@
     scroll_track_percent_paths = [
       "/get-coronavirus-test",
     ]
+    ga4_scroll_track_headings_paths = [
+      "/personal-tax-account",
+      "/log-in-file-self-assessment-tax-return",
+      "/benefits-calculators",
+      "/national-minimum-wage-rates",
+      "/order-coronavirus-rapid-lateral-flow-tests",
+      "/contact-hmrc",
+      "/dbs-update-service",
+      "/tax-free-childcare",
+      "/check-income-tax-current-year",
+      "/apply-apprenticeship",
+      "/report-covid19-result",
+      "/order-copy-birth-death-marriage-certificate",
+      "/global-health-insurance-card"
+    ]
   %>
   <% if scroll_track_headings_paths.include?(@content_item.base_path) %>
     <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker" data-track-type="headings"/>
   <% elsif scroll_track_percent_paths.include?(@content_item.base_path) %>
     <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker"/>
+  <% end %>
+
+  <% if ga4_scroll_track_headings_paths.include?(@content_item.base_path) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
   <% end %>
 
   <%= @requested_variant.analytics_meta_tag.html_safe if @requested_variant.present? %>

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -131,6 +131,14 @@
       "/repaying-your-student-loan/which-repayment-plan-you-are-on",
       "/changing-passport-information",
       "/change-circumstances-visa-brp",
+      "/standard-visitor",
+      "/apply-to-come-to-the-uk",
+      "/change-address-v5c",
+      "/pip",
+      "/skilled-worker-visa",
+      "/child-benefit",
+      "/vehicle-tax-rate-tables",
+      "/tax-codes"
     ]
 
     full_url = [@content_item.base_path, @content_item.part_slug].compact.join('/')


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Add percentage scroll tracking to some of the most visited guide and answer pages.

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/JfkV5NSI/750-add-scroll-tracking-top-100-pages
