### PR TITLE
Fix: improve 'Skip to contents' link text

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -46,7 +46,7 @@
 
     <% if @content_item.show_guide_navigation? %>
       <%= render "govuk_publishing_components/components/skip_link", {
-        text: t("guide.skip_to_contents"),
+        text: t("guide.skip_contents"),
         href: "#guide-contents"
       } %>
       <aside class="part-navigation-container" role="complementary">

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -694,7 +694,7 @@ ar:
     title: الصفحة التي تبحث عنها لم تعد متاحة
   guide:
     pages_in_guide: الصفحات في هذا الدليل
-    skip_to_contents: انتقل إلى محتويات الدليل
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: يتاح المنشور على %{url}

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -386,7 +386,7 @@ az:
     title: Axtardığınız səhifə artıq mövcud deyildir
   guide:
     pages_in_guide: Bu təlimatdakı səhifələr
-    skip_to_contents: Təlimatın məzmunlarına keçin
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Bu nəşr %{url} ünvanında mövcuddur

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -540,7 +540,7 @@ be:
     title: Старонка, якую вы шукаеце, больш не даступная
   guide:
     pages_in_guide: Старонкі ў гэтым кіраўніцтве
-    skip_to_contents: Перайсці да зместу кіраўніцтва
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Дадзеная публікацыя даступная па адрасе %{url}

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -386,7 +386,7 @@ bg:
     title: Страницата, която търсите, вече не е налична
   guide:
     pages_in_guide: Страници в това ръководство
-    skip_to_contents: Преминаване към съдържанието на ръководството
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Тази публикация е налична на адрес %{url}

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -386,7 +386,7 @@ bn:
     title: আপনি যে পেজটি খুঁজছেন তা আর উপলভ্য নেই
   guide:
     pages_in_guide: এই নির্দেশিকাতে পৃষ্ঠা
-    skip_to_contents: নির্দেশিকার বিষয়বস্তুতে চলে যান
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: এই প্রকাশনাটি %{url}-এ উপলভ্য

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -463,7 +463,7 @@ cs:
     title: Stránka, kterou hledáte, již není k dispozici
   guide:
     pages_in_guide: Stránky v této příručce
-    skip_to_contents: Přeskočit na obsah průvodce
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Tato publikace je k dispozici na adrese %{url}

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -694,7 +694,7 @@ cy:
     title: Dydy'r dudalen rydych chi'n chwilio amdani ddim ar gael mwyach
   guide:
     pages_in_guide: Tudalennau yn y canllaw hwn
-    skip_to_contents: Neidio i gynnwys y canllaw
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Mae'r cyhoeddiad hwn ar gael yn %{url}

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -398,7 +398,7 @@ da:
     title: Den side, du leder efter, er ikke længere tilgængelig
   guide:
     pages_in_guide: Sider i denne vejledning
-    skip_to_contents: Spring til vejledningens indhold
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Denne publikation er tilgængelig på %{url}

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -386,7 +386,7 @@ de:
     title: Die von Ihnen gesuchte Seite ist nicht mehr verfügbar
   guide:
     pages_in_guide: Seiten in diesem Leitfaden
-    skip_to_contents: Zum Inhalt des Leitfadens springen
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Diese Veröffentlichung ist verfügbar unter %{url}

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -386,7 +386,7 @@ dr:
     title: صفحه مورد نظر شما دیگر در دسترس نیست
   guide:
     pages_in_guide: صفحات موجود در این راهنما
-    skip_to_contents: به محتویات راهنما بروید
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: این نشریه در%{url} موجود است

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -386,7 +386,7 @@ el:
     title: Η σελίδα που αναζητάτε δεν είναι πλέον διαθέσιμη
   guide:
     pages_in_guide: Σελίδες σε αυτόν τον οδηγό
-    skip_to_contents: Μετάβαση στα περιεχόμενα του οδηγού
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Αυτή η δημοσίευση είναι διαθέσιμη στο %{url}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -386,7 +386,7 @@ en:
     title: The page you're looking for is no longer available
   guide:
     pages_in_guide: Pages in this guide
-    skip_to_contents: Skip to contents of guide
+    skip_contents: Skip contents
   html_publication:
     print_meta_data:
       available_at: This publication is available at %{url}

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -386,7 +386,7 @@ es-419:
     title: La página que busca ya no está disponible
   guide:
     pages_in_guide: Páginas en esta guía
-    skip_to_contents: Ir al contenido de la guía
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Esta publicación está disponible en %{url}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -386,7 +386,7 @@ es:
     title: La página que está buscando ya no está disponible
   guide:
     pages_in_guide: Páginas de esta guía
