### PR TITLE
Remove test for specialist topic breadcrumb

### DIFF
--- a/test/integration/manual_section_test.rb
+++ b/test/integration/manual_section_test.rb
@@ -17,10 +17,10 @@ class ManualSectionTest < ActionDispatch::IntegrationTest
 
   test "renders contextual breadcrumbs from parent manuals tagging" do
     setup_and_visit_manual_section
-    manual_topic = @manual["links"]["topics"].first
+    manual_taxonomy_topic = @manual["links"]["taxons"].first
 
     within ".gem-c-contextual-breadcrumbs" do
-      assert page.has_link?(manual_topic["title"], href: manual_topic["base_path"])
+      assert page.has_link?(manual_taxonomy_topic["title"], href: manual_taxonomy_topic["base_path"])
     end
   end
 


### PR DESCRIPTION
Specialist topics are no longer present in the links of any live content, so this test is no longer representative.

Please note: The CI will fail on this PR until https://github.com/alphagov/publishing-api/pull/2674 is merged

https://trello.com/c/ZDUYtKok/2484-remove-specialist-topic-test-from-government-frontend-s

