### PR TITLE
Use govuk publishing components content list to prevent hyphens being read out by screenreaders

### DIFF
--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -112,7 +112,7 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
     ordered_cips.map do |cip|
       {
         text: cip["title"],
-        url: cips.find { |cp| cp["content_id"] == cip["content_id"] }["web_url"],
+        href: cips.find { |cp| cp["content_id"] == cip["content_id"] }["web_url"],
       }
     end
   end

--- a/app/views/content_items/worldwide_organisation.html.erb
+++ b/app/views/content_items/worldwide_organisation.html.erb
@@ -117,11 +117,10 @@
 
     <% if @content_item.corporate_information_pages.any? %>
       <nav class="group corporate-information__sub-navigation" role="navigation">
-        <ul class="govuk-list">
-          <% @content_item.corporate_information_pages.each do |cip| %>
-            <li lang="<%= @content_item.locale %>"><%= link_to cip[:text], cip[:url], class: "govuk-link" %></li>
-          <% end %>
-        </ul>
+          <%= render "govuk_publishing_components/components/contents_list", {
+            underline_links: true,
+            contents: @content_item.corporate_information_pages,
+          } %>
       </nav>
     <% end %>
 


### PR DESCRIPTION
## What
Use the `contents-list` from `govuk-publishing-component` to render the list of corporate information pages for worldwide organisations.

## Why
The contents list component has a fix for an issue where nearly every screen reader  reads out the hyphen as either “dash“ or “hyphen“ before each item/link in the Corporate information list.  Screen reader users found that frustrating to read through, so this should improve the experience.

## Screenshots
| Before | After |
|--------|--------|
| <img width="1019" alt="image" src="https://github.com/alphagov/government-frontend/assets/17481621/73e84236-21b4-4a4b-accd-8d42a673afd7"> | <img width="996" alt="image" src="https://github.com/alphagov/government-frontend/assets/17481621/10544ca5-0e67-4965-8572-1b2f1ee8511c"> | 

Trello card: https://trello.com/c/pVeGF0WE