-    skip_to_contents: Ir al contenido de la guía
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Esta publicación está disponible en %{url}

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -386,7 +386,7 @@ et:
     title: Otsitav leht pole enam saadaval
   guide:
     pages_in_guide: Selle juhendi leheküljed
-    skip_to_contents: Mine juhendi sisu juurde
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: See publikatsioon on saadaval aadressil %{url}

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -386,7 +386,7 @@ fa:
     title: صفحه‌ای که به دنبال آن هستید، دیگر در دسترس نیست
   guide:
     pages_in_guide: صفحات موجود در این راهنما
-    skip_to_contents: رفتن به محتوای راهنما
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: این مورد منتشر شده در %{url} در دسترس است

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -386,7 +386,7 @@ fi:
     title: Etsimäsi sivu ei ole enää saatavana.
   guide:
     pages_in_guide: Tämän oppaan sivut
-    skip_to_contents: Siirry oppaan sisältöön
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Tämä julkaisu on saatavilla osoitteessa %{url}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -386,7 +386,7 @@ fr:
     title: La page que vous recherchez n'est plus disponible
   guide:
     pages_in_guide: Pages de ce guide
-    skip_to_contents: Passer au contenu du guide
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Cette publication est disponible à %{url}

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -540,7 +540,7 @@ gd:
     title: Níl an leathanach iarrtha ar fáil a thuilleadh
   guide:
     pages_in_guide: Leathanaigh na treorach seo
-    skip_to_contents: Scipeáil chuig tús na treorach
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Tá an foilseachán seo i láthair ar %{url}

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -386,7 +386,7 @@ gu:
     title: તમે જે પેજ શોધો છો, તે હવે ઉપલબ્ધ નથી
   guide:
     pages_in_guide: આ માર્ગદર્શિકામાંના પૃષ્ઠો
-    skip_to_contents: માર્ગદર્શિકાની સામગ્રી પર જાઓ
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: આ પ્રકાશન %{url} પર ઉપલબ્ધ છે

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -386,7 +386,7 @@ he:
     title: הדף שאתה מחפש אינו זמין יותר
   guide:
     pages_in_guide: דפים במדריך זה
-    skip_to_contents: דלג לתוכן המדריך
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: פרסום זה זמין בכתובת %{url}

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -386,7 +386,7 @@ hi:
     title: आप जो पेज खोज रहे हैं वह अब उपलब्ध नहीं है
   guide:
     pages_in_guide: इस गाइड में पेज
-    skip_to_contents: गाइड की सामग्री पर जाएं
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: यह प्रकाशन %{url} पर उपलब्ध है

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -463,7 +463,7 @@ hr:
     title: Stranica koju tražite više nije dostupna
   guide:
     pages_in_guide: Stranice u ovom vodiču
-    skip_to_contents: Preskoči na sadržaj vodiča
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Ova je publikacija dostupna na %{url}

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -386,7 +386,7 @@ hu:
     title: Az Ön által keresett oldal már nem elérhető
   guide:
     pages_in_guide: A jelen útmutató oldalai
-    skip_to_contents: Kihagyás és továbblépés az útmutató tartalomjegyzékéhez
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: 'A kiadvány elérhető a következő helyen: %{url}'

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -386,7 +386,7 @@ hy:
     title: Ձեր փնտրած էջն այլևս հասանելի չէ
   guide:
     pages_in_guide: Այս ուղեցույցում առկա էջերը
-    skip_to_contents: Անցնել ուղեցույցի բովանդակությանը
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Այս հրապարակումը հասանելի էt %{url} հասցեով

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -309,7 +309,7 @@ id:
     title: Halaman yang dicari tidak lagi tersedia
   guide:
     pages_in_guide: Halaman dalam panduan ini
-    skip_to_contents: Lewatkan ke konten panduan
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Publikasi ini tersedia di %{url}

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -386,7 +386,7 @@ is:
     title: Síðan sem þú leitar að er ekki lengur aðgengileg
   guide:
     pages_in_guide: Síður í þessum leiðbeiningum
-    skip_to_contents: Fara beint í leiðbeiningarnar
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Þessi útgáfa er aðgengileg á %{url}

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -386,7 +386,7 @@ it:
     title: La pagina che stai cercando non è più disponibile
   guide:
     pages_in_guide: Pagine in questa guida
