### PR TITLE
Set up DWP user research banner

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -2,6 +2,7 @@ require "slimmer/headers"
 
 class ContentItemsController < ApplicationController
   include GovukPersonalisation::ControllerConcern
+  include RecruitmentBannerHelper
   include Slimmer::Headers
   include Slimmer::Template
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,8 @@
       <% end %>
     <% end %>
 
+    <%= render partial: 'shared/intervention_banner' %> 
+
     <%= yield :header %>
 
     <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">

--- a/lib/data/recruitment_banners.yml
+++ b/lib/data/recruitment_banners.yml
@@ -9,3 +9,12 @@
   #     - /foreign-travel-advice
 
 banners:
+- name: DWP user research banner
+  suggestion_text: Help improve GOV.UK
+  suggestion_link_text: Take part in user research (opens in a new tab)
+  survey_url: https://forms.office.com/e/CkfCRwdLQj
+  page_paths:
+    - /maternity-allowance
+    - /funeral-payments
+    - /disability-living-allowance-children
+    - /pension-credit

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "Brand user research banner is displayed on pages of interest" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+
+    pages_of_interest =
+      [
+        "/maternity-allowance",
+        "/funeral-payments",
+        "/disability-living-allowance-children",
+        "/pension-credit",
+      ]
+
+    pages_of_interest.each do |path|
+      guide["base_path"] = path
+      stub_content_store_has_item(guide["base_path"], guide.to_json)
+      visit guide["base_path"]
+
+      assert page.has_css?(".gem-c-intervention")
+      assert page.has_link?("Take part in user research", href: "https://forms.office.com/e/CkfCRwdLQj")
+    end
+  end
+
+  test "Brand user research banner is not displayed on all pages" do
+    guide = GovukSchemas::Example.find("guide", example_name: "guide")
+    guide["base_path"] = "/nothing-to-see-here"
+    stub_content_store_has_item(guide["base_path"], guide.to_json)
+    visit guide["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://forms.office.com/e/CkfCRwdLQj")
+  end
+end


### PR DESCRIPTION
The banner will be added on the following pages:    
- [/maternity-allowance](https://www.gov.uk/maternity-allowance)
![image](https://github.com/alphagov/government-frontend/assets/17481621/5c7947a3-bce7-48fa-932f-d05ef1c1a887)

- [/funeral-payments](https://www.gov.uk/funeral-payments)
![image](https://github.com/alphagov/government-frontend/assets/17481621/d64a5dca-b604-4143-a728-3e15fa92ce99)

- [/disability-living-allowance-children](https://www.gov.uk/disability-living-allowance-children)
![image](https://github.com/alphagov/government-frontend/assets/17481621/acba2e6b-755a-4e2b-9161-c65a5f7eb7c1)

- [/pension-credit](https://www.gov.uk/pension-credit)
![image](https://github.com/alphagov/government-frontend/assets/17481621/3ea451ae-2791-4044-b5c8-a76cecc0257c)


Trello card: https://trello.com/c/zfgadIUN