### PR TITLE
Address deprecation warning from minitest

### DIFF
--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -128,7 +128,7 @@ class DocumentCollectionPresenterTest
 
         public_updated_at = grouped[0][:metadata][:public_updated_at]
 
-        assert_equal nil, public_updated_at
+        assert_nil nil, public_updated_at
       end
     end
   end


### PR DESCRIPTION
Addressing the deprecation warning:

```
DEPRECATED: Use assert_nil if expecting nil. This will fail in Minitest 6.
```

Using assert_equal nil will be deprecated in minitest 6. We should address this deprecation so upgrading will be easier when the time comes, as well as to keep our test outputs nice and clear.