-    skip_to_contents: Passa ai contenuti di questa guida
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Questa pubblicazione è disponibile all’indirizzo %{url}

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -309,7 +309,7 @@ ja:
     title: お探しのページはご利用いただけなくなりました
   guide:
     pages_in_guide: このガイドのページ
-    skip_to_contents: ガイドのコンテンツに移動
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: この出版物は％{url}で入手できます

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -386,7 +386,7 @@ ka:
     title: გვერდი, რომელსაც თქვენ ეძებთ, აღარ არის ხელმისაწვდომი
   guide:
     pages_in_guide: გვერდები ამ სახელმძღვანელოში
-    skip_to_contents: გადადით სახელმძღვანელოს შინაარსზე
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: ეს პუბლიკაცია ხელმისაწვდომია %{url}-ზე

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -386,7 +386,7 @@ kk:
     title: Сіз іздеген бет енді қол жетімді емес
   guide:
     pages_in_guide: Бұл нұсқаулықтағы беттер
-    skip_to_contents: Нұсқаулық мазмұнына өту
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Бұл жарияланым %{url} сайтында қолжетімді

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -309,7 +309,7 @@ ko:
     title: 지금 보고있는 페이지를 더 이상 이용할 수 없습니다
   guide:
     pages_in_guide: 이 지침 내 페이지
-    skip_to_contents: 지침 콘텐츠로 건너뛰기
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: 이 발행물은 %{url}에서 이용할 수 있습니다

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -463,7 +463,7 @@ lt:
     title: Jūsų ieškomas puslapis nebepasiekiamas
   guide:
     pages_in_guide: Puslapiai šiame vadove
-    skip_to_contents: Pereiti prie vadovo puslapių
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Šis leidinys prieinamas %{url}

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -386,7 +386,7 @@ lv:
     title: Lapa, kuru meklējat, vairs nav pieejama
   guide:
     pages_in_guide: Lapas šajā ceļvedī
-    skip_to_contents: Izlaist un pāriet uz ceļveža saturu
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Šī publikācija ir pieejama vietnē %{url}

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -309,7 +309,7 @@ ms:
     title: Laman yang anda cari sudah tiada
   guide:
     pages_in_guide: Laman dalam panduan ini
-    skip_to_contents: Langkau ke kandungan panduan
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Penerbitan ini tersedia di %{url}

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -540,7 +540,7 @@ mt:
     title: Il-paġna li qed tfittex mhijiex disponibbli iktar
   guide:
     pages_in_guide: Paġni f'dan il-gwida
-    skip_to_contents: Aqbeż għall-kontenut tal-gwida
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Din il-pubblikazzjoni hija disponibbli fuq %{url}

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -386,7 +386,7 @@ ne:
     title: तपाईंले खोज्नु भएको पृष्ठ अब उपलब्ध छैन
   guide:
     pages_in_guide: यस गाइडका पृष्ठहरू
-    skip_to_contents: गाइडको बिषयबस्तुमा सिधै जानुहोस्
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: यो प्रकाशन %{url} मा उपलब्ध छ

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -386,7 +386,7 @@ nl:
     title: De pagina die u zoekt is niet langer beschikbaar
   guide:
     pages_in_guide: Pagina's in deze gids
-    skip_to_contents: Naar de inhoud van de gids gaan
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Deze publicatie is beschikbaar op %{url}

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -386,7 +386,7 @@
     title: Siden du leter etter er ikke lenger tilgjengelig
   guide:
     pages_in_guide: Sider i denne veiledningen
-    skip_to_contents: Gå til innholdet i guiden
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Denne publikasjonen er tilgjengelig på %{url}

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -386,7 +386,7 @@ pa-pk:
     title: جہیڑا ورقہ تُسی لبھ رئے او ہُن او موجود نئیں
   guide:
     pages_in_guide: ایس ہدایت نامے وچ ورقے
-    skip_to_contents: رہنمائی دے مواد نوں چھڈ دیوؤ
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: ایہ اشاعت ایتھے موجود اے {url}%

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -386,7 +386,7 @@ pa:
     title: ਜਿਸ ਪੰਨੇ ਨੂੰ ਤੁਸੀਂ ਲੱਭ ਰਹੇ ਹੋ ਉਹ ਹੁਣ ਉਪਲਬਧ ਨਹੀਂ ਹੈ
   guide:
     pages_in_guide: ਇਸ ਗਾਈਡ ਦੇ ਪੰਨੇ
