### PR TITLE
Update NewsImage to render multiple defaults

### DIFF
--- a/app/presenters/content_item/news_image.rb
+++ b/app/presenters/content_item/news_image.rb
@@ -7,16 +7,14 @@ module ContentItem
   private
 
     def default_news_image
-      if content_item["document_type"].eql? "world_news_story"
-        return first_worldwide_organisation_default_news_image
-      end
+      return first_worldwide_organisation_default_news_image if world_news_story?
 
       first_primary_publishing_organisation_default_news_image
     end
 
     def placeholder_image
       # this image has been uploaded to asset-manager
-      if content_item["document_type"] == "world_news_story"
+      if world_news_story?
         { "url" => "https://assets.publishing.service.gov.uk/media/5e985599d3bf7f3fc943bbd8/UK_government_logo.jpg" }
       else
         { "url" => "https://assets.publishing.service.gov.uk/media/5e59279b86650c53b2cefbfe/placeholder.jpg" }
@@ -31,6 +29,10 @@ module ContentItem
     def first_primary_publishing_organisation_default_news_image
       organisation = content_item.dig("links", "primary_publishing_organisation")
       organisation[0].dig("details", "default_news_image") if organisation.present?
+    end
+
+    def world_news_story?
+      content_item["document_type"] == "world_news_story"
     end
   end
 end

--- a/app/presenters/content_item/news_image.rb
+++ b/app/presenters/content_item/news_image.rb
@@ -7,8 +7,11 @@ module ContentItem
   private
 
     def default_news_image
-      organisation = content_item.dig("links", "primary_publishing_organisation")
-      organisation[0].dig("details", "default_news_image") if organisation.present?
+      if content_item["document_type"].eql? "world_news_story"
+        return first_worldwide_organisation_default_news_image
+      end
+
+      first_primary_publishing_organisation_default_news_image
     end
 
     def placeholder_image
@@ -18,6 +21,16 @@ module ContentItem
       else
         { "url" => "https://assets.publishing.service.gov.uk/media/5e59279b86650c53b2cefbfe/placeholder.jpg" }
       end
+    end
+
+    def first_worldwide_organisation_default_news_image
+      worldwide_organisation = content_item.dig("links", "worldwide_organisations")
+      worldwide_organisation[0].dig("details", "default_news_image") if worldwide_organisation.present?
+    end
+
+    def first_primary_publishing_organisation_default_news_image
+      organisation = content_item.dig("links", "primary_publishing_organisation")
+      organisation[0].dig("details", "default_news_image") if organisation.present?
     end
   end
 end

--- a/test/presenters/content_item/news_image_test.rb
+++ b/test/presenters/content_item/news_image_test.rb
@@ -14,7 +14,7 @@ class ContentItemNewsImageTest < ActiveSupport::TestCase
     end
   end
 
-  test "presents the document's image if present" do
+  test "presents the document image if present" do
     item = DummyContentItem.new
     image = { "url" => "http://www.test.dev.gov.uk/lead_image.jpg" }
     item.content_item["details"]["image"] = image
@@ -22,9 +22,9 @@ class ContentItemNewsImageTest < ActiveSupport::TestCase
     assert_equal image, item.image
   end
 
-  test "presents the document's organisation's default_news_image if document's image is not present" do
+  test "presents the first primary publishing organisation default_news_image if document image is not present" do
     item = DummyContentItem.new
-    default_news_image = { "url" => "http://www.test.dev.gov.uk/default_news_image.jpg" }
+    default_news_image = { "url" => "http://www.test.dev.gov.uk/primary_publishing_organisation_default_news_image.jpg" }
     item.content_item["links"]["primary_publishing_organisation"] = [
       "details" => { "default_news_image" => default_news_image },
     ]
@@ -32,18 +32,30 @@ class ContentItemNewsImageTest < ActiveSupport::TestCase
     assert_equal default_news_image, item.image
   end
 
-  test "presents a placeholder image if document has no image or default news image" do
-    item = DummyContentItem.new
-    placeholder_image = { "url" => "https://assets.publishing.service.gov.uk/media/5e59279b86650c53b2cefbfe/placeholder.jpg" }
-
-    assert_equal placeholder_image, item.image
-  end
-
-  test "presents a placeholder image if world location news has no image or default news image" do
+  test "presents the first worldwide_organisation default_news_image if the document image is not present" do
     item = DummyContentItem.new
     item.content_item["document_type"] = "world_news_story"
-    placeholder_image = { "url" => "https://assets.publishing.service.gov.uk/media/5e985599d3bf7f3fc943bbd8/UK_government_logo.jpg" }
+    default_news_image = { "url" => "http://www.test.dev.gov.uk/worldwide_organisation_default_news_image.jpg" }
+    item.content_item["links"]["worldwide_organisations"] = [
+      "details" => { "default_news_image" => default_news_image },
+    ]
 
-    assert_equal placeholder_image, item.image
+    assert_equal default_news_image, item.image
+  end
+
+  test "presents the correct placeholder image if document has no image or default news image" do
+    item = DummyContentItem.new
+    expected_placeholder_image = { "url" => "https://assets.publishing.service.gov.uk/media/5e59279b86650c53b2cefbfe/placeholder.jpg" }
+
+    assert_equal expected_placeholder_image, item.image
+  end
+
+  test "presents the correct placeholder image if a world_news_story has no image or default news image" do
+    item = DummyContentItem.new
+    item.content_item["document_type"] = "world_news_story"
+
+    expected_placeholder_image = { "url" => "https://assets.publishing.service.gov.uk/media/5e985599d3bf7f3fc943bbd8/UK_government_logo.jpg" }
+
+    assert_equal expected_placeholder_image, item.image
   end
 end


### PR DESCRIPTION
The logic to render an image for a news item is:

- render the details > image if there is one
- render the organisation > default image if there is one
- render a placeholder

Organisation here could be one of two types:

- Organisation, presented in the primary_publishing_organisation link
- WorldwideOrganisation, presented in the worldwide_organisations link

The placeholder is also dependent on which type of document and so which
type of organisation the content links to.

Here we allow the module to render the default image from the worldwide
organisation link, when the document is the appropriate type and one is
available.

Right now this change will not be used as Whitehall currently sets
details > image to the default image for worldwide organisation news
items, but this is set to change as we want this logic out of the
publishing applications and for all related concepts like 'the default
news image' to work the same way.

With this change, once we do turn the replacement in Whitehall off,
everything will continnue to work without change.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
