### PR TITLE
Use ww cips multi part

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -178,6 +178,7 @@ private
     return "manual_updates" if @content_item.manual_updates?
     return "hmrc_manual_updates" if @content_item.hmrc_manual_updates?
     return "worldwide_organisation_office" if @content_item.worldwide_organisation_office?
+    return "worldwide_organisation_page" if @content_item.worldwide_organisation_page?
 
     @content_item.schema_name
   end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -114,6 +114,10 @@ class ContentItemPresenter
     view_context.request.path =~ /^\/world\/.*\/office\/.*$/ && content_item["schema_name"] == "worldwide_organisation"
   end
 
+  def worldwide_organisation_page?
+    view_context.request.path =~ /^\/world\/.*\/about\/.*$/ && content_item["schema_name"] == "worldwide_organisation"
+  end
+
   def show_default_breadcrumbs?
     true
   end

--- a/app/presenters/worldwide_organisation_page_presenter.rb
+++ b/app/presenters/worldwide_organisation_page_presenter.rb
@@ -1,0 +1,47 @@
+class WorldwideOrganisationPagePresenter < ContentItemPresenter
+  include ContentItem::Body
+  include ContentItem::ContentsList
+  include WorldwideOrganisation::Branding
+
+  def formatted_title
+    worldwide_organisation&.formatted_title
+  end
+
+  def title
+    page["title"]
+  end
+
+  def summary
+    page["summary"]
+  end
+
+  def body
+    page["body"]
+  end
+
+  def show_default_breadcrumbs?
+    false
+  end
+
+  def page
+    pages = content_item.dig("details", "page_parts")
+
+    pages.select { |page|
+      page["slug"] == requested_path.gsub("#{content_item['base_path']}/", "")
+    }.first
+  end
+
+  def worldwide_organisation
+    WorldwideOrganisationPresenter.new(content_item, requested_path, view_context)
+  end
+
+  def sponsoring_organisations
+    worldwide_organisation&.sponsoring_organisations
+  end
+
+private
+
+  def show_contents_list?
+    true
+  end
+end

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -107,16 +107,13 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
   end
 
   def corporate_information_pages
-    cips = content_item.dig("links", "corporate_information_pages")
-    return [] if cips.blank?
-
     ordered_cips = content_item.dig("details", "ordered_corporate_information_pages")
     return [] if ordered_cips.blank?
 
     ordered_cips.map do |cip|
       {
         text: cip["title"],
-        url: cips.find { |cp| cp["content_id"] == cip["content_id"] }["web_url"],
+        url: full_path_for_slug(cip["path"]),
       }
     end
   end
@@ -159,5 +156,9 @@ private
 
   def world_locations
     content_item.dig("links", "world_locations") || []
+  end
+
+  def full_path_for_slug(slug)
+    "#{content_item['base_path']}/#{slug}"
   end
 end

--- a/app/services/presenter_builder.rb
+++ b/app/services/presenter_builder.rb
@@ -38,6 +38,7 @@ private
     return "ManualUpdatesPresenter" if manual_updates?
     return "HmrcManualUpdatesPresenter" if hmrc_manual_updates?
     return "WorldwideOrganisationOfficePresenter" if worldwide_organisation_office?
+    return "WorldwideOrganisationPagePresenter" if worldwide_organisation_page?
 
     "#{content_item['schema_name'].classify}Presenter"
   end
@@ -52,6 +53,10 @@ private
 
   def worldwide_organisation_office?
     view_context.request.path =~ /^\/world\/.*\/office\/.*$/ && content_item["schema_name"] == "worldwide_organisation"
+  end
+
+  def worldwide_organisation_page?
+    view_context.request.path =~ /^\/world\/.*\/about\/.*$/ && content_item["schema_name"] == "worldwide_organisation"
   end
 
   def service_sign_in_format?

