### PR TITLE
[WIP] [DO NOT MERGE] Add tracking to details elements in attachments on form pages

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -11,7 +11,11 @@ class PublicationPresenter < ContentItemPresenter
   end
 
   def documents
-    content_item["details"]["documents"].to_a.join("")
+    docs = content_item["details"]["attachments"].select { |a| a["locale"] == locale }
+    docs.each do |doc|
+      doc.delete("alternative_format_contact_email") if doc["accessible"] == true
+    end
+    docs
   end
 
   def featured_attachments

--- a/app/views/content_items/_attachments.html.erb
+++ b/app/views/content_items/_attachments.html.erb
@@ -1,26 +1,37 @@
-<% attachments ||= [] %>
-<% attachment_details = attachments.filter_map { |id| @content_item&.attachment_details(id) } %>
-<% if legacy_pre_rendered_documents.present? || attachment_details.any? %>
+<%
+  attachments ||= nil
+  attachments_html ||= nil
+  featured_attachments ||= []
+  attachment_details = featured_attachments.filter_map { |id| @content_item&.attachment_details(id) }
+%>
+<% if attachments || attachments_html %>
   <section id="<%= title.parameterize %>">
     <%= render 'govuk_publishing_components/components/heading',
         text: title,
         mobile_top_margin: true %>
 
-    <% if legacy_pre_rendered_documents.present? %>
+    <% add_gem_component_stylesheet("details") %>
+    <% if attachments %>
+      <% attachments.each do |details| %>
+        <%= render 'govuk_publishing_components/components/attachment', {
+          heading_level: 3,
+          attachment: details,
+          margin_bottom: 6
+        } %>
+      <% end %>
+    <% elsif attachments_html %>
       <%= render 'govuk_publishing_components/components/govspeak', {
         direction: page_text_direction,
       } do %>
-        <% add_gem_component_stylesheet("details") if legacy_pre_rendered_documents.include? "govuk\-details" %>
-        <%= raw(legacy_pre_rendered_documents) %>
+        <%= raw(attachments_html) %>
       <% end %>
     <% else %>
       <% attachment_details.each do |details| %>
-        <div class="govuk-!-static-margin-bottom-6">
-          <%= render 'govuk_publishing_components/components/attachment', {
-            heading_level: 3,
-            attachment: details
-          } %>
-        </div>
+        <%= render 'govuk_publishing_components/components/attachment', {
+          heading_level: 3,
+          attachment: details,
+          margin_bottom: 6
+        } %>
       <% end %>
     <% end %>
   </section>

--- a/app/views/content_items/call_for_evidence.html.erb
+++ b/app/views/content_items/call_for_evidence.html.erb
@@ -44,8 +44,8 @@
 
       <%= render "attachments",
           title: t("call_for_evidence.download_outcome"),
-          legacy_pre_rendered_documents: @content_item.outcome_documents,
-          attachments: @content_item.outcome_attachments %>
+          attachments_html: @content_item.outcome_documents,
+          featured_attachments: @content_item.outcome_attachments %>
 
       <%= render 'govuk_publishing_components/components/heading', text: t("call_for_evidence.detail_of_outcome"), mobile_top_margin: true %>
       <div class="call-for-evidence-outcome-detail">
@@ -118,8 +118,8 @@
 
       <%= render "attachments",
           title: t("call_for_evidence.documents"),
-          legacy_pre_rendered_documents: @content_item.documents,
-          attachments: @content_item.featured_attachments %>
+          attachments_html: @content_item.documents,
+          featured_attachments: @content_item.featured_attachments %>
     </div>
 
     <% if @content_item.ways_to_respond? %>

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -55,8 +55,8 @@
 
       <%= render "attachments",
           title: t("consultation.download_outcome"),
