### PR TITLE
Add GA4 tracking to webchat available link

### DIFF
--- a/app/views/shared/_webchat.html.erb
+++ b/app/views/shared/_webchat.html.erb
@@ -20,7 +20,15 @@
       </span>
       <span class="js-webchat-advisers-available govuk-!-display-none">
         <%= t("shared.webchat.available") %>
-        <a href="#" data-redirect="<%=  @content_item.webchat.open_url_redirect.present? ? 'true' : 'false' %>" rel="external" class="js-webchat-open-button"><%= t("shared.webchat.speak_to_adviser") %></a>.
+        <a
+          href="#"
+          data-redirect="<%=  @content_item.webchat.open_url_redirect.present? ? 'true' : 'false' %>"
+          rel="external"
+          class="js-webchat-open-button"
+          data-module="ga4-link-tracker"
+          data-ga4-link="<%= { event_name: "navigation", type: "webchat", text: t("shared.webchat.speak_to_adviser", lang: :en) }.to_json %>">
+            <%= t("shared.webchat.speak_to_adviser") %>
+        </a>.
       </span>
     <% end %>
   </span>

--- a/test/integration/contact_test.rb
+++ b/test/integration/contact_test.rb
@@ -81,4 +81,11 @@ class ContactTest < ActionDispatch::IntegrationTest
     # reset back to default driver
     Capybara.use_default_driver
   end
+
+  test "has GA4 tracking on the webchat available link" do
+    setup_and_visit_content_item("contact", { base_path: "/government/organisations/hm-passport-office/contact/hm-passport-office-webchat", details: { "more_info_webchat": "<p>Some HTML</p>\n" } })
+
+    assert_selector ".js-webchat-advisers-available a[data-module=ga4-link-tracker]"
+    assert_selector ".js-webchat-advisers-available a[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"webchat\",\"text\":\"Speak to an adviser now\"}']"
+  end
 end


### PR DESCRIPTION
## What

- Adds GA4 tracking to the webchat 'available' link
- It's on this page: http://127.0.0.1:3090/government/organisations/hm-passport-office/contact/hm-passport-office-webchat (if it says webchat is unavailable, inspect element as the relevant GA4 HTML will still be there, it's just hidden via CSS)

## Why
https://trello.com/c/Yha4qZD2/790-add-tracking-webchat-link

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
