### PR TITLE
Fix the '+(xx) others' link losing focus after activation

### DIFF
--- a/app/assets/javascripts/modules/hide-other-links.js
+++ b/app/assets/javascripts/modules/hide-other-links.js
@@ -9,7 +9,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.hiddenElementContainer = this.createHiddenElementContainer()
     this.shownElements = []
     this.hiddenElements = []
-    this.showLink = document.createElement('a')
+    this.showLink = document.createElement('button')
   }
 
   HideOtherLinks.prototype.init = function () {
@@ -51,7 +51,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     this.showLink.classList.add('show-other-content', 'govuk-link')
     this.showLink.innerHTML = linkText
-    this.showLink.href = '#'
+    this.showLink.setAttribute('aria-expanded', 'false')
+    this.showLink.setAttribute('aria-controls', 'other-content')
 
     this.showLink.addEventListener('click', this.showHiddenLinks.bind(this))
 
@@ -71,6 +72,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   HideOtherLinks.prototype.createHiddenElementContainer = function () {
     var showHide = document.createElement('span')
     showHide.classList.add('other-content')
+    showHide.id = 'other-content'
 
     return showHide
   }
@@ -79,8 +81,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     event.preventDefault()
 
     this.hiddenElementContainer.style.display = ''
+    this.hiddenElementContainer.querySelectorAll('a')[0].focus()
     this.showLink.remove()
-    this.hiddenElementContainer.focus()
   }
 
   Modules.HideOtherLinks = HideOtherLinks

--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -6,9 +6,14 @@
 .js-enabled {
   .worldwide-organisation-header {
     .show-other-content {
-      @include govuk-font(14);
+      all: inherit;
+      display: inline;
       margin-left: .3em;
       white-space: nowrap;
+      color: $govuk-link-colour;
+      cursor: pointer;
+      @include govuk-link-common;
+      @include govuk-font(16);
     }
   }
 }


### PR DESCRIPTION
## What/Why

From [Trello](https://trello.com/c/jrwE1oz3/2588-using-link-loses-focus-with-jaws-s-m):
_When using the ‘+ 12 others’ link with JAWS, the focus is lost. Using the tab key gets you to the first inserted link. But when navigating ‘in context’, using arrow keys to read through the page, the focus for JAWS users gets moved back to the start of the page which causes them to lose their place._ 

## More info
This was reported as an issue in JAWS. After testing, I also observed this as a problem in other screen-readers. However, this issue was potentially a problem for _all_ users as it did not focus a relevant element after activation. It would be confusing for non-screen-reader users who use the keyboard to navigate.

The behaviour has now changed:
* Anchor element is replaced with a button for improved accessibility
* After activation, focus the first link in the now-visible dropdown

Styling modified:
* Button inherits parent styles to appear like a link
* Text size increased to 16px to match surrounding elements

I've tested this extensively in Assistiv Labs using JAWS, NVDA and Talkback and the behaviour now seems consistent:

* Use tab or up/down arrows to move through elements in screen reader view
* When the _+XX others_ text is focused, user activates it with enter or space
* Other languages are displayed and the _+XX others_ text is removed
* The first language in the revealed list now has focus

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
