### PR TITLE
Convert publications to local rendering

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -11,7 +11,9 @@ class PublicationPresenter < ContentItemPresenter
   end
 
   def documents
-    docs = content_item["details"]["attachments"].select { |a| a["locale"] == locale } if content_item["details"]["attachments"]
+    return [] unless content_item["details"]["attachments"]
+
+    docs = content_item["details"]["attachments"].select { |a| a["locale"] == locale }
     docs.each { |t| t["type"] = "html" unless t["content_type"] }
   end
 

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -11,7 +11,8 @@ class PublicationPresenter < ContentItemPresenter
   end
 
   def documents
-    content_item["details"]["documents"].to_a.join("")
+    docs = content_item["details"]["attachments"].select { |a| a["locale"] == locale } if content_item["details"]["attachments"]
+    docs.each { |t| t["type"] = "html" unless t["content_type"] }
   end
 
   def featured_attachments

--- a/app/views/content_items/_attachments_list.html.erb
+++ b/app/views/content_items/_attachments_list.html.erb
@@ -1,27 +1,21 @@
-<% attachments ||= [] %>
-<% attachment_details = attachments.filter_map { |id| @content_item&.attachment_details(id) } %>
-<% if legacy_pre_rendered_documents.present? || attachment_details.any? %>
-  <section id="<%= title.parameterize %>">
-    <%= render 'govuk_publishing_components/components/heading',
-        text: title,
-        mobile_top_margin: true %>
-
-    <% if legacy_pre_rendered_documents.present? %>
-      <%= render 'govuk_publishing_components/components/govspeak', {
-        direction: page_text_direction,
-      } do %>
-        <% add_gem_component_stylesheet("details") if legacy_pre_rendered_documents.include? "govuk\-details" %>
-        <%= raw(legacy_pre_rendered_documents) %>
-      <% end %>
-    <% else %>
-      <% attachment_details.each do |details| %>
-        <div class="govuk-!-static-margin-bottom-6">
-          <%= render 'govuk_publishing_components/components/attachment', {
-            heading_level: 3,
-            attachment: details
-          } %>
-        </div>
-      <% end %>
+<%
+  attachments ||= nil
+  featured_attachments ||= []
+  attachment_details = featured_attachments.filter_map { |id| @content_item&.attachment_details(id) }
+%>
+<section id="<%= title.parameterize %>">
+  <%= render 'govuk_publishing_components/components/heading',
+    text: title,
+    mobile_top_margin: true
+  %>
+  <% if attachment_details.length > 0 %>
+    <% add_gem_component_stylesheet("details") %>
+    <% attachment_details.each do |details| %>
+      <%= render 'govuk_publishing_components/components/attachment', {
+        heading_level: 3,
+        attachment: details,
+        margin_bottom: 6
+      } %>
     <% end %>
-  </section>
-<% end %>
+  <% end %>
+</section>

--- a/app/views/content_items/_attachments_list.html.erb
+++ b/app/views/content_items/_attachments_list.html.erb
@@ -1,0 +1,27 @@
+<% attachments ||= [] %>
+<% attachment_details = attachments.filter_map { |id| @content_item&.attachment_details(id) } %>
+<% if legacy_pre_rendered_documents.present? || attachment_details.any? %>
+  <section id="<%= title.parameterize %>">
+    <%= render 'govuk_publishing_components/components/heading',
+        text: title,
+        mobile_top_margin: true %>
+
+    <% if legacy_pre_rendered_documents.present? %>
+      <%= render 'govuk_publishing_components/components/govspeak', {
+        direction: page_text_direction,
+      } do %>
+        <% add_gem_component_stylesheet("details") if legacy_pre_rendered_documents.include? "govuk\-details" %>
+        <%= raw(legacy_pre_rendered_documents) %>
+      <% end %>
+    <% else %>
+      <% attachment_details.each do |details| %>
+        <div class="govuk-!-static-margin-bottom-6">
+          <%= render 'govuk_publishing_components/components/attachment', {
+            heading_level: 3,
+            attachment: details
+          } %>
+        </div>
+      <% end %>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -49,7 +49,7 @@
       <% end %>
 
       <div class="responsive-bottom-margin">
-        <%= render "attachments",
+        <%= render "attachments_list",
           title: t("publication.documents", count: 5), # This should always be pluralised.
           legacy_pre_rendered_documents: @content_item.documents,
           attachments: @content_item.featured_attachments

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -51,8 +51,8 @@
       <div class="responsive-bottom-margin">
         <%= render "attachments_list",
           title: t("publication.documents", count: 5), # This should always be pluralised.
-          legacy_pre_rendered_documents: @content_item.documents,
-          attachments: @content_item.featured_attachments
+          attachments: @content_item.documents,
+          featured_attachments: @content_item.featured_attachments
         %>
 
         <section id="details">

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -32,12 +32,38 @@ class PublicationTest < ActionDispatch::IntegrationTest
     assert_footer_has_published_dates("Published 3 May 2016")
   end
 
