### PR TITLE
Prevent hyphens being read out by screen readers

### DIFF
--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -58,25 +58,3 @@
     }
   }
 }
-
-.corporate-information__sub-navigation {
-  ul {
-    padding-inline-start: 0;
-  }
-
-  li {
-    @media (min-width: 1px) { // stylelint-disable-line media-feature-range-notation
-      list-style: none;
-      padding-left: $govuk-gutter-half;
-      @include govuk-responsive-padding(1, "top");
-
-      &:before { // stylelint-disable-line selector-pseudo-element-colon-notation
-        content: "-";
-        position: relative;
-        float: left;
-        width: $govuk-gutter-half;
-        margin-left: $govuk-gutter-half * -1;
-      }
-    }
-  }
-}

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -99,21 +99,19 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
   end
 
   def show_corporate_info_section?
-    corporate_information_pages.any? || secondary_corporate_information.present?
+    corporate_information_pages.present? || secondary_corporate_information.present?
   end
 
   def corporate_information_pages
     cips = content_item.dig("links", "corporate_information_pages")
-    return [] if cips.blank?
+    return if cips.blank?
 
     ordered_cips = content_item.dig("details", "ordered_corporate_information_pages")
-    return [] if ordered_cips.blank?
+    return if ordered_cips.blank?
 
     ordered_cips.map do |cip|
-      {
-        text: cip["title"],
-        url: cips.find { |cp| cp["content_id"] == cip["content_id"] }["web_url"],
-      }
+      link = cips.find { |cp| cp["content_id"] == cip["content_id"] }["web_url"]
+      link_to(cip["title"], link, class: "govuk-link").html_safe
     end
   end
 

--- a/app/views/content_items/worldwide_organisation.html.erb
+++ b/app/views/content_items/worldwide_organisation.html.erb
@@ -116,13 +116,10 @@
     } %>
 
     <% if @content_item.corporate_information_pages.any? %>
-      <nav class="group corporate-information__sub-navigation" role="navigation">
-        <ul class="govuk-list">
-          <% @content_item.corporate_information_pages.each do |cip| %>
-            <li lang="<%= @content_item.locale %>"><%= link_to cip[:text], cip[:url], class: "govuk-link" %></li>
-          <% end %>
-        </ul>
-      </nav>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: @content_item.corporate_information_pages
+      } %>
     <% end %>
 
     <% if @content_item.secondary_corporate_information.present? %>


### PR DESCRIPTION
## What
Use the `list` from `govuk-publishing-component` to render the list of corporate information pages for worldwide organisations.

## Why
The  list component means we can remove the hyphens that were rendered previously. These were read out as either “dash“ or “hyphen“ before each item/link in the Corporate information list.  Screen reader users found that frustrating to read through, so this should improve the experience.

## Screenshots
| Before | After |
|--------|--------|
| <img width="1030" alt="image" src="https://github.com/alphagov/government-frontend/assets/17481621/3a8d0612-61fd-4c83-812c-d8b2e2da24be"> | <img width="991" alt="image" src="https://github.com/alphagov/government-frontend/assets/17481621/be49b8a0-84a5-456d-a457-4dc07530f9d4"> | 

Trello card: https://trello.com/c/pVeGF0WE