--- a/app/views/content_items/worldwide_organisation_page.html.erb
+++ b/app/views/content_items/worldwide_organisation_page.html.erb
@@ -1,0 +1,29 @@
+<%= render partial: "content_items/worldwide_organisation/header", locals: {
+  worldwide_organisation: @content_item.worldwide_organisation,
+} %>
+
+<article class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <%= render "govuk_publishing_components/components/contents_list",
+               contents: @content_item.contents,
+               underline_links: true
+    %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: @content_item.title,
+      heading_level: 2,
+      font_size: "xl",
+      margin_bottom: 4,
+    } %>
+
+    <p class="govuk-body-l"><%= @content_item.summary %></p>
+
+    <div class="body">
+      <%= render "govuk_publishing_components/components/govspeak", {} do
+        raw(@content_item.body)
+      end %>
+    </div>
+  </div>
+</article>

--- a/test/presenters/worldwide_organisation_page_presenter_test.rb
+++ b/test/presenters/worldwide_organisation_page_presenter_test.rb
@@ -1,0 +1,70 @@
+require "presenter_test_helper"
+
+class WorldwideOrganisationPagePresenterTest < PresenterTestCase
+  def schema_name
+    "worldwide_organisation"
+  end
+
+  def requested_path
+    "#{schema_item['base_path']}/#{schema_item.dig('details', 'page_parts', 0, 'slug')}"
+  end
+
+  def present_example(example)
+    create_presenter(
+      "WorldwideOrganisationPagePresenter".safe_constantize,
+      content_item: example,
+      requested_path:,
+    )
+  end
+
+  test "#title returns the title of the page" do
+    assert_equal "Personal information charter", presented_item.title
+  end
+
+  test "#summary returns the summary of the page" do
+    assert_equal "Public holidays information about the British Deputy High Commission Hyderabad.", presented_item.summary
+  end
+
+  test "#body returns the body of the page" do
+    assert_equal schema_item.dig("details", "page_parts", 0, "body"), presented_item.body
+  end
+
+  test "#sponsoring_organisation_logo returns the logo details of the item" do
+    with_non_default_crest = schema_item
+    sponsoring_organisation = first_sponsoring_organisation(with_non_default_crest)
+    sponsoring_organisation["details"]["logo"]["crest"] = "dbt"
+
+    presented = present_example(with_non_default_crest)
+
+    expected = { name: "British Deputy High Commission<br/>Hyderabad", url: "/world/uk-embassy-in-country", crest: "dbt", brand: "foreign-commonwealth-development-office" }
+    assert_equal expected, presented.organisation_logo
+  end
+
+  test "#sponsoring_organisation_logo returns default values when the crest and brand of the first sponsoring organisation are blank" do
+    with_empty_logo = schema_item
+    sponsoring_organisation = first_sponsoring_organisation(with_empty_logo)
+    sponsoring_organisation["details"]["logo"]["crest"] = nil
+    sponsoring_organisation["details"]["brand"] = nil
+
+    presented = present_example(with_empty_logo)
+
+    expected = { name: "British Deputy High Commission<br/>Hyderabad", url: "/world/uk-embassy-in-country", crest: "single-identity", brand: "single-identity" }
+    assert_equal expected, presented.organisation_logo
+  end
+
+  test "#sponsoring_organisation_logo returns default values when the sponsoring organisations are nil" do
+    without_sponsoring_organisations = schema_item
+    without_sponsoring_organisations["links"].delete("sponsoring_organisations")
+
+    presented = present_example(without_sponsoring_organisations)
+
+    expected = { name: "British Deputy High Commission<br/>Hyderabad", url: "/world/uk-embassy-in-country", crest: "single-identity", brand: "single-identity" }
+    assert_equal expected, presented.organisation_logo
+  end
+
+private
+
+  def first_sponsoring_organisation(item)
+    item["links"]["sponsoring_organisations"][0]
+  end
+end


### PR DESCRIPTION
https://trello.com/c/npYpoK31

### Use details for links to primary corporate information pages
Primary corporate informaiton pages are displayed as a list.

### Add support for CIPs embedded in worldwide organisations
As part of the switch to Worldwide Organisation content items containing
the content for their corporate information pages, we need to switch the
rendering of the CIP pages to use these parts.

This makes that switch in a backward compatible way, so we can continue
rendering CIP pages under the existing content items until the office
routes are updated to point to the organisation's content item.

In a later PR, we will remove `WorldwideCorporateInformationPagePresenter`
and it's associated view.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
