### PR TITLE
Use components for consultation attachments

### DIFF
--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -53,11 +53,10 @@
     <% elsif @content_item.final_outcome? %>
       <%= render 'govuk_publishing_components/components/notice', title: t("consultation.concluded") %>
 
-      <%= render "attachments",
-          title: t("consultation.download_outcome"),
-          legacy_pre_rendered_documents: @content_item.final_outcome_documents,
-          attachments: @content_item.final_outcome_attachments %>
-
+      <%= render "attachments_list",
+        title: t("consultation.download_outcome"),
+        attachments_for_components: @content_item.final_outcome_attachments_for_components
+      %>
       <%= render 'govuk_publishing_components/components/heading', text: t("consultation.detail_of_outcome"), mobile_top_margin: true %>
       <div class="consultation-outcome-detail">
         <%= render 'govuk_publishing_components/components/govspeak', {
@@ -68,11 +67,10 @@
       </div>
     <% end %>
 
-    <%= render "attachments",
-        title: t("consultation.feedback_received"),
-        legacy_pre_rendered_documents: @content_item.public_feedback_documents,
-        attachments: @content_item.public_feedback_attachments %>
-
+    <%= render "attachments_list",
+      title: t("consultation.feedback_received"),
+      attachments_for_components: @content_item.public_feedback_attachments_for_components
+    %>
     <% if @content_item.public_feedback_detail %>
       <%= render 'govuk_publishing_components/components/heading', {
         mobile_top_margin: true,
@@ -146,10 +144,16 @@
         <%= raw(@content_item.govspeak_body[:content]) %>
       <% end %>
 
+      <%= render "attachments_list",
+        title: t("consultation.documents"),
+        attachments_for_components: @content_item.documents_attachments_for_components
+      %>
+      <% if false %>
       <%= render "attachments",
           title: t("consultation.documents"),
           legacy_pre_rendered_documents: @content_item.documents,
           attachments: @content_item.featured_attachments %>
+      <% end %>
     </div>
 
     <% if @content_item.ways_to_respond? %>

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -1,6 +1,82 @@
 require "test_helper"
 
 class ConsultationTest < ActionDispatch::IntegrationTest
+  general_overrides = {
+    "details" => {
+      "attachments" => [
+        {
+          "accessible" => false,
+          "alternative_format_contact_email" => "publications@ofqual.gov.uk",
+          "attachment_type" => "file",
+          "command_paper_number" => "",
+          "content_type" => "application/pdf",
+          "file_size" => 803,
+          "filename" => "Setting_grade_standards_part_2.pdf",
+          "hoc_paper_number" => "",
+          "id" => "01",
+          "isbn" => "",
+          "number_of_pages" => 33,
+          "title" => "Setting the grade standards of new GCSEs in England – part 2",
+          "unique_reference" => "Ofqual/16/5939",
+          "unnumbered_command_paper" => false,
+          "unnumbered_hoc_paper" => false,
+          "url" => "https://assets.publishing.service.gov.uk/media/5a7f7b63ed915d74e33f6b3d/Setting_grade_standards_part_2.pdf",
+        },
+        {
+          "accessible" => false,
+          "alternative_format_contact_email" => "publications@ofqual.gov.uk",
+          "attachment_type" => "file",
+          "command_paper_number" => "",
+          "content_type" => "application/pdf",
+          "file_size" => 365,
+          "filename" => "Decisions_-_setting_GCSE_grade_standards_-_part_2.pdf",
+          "hoc_paper_number" => "",
+          "id" => "02",
+          "isbn" => "",
+          "number_of_pages" => 10,
+          "title" => "Decisions on setting the grade standards of new GCSEs in England - part 2",
+          "unique_reference" => "Ofqual/16/6102",
+          "unnumbered_command_paper" => false,
+          "unnumbered_hoc_paper" => false,
+          "url" => "https://assets.publishing.service.gov.uk/media/5a817d87ed915d74e62328cf/Decisions_-_setting_GCSE_grade_standards_-_part_2.pdf",
+        },
+        {
+          "accessible" => false,
+          "alternative_format_contact_email" => "publications@ofqual.gov.uk",
+          "attachment_type" => "file",
+          "command_paper_number" => "",
+          "content_type" => "application/pdf",
+          "file_size" => 646,
+          "filename" => "Grading-consulation-Equalities-Impact-Assessment.pdf",
+          "hoc_paper_number" => "",
+          "id" => "03",
+          "isbn" => "",
+          "number_of_pages" => 5,
+          "title" => "Equalities impact assessment: setting the grade standards of new GCSEs in England – part 2",
+          "unique_reference" => "Ofqual/16/6104",
+          "unnumbered_command_paper" => false,
+          "unnumbered_hoc_paper" => false,
+          "url" => "https://assets.publishing.service.gov.uk/media/5a8014d6ed915d74e622c5af/Grading-consulation-Equalities-Impact-Assessment.pdf",
+        },
+        {
+          "accessible" => false,
+          "alternative_format_contact_email" => "publications@ofqual.gov.uk",
+          "attachment_type" => "file",
+          "content_type" => "application/pdf",
+          "file_size" => 175,
+          "filename" => "Grading-consultation-analysis-of-responses.pdf",
+          "id" => "04",
+          "number_of_pages" => 24,
+          "title" => "Analysis of responses to our consultation on setting the grade standards of new GCSEs in England – part 2",
+          "url" => "https://assets.publishing.service.gov.uk/media/5a819d85ed915d74e6233377/Grading-consultation-analysis-of-responses.pdf",
+        },
+      ],
+      "final_outcome_attachments" => %w[01],
+      "public_feedback_attachments" => %w[02],
+      "featured_attachments" => %w[03],
+    },
+  }
+
   test "consultation" do
     setup_and_visit_content_item("open_consultation")
 
@@ -23,18 +99,18 @@ class ConsultationTest < ActionDispatch::IntegrationTest
   end
 
   test "renders document attachments (as-is and directly)" do
-    setup_and_visit_content_item("closed_consultation")
+    setup_and_visit_content_item("closed_consultation", general_overrides)
 
     assert page.has_text?("Documents")
     within "#documents" do
-      assert page.has_text?("Museums Review Terms of Reference")
+      assert page.has_text?("Equalities impact assessment: setting the grade standards of new GCSEs in England – part 2")
     end
 
-    setup_and_visit_content_item("consultation_outcome_with_featured_attachments")
+    setup_and_visit_content_item("consultation_outcome_with_featured_attachments", general_overrides)
 
     assert page.has_text?("Documents")
     within "#documents" do
-      assert page.has_text?("Setting the grade standards of new GCSEs in England – part 2")
+      assert page.has_text?("Equalities impact assessment: setting the grade standards of new GCSEs in England – part 2")
     end
   end
 
@@ -96,11 +172,11 @@ class ConsultationTest < ActionDispatch::IntegrationTest
   end
 
   test "renders consultation outcome attachments (as-is and directly)" do
-    setup_and_visit_content_item("consultation_outcome")
+    setup_and_visit_content_item("consultation_outcome", general_overrides)
 
     assert page.has_text?("Download the full outcome")
     within "#download-the-full-outcome" do
-      assert page.has_text?("Employee Share Schemes: NIC elections - consulation response")
+      assert page.has_text?("Setting the grade standards of new GCSEs in England – part 2")
     end
 
     setup_and_visit_content_item("consultation_outcome_with_featured_attachments")
@@ -112,11 +188,11 @@ class ConsultationTest < ActionDispatch::IntegrationTest
   end
 
   test "shows pre-rendered public feedback documents" do
-    setup_and_visit_content_item("consultation_outcome_with_feedback")
+    setup_and_visit_content_item("consultation_outcome_with_feedback", general_overrides)
 
     assert page.has_text?("Feedback received")
     within "#feedback-received" do
-      assert page.has_text?("Analysis of responses to our consultation on setting the grade standards of new GCSEs in England – part 2")
+      assert page.has_text?("Decisions on setting the grade standards of new GCSEs in England - part 2")
     end
   end
 
@@ -126,6 +202,143 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     assert page.has_text?("Feedback received")
     within "#feedback-received" do
       assert page.has_text?("Analysis of responses to our consultation on setting the grade standards of new GCSEs in England – part 2")
+    end
+  end
+
+  test "renders accessible format option when accessible is false and email is supplied" do
+    overrides = {
+      "details" => {
+        "attachments" => [
+          {
+            "accessible" => false,
+            "alternative_format_contact_email" => "ddc-modinternet@mod.gov.uk",
+            "attachment_type" => "file",
+            "id" => "01",
+            "title" => "Number of ex-regular service personnel now part of FR20",
+            "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
+            "content_type" => "application/pdf",
+            "filename" => "PUBLIC_1392629965.pdf",
+            "locale" => "en",
+          },
+        ],
+        "featured_attachments" => %w[01],
+      },
+    }
+    setup_and_visit_content_item("consultation_outcome_with_featured_attachments", overrides)
+    within "#documents" do
+      assert page.has_text?("Request an accessible format")
+    end
+  end
+
+  test "doesn't render accessible format option when accessible is true and email is supplied" do
+    overrides = {
+      "details" => {
+        "attachments" => [
+          {
+            "accessible" => true,
+            "alternative_format_contact_email" => "ddc-modinternet@mod.gov.uk",
+            "attachment_type" => "file",
+            "id" => "01",
+            "title" => "Number of ex-regular service personnel now part of FR20",
+            "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
+            "content_type" => "application/pdf",
+            "filename" => "PUBLIC_1392629965.pdf",
+            "locale" => "en",
+          },
+        ],
+        "featured_attachments" => %w[01],
+      },
+    }
+    setup_and_visit_content_item("consultation_outcome_with_featured_attachments", overrides)
+    within "#documents" do
+      assert page.has_no_text?("Request an accessible format")
+    end
+  end
+
+  test "doesn't render accessible format option when accessible is false and email is not supplied" do
+    overrides = {
+      "details" => {
+        "attachments" => [
+          {
+            "accessible" => false,
+            "attachment_type" => "file",
+            "id" => "01",
+            "title" => "Number of ex-regular service personnel now part of FR20",
+            "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
+            "content_type" => "application/pdf",
+            "filename" => "PUBLIC_1392629965.pdf",
+            "locale" => "en",
+          },
+        ],
+        "featured_attachments" => %w[01],
+      },
+    }
+    setup_and_visit_content_item("consultation_outcome_with_featured_attachments", overrides)
+    within "#documents" do
+      assert page.has_no_text?("Request an accessible format")
+    end
+  end
+
+  test "tracks details elements in attachments correctly" do
+    overrides = {
+      "details" => {
+        "attachments" => [
+          {
+            "accessible" => false,
+            "alternative_format_contact_email" => "ddc-modinternet@mod.gov.uk",
+            "id" => "01",
+            "title" => "Attachment 1 - should have details element",
+            "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
+            "content_type" => "application/pdf",
+            "filename" => "PUBLIC_1392629965.pdf",
+            "locale" => "en",
+          },
+          {
+            "accessible" => true,
+            "alternative_format_contact_email" => "ddc-modinternet@mod.gov.uk",
+            "id" => "02",
+            "title" => "Attachment 2",
+            "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
+            "content_type" => "application/pdf",
+            "filename" => "PUBLIC_1392629965.pdf",
+            "locale" => "en",
+          },
+          {
+            "accessible" => true,
+            "alternative_format_contact_email" => nil,
+            "id" => "03",
+            "title" => "Attachment 3",
+            "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
+            "content_type" => "application/pdf",
+            "filename" => "PUBLIC_1392629965.pdf",
+            "locale" => "en",
+          },
+          {
+            "accessible" => false,
+            "alternative_format_contact_email" => "ddc-modinternet@mod.gov.uk",
+            "id" => "04",
+            "title" => "Attachment 4 - should have details element",
+            "url" => "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/315163/PUBLIC_1392629965.pdf",
+            "content_type" => "application/pdf",
+            "filename" => "PUBLIC_1392629965.pdf",
+            "locale" => "en",
+          },
+        ],
+        "final_outcome_attachments" => %w[01],
+        "public_feedback_attachments" => %w[02 03],
+        "featured_attachments" => %w[04],
+      },
+    }
+    setup_and_visit_content_item("consultation_outcome_with_featured_attachments", overrides)
+    attachments = page.find_all(".gem-c-attachment")
+    assert_equal attachments.length, overrides["details"]["attachments"].length
+
+    attachments.each do |attachment|
+      next unless attachment.has_css?(".govuk-details__summary")
+
+      details = attachment.find(".govuk-details__summary")["data-ga4-event"]
+      actual_tracking = JSON.parse(details)
+      assert_equal actual_tracking["index_section_count"], 2
     end
   end
 

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -6,6 +6,18 @@ class ConsultationPresenterTest
       "consultation"
     end
 
+    test_documents = [
+      {
+        "id" => "01",
+      },
+      {
+        "id" => "02",
+      },
+      {
+        "id" => "03",
+      },
+    ]
+
     test "presents the schema name" do
       assert_equal schema_item("open_consultation")["document_type"], presented_item("open_consultation").document_type
       assert_equal schema_item("open_consultation")["details"]["body"], presented_item("open_consultation").body
@@ -64,26 +76,32 @@ class ConsultationPresenterTest
 
     test "presents consultation documents" do
       schema = schema_item("closed_consultation")
-      schema["details"]["documents"] = %W[<section>\n<p>a</p>\n</section> <section>\n<p>b</p>\n</section> <section>\n<p>c</p>\n</section>]
+      schema["details"]["attachments"] = test_documents
+      schema["details"]["featured_attachments"] = %w[01 02]
       presented = presented_item("closed_consultation", schema)
-
-      assert_equal "<section>\n<p>a</p>\n</section><section>\n<p>b</p>\n</section><section>\n<p>c</p>\n</section>", presented.documents
+      assert_equal presented.documents_attachments_for_components.length, 2
+      assert_equal presented.documents_attachments_for_components[0]["id"], "01"
+      assert_equal presented.documents_attachments_for_components[1]["id"], "02"
     end
 
     test "presents final outcome documents" do
       schema = schema_item("consultation_outcome")
-      schema["details"]["final_outcome_documents"] = %W[<section>\n<p>a</p>\n</section> <section>\n<p>b</p>\n</section> <section>\n<p>c</p>\n</section>]
+      schema["details"]["attachments"] = test_documents
+      schema["details"]["final_outcome_attachments"] = %w[02 03]
       presented = presented_item("consultation_outcome", schema)
-
-      assert_equal "<section>\n<p>a</p>\n</section><section>\n<p>b</p>\n</section><section>\n<p>c</p>\n</section>", presented.final_outcome_documents
+      assert_equal presented.final_outcome_attachments_for_components.length, 2
+      assert_equal presented.final_outcome_attachments_for_components[0]["id"], "02"
+      assert_equal presented.final_outcome_attachments_for_components[1]["id"], "03"
     end
 
     test "presents public feedback documents" do
       schema = schema_item("consultation_outcome_with_feedback")
-      schema["details"]["public_feedback_documents"] = %W[<section>\n<p>a</p>\n</section> <section>\n<p>b</p>\n</section> <section>\n<p>c</p>\n</section>]
+      schema["details"]["attachments"] = test_documents
+      schema["details"]["public_feedback_attachments"] = %w[01 03]
       presented = presented_item("consultation_outcome_with_feedback", schema)
-
-      assert_equal "<section>\n<p>a</p>\n</section><section>\n<p>b</p>\n</section><section>\n<p>c</p>\n</section>", presented.public_feedback_documents
+      assert_equal presented.public_feedback_attachments_for_components.length, 2
+      assert_equal presented.public_feedback_attachments_for_components[0]["id"], "01"
+      assert_equal presented.public_feedback_attachments_for_components[1]["id"], "03"
     end
 
     test "presents URL for consultations held on another website" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Output attachments in consultation pages using the data from the content item, rather than the pre-rendered markup from the content item, and apply GA4 tracking to those attachments that contain Details elements.

This follows on from the work to convert publications in the same manner: https://github.com/alphagov/government-frontend/pull/3058

Attachments on consultation pages can occur in three places, so this is a bit more complex than publications, although some of the code and tests have been copied from that previous work.

Example pages to test with:

- [concluded consultation](https://www.gov.uk/government/consultations/setting-the-grade-standards-of-new-gcses-in-england-2017-2018) that displays documents in all three places
- [another concluded consultation](https://www.gov.uk/government/consultations/improving-the-ssros-response-to-contract-specific-queries-on-the-regulatory-framework-for-single-source-defence-contracts) with documents in two places
- [consultation in progress](https://www.gov.uk/government/consultations/domestic-maritime-decarbonisation-the-course-to-net-zero-emissions) with documents in two places

Note: an interesting side point on margin - there's some code for logic around a margin to appear beneath boxes that appear at the top of in-progress consultations ('We are analysing your feedback') so that spacing is only applied if there's stuff beneath it. Pretty sure I've preserved the logic but worth checking.

## Why
This work is for two reasons:

- to convert the rendering of attachments to using components so that tracking can be added to Details elements within attachments (for the 'Request an accessible format' element)
- to generally move away from the use of pre-rendered markup passed through content items

## Visual changes
Mostly should be no visual changes, however this change does remove custom thumbnails for PDFs (as previously removed for publications). This has been agreed and widely discussed around the previous work.

Trello card: https://trello.com/c/tcTN1jbu/28-update-rendering-of-govspeak-attachments
