### PR TITLE
Change publishing outcome pages text

### DIFF
--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -52,7 +52,7 @@ class ConsultationPresenter < ContentItemPresenter
     content_item["details"]["final_outcome_detail"]
   end
 
-  # Download the full outcome, top of page
+  # Read the full outcome, top of page
   def final_outcome_attachments_for_components
     documents.select { |doc| final_outcome_attachments.include? doc["id"] }
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,7 +11,7 @@ en:
     description: Call for evidence description
     detail_of_outcome: Detail of outcome
     documents: Documents
-    download_outcome: Download the full outcome
+    download_outcome: Read the full outcome
     either: either
     email_to: 'Email to:'
     is_being: is being
@@ -58,7 +58,7 @@ en:
     detail_of_feedback_received: Detail of feedback received
     detail_of_outcome: Detail of outcome
     documents: Documents
-    download_outcome: Download the full outcome
+    download_outcome: Read the full outcome
     either: either
     email_to: 'Email to:'
     feedback_received: Feedback received

--- a/test/integration/call_for_evidence_test.rb
+++ b/test/integration/call_for_evidence_test.rb
@@ -120,8 +120,8 @@ class CallForEvidenceTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item("call_for_evidence_outcome")
 
     assert page.has_text?("This call for evidence has closed")
-    assert page.has_text?("Download the full outcome")
-    within "#download-the-full-outcome" do
+    assert page.has_text?("Read the full outcome")
+    within "#read-the-full-outcome" do
       assert page.has_text?("Employee Share Schemes: NIC elections - consulation response")
     end
   end
@@ -129,8 +129,8 @@ class CallForEvidenceTest < ActionDispatch::IntegrationTest
   test "renders featured call for evidence outcome attachments" do
     setup_and_visit_content_item("call_for_evidence_outcome_with_featured_attachments")
 
-    assert page.has_text?("Download the full outcome")
-    within "#download-the-full-outcome" do
+    assert page.has_text?("Read the full outcome")
+    within "#read-the-full-outcome" do
       assert page.has_text?("Equalities impact assessment: setting the grade standards of new GCSEs in England – part 2")
     end
   end

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -174,15 +174,15 @@ class ConsultationTest < ActionDispatch::IntegrationTest
   test "renders consultation outcome attachments (as-is and directly)" do
     setup_and_visit_content_item("consultation_outcome", general_overrides)
 
-    assert page.has_text?("Download the full outcome")
-    within "#download-the-full-outcome" do
+    assert page.has_text?("Read the full outcome")
+    within "#read-the-full-outcome" do
       assert page.has_text?("Setting the grade standards of new GCSEs in England – part 2")
     end
 
     setup_and_visit_content_item("consultation_outcome_with_featured_attachments")
 
-    assert page.has_text?("Download the full outcome")
-    within "#download-the-full-outcome" do
+    assert page.has_text?("Read the full outcome")
+    within "#read-the-full-outcome" do
       assert page.has_text?("Equalities impact assessment: setting the grade standards of new GCSEs in England – part 2")
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Changes the heading on consultations and calls for evidence pages from 'Download the full outcome' to 'Read the full outcome'.

Example pages:

- https://www.gov.uk/government/consultations/pre-employment-checks-for-health-and-care-volunteers

## Why
Text doesn't always make sense, specifically because some of the things being linked to are web pages, and some are PDFs (which for the most part just open in the browser rather than being downloaded).

Note that this change has been made only in the English translation for these pages. This is partly because getting all the translations is hard and not having them in one language shouldn't block the change for other languages, and also because we think there aren't any calls for evidence not in English. There are potentially some consultations in other languages though, so more work may need to be done.

## Visual changes

Before | After
------ | ------
![Screenshot 2024-06-04 at 09 50 42](https://github.com/alphagov/government-frontend/assets/861310/b0e68b95-af8b-468b-8b2d-c8f24fe2ed80) | ![Screenshot 2024-06-04 at 09 50 48](https://github.com/alphagov/government-frontend/assets/861310/bf1b1bea-2211-4363-a50e-fb9c21fcc8c4)


Trello card: https://trello.com/c/GfUczqKP/733-request-to-change-terminology-on-publishing-outcome-now-pages-are-in-html