### PR TITLE
Document collections are showing misleading "last updated" data for mainstream content

### DIFF
--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -41,7 +41,7 @@ class DocumentCollectionPresenter < ContentItemPresenter
           },
         },
         metadata: {
-          public_updated_at: link["public_updated_at"]&.then { |time| Time.zone.parse(time) },
+          public_updated_at: group_document_link_public_updated_at(link),
           document_type: I18n.t(
             "content_item.schema_name.#{link['document_type']}",
             count: 1,
@@ -68,6 +68,22 @@ class DocumentCollectionPresenter < ContentItemPresenter
   end
 
 private
+
+  def group_document_link_public_updated_at(link)
+    disallowed_document_types = %w[answer
+                                   completed_transaction
+                                   guide
+                                   help_page
+                                   local_transaction
+                                   place
+                                   simple_smart_answer
+                                   transaction
+                                   smart_answer]
+
+    return nil if disallowed_document_types.include?(link["document_type"])
+
+    link["public_updated_at"]&.then { |time| Time.zone.parse(time) }
+  end
 
   def group_documents(group)
     group["documents"].map { |id| documents_hash[id] }.compact

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -103,6 +103,34 @@ class DocumentCollectionPresenterTest
 
       assert_nil grouped.first[:metadata][:public_updated_at]
     end
+
+    test "it returns nil if specfic document_type is in the disallowed_document_types list" do
+      schema_data = schema_item
+
+      disallowed_document_types = %w[answer
+                                     completed_transaction
+                                     guide
+                                     help_page
+                                     local_transaction
+                                     place
+                                     simple_smart_answer
+                                     transaction
+                                     smart_answer]
+
+      disallowed_document_types.each do |document_type|
+        document = schema_data["links"]["documents"].first
+        document["document_type"] = document_type
+
+        grouped = present_example(schema_data).group_document_links(
+          { "documents" => [document["content_id"]] },
+          0,
+        )
+
+        public_updated_at = grouped[0][:metadata][:public_updated_at]
+
+        assert_equal nil, public_updated_at
+      end
+    end
   end
 
   class GroupWithMissingDocument < TestCase


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


Ticket: https://trello.com/c/P4zeXabu/1757-document-collections-are-showing-misleading-last-updated-data-for-mainstream-content-m



Before link: https://www.gov.uk/government/collections/how-hmrc-resolves-civil-tax-disputes
After link: https://government-frontend-pr-3041.herokuapp.com/government/collections/how-hmrc-resolves-civil-tax-disputes


**Screenshots Example** 

Before:
<img width="800" alt="Screenshot 2024-01-12 at 15 21 04" src="https://github.com/alphagov/government-frontend/assets/40758489/f86b01a5-5693-4ef7-bfba-214f7083f6e5">

<img width="768" alt="Screenshot 2024-01-12 at 15 26 16" src="https://github.com/alphagov/government-frontend/assets/40758489/da65ee62-74d4-4ae4-83dc-3a4f0679b6b1">



After
<img width="897" alt="Screenshot 2024-01-12 at 15 20 57" src="https://github.com/alphagov/government-frontend/assets/40758489/d839d7fd-f17b-45db-b105-17afd95e0006">

<img width="784" alt="Screenshot 2024-01-12 at 15 27 04" src="https://github.com/alphagov/government-frontend/assets/40758489/20902d91-8a50-40b3-a173-2dc432fed5b4">
