### PR TITLE
Use formatted name for worldwide organisations

### DIFF
--- a/app/presenters/worldwide_corporate_information_page_presenter.rb
+++ b/app/presenters/worldwide_corporate_information_page_presenter.rb
@@ -3,6 +3,10 @@ class WorldwideCorporateInformationPagePresenter < ContentItemPresenter
   include ContentItem::ContentsList
   include WorldwideOrganisation::Branding
 
+  def formatted_title
+    worldwide_organisation&.formatted_title
+  end
+
   def show_default_breadcrumbs?
     false
   end
@@ -15,10 +19,6 @@ class WorldwideCorporateInformationPagePresenter < ContentItemPresenter
 
   def sponsoring_organisations
     worldwide_organisation&.sponsoring_organisations
-  end
-
-  def organisation_logo
-    super.merge!(name: worldwide_organisation&.title)
   end
 
 private

--- a/app/presenters/worldwide_office_presenter.rb
+++ b/app/presenters/worldwide_office_presenter.rb
@@ -2,6 +2,10 @@ class WorldwideOfficePresenter < ContentItemPresenter
   include ContentItem::ContentsList
   include WorldwideOrganisation::Branding
 
+  def formatted_title
+    worldwide_organisation&.formatted_title
+  end
+
   def body
     content_item.dig("details", "access_and_opening_times")
   end

