### PR TITLE
Add GA4 tracking to details in attachments

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -14,6 +14,10 @@ class PublicationPresenter < ContentItemPresenter
     documents.select { |doc| featured_attachments.include? doc["id"] }
   end
 
+  def attachments_with_details
+    attachments_for_components.select { |doc| doc["accessible"] == false && doc["alternative_format_contact_email"] }.count
+  end
+
   def documents
     return [] unless content_item["details"]["attachments"]
 

--- a/app/views/content_items/_attachments_list.html.erb
+++ b/app/views/content_items/_attachments_list.html.erb
@@ -9,7 +9,10 @@
       <%= render 'govuk_publishing_components/components/attachment', {
         heading_level: 3,
         attachment: details,
-        margin_bottom: 6
+        margin_bottom: 6,
+        details_ga4_attributes: {
+          index_section_count: @content_item.attachments_with_details
+        }
       } %>
     <% end %>
   </section>

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -39,18 +39,11 @@ class PublicationTest < ActionDispatch::IntegrationTest
           "accessible" => false,
           "alternative_format_contact_email" => "customerservices@publicguardian.gov.uk",
           "attachment_type" => "file",
-          "command_paper_number" => "",
           "content_type" => "application/pdf",
-          "file_size" => 123_456,
           "filename" => "veolia-permit.pdf",
-          "hoc_paper_number" => "",
           "id" => "violia-permit",
-          "isbn" => "",
           "locale" => "en",
           "title" => "Permit: Veolia ES (UK) Limited",
-          "unique_reference" => "",
-          "unnumbered_command_paper" => false,
-          "unnumbered_hoc_paper" => false,
           "url" => "https://assets.publishing.service.gov.uk/media/123abc/veolia-permit.zip",
         }],
         "featured_attachments" => [],
@@ -89,16 +82,8 @@ class PublicationTest < ActionDispatch::IntegrationTest
           "id" => "PUBLIC_1392629965.pdf",
           "title" => "Number of ex-regular service personnel now part of FR20",
           "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
-          "command_paper_number" => "",
-          "hoc_paper_number" => "",
-          "isbn" => "",
-          "unique_reference" => "",
-          "unnumbered_command_paper" => false,
-          "unnumbered_hoc_paper" => false,
           "content_type" => "application/pdf",
-          "file_size" => 932,
           "filename" => "PUBLIC_1392629965.pdf",
-          "number_of_pages" => 2,
           "locale" => "en",
         }],
       },
@@ -118,16 +103,8 @@ class PublicationTest < ActionDispatch::IntegrationTest
           "id" => "PUBLIC_1392629965.pdf",
           "title" => "Number of ex-regular service personnel now part of FR20",
           "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
-          "command_paper_number" => "",
-          "hoc_paper_number" => "",
-          "isbn" => "",
-          "unique_reference" => "",
-          "unnumbered_command_paper" => false,
-          "unnumbered_hoc_paper" => false,
           "content_type" => "application/pdf",
-          "file_size" => 932,
           "filename" => "PUBLIC_1392629965.pdf",
-          "number_of_pages" => 2,
           "locale" => "en",
         }],
       },
@@ -148,16 +125,8 @@ class PublicationTest < ActionDispatch::IntegrationTest
           "id" => "PUBLIC_1392629965.pdf",
           "title" => "Number of ex-regular service personnel now part of FR20",
           "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
-          "command_paper_number" => "",
-          "hoc_paper_number" => "",
-          "isbn" => "",
-          "unique_reference" => "",
-          "unnumbered_command_paper" => false,
-          "unnumbered_hoc_paper" => false,
           "content_type" => "application/pdf",
-          "file_size" => 932,
           "filename" => "PUBLIC_1392629965.pdf",
-          "number_of_pages" => 2,
           "locale" => "en",
         }],
       },
@@ -165,6 +134,68 @@ class PublicationTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item("publication-with-featured-attachments", overrides)
     within "#documents" do
       assert page.has_no_text?("Request an accessible format")
