### PR TITLE
Fix publication attachments

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -10,10 +10,14 @@ class PublicationPresenter < ContentItemPresenter
     content_item["details"]["body"]
   end
 
+  def attachments_for_components
+    documents.select { |doc| featured_attachments.include? doc["id"] }
+  end
+
   def documents
     return [] unless content_item["details"]["attachments"]
 
-    docs = content_item["details"]["attachments"].select { |a| a["locale"] == locale }
+    docs = content_item["details"]["attachments"].select { |a| !a.key?("locale") || a["locale"] == locale }
     docs.each do |doc|
       doc["type"] = "html" unless doc["content_type"]
       doc["alternative_format_contact_email"] = nil if doc["accessible"] == true

--- a/app/views/content_items/_attachments_list.html.erb
+++ b/app/views/content_items/_attachments_list.html.erb
@@ -1,21 +1,16 @@
-<%
-  attachments ||= nil
-  featured_attachments ||= []
-  attachment_details = featured_attachments.filter_map { |id| @content_item&.attachment_details(id) }
-%>
-<section id="<%= title.parameterize %>">
-  <%= render 'govuk_publishing_components/components/heading',
-    text: title,
-    mobile_top_margin: true
-  %>
-  <% if attachment_details.length > 0 %>
+<% if attachments_for_components.any? %>
+  <section id="<%= title.parameterize %>">
+    <%= render 'govuk_publishing_components/components/heading',
+      text: title,
+      mobile_top_margin: true
+    %>
     <% add_gem_component_stylesheet("details") %>
-    <% attachment_details.each do |details| %>
+    <% attachments_for_components.each do |details| %>
       <%= render 'govuk_publishing_components/components/attachment', {
         heading_level: 3,
         attachment: details,
         margin_bottom: 6
       } %>
     <% end %>
-  <% end %>
-</section>
+  </section>
+<% end %>

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -51,8 +51,7 @@
       <div class="responsive-bottom-margin">
         <%= render "attachments_list",
           title: t("publication.documents", count: 5), # This should always be pluralised.
-          attachments: @content_item.documents,
-          featured_attachments: @content_item.featured_attachments
+          attachments_for_components: @content_item.attachments_for_components
         %>
 
         <section id="details">

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -58,9 +58,7 @@ class PublicationTest < ActionDispatch::IntegrationTest
     }
 
     setup_and_visit_content_item("publication", overrides)
-    within "#documents" do
-      assert page.has_no_text?("Permit: Veolia ES (UK) Limited")
-    end
+    assert page.has_no_text?("Permit: Veolia ES (UK) Limited")
   end
 
   test "renders featured document attachments using components" do
@@ -69,6 +67,16 @@ class PublicationTest < ActionDispatch::IntegrationTest
       assert page.has_text?("Number of ex-regular service personnel now part of FR20")
       assert page.has_css?(".gem-c-attachment")
     end
+  end
+
+  test "doesn't render the documents section if no documents" do
+    overrides = {
+      "details" => {
+        "attachments" => [{}],
+      },
+    }
+    setup_and_visit_content_item("publication-with-featured-attachments", overrides)
+    assert page.has_no_text?("Documents")
   end
 
   test "renders accessible format option when accessible is false and email is supplied" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- simplify and fix the code to display attachments on publication/form pages
- move most of the code into the presenter, to reduce ambiguity
- pass only one thing to the attachments_list component
- update tests

Follows on from the work done in https://github.com/alphagov/government-frontend/pull/3058

## Why
Recent changes to rendering of publication attachments were not fully correct, as reported in zendesk ticket https://govuk.zendesk.com/agent/tickets/5807151 and elsewhere.

Specifically:

- attachments on https://www.gov.uk/government/publications/further-education-workforce-data-collection should not be marked as inaccessible, so the option to request an accessible format should not be shown
- attachments on https://www.gov.uk/government/publications/dvsa-vision-to-2030 were not marked as HTML where they should be

## Visual changes
See 'why'.

Trello card: https://trello.com/c/tcTN1jbu/28-update-rendering-of-govspeak-attachments