-          legacy_pre_rendered_documents: @content_item.final_outcome_documents,
-          attachments: @content_item.final_outcome_attachments %>
+          attachments_html: @content_item.final_outcome_documents,
+          featured_attachments: @content_item.final_outcome_attachments %>
 
       <%= render 'govuk_publishing_components/components/heading', text: t("consultation.detail_of_outcome"), mobile_top_margin: true %>
       <div class="consultation-outcome-detail">
@@ -70,8 +70,8 @@
 
     <%= render "attachments",
         title: t("consultation.feedback_received"),
-        legacy_pre_rendered_documents: @content_item.public_feedback_documents,
-        attachments: @content_item.public_feedback_attachments %>
+        attachments_html: @content_item.public_feedback_documents,
+        featured_attachments: @content_item.public_feedback_attachments %>
 
     <% if @content_item.public_feedback_detail %>
       <%= render 'govuk_publishing_components/components/heading', {
@@ -148,8 +148,8 @@
 
       <%= render "attachments",
           title: t("consultation.documents"),
-          legacy_pre_rendered_documents: @content_item.documents,
-          attachments: @content_item.featured_attachments %>
+          attachments_html: @content_item.documents,
+          featured_attachments: @content_item.featured_attachments %>
     </div>
 
     <% if @content_item.ways_to_respond? %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -51,8 +51,8 @@
       <div class="responsive-bottom-margin">
         <%= render "attachments",
           title: t("publication.documents", count: 5), # This should always be pluralised.
-          legacy_pre_rendered_documents: @content_item.documents,
-          attachments: @content_item.featured_attachments
+          attachments: @content_item.documents,
+          featured_attachments: @content_item.featured_attachments
         %>
 
         <section id="details">

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -10,7 +10,7 @@ class PublicationPresenterTest < PresenterTestCase
     assert_equal schema_item["schema_name"], presented_item.schema_name
     assert_equal schema_item["title"], presented_item.title
     assert_equal schema_item["details"]["body"], presented_item.details
-    assert_equal schema_item["details"]["documents"].join(""), presented_item.documents
+    assert_equal schema_item["details"]["documents"], presented_item.documents_attachments
   end
 
   test "#published returns a formatted date of the day the content item became public" do

--- a/test/views/content_items/attachments.html.erb_test.rb
+++ b/test/views/content_items/attachments.html.erb_test.rb
@@ -1,15 +1,54 @@
 require "test_helper"
 
 class ContentItemsAttachmentsTest < ActionView::TestCase
-  test "it shows pre-rendered attachments by default" do
+  def test_data
+    {
+      accessible: true,
+      attachment_type: "file",
+      command_paper_number: "",
+      content_type: "application/pdf",
+      file_size: "1570742",
+      filename: "aa1-interactive-claim-form.pdf",
+      hoc_paper_number: "",
+      id: "7556005",
+      isbn: "",
+      locale: "en",
+      number_of_pages: 30,
+      title: "Attendance Allowance claim form",
+      unique_reference: "AA1",
+      unnumbered_command_paper: false,
+      unnumbered_hoc_paper: false,
+      url: "https://assets.publishing.service.gov.uk/media/64132b818fa8f55576ac627e/aa1-interactive-claim-form.pdf",
+    }
+  end
+
+  test "it can display pre-rendered attachments" do
     render(
       partial: "content_items/attachments",
-      locals: { title: "Documents",
-                legacy_pre_rendered_documents: "some html" },
+      locals: {
+        title: "Documents",
+        attachments_html: "some html",
+      },
     )
 
     assert_includes rendered, "gem-c-govspeak"
     assert_includes rendered, "some html"
+  end
+
+  test "it can render an array of attachments" do
+    render(
+      partial: "content_items/attachments",
+      locals: {
+        title: "Documents",
+        attachments: [
+          test_data,
+        ],
+      },
+    )
+
+    assert_includes rendered, "gem-c-attachment"
+    assert_includes rendered, "govuk-link", text: "Attendance Allowance claim form"
+    assert_not_includes rendered, "gem-c-details"
   end
 
   test "can render attachments using their metadata" do
@@ -24,8 +63,8 @@ class ContentItemsAttachmentsTest < ActionView::TestCase
     render(
       partial: "content_items/attachments",
       locals: { title: "Documents",
-                legacy_pre_rendered_documents: "",
-                attachments: %w[attachment_id] },
+                attachments: "",
+                featured_attachments: %w[attachment_id] },
     )
 
     assert_includes rendered, "gem-c-attachment"