+    end
+  end
+
+  test "tracks details elements in attachments correctly" do
+    overrides = {
+      "details" => {
+        "attachments" => [
+          {
+            "accessible" => false,
+            "alternative_format_contact_email" => "ddc-modinternet@mod.gov.uk",
+            "id" => "PUBLIC_1392629965.pdf",
+            "title" => "Attachment 1 - should have details element",
+            "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
+            "content_type" => "application/pdf",
+            "filename" => "PUBLIC_1392629965.pdf",
+            "locale" => "en",
+          },
+          {
+            "accessible" => true,
+            "alternative_format_contact_email" => "ddc-modinternet@mod.gov.uk",
+            "id" => "PUBLIC_1392629965.pdf",
+            "title" => "Attachment 2",
+            "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
+            "content_type" => "application/pdf",
+            "filename" => "PUBLIC_1392629965.pdf",
+            "locale" => "en",
+          },
+          {
+            "accessible" => true,
+            "alternative_format_contact_email" => nil,
+            "id" => "PUBLIC_1392629965.pdf",
+            "title" => "Attachment 3",
+            "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
+            "content_type" => "application/pdf",
+            "filename" => "PUBLIC_1392629965.pdf",
+            "locale" => "en",
+          },
+          {
+            "accessible" => false,
+            "alternative_format_contact_email" => "ddc-modinternet@mod.gov.uk",
+            "id" => "PUBLIC_1392629965.pdf",
+            "title" => "Attachment 4 - should have details element",
+            "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
+            "content_type" => "application/pdf",
+            "filename" => "PUBLIC_1392629965.pdf",
+            "locale" => "en",
+          },
+        ],
+      },
+    }
+    setup_and_visit_content_item("publication-with-featured-attachments", overrides)
+    within "#documents" do
+      attachments = page.find_all(".gem-c-attachment")
+      assert_equal attachments.length, overrides["details"]["attachments"].length
+
+      attachments.each do |attachment|
+        next unless attachment.has_css?(".govuk-details__summary")
+
+        details = attachment.find(".govuk-details__summary")["data-ga4-event"]
+        actual_tracking = JSON.parse(details)
+        assert_equal actual_tracking["index_section_count"], 2
+      end
     end
   end
 
@@ -178,16 +209,8 @@ class PublicationTest < ActionDispatch::IntegrationTest
           "id" => "PUBLIC_1392629965.pdf",
           "title" => "Number of ex-regular service personnel now part of FR20",
           "url" => "https://not-a-real-website-hopefully",
-          "command_paper_number" => "",
-          "hoc_paper_number" => "",
-          "isbn" => "",
-          "unique_reference" => "",
-          "unnumbered_command_paper" => false,
-          "unnumbered_hoc_paper" => false,
           "content_type" => "application/pdf",
-          "file_size" => 932,
           "filename" => "PUBLIC_1392629965.pdf",
-          "number_of_pages" => 2,
           "locale" => "en",
         }],
       },


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Add GA4 tracking attributes to details components within attachment components on publication pages.

The tracking for the details components is mostly handled automatically, but the component can't determine the value for `index_section_count` (the total number of related things being tracked) so this must be passed to the component. In this case it is the number of attachments that have a details component showing, which is not necessarily the same as the total number of attachments.

Some example pages to test:

- https://www.gov.uk/government/publications/make-a-lasting-power-of-attorney
- https://www.gov.uk/government/publications/application-for-a-vehicle-registration-certificate
- https://www.gov.uk/government/publications/attendance-allowance-claim-form
- https://www.gov.uk/government/publications/self-assessment-tax-return-sa100
- https://www.gov.uk/government/publications/new-year-honours-list-2024

Also removes some unnecessary data from the tests in the same file.

## Visual changes
None.

Trello card: https://trello.com/c/xhASj1rp/765-add-tracking-to-details-component