### PR TITLE
Fix see all updates for manuals

### DIFF
--- a/app/presenters/content_item/manual.rb
+++ b/app/presenters/content_item/manual.rb
@@ -44,8 +44,16 @@ module ContentItem
     end
 
     def updated_metadata(updated_at)
-      updates_link = view_context.link_to(I18n.t("manuals.see_all_updates"), "#{base_path}/updates")
-      { I18n.t("manuals.updated") => "#{display_date(updated_at)}, #{updates_link}" }
+      current_path = view_context.request.path
+
+      if (hmrc? || manual?) && current_path == "#{base_path}/updates"
+        update_at_text = display_date(updated_at).to_s
+      else
+        updates_link = view_context.link_to(I18n.t("manuals.see_all_updates"), "#{base_path}/updates")
+        update_at_text = "#{display_date(updated_at)} - #{updates_link}"
+      end
+
+      { I18n.t("manuals.updated") => update_at_text }
     end
 
     def details
@@ -54,6 +62,10 @@ module ContentItem
 
     def hmrc?
       %w[hmrc_manual hmrc_manual_section].include?(schema_name)
+    end
+
+    def manual?
+      %w[manual manual_section].include?(schema_name)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,7 +47,7 @@ en:
       hide_all_updates: hide all updates
       last_updated: Last updated %{date}
       published: Published %{date}
-      see_all_updates: see all updates
+      see_all_updates: See all updates
       show_all_updates: show all updates
     publisher_metadata:
       hide_all: hide all
@@ -484,7 +484,7 @@ en:
     pages_in_manual_section: Manual section pages
     previous_page: Previous page
     search_this_manual: Search this manual
-    see_all_updates: see all updates
+    see_all_updates: See all updates
     title: "%{title}Guidance"
     updated: Updated
     updates_amendments: published amendments

--- a/test/integration/hmrc_manual_updates_test.rb
+++ b/test/integration/hmrc_manual_updates_test.rb
@@ -25,9 +25,7 @@ class HmrcManualUpdatesTest < ActionDispatch::IntegrationTest
       {
         from: { "HM Revenue & Customs": "/government/organisations/hm-revenue-customs" },
         first_published: "11 February 2015",
-        other: {
-          I18n.t("manuals.see_all_updates") => "#{@content_item['base_path']}/updates",
-        },
+        other: {},
       },
       extra_metadata_classes: ".gem-c-metadata--inverse",
     )

--- a/test/integration/manual_updates_test.rb
+++ b/test/integration/manual_updates_test.rb
@@ -21,9 +21,7 @@ class ManualUpdatesTest < ActionDispatch::IntegrationTest
       {
         from: { "Government Digital Service": "/government/organisations/government-digital-service" },
         first_published: "27 April 2015",
-        other: {
-          I18n.t("manuals.see_all_updates") => "#{@content_item['base_path']}/updates",
-        },
+        other: {},
       },
       extra_metadata_classes: ".gem-c-metadata--inverse",
     )

--- a/test/presenters/content_item/manual_test.rb
+++ b/test/presenters/content_item/manual_test.rb
@@ -63,11 +63,18 @@ class ContentItemManualTest < ActiveSupport::TestCase
     item = DummyContentItem.new
     item.stubs(:display_date).returns("23 March 2022")
 
+    view_context = mock
+    view_context.stubs(:request).returns(ActionDispatch::TestRequest.create)
+    view_context.stubs(:link_to).with("blah", "/blah", class: "govuk-link").returns("<a class=\"govuk-link\" href=\"/blah\">blah</a>")
+    view_context.stubs(:link_to).with("See all updates", "/a/base/path/updates").returns("<a href=\"/a/base/path/updates\">See all updates</a>")
+
+    item.stubs(:view_context).returns(view_context)
+
     expected_metadata = {
       from: ["<a class=\"govuk-link\" href=\"/blah\">blah</a>"],
       first_published: "23 March 2022",
       other: {
-        I18n.t("manuals.updated") => "23 March 2022, <a href=\"/a/base/path/updates\">#{I18n.t('manuals.see_all_updates')}</a>",
+        I18n.t("manuals.updated") => "23 March 2022 - <a href=\"/a/base/path/updates\">#{I18n.t('manuals.see_all_updates')}</a>",
       },
       inverse: true,
       inverse_compress: true,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Manual page: https://www.gov.uk/hmrc-internal-manuals/employment-income-manual/updates

Review app change: https://government-frontend-pr-3086.herokuapp.com/hmrc-internal-manuals/employment-income-manual/updates