### PR TITLE
Update .govuk_dependabot_merger.yml

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -23,7 +23,6 @@ auto_merge:
   - dependency: govuk_publishing_components
     allowed_semver_bumps:
       - patch
-      - minor
   - dependency: plek
     allowed_semver_bumps:
       - patch


### PR DESCRIPTION
Temporarily prevent automerging minor bumps of the gem

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
