### PR TITLE
Update Japanese translation of Japanese

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -351,7 +351,7 @@ ja:
     id:
     is:
     it:
-    ja: 日本
+    ja: 日本語
     ka:
     kk:
     ko:


### PR DESCRIPTION
The translation of Japanese (日本語) was mistakenly put in as Japan[日本)

This was requested via [zendesk](https://govuk.zendesk.com/agent/tickets/5644887)

## Before:
<img width="996" alt="image" src="https://github.com/alphagov/government-frontend/assets/17481621/4d93cc0f-e333-4e8a-a931-621615ca1f81">

## After:
<img width="1001" alt="image" src="https://github.com/alphagov/government-frontend/assets/17481621/6c910304-f91d-4c7d-a525-3fb1ef0fa6e8">