@@ -35,12 +74,36 @@ class ContentItemsAttachmentsTest < ActionView::TestCase
   test "it prioritises pre-rendered attachments" do
     render(
       partial: "content_items/attachments",
-      locals: { title: "Documents",
-                legacy_pre_rendered_documents: "some html",
-                attachments: %w[attachment_id] },
+      locals: {
+        title: "Documents",
+        attachments: [
+          test_data,
+        ],
+        featured_attachments: %w[attachment_id],
+      },
     )
 
-    assert_includes rendered, "gem-c-govspeak"
-    assert_includes rendered, "some html"
+    assert_includes rendered, "gem-c-attachment"
+    assert_includes rendered, "govuk-link", text: "Attendance Allowance claim form"
+  end
+
+  test "it shows extra information for inaccessible attachments" do
+    data = test_data
+    data[:accessible] = false
+    data[:alternative_format_contact_email] = "accessible.formats@dwp.gov.uk"
+    render(
+      partial: "content_items/attachments",
+      locals: {
+        title: "Documents",
+        attachments: [
+          data,
+        ],
+      },
+    )
+
+    assert_includes rendered, "gem-c-attachment"
+    assert_includes rendered, "govuk-link", text: "Attendance Allowance claim form"
+    assert_includes rendered, "gem-c-attachment__metadata", text: "This file may not be suitable for users of assistive technology."
+    assert_includes rendered, "govuk-details__summary-text", text: "Request an accessible format."
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Rework [form pages](https://docs.publishing.service.gov.uk/document-types/form.html) to include tracking on details components that appear inside attachment components.

Specifically, rework the list of documents on the forms pages to use the content item data in `details->attachments` to render the required content, in place of the data in `details->documents`, which is pre-rendered. 

This presents some problems, because the `attachments` partial used here is used elsewhere (consultations, call for evidence) where switching from a pre-rendered chunk of markup is not so straightforward. I've gone for a middle ground where `attachments` now accepts two parameters for the main content - either the pre-rendered markup (to keep the existing pages from breaking) or an array of data to be used in the template with components to generate the page - and updated all the places where the partial is called accordingly.

This change will impact `form` pages as well as some other page types. I'm a bit confused by the naming conventions, `form` pages are handled by `publication` code, but this will also impact `call for evidence` and `consultation` pages.

Example form pages:

- https://www.gov.uk/government/publications/make-a-lasting-power-of-attorney
- https://www.gov.uk/government/publications/application-for-a-vehicle-registration-certificate
- https://www.gov.uk/government/publications/attendance-allowance-claim-form
- https://www.gov.uk/government/publications/self-assessment-tax-return-sa100
- https://www.gov.uk/government/publications/new-year-honours-list-2024

Still to do:

- [ ] attachment thumbnails are not included in the content item outside of the pre-rendered markup, will need to find a way to pass them
- [ ] ...then republish so they come through in the content item
- [ ] fix failing tests
- [ ] apply tracking to the details components, where they appear

## Why
Good question! We need to put tracking on the details components that can (sometimes) appear beneath the list of attachments, and that's very hard to do here on pre-rendered markup - normally we'd just pass some options to the component.

![Screenshot 2024-01-22 at 13 59 49](https://github.com/alphagov/government-frontend/assets/861310/f8164549-63f0-450c-bb08-bb8462365c06)

## Visual changes
None, hopefully.

Trello card: https://trello.com/c/xhASj1rp/765-add-tracking-to-details-component