### PR TITLE
Improve important metadata print styles

### DIFF
--- a/app/assets/stylesheets/components/_important-metadata.scss
+++ b/app/assets/stylesheets/components/_important-metadata.scss
@@ -10,6 +10,19 @@
     overflow: auto;
     padding: govuk-spacing(4) govuk-spacing(6);
   }
+
+  @include govuk-media-query($media-type: print) {
+    padding: 0;
+    color: $govuk-text-colour;
+
+    .govuk-link {
+      color: $govuk-text-colour;
+    }
+
+    .app-c-important-metadata__definition {
+      padding-bottom: govuk-spacing(2);
+    }
+  }
 }
 
 // this will be moved and extended into a model for general component spacing


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- improve the print styles for the important metadata component
- was defaulting to a light grey text that was quite hard to read
- setting colour and link colour to govuk-text-color (black, basically)
- also adding some padding between the items to improve readability, as includes the full links in the text when printed, so the box can look quite overwhelming

Can be seen on pages such as: https://www.gov.uk/find-funding-for-land-or-farms/wbd2-manage-ditches

## Why
Responding to a request from another department.

## Visual changes

Before | After
------ | ------
![Screenshot 2024-06-20 at 15 36 21](https://github.com/alphagov/government-frontend/assets/861310/1a266a21-3898-4e35-b782-192e604ddc88) | ![Screenshot 2024-06-20 at 15 36 11](https://github.com/alphagov/government-frontend/assets/861310/20099cfd-b5d8-4b41-b0e7-f8b5a1d9dd52)


Trello card: https://trello.com/c/UPuK4WOc/74-improve-print-styles-across-govuk
