### PR TITLE
Fix missing headings and replace subpage breadcrumb with back link

### DIFF
--- a/app/assets/stylesheets/views/_manual.scss
+++ b/app/assets/stylesheets/views/_manual.scss
@@ -102,7 +102,7 @@
 
 .manual-body {
   @include govuk-media-query($from: tablet) {
-    margin-top: govuk-spacing(6);
+    margin-top: govuk-spacing(4);
   }
 
   .section-title {

--- a/app/views/content_items/manuals/_header.html.erb
+++ b/app/views/content_items/manuals/_header.html.erb
@@ -3,6 +3,7 @@
   type ||= nil
 
   classes = %w[govuk-grid-row manuals-header]
+  classes << %w[govuk-!-margin-bottom-4]
   classes << "hmrc" if green_background
 %>
 
@@ -47,8 +48,3 @@
     </div>
   </div>
 <% end %>
-
-<%= render "govuk_publishing_components/components/breadcrumbs", {
-           border: "bottom",
-           breadcrumbs: @content_item.breadcrumbs,
-           collapse_on_mobile: false } %>

--- a/app/views/content_items/manuals/_manual_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_layout.html.erb
@@ -1,4 +1,8 @@
 <% content_for :main do %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("manuals.summary_title"),
+    margin_bottom: 4
+  } %>
   <div id="manuals-frontend" class="manuals-frontend-body">
 
   <%= machine_readable_metadata(schema: :article) %>
@@ -14,6 +18,11 @@
         <%= raw(@content_item.body) %>
       <% end %>
     <% end %>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("manuals.contents_title"),
+      margin_bottom: 4
+    } %>
 
     <%= yield %>
 

--- a/app/views/content_items/manuals/_manual_section_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_section_layout.html.erb
@@ -1,6 +1,10 @@
 <% show_contents ||= false %>
 
 <% content_for :main do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    text: t("manuals.breadcrumb_contents"),
+    href: @content_item.base_path
+  } %>
   <div id="manuals-frontend" class="manuals-frontend-body">
     <% if show_contents %>
       <%= render "govuk_publishing_components/components/contents_list", {

--- a/app/views/content_items/manuals/_manual_updates_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_updates_layout.html.erb
@@ -1,4 +1,8 @@
 <% content_for :main do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    text: t("manuals.breadcrumb_contents"),
+    href: @content_item.base_path
+  } %>
   <div id="manuals-frontend" class="manuals-frontend-body">
     <%= render "content_items/manuals/updates", content_item: @content_item %>
   </div>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -775,8 +775,10 @@ ar:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -467,8 +467,10 @@ az:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -621,8 +621,10 @@ be:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -467,8 +467,10 @@ bg:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -467,8 +467,10 @@ bn:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -544,8 +544,10 @@ cs:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -775,8 +775,10 @@ cy:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -479,8 +479,10 @@ da:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -467,8 +467,10 @@ de:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -470,8 +470,10 @@ dr:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -467,8 +467,10 @@ el:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -467,8 +467,10 @@ en:
     zh-hk: Cantonese
     zh-tw: Traditional Chinese
   manuals:
-    breadcrumb_contents: Contents
+    summary_title: Summary
+    breadcrumb_contents: Back to contents
     contents_list_breadcrumb_contents: Manual homepage
