### PR TITLE
DRY up new attachment code

### DIFF
--- a/app/presenters/call_for_evidence_presenter.rb
+++ b/app/presenters/call_for_evidence_presenter.rb
@@ -1,12 +1,12 @@
 class CallForEvidencePresenter < ContentItemPresenter
+  include ContentItem::Attachments
   include ContentItem::Body
   include ContentItem::Metadata
   include ContentItem::NationalApplicability
   include ContentItem::Political
   include ContentItem::Shareable
-  include ContentItem::TitleAndContext
-  include ContentItem::Attachments
   include ContentItem::SinglePageNotificationButton
+  include ContentItem::TitleAndContext
 
   def opening_date_time
     content_item["details"]["opening_date"]
@@ -50,40 +50,18 @@ class CallForEvidencePresenter < ContentItemPresenter
 
   # Read the full outcome, top of page
   def outcome_documents
-    # content_item["details"]["outcome_documents"]&.join("")
-    documents.select { |doc| outcome_attachments.include? doc["id"] }
+    attachments_from(content_item["details"]["outcome_attachments"])
   end
 
   # Documents, bottom of page
   def general_documents
-    documents.select { |doc| featured_attachments.include? doc["id"] }
+    attachments_from(content_item["details"]["featured_attachments"])
   end
 
   def attachments_with_details
     items = [].push(*outcome_documents)
     items.push(*general_documents)
     items.select { |doc| doc["accessible"] == false && doc["alternative_format_contact_email"] }.count
-  end
-
-  def outcome_attachments
-    content_item["details"]["outcome_attachments"]
-  end
-
-  def featured_attachments
-    content_item["details"]["featured_attachments"]
-  end
-
-  def documents
-    # content_item["details"]["documents"]&.join("")
-    return [] unless content_item["details"]["attachments"]
-
-    docs = content_item["details"]["attachments"].select { |a| !a.key?("locale") || a["locale"] == locale }
-    docs.each do |doc|
-      doc["type"] = "html" unless doc["content_type"]
-      doc["type"] = "external" if doc["attachment_type"] == "external"
-      doc["preview_url"] = "#{doc['url']}/preview" if doc["preview_url"]
-      doc["alternative_format_contact_email"] = nil if doc["accessible"] == true
-    end
   end
 
   def held_on_another_website?

--- a/app/presenters/content_item/attachments.rb
+++ b/app/presenters/content_item/attachments.rb
@@ -1,9 +1,19 @@
 module ContentItem
   module Attachments
-    def attachment_details(attachment_id)
-      content_item.dig("details", "attachments")&.find do |attachment|
-        attachment["id"] == attachment_id
+    def attachments
+      return [] unless content_item["details"]["attachments"]
+
+      docs = content_item["details"]["attachments"].select { |a| !a.key?("locale") || a["locale"] == locale }
+      docs.each do |doc|
+        doc["type"] = "html" unless doc["content_type"]
+        doc["type"] = "external" if doc["attachment_type"] == "external"
+        doc["preview_url"] = "#{doc['url']}/preview" if doc["preview_url"]
+        doc["alternative_format_contact_email"] = nil if doc["accessible"] == true
       end
+    end
+
+    def attachments_from(attachment_id_list)
+      attachments.select { |doc| (attachment_id_list || []).include? doc["id"] }
     end
   end
 end

--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -1,9 +1,9 @@
 class PublicationPresenter < ContentItemPresenter
+  include ContentItem::Attachments
   include ContentItem::Metadata
   include ContentItem::NationalApplicability
   include ContentItem::NationalStatisticsLogo
   include ContentItem::Political
-  include ContentItem::Attachments
   include ContentItem::SinglePageNotificationButton
 
   def details
@@ -11,27 +11,11 @@ class PublicationPresenter < ContentItemPresenter
   end
 
   def attachments_for_components
-    documents.select { |doc| featured_attachments.include? doc["id"] }
+    attachments_from(content_item["details"]["featured_attachments"])
   end
 
   def attachments_with_details
     attachments_for_components.select { |doc| doc["accessible"] == false && doc["alternative_format_contact_email"] }.count
-  end
-
-  def documents
-    return [] unless content_item["details"]["attachments"]
-
-    docs = content_item["details"]["attachments"].select { |a| !a.key?("locale") || a["locale"] == locale }
-    docs.each do |doc|
-      doc["type"] = "html" unless doc["content_type"]
-      doc["type"] = "external" if doc["attachment_type"] == "external"
-      doc["preview_url"] = "#{doc['url']}/preview" if doc["preview_url"]
-      doc["alternative_format_contact_email"] = nil if doc["accessible"] == true
-    end
-  end
-
-  def featured_attachments
-    content_item["details"]["featured_attachments"].to_a
   end
 
   def national_statistics?


### PR DESCRIPTION
- Attachment code in Publications, Consultations, and calls for evidence was recently updated to render locally rather than using the pre-rendered HTML from whitehall
- We move some of the duplicated code into the Content Item::Attachment concern, and delete the existing code there (which wasn't being used), and provide a utility method to simplify some of the unavoidably repeated code.
- Coverage slightly improved (presumable due to the deleted unused method).

https://trello.com/c/tcTN1jbu/28-update-rendering-of-govspeak-attachments

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