-    skip_to_contents: ਗਾਈਡ ਦੀ ਸਮਗਰੀ ਤੇ ਜਾਓ
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: ਇਹ ਪ੍ਰਕਾਸ਼ਨ %{url} ਤੇ ਉਪਲਬਧ ਹੈ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -540,7 +540,7 @@ pl:
     title: Strona, której szukasz, nie jest już dostępna
   guide:
     pages_in_guide: Strony w tym przewodniku
-    skip_to_contents: Przejdź do treści przewodnika
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Ta publikacja jest dostępna pod adresem %{url}

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -386,7 +386,7 @@ ps:
     title: هغه پاڼه چې تاسو یې په لټه کې یاست نور شتون نلري
   guide:
     pages_in_guide: په دې لارښود کې پاڼې
-    skip_to_contents: د لارښود مینځپانګې ته لاړشئ
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: دا خپرونه په%{url} کې شتون لري

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -386,7 +386,7 @@ pt:
     title: A página que procura já não está disponível
   guide:
     pages_in_guide: Páginas neste guia
-    skip_to_contents: Saltar para o conteúdo do guia
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Esta publicação está disponível em %{url}

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -463,7 +463,7 @@ ro:
     title: Pagina pe care o căutați nu mai este disponibilă.
   guide:
     pages_in_guide: Paginile din acest ghid
-    skip_to_contents: Accesați direct conținutul ghidului
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Această publicație este disponibilă la %{url}

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -540,7 +540,7 @@ ru:
     title: Страница, которую Вы ищите более не доступна
   guide:
     pages_in_guide: Страница в руководстве
-    skip_to_contents: Перейти к содержанию руководства
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Данная публикация доступна на %{url}

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -386,7 +386,7 @@ si:
     title: ඔබ සොයන පිටුව තවදුරටත් ලබා ගත නොහැක
   guide:
     pages_in_guide: මෙම මාර්ගෝපදේශයෙහි තුළ පිටු
-    skip_to_contents: මාර්ගෝපදේශය අන්තර්ගතය වෙත මඟහැරී යන්න
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: මෙම ප්රකාශනය %{url} වෙතින් ලබා ගත හැකිය

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -463,7 +463,7 @@ sk:
     title: Stránka, ktorú hľadáte, už nie je k dispozícii
   guide:
     pages_in_guide: Stránky v tejto príručke
-    skip_to_contents: Prejsť na obsah príručky
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Táto publikácia je k dispozícii na %{url}

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -540,7 +540,7 @@ sl:
     title: Stran, ki ste jo iskali, ni več na voljo
   guide:
     pages_in_guide: Strani v tem vodiču
-    skip_to_contents: Skočite na vsebino vodiča
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Ta publikacija je na voljo na %{url}

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -386,7 +386,7 @@ so:
     title: Boga aad doon doonaysaa lama heli karo
   guide:
     pages_in_guide: Bogaga tilmaamahan
-    skip_to_contents: Dhaafi waxyaabaha ay ka koobantahay tilmaamtani
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Daabacaadan waxa laga heli karaa %{url}

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -386,7 +386,7 @@ sq:
     title: Faqja që po kërkoni nuk është më e disponueshme
   guide:
     pages_in_guide: Faqet në këtë udhëzim
-    skip_to_contents: Kaloni te përmbajtja e udhëzuesit
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Ky publikim është i disponueshëm në %{url}

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -463,7 +463,7 @@ sr:
     title: Stranica koju tražite nije više dostupna
   guide:
     pages_in_guide: Stranice u ovom vodiču
-    skip_to_contents: Preskoči na sadržaj vodiča
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Ova publikacija je dostupna na adresi %{url}

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -386,7 +386,7 @@ sv:
     title: Sidan du letar efter är inte längre tillgänglig.
   guide:
     pages_in_guide: Sidor i den här guiden
-    skip_to_contents: Hoppa till innehållet i guiden
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Den här publikationen finns på %{url}

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -386,7 +386,7 @@ sw:
     title: Ukurasa unaotafuta haupatikani tena
   guide:
     pages_in_guide: Kurasa za mwongozo huu
-    skip_to_contents: Nenda kwenye maudhui ya mwongozo
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Chapisho hili linapatikana katika %{url}

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -386,7 +386,7 @@ ta:
     title: நீங்கள் தேடும் பக்கம் இனி கிடைக்காது
   guide:
     pages_in_guide: இந்த வழிகாட்டுதலில் உள்ள பக்கங்கள்
-    skip_to_contents: வழிகாட்டுதல் விபரங்களுக்குச் செல்க
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: "%{url}-ல் இந்த வெளியீடு உள்ளது"

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -309,7 +309,7 @@ th:
     title: ไม่มีหน้าที่คุณกำลังค้นหาอีกต่อไป
   guide:
     pages_in_guide: หน้าในคู่มือนี้
