### PR TITLE
Fix publication external links

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -20,6 +20,7 @@ class PublicationPresenter < ContentItemPresenter
     docs = content_item["details"]["attachments"].select { |a| !a.key?("locale") || a["locale"] == locale }
     docs.each do |doc|
       doc["type"] = "html" unless doc["content_type"]
+      doc["type"] = "external" if doc["attachment_type"] == "external"
       doc["alternative_format_contact_email"] = nil if doc["accessible"] == true
     end
   end

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -168,6 +168,37 @@ class PublicationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "renders external links correctly" do
+    overrides = {
+      "details" => {
+        "attachments" => [{
+          "accessible" => true,
+          "alternative_format_contact_email" => "ddc-modinternet@mod.gov.uk",
+          "attachment_type" => "external",
+          "id" => "PUBLIC_1392629965.pdf",
+          "title" => "Number of ex-regular service personnel now part of FR20",
+          "url" => "https://not-a-real-website-hopefully",
+          "command_paper_number" => "",
+          "hoc_paper_number" => "",
+          "isbn" => "",
+          "unique_reference" => "",
+          "unnumbered_command_paper" => false,
+          "unnumbered_hoc_paper" => false,
+          "content_type" => "application/pdf",
+          "file_size" => 932,
+          "filename" => "PUBLIC_1392629965.pdf",
+          "number_of_pages" => 2,
+          "locale" => "en",
+        }],
+      },
+    }
+    setup_and_visit_content_item("publication-with-featured-attachments", overrides)
+    within "#documents" do
+      assert page.has_text?("https://not-a-real-website-hopefully")
+      assert page.has_no_text?("HTML")
+    end
+  end
+
   test "withdrawn publication" do
     setup_and_visit_content_item("withdrawn_publication")
     assert page.has_css?("title", text: "[Withdrawn]", visible: false)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

- some attachments are simply links to another website
- for these we need to identify the type as 'external' and pass the right option to the attachment component
- added test for this


## Why

Pages like this were showing external links as HTML attachments: https://www.gov.uk/government/publications/national-risk-register-2023


## Visual changes
External links should now look like this:

![Screenshot 2024-04-18 at 14 52 54](https://github.com/alphagov/government-frontend/assets/861310/d55dc332-3739-40c5-9e81-08d159001be0)


Trello card: https://trello.com/c/tcTN1jbu/28-update-rendering-of-govspeak-attachments
