### PR TITLE
CA/ACB - Change current A/B tests for phase 2

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -26,9 +26,8 @@ class ContentItemsController < ApplicationController
     load_content_item
 
     temporary_ab_test_find_utr_page
-    temporary_ab_test_stop_self_employed
-    temporary_ab_test_sa_video_return_1
-    temporary_ab_test_sa_video_pay_bill
+    temporary_ab_test_stop_self_employed_2
+    temporary_ab_test_sa_video_return_2
     set_expiry
 
     if is_service_manual?
@@ -298,11 +297,11 @@ private
     end
   end
 
-  def temporary_ab_test_stop_self_employed
-    placeholder = "{{ab_test_sa_video_stop_self_employed}}"
+  def temporary_ab_test_stop_self_employed_2
+    placeholder = "{{ab_test_sa_video_stop_self_employed_2}}"
     if @content_item.base_path == "/stop-being-self-employed" && @content_item.body.include?(placeholder)
       ab_test = GovukAbTesting::AbTest.new(
-        "SAVideoStopSelfEmployed",
+        "SAVideoStopSelfEmployed2",
         dimension: 47, # https://docs.google.com/spreadsheets/d/1h4vGXzIbhOWwUzourPLIc8WM-iU1b6WYOVDOZxmU1Uo/edit#gid=254065189&range=69:69
         allowed_variants: %w[A B Z],
         control_variant: "Z",
@@ -312,21 +311,21 @@ private
 
       replacement = case @requested_variant.variant_name
                     when "A"
-                      I18n.t("ab_tests.sa_video_stop_self_employed.A")
+                      I18n.t("ab_tests.sa_video_stop_self_employed_2.A")
                     when "B"
-                      I18n.t("ab_tests.sa_video_stop_self_employed.B")
+                      I18n.t("ab_tests.sa_video_stop_self_employed_2.B")
                     else
-                      I18n.t("ab_tests.sa_video_stop_self_employed.Z")
+                      I18n.t("ab_tests.sa_video_stop_self_employed_2.Z")
                     end
       @content_item.body.sub!(placeholder, replacement)
     end
   end
 
-  def temporary_ab_test_sa_video_return_1
-    placeholder = "{{ab_test_sa_video_return_1}}"
+  def temporary_ab_test_sa_video_return_2
+    placeholder = "{{ab_test_sa_video_return_2}}"
     if @content_item.base_path == "/log-in-file-self-assessment-tax-return" && @content_item.body.include?(placeholder)
       ab_test = GovukAbTesting::AbTest.new(
-        "SAVideoReturn1",
+        "SAVideoReturn2",
         dimension: 47,
         allowed_variants: %w[A B Z],
         control_variant: "Z",
@@ -336,37 +335,13 @@ private
 
       replacement = case @requested_variant.variant_name
                     when "A"
-                      I18n.t("ab_tests.sa_video_return_1.A")
+                      I18n.t("ab_tests.sa_video_return_2.A")
                     when "B"
-                      I18n.t("ab_tests.sa_video_return_1.B")
+                      I18n.t("ab_tests.sa_video_return_2.B")
                     else
-                      I18n.t("ab_tests.sa_video_return_1.Z")
+                      I18n.t("ab_tests.sa_video_return_2.Z")
                     end
       @content_item.body.sub!(placeholder, replacement)
-    end
-  end
-
-  def temporary_ab_test_sa_video_pay_bill
-    placeholder = "{{ab_test_sa_video_pay_bill}}"
-    if @content_item.base_path == "/pay-self-assessment-tax-bill" && @content_item.current_part_body.include?(placeholder)
-      ab_test = GovukAbTesting::AbTest.new(
-        "SAVideoPayBill",
-        dimension: 47,
-        allowed_variants: %w[A B Z],
-        control_variant: "Z",
-      )
-      @requested_variant = ab_test.requested_variant(request.headers)
-      @requested_variant.configure_response(response)
-
-      replacement = case @requested_variant.variant_name
-                    when "A"
-                      I18n.t("ab_tests.sa_video_pay_bill.A")
-                    when "B"
-                      I18n.t("ab_tests.sa_video_pay_bill.B")
-                    else
-                      I18n.t("ab_tests.sa_video_pay_bill.Z")
-                    end
-      @content_item.current_part_body.sub!(placeholder, replacement)
     end
   end
   # /TEMPORARY

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -5,19 +5,7 @@ ar:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -13,7 +13,15 @@ ar:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -5,19 +5,7 @@ az:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -13,7 +13,15 @@ az:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -13,7 +13,15 @@ be:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -5,19 +5,7 @@ be:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -5,19 +5,7 @@ bg:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -13,7 +13,15 @@ bg:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -13,7 +13,15 @@ bn:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -5,19 +5,7 @@ bn:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -5,19 +5,7 @@ cs:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -13,7 +13,15 @@ cs:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -5,19 +5,7 @@ cy:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -13,7 +13,15 @@ cy:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -13,7 +13,15 @@ da:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -5,19 +5,7 @@ da:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -5,19 +5,7 @@ de:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -13,7 +13,15 @@ de:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -5,19 +5,7 @@ dr:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -13,7 +13,15 @@ dr:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -13,7 +13,15 @@ el:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -5,19 +5,7 @@ el:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,22 +5,10 @@ en:
       A: in the <a href="/guidance/download-the-hmrc-app"><abbr title="HM Revenue and Customs">HMRC</abbr> app</a> under 'Your details' or in the 'Self Assessment' section
       B: in the <a href="/guidance/download-the-hmrc-app"><abbr title="HM Revenue and Customs">HMRC</abbr> app</a> - watch a <a href="https://www.youtube.com/watch?v=LXw9ily9rTo">video about finding your UTR number in the app</a>
       Z: in the <a href="/guidance/download-the-hmrc-app"><abbr title="HM Revenue and Customs">HMRC</abbr> app</a> under 'Your details' or in the 'Self Assessment' section
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A: <h2 id="if-you-do-not-have-a-government-gateway-account">If you do not have a Government Gateway account</h2>
       B: <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak"><p>Watch this video to find out more about how to file your tax return.</p><p><a href="https://www.youtube.com/watch?v=_N0ekIOnURM">My first Self Assessment tax return</a></p></div><h2 id="if-you-do-not-have-a-government-gateway-account">If you do not have a Government Gateway account</h2>
       Z: <h2 id="if-you-do-not-have-a-government-gateway-account">If you do not have a Government Gateway account</h2>
-    sa_video_stop_self_employed:
-      A:
-      B:
-      Z:
     sa_video_stop_self_employed_2:
       A: <p>You’ll need to provide your <a href="/national-insurance/your-national-insurance-number">National Insurance number</a> and <a href="/find-utr-number">your UTR number</a>.</p>
       B: <p>You’ll need to provide your <a href="/national-insurance/your-national-insurance-number">National Insurance number</a> and <a href="/find-utr-number">your UTR number</a>.</p><div class="gem-c-govspeak govuk-govspeak" data-module="govspeak"><p>Watch this video to find out how to tell HMRC you're stopping self-employment.</p><p><a href="https://www.youtube.com/watch?v=g-CkQRLGb0Q">How to stop Self Assessment online if you’re self-employed</a></p></div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,16 +6,24 @@ en:
       B: in the <a href="/guidance/download-the-hmrc-app"><abbr title="HM Revenue and Customs">HMRC</abbr> app</a> - watch a <a href="https://www.youtube.com/watch?v=LXw9ily9rTo">video about finding your UTR number in the app</a>
       Z: in the <a href="/guidance/download-the-hmrc-app"><abbr title="HM Revenue and Customs">HMRC</abbr> app</a> under 'Your details' or in the 'Self Assessment' section
     sa_video_pay_bill:
-      A: <p>Go to your <a rel="external" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/self-assessment/&amp;origin=SA-frontend">HM Revenue and Customs (<abbr title="HM Revenue and Customs">HMRC</abbr>) online account</a> and set up a Direct Debit. Choose the Budget Payment Plan option and follow the instructions to set up your plan.</p>
-      B: <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak"><p>Go to your <a rel="external" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/self-assessment/&amp;origin=SA-frontend">HM Revenue and Customs (<abbr title="HM Revenue and Customs">HMRC</abbr>) online account</a> and set up a Direct Debit. Choose the Budget Payment Plan option and follow the instructions to set up your plan.</p><p>Watch this video to find out how a budget payment plan can help you pay your tax bill on time.</p><p><a href="https://www.youtube.com/watch?v=xHn31myAkio">How do I budget for my Self Assessment tax bill?</a></p></div>
-      Z: <p>Go to your <a rel="external" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/self-assessment/&amp;origin=SA-frontend">HM Revenue and Customs (<abbr title="HM Revenue and Customs">HMRC</abbr>) online account</a> and set up a Direct Debit. Choose the Budget Payment Plan option and follow the instructions to set up your plan.</p>
+      A:
+      B:
+      Z:
     sa_video_return_1:
-      A: "<p>You do not have to complete your return in one go. You can save your entry and go back to it later if you need to.</p>"
-      B: <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak"><p>You do not have to complete your return in one go. You can save your entry and go back to it later if you need to.</p><p>Watch this video to find out more about how to file your tax return.</p><p><a href="https://www.youtube.com/watch?v=_N0ekIOnURM">My first Self Assessment tax return</a></p></div>
-      Z: "<p>You do not have to complete your return in one go. You can save your entry and go back to it later if you need to.</p>"
+      A:
+      B:
+      Z:
+    sa_video_return_2:
+      A: <h2 id="if-you-do-not-have-a-government-gateway-account">If you do not have a Government Gateway account</h2>
+      B: <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak"><p>Watch this video to find out more about how to file your tax return.</p><p><a href="https://www.youtube.com/watch?v=_N0ekIOnURM">My first Self Assessment tax return</a></p></div><h2 id="if-you-do-not-have-a-government-gateway-account">If you do not have a Government Gateway account</h2>
+      Z: <h2 id="if-you-do-not-have-a-government-gateway-account">If you do not have a Government Gateway account</h2>
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A: <p>You’ll need to provide your <a href="/national-insurance/your-national-insurance-number">National Insurance number</a> and <a href="/find-utr-number">your UTR number</a>.</p>
-      B: <p>You’ll need to provide your <a href="/national-insurance/your-national-insurance-number">National Insurance number</a> and <a href="/find-utr-number">your UTR number</a>.</p><p><a href="https://www.youtube.com/watch?v=g-CkQRLGb0Q">Watch this video to find out how to tell HMRC you're stopping self-employment</a></p>
+      B: <p>You’ll need to provide your <a href="/national-insurance/your-national-insurance-number">National Insurance number</a> and <a href="/find-utr-number">your UTR number</a>.</p><div class="gem-c-govspeak govuk-govspeak" data-module="govspeak"><p>Watch this video to find out how to tell HMRC you're stopping self-employment.</p><p><a href="https://www.youtube.com/watch?v=g-CkQRLGb0Q">How to stop Self Assessment online if you’re self-employed</a></p></div>
       Z: <p>You’ll need to provide your <a href="/national-insurance/your-national-insurance-number">National Insurance number</a> and <a href="/find-utr-number">your UTR number</a>.</p>
   call_for_evidence:
     and: and

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -5,19 +5,7 @@ es-419:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -13,7 +13,15 @@ es-419:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5,19 +5,7 @@ es:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -13,7 +13,15 @@ es:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -5,19 +5,7 @@ et:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -13,7 +13,15 @@ et:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -5,19 +5,7 @@ fa:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -13,7 +13,15 @@ fa:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -13,7 +13,15 @@ fi:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -5,19 +5,7 @@ fi:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -5,19 +5,7 @@ fr:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -13,7 +13,15 @@ fr:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -5,19 +5,7 @@ gd:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -13,7 +13,15 @@ gd:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -5,19 +5,7 @@ gu:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -13,7 +13,15 @@ gu:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -5,19 +5,7 @@ he:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -13,7 +13,15 @@ he:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -13,7 +13,15 @@ hi:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -5,19 +5,7 @@ hi:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -5,19 +5,7 @@ hr:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -13,7 +13,15 @@ hr:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -5,19 +5,7 @@ hu:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -13,7 +13,15 @@ hu:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -13,7 +13,15 @@ hy:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -5,19 +5,7 @@ hy:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -5,19 +5,7 @@ id:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -13,7 +13,15 @@ id:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -5,19 +5,7 @@ is:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -13,7 +13,15 @@ is:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -13,7 +13,15 @@ it:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -5,19 +5,7 @@ it:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,19 +5,7 @@ ja:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,7 +13,15 @@ ja:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -13,7 +13,15 @@ ka:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -5,19 +5,7 @@ ka:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -5,19 +5,7 @@ kk:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -13,7 +13,15 @@ kk:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -5,19 +5,7 @@ ko:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -13,7 +13,15 @@ ko:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -13,7 +13,15 @@ lt:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -5,19 +5,7 @@ lt:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -5,19 +5,7 @@ lv:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -13,7 +13,15 @@ lv:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -5,19 +5,7 @@ ms:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -13,7 +13,15 @@ ms:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -13,7 +13,15 @@ mt:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -5,19 +5,7 @@ mt:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -5,19 +5,7 @@ ne:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -13,7 +13,15 @@ ne:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -5,19 +5,7 @@ nl:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -13,7 +13,15 @@ nl:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -5,19 +5,7 @@
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -13,7 +13,15 @@
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -5,19 +5,7 @@ pa-pk:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -13,7 +13,15 @@ pa-pk:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -13,7 +13,15 @@ pa:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -5,19 +5,7 @@ pa:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -13,7 +13,15 @@ pl:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -5,19 +5,7 @@ pl:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -13,7 +13,15 @@ ps:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -5,19 +5,7 @@ ps:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -13,7 +13,15 @@ pt:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -5,19 +5,7 @@ pt:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -5,19 +5,7 @@ ro:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -13,7 +13,15 @@ ro:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -13,7 +13,15 @@ ru:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -5,19 +5,7 @@ ru:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -5,19 +5,7 @@ si:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -13,7 +13,15 @@ si:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -13,7 +13,15 @@ sk:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -5,19 +5,7 @@ sk:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -5,19 +5,7 @@ sl:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -13,7 +13,15 @@ sl:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -5,19 +5,7 @@ so:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -13,7 +13,15 @@ so:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -13,7 +13,15 @@ sq:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -5,19 +5,7 @@ sq:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -5,19 +5,7 @@ sr:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -13,7 +13,15 @@ sr:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -13,7 +13,15 @@ sv:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -5,19 +5,7 @@ sv:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -13,7 +13,15 @@ sw:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -5,19 +5,7 @@ sw:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -5,19 +5,7 @@ ta:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -13,7 +13,15 @@ ta:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -13,7 +13,15 @@ th:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -5,19 +5,7 @@ th:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -13,7 +13,15 @@ tk:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -5,19 +5,7 @@ tk:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -5,19 +5,7 @@ tr:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -13,7 +13,15 @@ tr:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -5,19 +5,7 @@ uk:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -13,7 +13,15 @@ uk:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -13,7 +13,15 @@ ur:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -5,19 +5,7 @@ ur:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -13,7 +13,15 @@ uz:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -5,19 +5,7 @@ uz:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -13,7 +13,15 @@ vi:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -5,19 +5,7 @@ vi:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -5,19 +5,7 @@ yi:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -13,7 +13,15 @@ yi:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -5,19 +5,7 @@ zh-hk:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -13,7 +13,15 @@ zh-hk:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -5,19 +5,7 @@ zh-tw:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -13,7 +13,15 @@ zh-tw:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -13,7 +13,15 @@ zh:
       A:
       B:
       Z:
+    sa_video_return_2:
+      A:
+      B:
+      Z:
     sa_video_stop_self_employed:
+      A:
+      B:
+      Z:
+    sa_video_stop_self_employed_2:
       A:
       B:
       Z:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -5,19 +5,7 @@ zh:
       A:
       B:
       Z:
-    sa_video_pay_bill:
-      A:
-      B:
-      Z:
-    sa_video_return_1:
-      A:
-      B:
-      Z:
     sa_video_return_2:
-      A:
-      B:
-      Z:
-    sa_video_stop_self_employed:
       A:
       B:
       Z:

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -367,44 +367,44 @@ class ContentItemsControllerTest < ActionController::TestCase
   test "AB test replaces content on the stop-being-self-employed page with default" do
     content_item = content_store_has_schema_example("answer", "answer")
     content_item["base_path"] = "/stop-being-self-employed"
-    content_item["details"]["body"] = "{{ab_test_sa_video_stop_self_employed}}"
+    content_item["details"]["body"] = "{{ab_test_sa_video_stop_self_employed_2}}"
 
     stub_content_store_has_item(content_item["base_path"], content_item)
-    with_variant SAVideoStopSelfEmployed: "Z" do
+    with_variant SAVideoStopSelfEmployed2: "Z" do
       get :show, params: { path: path_for(content_item) }
       assert_response :success
-      assert_no_match "{{ab_test_sa_video_stop_self_employed}}", response.body
-      assert_match I18n.t("ab_tests.sa_video_stop_self_employed.Z").to_s, response.body
+      assert_no_match "{{ab_test_sa_video_stop_self_employed_2}}", response.body
+      assert_match I18n.t("ab_tests.sa_video_stop_self_employed_2.Z").to_s, response.body
     end
   end
 
   test "AB test replaces content on the stop-being-self-employed page with variant A" do
     content_item = content_store_has_schema_example("answer", "answer")
     content_item["base_path"] = "/stop-being-self-employed"
-    content_item["details"]["body"] = "{{ab_test_sa_video_stop_self_employed}}"
+    content_item["details"]["body"] = "{{ab_test_sa_video_stop_self_employed_2}}"
 
     stub_content_store_has_item(content_item["base_path"], content_item)
 
-    with_variant SAVideoStopSelfEmployed: "A" do
+    with_variant SAVideoStopSelfEmployed2: "A" do
       get :show, params: { path: path_for(content_item) }
       assert_response :success
-      assert_no_match "{{ab_test_sa_video_stop_self_employed}}", response.body
-      assert_match I18n.t("ab_tests.sa_video_stop_self_employed.A").to_s, response.body
+      assert_no_match "{{ab_test_sa_video_stop_self_employed_2}}", response.body
+      assert_match I18n.t("ab_tests.sa_video_stop_self_employed_2.A").to_s, response.body
     end
   end
 
   test "AB test replaces content on the stop-being-self-employed page with variant B" do
     content_item = content_store_has_schema_example("answer", "answer")
     content_item["base_path"] = "/stop-being-self-employed"
-    content_item["details"]["body"] = "{{ab_test_sa_video_stop_self_employed}}"
+    content_item["details"]["body"] = "{{ab_test_sa_video_stop_self_employed_2}}"
 
     stub_content_store_has_item(content_item["base_path"], content_item)
 
-    with_variant SAVideoStopSelfEmployed: "B" do
+    with_variant SAVideoStopSelfEmployed2: "B" do
       get :show, params: { path: path_for(content_item) }
       assert_response :success
-      assert_no_match "{{ab_test_sa_video_stop_self_employed}}", response.body
-      assert_match I18n.t("ab_tests.sa_video_stop_self_employed.B").to_s, response.body
+      assert_no_match "{{ab_test_sa_video_stop_self_employed_2}}", response.body
+      assert_match I18n.t("ab_tests.sa_video_stop_self_employed_2.B").to_s, response.body
     end
   end
 
@@ -456,104 +456,45 @@ class ContentItemsControllerTest < ActionController::TestCase
   test "AB test replaces content on the log-in-file-self-assessment-tax-return page with default" do
     content_item = content_store_has_schema_example("answer", "answer")
     content_item["base_path"] = "/log-in-file-self-assessment-tax-return"
-    content_item["details"]["body"] = "<li>{{ab_test_sa_video_return_1}}</li>"
+    content_item["details"]["body"] = "<li>{{ab_test_sa_video_return_2}}</li>"
 
     stub_content_store_has_item(content_item["base_path"], content_item)
 
-    with_variant SAVideoReturn1: "Z" do
+    with_variant SAVideoReturn2: "Z" do
       get :show, params: { path: path_for(content_item) }
       assert_response :success
-      assert_no_match "{{ab_test_sa_video_return_1}}", response.body
-      assert_match "<li>#{I18n.t('ab_tests.sa_video_return_1.Z')}</li>", response.body
+      assert_no_match "{{ab_test_sa_video_return_2}}", response.body
+      assert_match "<li>#{I18n.t('ab_tests.sa_video_return_2.Z')}</li>", response.body
     end
   end
 
   test "AB test replaces content on the log-in-file-self-assessment-tax-return page with variant A" do
     content_item = content_store_has_schema_example("answer", "answer")
     content_item["base_path"] = "/log-in-file-self-assessment-tax-return"
-    content_item["details"]["body"] = "<li>{{ab_test_sa_video_return_1}}</li>"
+    content_item["details"]["body"] = "<li>{{ab_test_sa_video_return_2}}</li>"
 
     stub_content_store_has_item(content_item["base_path"], content_item)
 
-    with_variant SAVideoReturn1: "A" do
+    with_variant SAVideoReturn2: "A" do
       get :show, params: { path: path_for(content_item) }
       assert_response :success
-      assert_no_match "{{ab_test_sa_video_return_1}}", response.body
-      assert_match "<li>#{I18n.t('ab_tests.sa_video_return_1.A')}</li>", response.body
+      assert_no_match "{{ab_test_sa_video_return_2}}", response.body
+      assert_match "<li>#{I18n.t('ab_tests.sa_video_return_2.A')}</li>", response.body
     end
   end
 
   test "AB test replaces content on the log-in-file-self-assessment-tax-return page with variant B" do
     content_item = content_store_has_schema_example("answer", "answer")
     content_item["base_path"] = "/log-in-file-self-assessment-tax-return"
-    content_item["details"]["body"] = "<li>{{ab_test_sa_video_return_1}}</li>"
+    content_item["details"]["body"] = "<li>{{ab_test_sa_video_return_2}}</li>"
 
     stub_content_store_has_item(content_item["base_path"], content_item)
 
-    with_variant SAVideoReturn1: "B" do
+    with_variant SAVideoReturn2: "B" do
       get :show, params: { path: path_for(content_item) }
       assert_response :success
-      assert_no_match "{{ab_test_sa_video_return_1}}", response.body
-      assert_match "<li>#{I18n.t('ab_tests.sa_video_return_1.B')}</li>", response.body
-    end
-  end
-
-  test "AB test replaces content on the pay-weekly-monthly page with default" do
-    content_item = govuk_content_schema_example("guide", "guide")
-    content_item["base_path"] = "/pay-self-assessment-tax-bill"
-    content_item["details"]["parts"] = []
-    parts = {
-      "body" => "{{ab_test_sa_video_pay_bill}}",
-      "slug" => "pay-weekly-monthly",
-    }
-    content_item["details"]["parts"] << parts
-
-    stub_content_store_has_item(content_item["base_path"], content_item)
-
-    with_variant SAVideoPayBill: "Z" do
-      get :show, params: { path: path_for(content_item) }
-      assert_response :success
-      assert_no_match "{{ab_test_sa_video_pay_bill}}", response.body
-      assert_match I18n.t("ab_tests.sa_video_pay_bill.Z").to_s, response.body
-    end
-  end
-
-  test "AB test replaces content on the pay-weekly-monthly page with Variant A" do
-    content_item = govuk_content_schema_example("guide", "guide")
-    content_item["base_path"] = "/pay-self-assessment-tax-bill"
-    content_item["details"]["parts"] = []
-    parts = {
-      "body" => "{{ab_test_sa_video_pay_bill}}",
-      "slug" => "pay-weekly-monthly",
-    }
-    content_item["details"]["parts"] << parts
-
-    stub_content_store_has_item(content_item["base_path"], content_item)
-
-    with_variant SAVideoPayBill: "A" do
-      get :show, params: { path: path_for(content_item) }
-      assert_response :success
-      assert_no_match "{{ab_test_sa_video_pay_bill}}", response.body
-      assert_match I18n.t("ab_tests.sa_video_pay_bill.A").to_s, response.body
-    end
-  end
-
-  test "AB test replaces content on the pay-weekly-monthly page with Variant B" do
-    content_item = govuk_content_schema_example("guide", "guide")
-    content_item["base_path"] = "/pay-self-assessment-tax-bill"
-    content_item["details"]["parts"] = []
-    parts = {
-      "body" => "{{ab_test_sa_video_pay_bill}}",
-      "slug" => "pay-weekly-monthly",
-    }
-    content_item["details"]["parts"] << parts
-
-    stub_content_store_has_item(content_item["base_path"], content_item)
-    with_variant SAVideoPayBill: "B" do
-      get :show, params: { path: path_for(content_item) }
-      assert_response :success
-      assert_no_match "{{ab_test_sa_video_pay_bill}}", response.body
-      assert_match I18n.t("ab_tests.sa_video_pay_bill.B").to_s, response.body
+      assert_no_match "{{ab_test_sa_video_return_2}}", response.body
+      assert_match "<li>#{I18n.t('ab_tests.sa_video_return_2.B')}</li>", response.body
     end
   end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/8n9KMaqo/611-video-a-b-tests-setup-phase-2-a-b-tests)
[Trello card](https://trello.com/c/BDVKG43b/612-video-a-b-tests-take-down-phase-1-a-b-test)
This PR is to change the previously added A/B tests to the phase 2 A/B tests. It also removes one A/B test.

![image](https://github.com/alphagov/government-frontend/assets/56640446/1c4ec084-012a-4431-a33f-7d31ab98acae)

![image](https://github.com/alphagov/government-frontend/assets/56640446/097b905d-2e7e-4d15-868a-8422711364fd)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