--- a/app/presenters/worldwide_organisation/branding.rb
+++ b/app/presenters/worldwide_organisation/branding.rb
@@ -7,7 +7,7 @@ module WorldwideOrganisation
 
       sponsoring_organisation = sponsoring_organisations&.first
       {
-        name: content_item["title"],
+        name: formatted_title.html_safe,
         url: link_to_organisation ? worldwide_organisation.base_path : nil,
         crest: sponsoring_organisation&.dig("details", "logo", "crest") || DEFAULT_ORGANISATION_LOGO,
         brand: sponsoring_organisation&.dig("details", "brand") || DEFAULT_ORGANISATION_LOGO,

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -3,6 +3,10 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
   include WorldwideOrganisation::Branding
   include ActionView::Helpers::UrlHelper
 
+  def formatted_title
+    content_item.dig("details", "logo", "formatted_title")
+  end
+
   def sponsoring_organisation_links
     return if sponsoring_organisations.empty?
 

--- a/test/integration/worldwide_corporate_information_page_test.rb
+++ b/test/integration/worldwide_corporate_information_page_test.rb
@@ -41,7 +41,8 @@ class WorldwideCorporateInformationPageTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item("worldwide_corporate_information_page")
 
     assert_has_component_organisation_logo
-    assert page.has_link? "British Embassy Manila", href: "/world/organisations/british-embassy-manila"
+    assert_has_component_title("British Embassy\nManila")
+    assert page.has_link? "British EmbassyManila", href: "/world/organisations/british-embassy-manila"
   end
 
   test "includes the world locations and sponsoring organisations" do

--- a/test/integration/worldwide_office_test.rb
+++ b/test/integration/worldwide_office_test.rb
@@ -74,11 +74,12 @@ class WorldwideOfficeTest < ActionDispatch::IntegrationTest
     assert page.has_content? "24/7 consular support is available by telephone for all routine enquiries and emergencies."
   end
 
-  test "includes the logo and name of the worldwide organisation as a link" do
+  test "includes the logo and formatted name of the worldwide organisation as a link" do
     setup_and_visit_content_item("worldwide_office")
 
     assert_has_component_organisation_logo
-    assert page.has_link? "British Embassy Manila", href: "/world/organisations/british-embassy-manila"
+    assert_has_component_title("British Embassy\nManila")
+    assert page.has_link? "British EmbassyManila", href: "/world/organisations/british-embassy-manila"
   end
 
   test "includes the world locations and sponsoring organisations" do

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
   test "renders basic worldwide organisation page" do
     setup_and_visit_content_item("worldwide_organisation")
-    assert_has_component_title(@content_item["title"])
+    assert_has_component_title("British Deputy High Commission\nHyderabad")
     assert page.has_text?(@content_item["description"])
   end
 

--- a/test/presenters/worldwide_corporate_information_page_presenter_test.rb
+++ b/test/presenters/worldwide_corporate_information_page_presenter_test.rb
@@ -20,7 +20,7 @@ class WorldwideCorporateInformationPagePresenterTest < PresenterTestCase
 
     presented = create_presenter(WorldwideCorporateInformationPagePresenter, content_item: with_non_default_crest)
 
-    expected = { name: "British Embassy Manila", url: "/world/organisations/british-embassy-manila", crest: "dbt", brand: "foreign-commonwealth-development-office" }
+    expected = { name: "British Embassy<br/>Manila", url: "/world/organisations/british-embassy-manila", crest: "dbt", brand: "foreign-commonwealth-development-office" }
     assert_equal expected, presented.organisation_logo
   end
 
@@ -32,7 +32,7 @@ class WorldwideCorporateInformationPagePresenterTest < PresenterTestCase
 
     presented = create_presenter(WorldwideCorporateInformationPagePresenter, content_item: with_empty_logo)
 
-    expected = { name: "British Embassy Manila", url: "/world/organisations/british-embassy-manila", crest: "single-identity", brand: "single-identity" }
+    expected = { name: "British Embassy<br/>Manila", url: "/world/organisations/british-embassy-manila", crest: "single-identity", brand: "single-identity" }
     assert_equal expected, presented.organisation_logo
   end
 
@@ -42,7 +42,7 @@ class WorldwideCorporateInformationPagePresenterTest < PresenterTestCase
 
     presented = create_presenter(WorldwideCorporateInformationPagePresenter, content_item: without_sponsoring_organisations)
 
-    expected = { name: "British Embassy Manila", url: "/world/organisations/british-embassy-manila", crest: "single-identity", brand: "single-identity" }
+    expected = { name: "British Embassy<br/>Manila", url: "/world/organisations/british-embassy-manila", crest: "single-identity", brand: "single-identity" }
     assert_equal expected, presented.organisation_logo
   end
 

--- a/test/presenters/worldwide_office_presenter_test.rb
+++ b/test/presenters/worldwide_office_presenter_test.rb
@@ -24,7 +24,7 @@ class WorldwideOfficePresenterTest < PresenterTestCase
 
     presented = create_presenter(WorldwideOfficePresenter, content_item: with_non_default_crest)
 
-    expected = { name: "British Embassy Manila", url: "/world/organisations/british-embassy-manila", crest: "dbt", brand: "foreign-commonwealth-development-office" }
+    expected = { name: "British Embassy<br/>Manila", url: "/world/organisations/british-embassy-manila", crest: "dbt", brand: "foreign-commonwealth-development-office" }
     assert_equal expected, presented.organisation_logo
   end
 
@@ -36,7 +36,7 @@ class WorldwideOfficePresenterTest < PresenterTestCase
 
     presented = create_presenter(WorldwideOfficePresenter, content_item: with_empty_logo)
 
-    expected = { name: "British Embassy Manila", url: "/world/organisations/british-embassy-manila", crest: "single-identity", brand: "single-identity" }
+    expected = { name: "British Embassy<br/>Manila", url: "/world/organisations/british-embassy-manila", crest: "single-identity", brand: "single-identity" }
     assert_equal expected, presented.organisation_logo
   end
 
@@ -46,7 +46,7 @@ class WorldwideOfficePresenterTest < PresenterTestCase
 
     presented = create_presenter(WorldwideOfficePresenter, content_item: without_sponsoring_organisations)
 
-    expected = { name: "British Embassy Manila", url: "/world/organisations/british-embassy-manila", crest: "single-identity", brand: "single-identity" }
+    expected = { name: "British Embassy<br/>Manila", url: "/world/organisations/british-embassy-manila", crest: "single-identity", brand: "single-identity" }
     assert_equal expected, presented.organisation_logo
   end
 


### PR DESCRIPTION
We are currently presenting the Worldwide Organisation's title in the logo. This means there are no line breaks in the places specified by the user.

Updating to use the formatted title, which the publisher would have expected since they entered this in Whitehall.

## Screenshots

| Page| Current Rendering | Changed Rendering |
| -- | -- | -- |
| Worldwide Organisation | ![Screenshot showing the logo on a worldwide organisation page with no line break](https://github.com/alphagov/government-frontend/assets/6329861/e5e6ea9d-81e7-4e68-9ef2-9b5fc182979c) | ![Screenshot showing the logo on a worldwide organisation page with the line break in the correct place](https://github.com/alphagov/government-frontend/assets/6329861/8643aa84-9650-45b7-a485-e66735deaa70)  |
| Worldwide Office | ![Screenshot showing the logo on a worldwide office page with no line break](https://github.com/alphagov/government-frontend/assets/6329861/792935cf-910b-4f31-b754-f2eab772a2ac) | ![Screenshot showing the logo on a worldwide office page with the line break in the correct place](https://github.com/alphagov/government-frontend/assets/6329861/9009cb1c-2f92-4ca2-bc82-35e7f7467d68) |
| Worldwide Corporate Information Page | ![Screenshot showing the logo on a worldwide corporate information page with no line break](https://github.com/alphagov/government-frontend/assets/6329861/f89d79d8-3a9f-403a-b902-0f4d523693dd) | ![Screenshot showing the logo on a worldwide corporate information page with the line break in the correct place](https://github.com/alphagov/government-frontend/assets/6329861/6b956e95-5a91-4abb-a04b-481a7ada0a58) |

[Trello card](https://trello.com/c/yUCJohHp)