-    skip_to_contents: ข้ามไปยังเนื้อหาของคู่มือ
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: สิ่งพิมพ์นี้สามารถดูได้ที่ %{url}

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -386,7 +386,7 @@ tk:
     title: Gözleýän sahypaňyz indi elýeterli däl
   guide:
     pages_in_guide: Bu gollanmadaky sahypalar
-    skip_to_contents: Gollanmanyň mazmunyna geçiň
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Bu neşir %{url} -da elýeterlidir

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -386,7 +386,7 @@ tr:
     title: Aradığınız sayfa artık mevcut değil
   guide:
     pages_in_guide: Bu kılavuzdaki sayfalar
-    skip_to_contents: Kılavuz içeriklerine atla
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Bu yayına %{url} üzerinden ulaşılabilir

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -540,7 +540,7 @@ uk:
     title: Сторінка, яку ви шукаєте, більше не доступна
   guide:
     pages_in_guide: Сторінки цього посібника
-    skip_to_contents: Перейти до змісту посібника
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Ця публікація доступна за адресою %{url}

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -386,7 +386,7 @@ ur:
     title: جس صفحے کی آپ کو تلاش ہے وہ مزید دستیاب نہیں ہے
   guide:
     pages_in_guide: اس رہنما میں موجود صفحات
-    skip_to_contents: چھوڑ کر رہنما کے مشمولات پر جائیں
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: یہ پبلیکیشن %{url} پر دستیاب ہے

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -386,7 +386,7 @@ uz:
     title: Сиз излаётган саҳифа бундан буён йўқ.
   guide:
     pages_in_guide: Ушбу қўлланмадаги саҳифалар
-    skip_to_contents: Қўлланманинг мундарижасига ўтиш
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Ушбу нашр этиш %{url} манзилда эришимли

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -309,7 +309,7 @@ vi:
     title: Trang bạn đang tìm không có sẵn
   guide:
     pages_in_guide: Các trang trong hướng dẫn này
-    skip_to_contents: Chuyển đến nội dung của hướng dẫn
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: Ấn phẩm này có sẵn tại %{url}

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -386,7 +386,7 @@ yi:
     title:
   guide:
     pages_in_guide:
-    skip_to_contents:
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -309,7 +309,7 @@ zh-hk:
     title: 您搜尋之頁面不再可用
   guide:
     pages_in_guide: 本指引之頁面
-    skip_to_contents: 跳過指引內容
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: 本出版品可在 %{url} 獲取

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -309,7 +309,7 @@ zh-tw:
     title: 正在尋找的頁面不再適用
   guide:
     pages_in_guide: 本指南中的頁面
-    skip_to_contents: 跳至指南內容
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: 該出版物可在 %{url} 取得

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -309,7 +309,7 @@ zh:
     title: 您正在查找的页面不再可用
   guide:
     pages_in_guide: 本指南的页面
-    skip_to_contents: 跳到指南的内容
+    skip_contents:
   html_publication:
     print_meta_data:
       available_at: 本发表内容可在 %{url} 获取。


### PR DESCRIPTION
## What 

[Trello card](https://trello.com/c/bSg8Z4H1/2641-confusing-skip-link-text-on-guides)

The 'Skip to contents of guide' link text, which appears on focus just before the 'Contents' heading, has been updated to 'Skip contents'. This change addresses confusion among screen reader users, who mistook the link's destination to be the 'Content's section rather than the man document content.

## Why

It failed an accessibility audit **Structure and Purpose usability issue**. Changes to the content of the link aims to make it more clearer for screen reader users.

Note: we are not updating other translation locales at this time, therefore the values of the `skip_contents` have been removed. 

**We're currently also waiting for the Welsh translation for `skip_contents` which will be updated once confirmed.**

Reference links:

- [Initial change PR](https://github.com/alphagov/government-frontend/pull/2116)
- [Translation commit](https://github.com/alphagov/government-frontend/commit/e273fead63fc98ec422b1432b787e8915a9c53ad)

## Screenshots

| Before | After |
|--------|--------|
| <img width="869" alt="image" src="https://github.com/alphagov/government-frontend/assets/56222256/09f8282c-e1d2-4bae-855d-ee4cedbd031d"> | <img width="870" alt="image" src="https://github.com/alphagov/government-frontend/assets/56222256/08bb5f73-1cfa-4ef9-a344-9b6e98d87819"> |

