### PR TITLE
Fix link to worldwide office for translated worldwide organisations

### DIFF
--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -85,7 +85,7 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
     WorldwideOffice.new(
       contact: WorldwideOrganisation::LinkedContactPresenter.new(office_contact_item),
       has_access_and_opening_times?: office_item["access_and_opening_times"].present?,
-      public_url: "#{content_item['base_path']}/#{office_item['slug']}",
+      public_url: "#{content_item['base_path'].gsub(/\..*?$/, '')}/#{office_item['slug']}",
     )
   end
 

--- a/test/presenters/worldwide_organisation_presenter_test.rb
+++ b/test/presenters/worldwide_organisation_presenter_test.rb
@@ -164,6 +164,21 @@ class WorldwideOrganisationPresenterTest < PresenterTestCase
     assert_nil presented.main_office
   end
 
+  test "#main_office returns the correct link when the worldwide organisation is not a translation" do
+    presented = create_presenter(WorldwideOrganisationPresenter, content_item: schema_item)
+
+    assert_equal "/world/uk-embassy-in-country/office/british-embassy", presented.main_office.public_url
+  end
+
+  test "#main_office returns the correct link when the worldwide organisation is a translation" do
+    content_item = schema_item
+    content_item["base_path"] = "#{content_item['base_path']}.fr"
+
+    presented = create_presenter(WorldwideOrganisationPresenter, content_item:)
+
+    assert_equal "/world/uk-embassy-in-country/office/british-embassy", presented.main_office.public_url
+  end
+
   test "#home_page_offices returns an empty array when there are no home page offices" do
     without_home_page_offices = schema_item
     without_home_page_offices["details"].delete("home_page_office_parts")


### PR DESCRIPTION
We are currently linking the wrong place for worldwide offices on translated worldwide organisation pages.

E.g. for the content item in the test, we are currrenlty linking to `/world/uk-embassy-in-country.fr/office/british-embassy`, which results in a 404 response.

[Trello card](https://trello.com/c/9ivR4TGQ)