### PR TITLE
2412 heading sizes in government frontend

### DIFF
--- a/app/assets/stylesheets/views/_manual.scss
+++ b/app/assets/stylesheets/views/_manual.scss
@@ -142,3 +142,7 @@
     padding-right: govuk-spacing(3);
   }
 }
+
+.test-accordion-heading-s .govuk-accordion__section-heading-text {
+  font-size: 16px;
+}

--- a/app/views/content_items/hmrc_manual_updates.html.erb
+++ b/app/views/content_items/hmrc_manual_updates.html.erb
@@ -9,4 +9,4 @@
   } %>
 <% end %>
 
-<%= render "content_items/manuals/manual_updates_layout" %>
+<%= render "content_items/manuals/manual_updates_layout", type: I18n.t("manuals.hmrc_manual_type") %>

--- a/app/views/content_items/hmrc_manual_updates.html.erb
+++ b/app/views/content_items/hmrc_manual_updates.html.erb
@@ -2,7 +2,7 @@
 <% content_for :header do %>
   <%= render "content_items/manuals/header", {
     content_item: @content_item,
-    heading_level: 2,
+    heading_level: 1,
     margin_bottom: 6,
     green_background: true,
     type: I18n.t("manuals.hmrc_manual_type"),

--- a/app/views/content_items/hmrc_manual_updates.html.erb
+++ b/app/views/content_items/hmrc_manual_updates.html.erb
@@ -2,7 +2,7 @@
 <% content_for :header do %>
   <%= render "content_items/manuals/header", {
     content_item: @content_item,
-    heading_level: 1,
+    heading_level: 2,
     margin_bottom: 6,
     green_background: true,
     type: I18n.t("manuals.hmrc_manual_type"),

--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -20,7 +20,6 @@
           <div class="govuk-!-margin-bottom-3">
             <%= render "govuk_publishing_components/components/heading", {
               text: item[:heading][:text],
-              font_size: "m",
               margin_bottom: 1,
               id: item[:heading][:id],
             } %>

--- a/app/views/content_items/manual_section.html.erb
+++ b/app/views/content_items/manual_section.html.erb
@@ -1,7 +1,9 @@
 <% add_view_stylesheet("manual") %>
 <% content_for :header do %>
   <%= render "content_items/manuals/header", {
-    content_item: @content_item, heading_level: 1, margin_bottom: 6,
+    content_item: @content_item,
+    heading_level: 2,
+    margin_bottom: 6
   } %>
   <%= render partial: "content_items/manuals/breadcrumbs" %>
 <% end %>

--- a/app/views/content_items/manual_updates.html.erb
+++ b/app/views/content_items/manual_updates.html.erb
@@ -1,9 +1,7 @@
 <% add_view_stylesheet("manual") %>
 <% content_for :header do %>
   <%= render "content_items/manuals/header", {
-    content_item: @content_item,
-    heading_level: 2,
-    margin_bottom: 6
+    content_item: @content_item, heading_level: 2, margin_bottom: 6
   } %>
 <% end %>
 

--- a/app/views/content_items/manual_updates.html.erb
+++ b/app/views/content_items/manual_updates.html.erb
@@ -1,7 +1,7 @@
 <% add_view_stylesheet("manual") %>
 <% content_for :header do %>
   <%= render "content_items/manuals/header", {
-    content_item: @content_item, heading_level: 2, margin_bottom: 6,
+    content_item: @content_item, heading_level: 1, margin_bottom: 6,
   } %>
 <% end %>
 

--- a/app/views/content_items/manual_updates.html.erb
+++ b/app/views/content_items/manual_updates.html.erb
@@ -1,7 +1,9 @@
 <% add_view_stylesheet("manual") %>
 <% content_for :header do %>
   <%= render "content_items/manuals/header", {
-    content_item: @content_item, heading_level: 1, margin_bottom: 6,
+    content_item: @content_item,
+    heading_level: 2,
+    margin_bottom: 6
   } %>
 <% end %>
 

--- a/app/views/content_items/manuals/_header.html.erb
+++ b/app/views/content_items/manuals/_header.html.erb
@@ -15,7 +15,6 @@
 
     <%= render "govuk_publishing_components/components/heading", {
       text: content_item.title,
-      font_size: "l",
       inverse: true,
       id: "manual-title",
       heading_level: heading_level,

--- a/app/views/content_items/manuals/_manual_section_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_section_layout.html.erb
@@ -13,7 +13,7 @@
         <article aria-labelledby="section-title">
           <div class="govuk-grid-column-full">
             <%= render "govuk_publishing_components/components/heading", {
-              text: @content_item.document_heading.join(" - "),
+              text: "#{@content_item.title} - #{@content_item.document_heading.join(" - ")}",
               font_size: "l",
               id: "section-title",
               heading_level: 1,

--- a/app/views/content_items/manuals/_manual_updates_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_updates_layout.html.erb
@@ -1,9 +1,13 @@
+<%
+  type ||= nil
+%>
+
 <% content_for :main do %>
   <%= render "govuk_publishing_components/components/back_link", {
     text: t("manuals.breadcrumb_contents"),
     href: @content_item.base_path
   } %>
   <div id="manuals-frontend" class="manuals-frontend-body">
-    <%= render "content_items/manuals/updates", content_item: @content_item %>
+    <%= render "content_items/manuals/updates", content_item: @content_item, manual_type: type %>
   </div>
 <% end %>

--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -27,45 +27,49 @@
             text: year
           } %>
 
-          <%= render "govuk_publishing_components/components/accordion", {
-            heading_level: 3,
-            items: updates_by_year.each.with_index(1).map do |updated_documents, index|
-              accordion_content = capture do %>
-                <% change_notes = updated_documents.last %>
-                <div class="govuk-!-margin-top-3">
-                  <% change_notes.each do |change_note_entry| %>
-                    <% change_note_items = change_note_entry.last.collect { |i| i["change_note"] } %>
-                    <% change_note = change_note_entry.flatten.last %>
-                    <% if change_note["title"].present? %>
-                      <p class="govuk-body">
-                        <%= link_to change_note["title"], change_note["base_path"], class: "govuk-link" %>
-                      </p>
+          <div class="test-accordion-heading-s">
+            <%= render "govuk_publishing_components/components/accordion", {
+              heading_level: 3,
+              items: updates_by_year.each.with_index(1).map do |updated_documents, index|
+                accordion_content = capture do %>
+                  <% change_notes = updated_documents.last %>
+                  <div class="govuk-!-margin-top-3">
+                    <% change_notes.each do |change_note_entry| %>
+                      <% change_note_items = change_note_entry.last.collect { |i| i["change_note"] } %>
+                      <% change_note = change_note_entry.flatten.last %>
+                      <% if change_note["title"].present? %>
+                        <p class="govuk-body">
+                          <%= link_to change_note["title"], change_note["base_path"], class: "govuk-link" %>
+                        </p>
+                      <% end %>
+                      <% change_note_items.each do |change_note_item| %>
+                        <%= simple_format(change_note_item, class: "govuk-body") %>
+                      <% end %>
                     <% end %>
-                    <% change_note_items.each do |change_note_item| %>
-                      <%= simple_format(change_note_item, class: "govuk-body") %>
-                    <% end %>
-                  <% end %>
-                </div>
-              <% end
-              {
-                data_attributes: {
-                  ga4_event: {
-                    event_name: 'select_content',
-                    type: 'accordion',
-                    text: sanitize_manual_update_title(updated_documents.first),
-                    index: index,
-                    index_total: updates_by_year.length,
+                  </div>
+                <% end
+                {
+                  data_attributes: {
+                    ga4_event: {
+                      event_name: 'select_content',
+                      type: 'accordion',
+                      text: sanitize_manual_update_title(updated_documents.first),
+                      index: index,
+                      index_total: updates_by_year.length,
+                    }
+                  },
+                  heading: {
+                    text: updated_documents.first,
+                  },
+                  content: {
+                    html: accordion_content
                   }
-                },
-                heading: {
-                  text: updated_documents.first,
-                },
-                content: {
-                  html: accordion_content
                 }
-              }
-            end
-          } %>
+              end
+            } %>
+          </div>
+
+
         </div>
       <% end %>
     </article>

--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -14,8 +14,7 @@
       <% content_item.presented_change_notes.each do |year, updates_by_year| %>
         <div class="govuk-grid-column-two-thirds">
           <%= render "govuk_publishing_components/components/heading", {
-            text: year,
-            font_size: "l"
+            text: year
           } %>
 
           <%= render "govuk_publishing_components/components/accordion", {

--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -1,3 +1,13 @@
+<%
+  manual_type ||= nil
+
+  if manual_type
+    text = "#{t("manuals.updates_title", title: content_item.title)} - #{manual_type}"
+  else
+    text = t("manuals.updates_title", title: content_item.title)
+  end
+%>
+
 <div class="govuk-grid-row">
   <div class="manual-body">
     <article aria-labelledby="section-title">
@@ -7,7 +17,7 @@
           heading_level: 1,
           id: "section-title",
           margin_bottom: 4,
-          text: t("manuals.updates_title", title: content_item.title),
+          text: text
         } %>
       </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -483,7 +483,7 @@ en:
     updates_amendments: published amendments
     updates_description: List of updates to '%{title}'.
     updates_page_title: Updates - %{title}
-    updates_title: 'Updates: %{title}'
+    updates_title: 'Updates - %{title}'
   multi_page:
     next_page: Next
     previous_page: Previous

--- a/test/integration/manual_section_test.rb
+++ b/test/integration/manual_section_test.rb
@@ -50,7 +50,7 @@ class ManualSectionTest < ActionDispatch::IntegrationTest
   test "renders document heading" do
     setup_and_visit_manual_section
 
-    within "#manual-title.govuk-heading-l" do
+    within "#manual-title" do
       assert page.has_text?(@manual["title"])
     end
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/T1JGEeyz/2412-investigate-heading-sizes-in-government-frontend-m-l)

By way of an investigation into heading sizes, and a suggested way of dealing with inconsistencies and accessibility issues, I have made some small suggested changes to heading levels and sizes to make the three manuals headings consistent, based on the design [here](https://www.figma.com/file/KITAANxWkx64lUtH9U3Nlr/Manuals-Headings?type=design&node-id=0-1&mode=design&t=jObeFE1vLMTMICvK-0). 

Initially this brought two of these ("[Content design: planning, writing and managing content](https://www.gov.uk/guidance/content-design/updates)" and "[Employment Status Manual](https://www.gov.uk/hmrc-internal-manuals/employment-status-manual/updates)") into line with the recently updated "[Complete the school census](https://www.gov.uk/guidance/complete-the-school-census/census-dates)" page. 

This became problematic though because the `<h3>` elements on the two pages changed here are part of the accordion component and cannot (or maybe should not) be changed in terms of the font size. My feeling is that it should not be a problem to have different sized `<h3>`s across these pages since some of those are functioning as part of the accordion.

|Before|After|Changes|
|-|-|-|
|![Screenshot 2024-04-08 at 11 36 21](https://github.com/alphagov/government-frontend/assets/6080548/1a5d5f65-7a43-4200-af21-577ce7d7ed26)|![Screenshot 2024-04-12 at 14 53 46](https://github.com/alphagov/government-frontend/assets/6080548/33284497-2f13-4b2e-8dd9-32fea9771e22)|Top heading ("Content design: planning, writing and managing content") retained as `<h2>` and font size reduced to 27px<br><br>`<h1>` ("Updates: Content design: planning, writing and managing content") updated (slightly) to align content with page title<br><br>`<h2>` ("2023") reduced font size from 36px to 27px|
|![Screenshot 2024-04-08 at 11 43 57](https://github.com/alphagov/government-frontend/assets/6080548/1bdd7357-038a-43b4-bda6-aff0460e74b5)|![Screenshot 2024-04-12 at 15 05 28](https://github.com/alphagov/government-frontend/assets/6080548/98e766ea-ac35-40ba-9a88-a58b22f12dbf)|Top heading ("Employment Status Manual") retained as `<h2>` and font size reduced to 27px<br><br>`<h1>` ("Updates: Employment Status Manual") updated to align content with page title<br><br>`<h2>` ("2023") reduced font size from 36px to 27px|
|![Screenshot 2024-04-08 at 11 46 23](https://github.com/alphagov/government-frontend/assets/6080548/c06f3578-2af9-453e-a9a6-cbe0f32c0d83)|![Screenshot 2024-04-12 at 15 09 19](https://github.com/alphagov/government-frontend/assets/6080548/1f3dd53c-c03a-44f6-8380-1c99862ae0fa)|Top heading ("Complete the school census") changed to `<h2>` and font size reduced to 27px<br><br>`<h1>` ("Census dates") updated to align content with page title<br><br>`<h2>` ("2023 to 2024 census dates") changed from 24px to 27px|