### PR TITLE
Add element with id "Top" to receive focus from "Top of page" links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,7 @@
     <%= yield :header %>
 
     <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">
+      <span id="Top"></span>
       <%= yield :main %>
     </main>
   </div>


### PR DESCRIPTION
[Trello](https://trello.com/c/gopugt7K/2365-top-of-page-links-dont-move-focus)

This deals with a widespread use of a `<a href=“#Top”>` link within page content which visually returns the user to the top of the page. However, since there is no element with that ID on the page, focus remains on the link so keyboard-only and screen-reader users are unable to navigate from that point.

This change adds a `<span>` element with that ID so that focus is added to the top of the content and these users can continue to navigate the page.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