+    contents_title: Contents
     hmrc_manual_type: HMRC internal manual
     hmrc_title: "%{title}HMRC internal manual"
     next_page: Next page

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -467,8 +467,10 @@ es-419:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -467,8 +467,10 @@ es:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -467,8 +467,10 @@ et:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -467,8 +467,10 @@ fa:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -467,8 +467,10 @@ fi:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -467,8 +467,10 @@ fr:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -621,8 +621,10 @@ gd:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -467,8 +467,10 @@ gu:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -467,8 +467,10 @@ he:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -467,8 +467,10 @@ hi:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -544,8 +544,10 @@ hr:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -467,8 +467,10 @@ hu:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -467,8 +467,10 @@ hy:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -390,8 +390,10 @@ id:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -467,8 +467,10 @@ is:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -467,8 +467,10 @@ it:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -390,8 +390,10 @@ ja:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -467,8 +467,10 @@ ka:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -467,8 +467,10 @@ kk:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -390,8 +390,10 @@ ko:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -544,8 +544,10 @@ lt:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -467,8 +467,10 @@ lv:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -390,8 +390,10 @@ ms:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -621,8 +621,10 @@ mt:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -467,8 +467,10 @@ ne:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -467,8 +467,10 @@ nl:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -467,8 +467,10 @@
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -467,8 +467,10 @@ pa-pk:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -467,8 +467,10 @@ pa:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -621,8 +621,10 @@ pl:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -467,8 +467,10 @@ ps:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -467,8 +467,10 @@ pt:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -544,8 +544,10 @@ ro:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -621,8 +621,10 @@ ru:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -467,8 +467,10 @@ si:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -544,8 +544,10 @@ sk:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -621,8 +621,10 @@ sl:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -467,8 +467,10 @@ so:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -467,8 +467,10 @@ sq:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -544,8 +544,10 @@ sr:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -467,8 +467,10 @@ sv:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -467,8 +467,10 @@ sw:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -467,8 +467,10 @@ ta:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -390,8 +390,10 @@ th:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -467,8 +467,10 @@ tk:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -467,8 +467,10 @@ tr:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -621,8 +621,10 @@ uk:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -467,8 +467,10 @@ ur:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -467,8 +467,10 @@ uz:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -390,8 +390,10 @@ vi:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -467,8 +467,10 @@ yi:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -390,8 +390,10 @@ zh-hk:
     zh-hk: 中文
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -390,8 +390,10 @@ zh-tw:
     zh-hk:
     zh-tw: 繁體中文
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -390,8 +390,10 @@ zh:
     zh-hk:
     zh-tw:
   manuals:
+    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
+    contents_title:
     hmrc_manual_type:
     hmrc_title:
     next_page:

--- a/test/integration/hmrc_manual_section_test.rb
+++ b/test/integration/hmrc_manual_section_test.rb
@@ -42,13 +42,10 @@ class HmrcManualSectionTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders manual specific breadcrumbs" do
+  test "renders back link" do
     setup_and_visit_manual_section
 
-    manual_specific_breadcrumbs = page.all(".gem-c-breadcrumbs")[1]
-    within manual_specific_breadcrumbs do
-      assert page.has_text?(I18n.t("manuals.breadcrumb_contents"))
-    end
+    assert page.has_link?(I18n.t("manuals.breadcrumb_contents"), href: "/hmrc-internal-manuals/vat-government-and-public-bodies")
   end
 
   test "renders section group" do

--- a/test/integration/hmrc_manual_test.rb
+++ b/test/integration/hmrc_manual_test.rb
@@ -42,13 +42,16 @@ class HmrcManualTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders manual specific breadcrumbs" do
+  test "renders about title" do
     setup_and_visit_content_item("vat-government-public-bodies")
 
-    manual_specific_breadcrumbs = page.all(".gem-c-breadcrumbs")[1]
-    within manual_specific_breadcrumbs do
-      assert page.has_text?(I18n.t("manuals.breadcrumb_contents"))
-    end
+    assert page.has_text?(I18n.t("manuals.summary_title"))
+  end
+
+  test "renders contents title heading" do
+    setup_and_visit_content_item("vat-government-public-bodies")
+
+    assert page.has_selector?("h2", text: I18n.t("manuals.contents_title"))
   end
 
   test "renders section groups" do

--- a/test/integration/hmrc_manual_updates_test.rb
+++ b/test/integration/hmrc_manual_updates_test.rb
@@ -39,13 +39,10 @@ class HmrcManualUpdatesTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders manual specific breadcrumbs" do
+  test "renders back link" do
     setup_and_visit_manual_updates
 
