### PR TITLE
Remove abbr tag from contents list link

### DIFF
--- a/app/views/histories/1_horse_guards_road.html.erb
+++ b/app/views/histories/1_horse_guards_road.html.erb
@@ -34,7 +34,7 @@
         },
         {
           href: "#the-building-of-goggs",
-          text: "The building of <abbr title=\"Government Offices Great George Street\">GOGGS<abbr>".html_safe,
+          text: "The building of GOGGS",
         },
         {
           href: "#the-cabinet-war-rooms",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
- this page https://www.gov.uk/government/history/1-horse-guards-road calls the contents_list component and passes a series of links including one that includes an abbr (abbreviation) tag to explain the acronym 'GOGGS'
- this acroynm is explained several times already in the text of the page, as well as in the contents list link that immediately precedes this one
- there is no need for this tag inside this link, and this also causes significant complexity for the contents list component, which should not have anything other than text passed to it for the value of the text of a link

## Visual changes

Before | After
----- | -----
![Screenshot 2024-06-27 at 09 29 19](https://github.com/alphagov/government-frontend/assets/861310/0daf1d4a-580a-4650-ba99-04905f6fb8b1) | ![Screenshot 2024-06-27 at 09 29 25](https://github.com/alphagov/government-frontend/assets/861310/36b070b7-1db7-4b6d-821b-d369ce2b98f7)
