### PR TITLE
Fix incorrect test

### DIFF
--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -57,7 +57,8 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
 
   test "renders the secondary corporate information pages" do
     setup_and_visit_content_item("worldwide_organisation")
-    assert page.has_link?("Personal information charter", href: "https://www.integration.publishing.service.gov.uk/world/organisations/british-deputy-high-commission-hyderabad/about/personal-information-charter")
+    assert page.has_text?("Our Personal information charter explains how we treat your personal information.")
+    assert page.has_link?("Personal information charter", href: "/world/organisations/british-deputy-high-commission-hyderabad/about/personal-information-charter")
   end
 
   test "doesn't render the corporate pages section if there are no pages to show" do


### PR DESCRIPTION
https://trello.com/c/npYpoK31

Currently, the worldwide organisation example JSON is incorrect; it contains:
- The link to "Personal information charter" as a corporate information page with a full URL
- A secondary corporate information page with a relative URL.

The former shouldn't be present, and this test relies on it's existence.

This updates the test so that the corporate information page link can be removed in alphagov/publishing-api#2637

The current example JSON produces this:
<img width="791" alt="image" src="https://github.com/alphagov/government-frontend/assets/47089130/c7af4ed5-0583-42f8-9ace-2a3f5e75b0f2">

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
