### PR TITLE
Handle manual updates on same day correctly

### DIFF
--- a/app/views/content_items/manuals/_updates.html.erb
+++ b/app/views/content_items/manuals/_updates.html.erb
@@ -25,13 +25,16 @@
                 <% change_notes = updated_documents.last %>
                 <div class="govuk-!-margin-top-3">
                   <% change_notes.each do |change_note_entry| %>
+                    <% change_note_items = change_note_entry.last.collect { |i| i["change_note"] } %>
                     <% change_note = change_note_entry.flatten.last %>
                     <% if change_note["title"].present? %>
                       <p class="govuk-body">
                         <%= link_to change_note["title"], change_note["base_path"], class: "govuk-link" %>
                       </p>
                     <% end %>
-                    <%= simple_format(change_note["change_note"], class: "govuk-body") %>
+                    <% change_note_items.each do |change_note_item| %>
+                      <%= simple_format(change_note_item, class: "govuk-body") %>
+                    <% end %>
                   <% end %>
                 </div>
               <% end


### PR DESCRIPTION
- Previously manual updates to the same path on the same day were grouped together and only the last was shown, despite all being present in the content item. The grouping code was correct, but in the view only the last item was displayed.

Fixes: https://govuk.zendesk.com/agent/tickets/5624376

Before and after from: https://www.gov.uk/guidance/style-guide/updates

## Before

![Screenshot 2024-06-17 at 14 16 49](https://github.com/alphagov/government-frontend/assets/4225737/e30789b1-9b44-4b67-8b19-f275b3f9f76f)

## After 

![Screenshot 2024-06-17 at 14 17 03](https://github.com/alphagov/government-frontend/assets/4225737/d561fb26-65c2-466c-99ca-8e46c0f42e4c)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
