### PR TITLE
Add Welsh translation for consultation concluded

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -53,7 +53,7 @@ cy:
     closes: Mae'n cau am
     closes_at: Mae'r ymgynghoriad hwn yn cau am
     complete_a: Cwblhau
-    concluded:
+    concluded: Mae'r ymgynghoriad hwn wedi dod i ben
     description: Disgrifiad o'r ymgynghoriad
     detail_of_feedback_received: Manylion am yr adborth a gafwyd
     detail_of_outcome: Manylion am y canlyniad


### PR DESCRIPTION
## Description

We had a request to add a Welsh translation for the consultation concluded messaging.

## Zendesk ticket

https://govuk.zendesk.com/agent/tickets/5658237

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
