### PR TITLE
Implement fallback for empty links in HMRC Manuals

### DIFF
--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -26,9 +26,11 @@
                 <div class="govuk-!-margin-top-3">
                   <% change_notes.each do |change_note_entry| %>
                     <% change_note = change_note_entry.flatten.last %>
-                    <p class="govuk-body">
-                      <%= link_to change_note["title"], change_note["base_path"], class: "govuk-link" %>
-                    </p>
+                    <% if change_note["title"].present? %>
+                      <p class="govuk-body">
+                        <%= link_to change_note["title"], change_note["base_path"], class: "govuk-link" %>
+                      </p>
+                    <% end %>
                     <%= simple_format(change_note["change_note"], class: "govuk-body") %>
                   <% end %>
                 </div>


### PR DESCRIPTION
[Trello](https://trello.com/c/PqXBvn5k/2377-implement-fallback-for-empty-links-in-hmrc-manuals-m)

This deals with an accessibility fail whereby a link to the amended document is not being displayed, see [this page](https://www.gov.uk/hmrc-internal-manuals/employment-status-manual/updates), under the entry for 5 October 2023. 

This happens because there is no value entered in the data for `title`, which is used as the text content for the link. There is a outstanding suggestion to force this to be a required value so that this does not occur but as a more immediate fix to deal with existing instances of the problem it was decided to not render the link at all in these cases. This retains the current visual appearance of the page (see below) but removes the cause of the accessibility fail (the blank link).

|Description|Screenshot|
|-|-|
|View|![Screenshot 2024-02-13 at 12 58 00](https://github.com/alphagov/government-frontend/assets/6080548/b70af963-5257-4ccd-96fb-4db35d0ec938)|
|Markup&nbsp;before|![Screenshot 2024-02-21 at 14 51 15](https://github.com/alphagov/government-frontend/assets/6080548/b454a076-f0ac-4273-97dc-0413fafa2e6f)|
|Markup&nbsp;after|![Screenshot 2024-02-21 at 14 49 00](https://github.com/alphagov/government-frontend/assets/6080548/9458bf1a-ecbd-47ce-b75f-2e020683542a)|

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
