### PR TITLE
Use edition links for Worldwide Organisations

### DIFF
--- a/test/presenters/worldwide_organisation_presenter_test.rb
+++ b/test/presenters/worldwide_organisation_presenter_test.rb
@@ -5,8 +5,60 @@ class WorldwideOrganisationPresenterTest < PresenterTestCase
     "worldwide_organisation"
   end
 
-  test "description of primary_role_person should have spaces between roles" do
+  test "description of primary_role_person should have spaces between roles with non-edition links" do
     presenter = create_presenter(WorldwideOrganisationPresenter, content_item: { "links" => { "primary_role_person" => [{ "details" => { "image" => {} }, "links" => { "role_appointments" => [{ "details" => { "current" => true }, "links" => { "role" => [{ "content_id" => "1", "title" => "Example Role 1" }] } }, { "details" => { "current" => true }, "links" => { "role" => [{ "content_id" => "2", "title" => "Example Role 2" }] } }] } }], "roles" => [{ "content_id" => "1" }, { "content_id" => "2" }] } })
+    assert_equal "Example Role 1, Example Role 2", presenter.person_in_primary_role[:description]
+  end
+
+  test "description of primary_role_person should have spaces between roles with edition links" do
+    presenter = create_presenter(WorldwideOrganisationPresenter, content_item: {
+      "details" => { "people_role_associations" => [
+        {
+          "person_content_id" => "person_1",
+          "role_appointments" => [
+            {
+              "role_appointment_content_id" => "role_apppointment_1",
+              "role_content_id" => "role_1",
+            },
+            {
+              "role_appointment_content_id" => "role_apppointment_2",
+              "role_content_id" => "role_2",
+            },
+          ],
+        },
+      ] },
+      "links" => {
+        "primary_role_person" => [
+          {
+            "content_id" => "person_1",
+            "details" => { "image" => {} },
+            "links" => {},
+          },
+        ],
+        "role_appointments" => [
+          {
+            "content_id" => "role_apppointment_1",
+            "details" => { "current" => true },
+            "links" => {},
+          },
+          {
+            "content_id" => "role_apppointment_2",
+            "details" => { "current" => true },
+            "links" => {},
+          },
+        ],
+        "roles" => [
+          {
+            "content_id" => "role_1",
+            "title" => "Example Role 1",
+          },
+          {
+            "content_id" => "role_2",
+            "title" => "Example Role 2",
+          },
+        ],
+      },
+    })
     assert_equal "Example Role 1, Example Role 2", presenter.person_in_primary_role[:description]
   end
 
@@ -15,8 +67,60 @@ class WorldwideOrganisationPresenterTest < PresenterTestCase
     assert_equal "Example Role 1", presenter.person_in_primary_role[:description]
   end
 
-  test "description of people_in_non_primary_roles should have spaces between roles" do
+  test "description of people_in_non_primary_roles should have spaces between roles with non-edition links" do
     presenter = create_presenter(WorldwideOrganisationPresenter, content_item: { "links" => { "secondary_role_person" => [{ "details" => { "image" => {} }, "links" => { "role_appointments" => [{ "details" => { "current" => true }, "links" => { "role" => [{ "content_id" => "1", "title" => "Example Role 1" }] } }, { "details" => { "current" => true }, "links" => { "role" => [{ "content_id" => "2", "title" => "Example Role 2" }] } }] } }], "roles" => [{ "content_id" => "1" }, { "content_id" => "2" }] } })
+    assert_equal "Example Role 1, Example Role 2", presenter.people_in_non_primary_roles.first[:description]
+  end
+
+  test "description of people_in_non_primary_roles should have spaces between roles with edition links" do
+    presenter = create_presenter(WorldwideOrganisationPresenter, content_item: {
+      "details" => { "people_role_associations" => [
+        {
+          "person_content_id" => "person_1",
+          "role_appointments" => [
+            {
+              "role_appointment_content_id" => "role_apppointment_1",
+              "role_content_id" => "role_1",
+            },
+            {
+              "role_appointment_content_id" => "role_apppointment_2",
+              "role_content_id" => "role_2",
+            },
+          ],
+        },
+      ] },
+      "links" => {
+        "secondary_role_person" => [
+          {
+            "content_id" => "person_1",
+            "details" => { "image" => {} },
+            "links" => {},
+          },
+        ],
+        "role_appointments" => [
+          {
+            "content_id" => "role_apppointment_1",
+            "details" => { "current" => true },
+            "links" => {},
+          },
+          {
+            "content_id" => "role_apppointment_2",
+            "details" => { "current" => true },
+            "links" => {},
+          },
+        ],
+        "roles" => [
+          {
+            "content_id" => "role_1",
+            "title" => "Example Role 1",
+          },
+          {
+            "content_id" => "role_2",
+            "title" => "Example Role 2",
+          },
+        ],
+      },
+    })
     assert_equal "Example Role 1, Example Role 2", presenter.people_in_non_primary_roles.first[:description]
   end
 


### PR DESCRIPTION
In https://github.com/alphagov/whitehall/pull/8734 and https://github.com/alphagov/publishing-api/pull/2601, we have switched worldwide organisations to use edition links to fix a bug in editionable worldwide organisations.

This applies the changes needed to the frontend to reflect the lack of multi-level link expansion in edition links.

Whilst this change adds support for edition links, it also retains compatibility with non-edition links. This will allow us to deploy the frontend changes in advance of republishing the content items, preventing any downtime of these pages. The code for backward compatibility will be removed once the content items have all been republished with edition links (all the code to be removed has been marked with a comment so it is easy to identify).

[Trello card](https://trello.com/c/yNJwHw4K)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
