### PR TITLE
Check ruby test coverage before merging PRs

### DIFF
--- a/test/controllers/development_controller_test.rb
+++ b/test/controllers/development_controller_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class DevelopmentControllerTest < ActionController::TestCase
+  test "shows inde page" do
+    get :index
+    assert_response :ok
+    assert response.body.include?("This page is intended to be shown in development and on Heroku review apps.")
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,11 @@ ENV["GOVUK_ASSET_ROOT"] = "http://static.test.gov.uk"
 
 # Must go at top of file
 require "simplecov"
-SimpleCov.start
+
+SimpleCov.start "rails" do
+  enable_coverage :branch
+  minimum_coverage 95
+end
 
 require "i18n/coverage"
 require "i18n/coverage/printers/file_printer"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Set up automated checking of ruby test coverage by simplecov as a requirement before a PR can be merged. This can be done in two ways. Either a test can be added, which checks simplecov coverage or an additional step can be added to GitHub CI. Investigate which of those two approaches is easier to implement and implement it.

## Why

We need to keep ruby code test coverage at 95% as indicated by simplecov in order to maintain the requirement of dependabot automerger.

[Trello card](https://trello.com/c/c3Cvewr6/2665-check-ruby-test-coverage-before-merging-prs)
