### PR TITLE
Amend h1 font-size in manuals to l

### DIFF
--- a/app/views/content_items/manuals/_manual_section_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_section_layout.html.erb
@@ -14,7 +14,7 @@
           <div class="govuk-grid-column-full">
             <%= render "govuk_publishing_components/components/heading", {
               text: @content_item.document_heading.join(" - "),
-              font_size: "m",
+              font_size: "l",
               id: "section-title",
               heading_level: 1,
               margin_bottom: 4,

--- a/test/integration/manual_section_test.rb
+++ b/test/integration/manual_section_test.rb
@@ -50,7 +50,7 @@ class ManualSectionTest < ActionDispatch::IntegrationTest
   test "renders document heading" do
     setup_and_visit_manual_section
 
-    within ".govuk-heading-l" do
+    within "#manual-title.govuk-heading-l" do
       assert page.has_text?(@manual["title"])
     end
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/FhkENn3P/2372-h1-in-manuals-smaller-than-h2)

This PR addresses the styling of H1 headers in manual pages, so there is a visual distinction between H1s and H2s. 

The fix involves adjusting the font size in the `_manual_section_layout.html.erb` partial, increasing it from `m` to `l`.This ensures that H1s now render with a font size of `l` and apply the `govuk-heading-l` class for improved visual differentiation.

Additionally, modified the Manual Section Test to resolve an error that occurred due to an ambiguous match in the rendered document heading.

### **Census Dates**
**Before:**
<img width="989" alt="image" src="https://github.com/alphagov/government-frontend/assets/56222256/52e41d2f-023f-4f51-8bf5-79b76d574c4d">

**After:**
<img width="988" alt="image" src="https://github.com/alphagov/government-frontend/assets/56222256/2b592ee3-6afb-4169-969f-562c49039b38">

### **PAYE Manual**
**Before**:
<img width="1112" alt="image" src="https://github.com/alphagov/government-frontend/assets/56222256/a6095ddb-d6cb-4759-aec9-fc619a814f34">

**After**:
<img width="1010" alt="image" src="https://github.com/alphagov/government-frontend/assets/56222256/cf533e66-9a19-495a-9578-3581e61205d6">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
