### PR TITLE
Use relative URL for worldwide organisation links

### DIFF
--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -54,7 +54,7 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
 
     {
       name: person["title"],
-      href: person["web_url"],
+      href: person["base_path"],
       image_url: person["details"]["image"]["url"],
       image_alt: person["details"]["image"]["alt_text"],
       description: presented_title_for_roles(current_roles),
@@ -72,7 +72,7 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
 
       {
         name: person["title"],
-        href: person["web_url"],
+        href: person["base_path"],
         description: presented_title_for_roles(current_roles),
       }
     end
@@ -110,7 +110,7 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
     return if ordered_cips.blank?
 
     ordered_cips.map do |cip|
-      link = cips.find { |cp| cp["content_id"] == cip["content_id"] }["web_url"]
+      link = cips.find { |cp| cp["content_id"] == cip["content_id"] }["base_path"]
       link_to(cip["title"], link, class: "govuk-link").html_safe
     end
   end

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -28,14 +28,14 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
 
   test "renders the person in the primary role" do
     setup_and_visit_content_item("worldwide_organisation")
-    assert page.has_link?("Karen Pierce DCMG", href: "https://www.integration.publishing.service.gov.uk/government/people/karen-pierce")
+    assert page.has_link?("Karen Pierce DCMG", href: "/government/people/karen-pierce")
     assert page.has_css?("img[src=\"https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/583/s216_UKMissionGeneva__HMA_Karen_Pierce_-_uploaded.jpg\"]")
   end
 
   test "renders people in secondary and office roles" do
     setup_and_visit_content_item("worldwide_organisation")
-    assert page.has_link?("Justin Sosne", href: "https://www.integration.publishing.service.gov.uk/government/people/justin-sosne")
-    assert page.has_link?("Rachel Galloway", href: "https://www.integration.publishing.service.gov.uk/government/people/rachel-galloway")
+    assert page.has_link?("Justin Sosne", href: "/government/people/justin-sosne")
+    assert page.has_link?("Rachel Galloway", href: "/government/people/rachel-galloway")
   end
 
   test "doesn't render the people section if there are no appointed people" do
@@ -52,7 +52,7 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
 
   test "renders the navigational corporate information pages" do
     setup_and_visit_content_item("worldwide_organisation")
-    assert page.has_link?("Complaints procedure", href: "https://www.integration.publishing.service.gov.uk/world/organisations/british-deputy-high-commission-hyderabad/about/complaints-procedure")
+    assert page.has_link?("Complaints procedure", href: "/world/organisations/british-deputy-high-commission-hyderabad/about/complaints-procedure")
   end
 
   test "renders the secondary corporate information pages" do


### PR DESCRIPTION
Links from the Worldwide Organisation pages currently use the `web_url`, which is absolute, and never includes the draft part of the URL.

This means that a user viewing a draft Worldwide Organisation will be taken to the live version of the page.

Updating to make the URL relative, meaning users are always taken to the correct version of the page.

This was never previously an issue, since worldwide organisations have not previously been editionable.

[Trello card](https://trello.com/c/NFYppyyg)