### PR TITLE
Add URL to manuals search GA4 tracking

### DIFF
--- a/app/views/content_items/manuals/_header.html.erb
+++ b/app/views/content_items/manuals/_header.html.erb
@@ -33,7 +33,8 @@
             event_name: "search",
             type: "content",
             section: content_item.title,
-            action: "search"
+            action: "search",
+            url: "/search/all",
           }
         }
       %>


### PR DESCRIPTION
## What / Why

- Adds a `url` value to the manuals search GA4 tracking on pages like https://www.gov.uk/guidance/understanding-your-driving-test-result/car-driving-test
- This value was accidentally missed out when tracking was added
- https://trello.com/c/wQrfhyj3/829-add-url-to-search-on-manual-pages