### PR TITLE
Remove `puts` from test

### DIFF
--- a/test/integration/call_for_evidence_test.rb
+++ b/test/integration/call_for_evidence_test.rb
@@ -71,7 +71,6 @@ class CallForEvidenceTest < ActionDispatch::IntegrationTest
         "closing_date" => "2023-02-02T13:00:00.000+00:00",
       },
     })
-    p page.html
     assert page.has_text?("Open call for evidence")
     assert page.has_text?(:all, "closes at 1pm on 2 February 2023")
   end


### PR DESCRIPTION
This test was printing the page's HTML as output, which cluttered the test results.

Therefore removing.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
