### PR TITLE
Update copy for download link for travel advice map

### DIFF
--- a/app/views/shared/_travel_advice_first_part.html.erb
+++ b/app/views/shared/_travel_advice_first_part.html.erb
@@ -4,7 +4,7 @@
     <img src="<%= content_item.map["url"] %>" alt="<%= content_item.map["alt_text"] %>" class="map-image">
     <% if content_item.map_download_url %>
       <figcaption>
-        <%= render 'components/download_link', href: content_item.map_download_url, link_text: "Download map (PDF)" %>
+        <%= render 'components/download_link', href: content_item.map_download_url, link_text: "Download a more detailed map (PDF)" %>
       </figcaption>
     <% end %>
   </figure>

--- a/test/integration/travel_advice_test.rb
+++ b/test/integration/travel_advice_test.rb
@@ -41,7 +41,7 @@ class TravelAdviceTest < ActionDispatch::IntegrationTest
     end
 
     assert page.has_css?(".map img[src=\"#{@content_item['details']['image']['url']}\"]")
-    assert page.has_css?(".map figcaption a[href=\"#{@content_item['details']['document']['url']}\"]", text: "Download map (PDF)")
+    assert page.has_css?(".map figcaption a[href=\"#{@content_item['details']['document']['url']}\"]", text: "Download a more detailed map (PDF)")
   end
 
   test "travel advice part renders just that part" do


### PR DESCRIPTION
## Description

FCDO would like the copy of this link updated to be more specific. Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5495177

## Trello card

https://trello.com/c/acKHf0Md/2281-change-link-title-to-download-a-more-detailed-map

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
