### PR TITLE
Fix locale enforcement on GA4 webchat available link

### DIFF
--- a/app/views/shared/_webchat.html.erb
+++ b/app/views/shared/_webchat.html.erb
@@ -26,7 +26,7 @@
           rel="external"
           class="js-webchat-open-button"
           data-module="ga4-link-tracker"
-          data-ga4-link="<%= { event_name: "navigation", type: "webchat", text: t("shared.webchat.speak_to_adviser", lang: :en) }.to_json %>">
+          data-ga4-link="<%= { event_name: "navigation", type: "webchat", text: t("shared.webchat.speak_to_adviser", locale: :en) }.to_json %>">
             <%= t("shared.webchat.speak_to_adviser") %>
         </a>.
       </span>

--- a/test/integration/contact_test.rb
+++ b/test/integration/contact_test.rb
@@ -88,4 +88,11 @@ class ContactTest < ActionDispatch::IntegrationTest
     assert_selector ".js-webchat-advisers-available a[data-module=ga4-link-tracker]"
     assert_selector ".js-webchat-advisers-available a[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"webchat\",\"text\":\"Speak to an adviser now\"}']"
   end
+
+  test "has English text for GA4 on the webchat available link, even if the link is in another language" do
+    setup_and_visit_content_item("contact", { locale: "cy", base_path: "/government/organisations/hm-passport-office/contact/hm-passport-office-webchat", details: { "more_info_webchat": "<p>Some HTML</p>\n" } })
+    assert_selector ".js-webchat-advisers-available a[data-module=ga4-link-tracker]"
+    assert_selector ".js-webchat-advisers-available a[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"webchat\",\"text\":\"Speak to an adviser now\"}']"
+    assert_selector ".js-webchat-advisers-available a", text: "Siaradwch â chynghorydd nawr"
+  end
 end


### PR DESCRIPTION
## What
- Change `lang: :en` to `locale: :en` and add a test to ensure the GA4 webchat link text is always English

## Why
- I accidentally used the wrong word (`lang`) to enforce the English string. So I've fixed it and written a test to ensure it's working.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