-    manual_specific_breadcrumbs = page.all(".gem-c-breadcrumbs")[1]
-    within manual_specific_breadcrumbs do
-      assert page.has_link?(I18n.t("manuals.breadcrumb_contents"), href: @content_item["base_path"])
-    end
+    assert page.has_link?(I18n.t("manuals.breadcrumb_contents"), href: @content_item["base_path"])
   end
 
   test "renders change note updates" do

--- a/test/integration/manual_section_test.rb
+++ b/test/integration/manual_section_test.rb
@@ -55,13 +55,10 @@ class ManualSectionTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders manual specific breadcrumbs" do
+  test "renders back link" do
     setup_and_visit_manual_section
 
-    manual_specific_breadcrumbs = page.all(".gem-c-breadcrumbs")[1]
-    within manual_specific_breadcrumbs do
-      assert page.has_link?(I18n.t("manuals.breadcrumb_contents"), href: @manual["base_path"])
-    end
+    assert page.has_link?(I18n.t("manuals.breadcrumb_contents"), href: @manual["base_path"])
   end
 
   test "renders sections accordion" do

--- a/test/integration/manual_test.rb
+++ b/test/integration/manual_test.rb
@@ -38,13 +38,16 @@ class ManualTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders manual specific breadcrumbs" do
+  test "renders about title" do
     setup_and_visit_content_item("content-design")
 
-    manual_specific_breadcrumbs = page.all(".gem-c-breadcrumbs")[1]
-    within manual_specific_breadcrumbs do
-      assert page.has_text?(I18n.t("manuals.breadcrumb_contents"))
-    end
+    assert page.has_text?(I18n.t("manuals.summary_title"))
+  end
+
+  test "renders contents title heading" do
+    setup_and_visit_content_item("content-design")
+
+    assert page.has_selector?("h2", text: I18n.t("manuals.contents_title"))
   end
 
   test "renders body govspeak" do

--- a/test/integration/manual_updates_test.rb
+++ b/test/integration/manual_updates_test.rb
@@ -35,13 +35,10 @@ class ManualUpdatesTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders manual specific breadcrumbs" do
+  test "renders back link" do
     setup_and_visit_manual_updates
 
-    manual_specific_breadcrumbs = page.all(".gem-c-breadcrumbs")[1]
-    within manual_specific_breadcrumbs do
-      assert page.has_link?(I18n.t("manuals.breadcrumb_contents"), href: @content_item["base_path"])
-    end
+    assert page.has_link?(I18n.t("manuals.breadcrumb_contents"), href: @content_item["base_path"])
   end
 
   test "renders change note updates" do


### PR DESCRIPTION
## What

The main content of the page doesn’t have a heading. There is the H1 of the manual header and then no other heading until the footer. Other pages within manuals have a heading before the lead paragraph. [Trello](https://trello.com/c/O2VfbDGm/2622-page-missing-main-heading-m-l)

## Why

These pages currently fail on accessibility and need to be fixed according to the findings of the DAC audit.

## How

* Replaced the landing-page breadcrumb with H2
* Replaced the sub-page breadcrumb with the back link component
* Added a "Contents" H2 above the document list
* Rewrote tests accordingly

## Before/After: Missing Headings

<img width="1655" alt="image" src="https://github.com/alphagov/government-frontend/assets/56222256/ae1be5d6-86cc-4b6a-bc83-244ae9ab0e37">

## Before After: Replace breadcrumb with back link (Section)

![image](https://github.com/alphagov/government-frontend/assets/2166204/80cb0ecd-40dd-4bfc-a6a5-7fb400395f2d)

## Before After: Replace breadcrumb with back link (Updates)

![image](https://github.com/alphagov/government-frontend/assets/2166204/9819cf06-3751-4b9c-a5f3-41d31795fb15)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
