### PR TITLE
CA/ACB - Remove Find UTR Number A/B test for 31st January

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -25,7 +25,6 @@ class ContentItemsController < ApplicationController
   def show
     load_content_item
 
-    temporary_ab_test_find_utr_page
     temporary_ab_test_stop_self_employed_2
     temporary_ab_test_sa_video_return_2
     set_expiry
@@ -272,30 +271,6 @@ private
   end
 
   # TEMPORARY (author: richard.towers, expected end date: February 2024)
-  # Content specific AB test for the Find your UTR number page
-  def temporary_ab_test_find_utr_page
-    placeholder = "{{ab_test_find_utr_number_video_links}}"
-    if @content_item.base_path == "/find-utr-number" && @content_item.body.include?(placeholder)
-      ab_test = GovukAbTesting::AbTest.new(
-        "FindUtrNumberVideoLinks",
-        dimension: 61, # https://docs.google.com/spreadsheets/d/1h4vGXzIbhOWwUzourPLIc8WM-iU1b6WYOVDOZxmU1Uo/edit#gid=254065189&range=69:69
-        allowed_variants: %w[A B Z],
-        control_variant: "Z",
-      )
-      @requested_variant = ab_test.requested_variant(request.headers)
-      @requested_variant.configure_response(response)
-
-      replacement = case @requested_variant.variant_name
-                    when "A"
-                      I18n.t("ab_tests.find_utr_number_video_links.A")
-                    when "B"
-                      I18n.t("ab_tests.find_utr_number_video_links.B")
-                    else
-                      I18n.t("ab_tests.find_utr_number_video_links.Z")
-                    end
-      @content_item.body.sub!(placeholder, replacement)
-    end
-  end
 
   def temporary_ab_test_stop_self_employed_2
     placeholder = "{{ab_test_sa_video_stop_self_employed_2}}"

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1,10 +1,6 @@
 ---
 ar:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -1,10 +1,6 @@
 ---
 az:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -1,10 +1,6 @@
 ---
 be:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -1,10 +1,6 @@
 ---
 bg:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -1,10 +1,6 @@
 ---
 bn:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,10 +1,6 @@
 ---
 cs:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1,10 +1,6 @@
 ---
 cy:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -1,10 +1,6 @@
 ---
 da:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,10 +1,6 @@
 ---
 de:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -1,10 +1,6 @@
 ---
 dr:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -1,10 +1,6 @@
 ---
 el:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,10 +1,6 @@
 ---
 en:
   ab_tests:
-    find_utr_number_video_links:
-      A: in the <a href="/guidance/download-the-hmrc-app"><abbr title="HM Revenue and Customs">HMRC</abbr> app</a> under 'Your details' or in the 'Self Assessment' section
-      B: in the <a href="/guidance/download-the-hmrc-app"><abbr title="HM Revenue and Customs">HMRC</abbr> app</a> - watch a <a href="https://www.youtube.com/watch?v=LXw9ily9rTo">video about finding your UTR number in the app</a>
-      Z: in the <a href="/guidance/download-the-hmrc-app"><abbr title="HM Revenue and Customs">HMRC</abbr> app</a> under 'Your details' or in the 'Self Assessment' section
     sa_video_return_2:
       A: <h2 id="if-you-do-not-have-a-government-gateway-account">If you do not have a Government Gateway account</h2>
       B: <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak"><p>Watch this video to find out more about how to file your tax return.</p><p><a href="https://www.youtube.com/watch?v=_N0ekIOnURM">My first Self Assessment tax return</a></p></div><h2 id="if-you-do-not-have-a-government-gateway-account">If you do not have a Government Gateway account</h2>

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -1,10 +1,6 @@
 ---
 es-419:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,10 +1,6 @@
 ---
 es:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -1,10 +1,6 @@
 ---
 et:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1,10 +1,6 @@
 ---
 fa:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1,10 +1,6 @@
 ---
 fi:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,10 +1,6 @@
 ---
 fr:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -1,10 +1,6 @@
 ---
 gd:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -1,10 +1,6 @@
 ---
 gu:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1,10 +1,6 @@
 ---
 he:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -1,10 +1,6 @@
 ---
 hi:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -1,10 +1,6 @@
 ---
 hr:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1,10 +1,6 @@
 ---
 hu:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -1,10 +1,6 @@
 ---
 hy:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1,10 +1,6 @@
 ---
 id:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -1,10 +1,6 @@
 ---
 is:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,10 +1,6 @@
 ---
 it:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,10 +1,6 @@
 ---
 ja:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -1,10 +1,6 @@
 ---
 ka:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -1,10 +1,6 @@
 ---
 kk:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,10 +1,6 @@
 ---
 ko:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -1,10 +1,6 @@
 ---
 lt:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1,10 +1,6 @@
 ---
 lv:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -1,10 +1,6 @@
 ---
 ms:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -1,10 +1,6 @@
 ---
 mt:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -1,10 +1,6 @@
 ---
 ne:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,10 +1,6 @@
 ---
 nl:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -1,10 +1,6 @@
 ---
 'no':
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -1,10 +1,6 @@
 ---
 pa-pk:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -1,10 +1,6 @@
 ---
 pa:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,10 +1,6 @@
 ---
 pl:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -1,10 +1,6 @@
 ---
 ps:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,10 +1,6 @@
 ---
 pt:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,10 +1,6 @@
 ---
 ro:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,10 +1,6 @@
 ---
 ru:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -1,10 +1,6 @@
 ---
 si:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,10 +1,6 @@
 ---
 sk:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -1,10 +1,6 @@
 ---
 sl:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -1,10 +1,6 @@
 ---
 so:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -1,10 +1,6 @@
 ---
 sq:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -1,10 +1,6 @@
 ---
 sr:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,10 +1,6 @@
 ---
 sv:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -1,10 +1,6 @@
 ---
 sw:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -1,10 +1,6 @@
 ---
 ta:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -1,10 +1,6 @@
 ---
 th:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -1,10 +1,6 @@
 ---
 tk:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,10 +1,6 @@
 ---
 tr:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1,10 +1,6 @@
 ---
 uk:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -1,10 +1,6 @@
 ---
 ur:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -1,10 +1,6 @@
 ---
 uz:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1,10 +1,6 @@
 ---
 vi:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -1,10 +1,6 @@
 ---
 yi:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -1,10 +1,6 @@
 ---
 zh-hk:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -1,10 +1,6 @@
 ---
 zh-tw:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1,10 +1,6 @@
 ---
 zh:
   ab_tests:
-    find_utr_number_video_links:
-      A:
-      B:
-      Z:
     sa_video_return_2:
       A:
       B:

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -408,51 +408,6 @@ class ContentItemsControllerTest < ActionController::TestCase
     end
   end
 
-  test "AB test replaces content on the find-utr-number page with default" do
-    content_item = content_store_has_schema_example("answer", "answer")
-    content_item["base_path"] = "/find-utr-number"
-    content_item["details"]["body"] = "<li>{{ab_test_find_utr_number_video_links}}</li>"
-
-    stub_content_store_has_item(content_item["base_path"], content_item)
-
-    with_variant FindUtrNumberVideoLinks: "Z" do
-      get :show, params: { path: path_for(content_item) }
-      assert_response :success
-      assert_no_match "{{ab_test_find_utr_number_video_links}}", response.body
-      assert_match "<li>#{I18n.t('ab_tests.find_utr_number_video_links.Z')}</li>", response.body
-    end
-  end
-
-  test "AB test replaces content on the find-utr-number page with variant A" do
-    content_item = content_store_has_schema_example("answer", "answer")
-    content_item["base_path"] = "/find-utr-number"
-    content_item["details"]["body"] = "<li>{{ab_test_find_utr_number_video_links}}</li>"
-
-    stub_content_store_has_item(content_item["base_path"], content_item)
-
-    with_variant FindUtrNumberVideoLinks: "A" do
-      get :show, params: { path: path_for(content_item) }
-      assert_response :success
-      assert_no_match "{{ab_test_find_utr_number_video_links}}", response.body
-      assert_match "<li>#{I18n.t('ab_tests.find_utr_number_video_links.A')}</li>", response.body
-    end
-  end
-
-  test "AB test replaces content on the find-utr-number page with variant B" do
-    content_item = content_store_has_schema_example("answer", "answer")
-    content_item["base_path"] = "/find-utr-number"
-    content_item["details"]["body"] = "<li>{{ab_test_find_utr_number_video_links}}</li>"
-
-    stub_content_store_has_item(content_item["base_path"], content_item)
-
-    with_variant FindUtrNumberVideoLinks: "B" do
-      get :show, params: { path: path_for(content_item) }
-      assert_response :success
-      assert_no_match "{{ab_test_find_utr_number_video_links}}", response.body
-      assert_match "<li>#{I18n.t('ab_tests.find_utr_number_video_links.B')}</li>", response.body
-    end
-  end
-
   test "AB test replaces content on the log-in-file-self-assessment-tax-return page with default" do
     content_item = content_store_has_schema_example("answer", "answer")
     content_item["base_path"] = "/log-in-file-self-assessment-tax-return"


### PR DESCRIPTION
[Trello card](https://trello.com/c/YRKwmzna/613-take-down-a-b-test-on-find-your-utr-number-page-on-31-jan)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