-  test "renders document attachments (as-is and directly)" do
-    setup_and_visit_content_item("publication")
-    within "#documents" do
-      assert page.has_text?("Permit: Veolia ES (UK) Limited")
-    end
+  test "does not render non-featured attachments" do
+    overrides = {
+      "details" => {
+        "attachments" => [{
+          "accessible" => false,
+          "alternative_format_contact_email" => "customerservices@publicguardian.gov.uk",
+          "attachment_type" => "file",
+          "command_paper_number" => "",
+          "content_type" => "application/pdf",
+          "file_size" => 123_456,
+          "filename" => "veolia-permit.pdf",
+          "hoc_paper_number" => "",
+          "id" => "violia-permit",
+          "isbn" => "",
+          "locale" => "en",
+          "title" => "Permit: Veolia ES (UK) Limited",
+          "unique_reference" => "",
+          "unnumbered_command_paper" => false,
+          "unnumbered_hoc_paper" => false,
+          "url" => "https://assets.publishing.service.gov.uk/media/123abc/veolia-permit.zip",
+        }],
+        "featured_attachments" => [],
+      },
+    }
 
+    setup_and_visit_content_item("publication", overrides)
+    within "#documents" do
+      assert page.has_no_text?("Permit: Veolia ES (UK) Limited")
+    end
+  end
+
+  test "renders featured document attachments using components" do
     setup_and_visit_content_item("publication-with-featured-attachments")
     within "#documents" do
       assert page.has_text?("Number of ex-regular service personnel now part of FR20")

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -10,7 +10,6 @@ class PublicationPresenterTest < PresenterTestCase
     assert_equal schema_item["schema_name"], presented_item.schema_name
     assert_equal schema_item["title"], presented_item.title
     assert_equal schema_item["details"]["body"], presented_item.details
-    assert_equal schema_item["details"]["documents"].join(""), presented_item.documents
   end
 
   test "#published returns a formatted date of the day the content item became public" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Rework [form (publication) pages](https://docs.publishing.service.gov.uk/document-types/form.html) to render attachments locally in the application, rather than using the pre-rendered chunk of markup from the content item.

Specifically, rework the list of documents on the forms pages to use the content item data in `details->attachments` to render the required content, in place of the data in `details->documents`, which is pre-rendered. This has involved the creation of a new partial for publication pages, as the existing partial is used by other page types.

Example form pages:

- https://www.gov.uk/government/publications/make-a-lasting-power-of-attorney
- https://www.gov.uk/government/publications/application-for-a-vehicle-registration-certificate
- https://www.gov.uk/government/publications/attendance-allowance-claim-form
- https://www.gov.uk/government/publications/self-assessment-tax-return-sa100
- https://www.gov.uk/government/publications/new-year-honours-list-2024

## Why
Relates to previous work in https://github.com/alphagov/govuk_publishing_components/pull/3820

Reworked version of changes in https://github.com/alphagov/government-frontend/pull/3048

We need to put tracking on the details components that can (sometimes) appear beneath the list of attachments, and that's very hard to do here on pre-rendered markup - normally we'd just pass some options to the component. This work will be carried out in a follow up PR.

![Screenshot 2024-01-22 at 13 59 49](https://github.com/alphagov/government-frontend/assets/861310/68272c7c-b6ae-4e11-9506-bedd16ecf8f8)

## Visual changes
`details->attachments` doesn't include custom thumbnails for PDFs, as previously displayed. We looked at getting this included in the content item, but ultimately decided with consultation from leads that the default thumbnail for PDFs is acceptable. This is for several reasons:

- we believe custom thumbnails for PDFs draw users to click on PDFs over other formats, which we don't want to encourage
- technical difficulty of implementation
- as [reported to us](https://govuk.zendesk.com/agent/tickets/5580280) some PDFs produce a landscape thumbnail, which appears distorted as the attachment component expects it in portrait. While there are other solutions to this problem, removing custom thumbnails removes this problem

With the new data it looks like the attachments display the `Request an accessible format` option more than they used to. This seems to be valid (it happens if you pass an email address to the component via the `alternative_format_contact_email` option) and allowing users this option more often seems sensible, but it raises the question why some PDFs used to have this option and some didn't. 

See example below. Note how before only some of these PDFs had the accessible format option, but now all of them have.

Before | After
--- | ----
![Screenshot 2024-04-11 at 10 49 16](https://github.com/alphagov/government-frontend/assets/861310/e69b67f0-95ae-4cce-8442-e24dbcbbc305) | ![Screenshot 2024-04-11 at 10 49 22](https://github.com/alphagov/government-frontend/assets/861310/655c1539-7ed0-47bc-8f77-08dba1f68aeb)


Trello card: https://trello.com/c/xhASj1rp/765-add-tracking-to-details-component