### PR TITLE
Fix display of lists in RTL HTML publications

### DIFF
--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -65,7 +65,7 @@
     </div>
 
     <div class="main-content-container<% unless @content_item.contents.any? %> offset-empty-contents-list<% end %>">
-      <%= render "govuk_publishing_components/components/govspeak_html_publication", {} do %>
+      <%= render "govuk_publishing_components/components/govspeak_html_publication", { direction: page_text_direction } do %>
         <%= raw(@content_item.govspeak_body[:content]) %>
       <% end %>
     </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
- passes the `page_text_direction` into the govspeak html publication component to ensure that lists display properly in right to left content
- govspeak html publication is used as a wrapper for the govspeak component, with some additional styles included
- it still accepts and passes through to govspeak a `direction` parameter
- in this case, pages had the the correct `direction` class applied to the top of the page, which seems to work for most of the styles on the page, but the govspeak CSS for RTL is written specifically assuming that the `direction` class is applied to the govspeak component (wrapping element) rather than any higher element, so the styles weren't being used properly
- this resulted in a very subtle problem where lists had a margin applied to the wrong side (the default left side, for LTR content) instead of the right, which looks fine in most situations (because there's a gap between the right edge of the content and the left edge of the right hand column) unless the screen is shorter than the contents of the right hand column, forcing a scrollbar, which overlapped the bullets of the list
- passing the govspeak html publication a `direction` option (that already existed, but wasn't being used for this purpose) fixes the problem, as the govspeak component now applies correct RTL styling to lists
- consequence is that for LTR content this parameter is now explicitly passed, instead of previously assumed, but a quick visual/sense check suggests that this should be fine

Example HTML publication pages:

- [RTL page where this problem occurs](https://www.gov.uk/government/publications/physical-and-mental-health-support-for-people-seeking-asylum/bf985a69-bad2-479d-b33b-cd326d71dd6a)
- [LTR page without this problem](https://www.gov.uk/government/publications/car-show-me-tell-me-vehicle-safety-questions/car-show-me-tell-me-vehicle-safety-questions)

## Visual changes
First, here's the problem.

Seems fine | But my screen is shorter forcing a scrollbar on the right column
---------- | ---------
![Screenshot 2024-07-08 at 15 13 30](https://github.com/alphagov/government-frontend/assets/861310/63dba554-d257-4bea-ab2d-d5987afa0c02) | ![Screenshot 2024-07-08 at 15 13 37](https://github.com/alphagov/government-frontend/assets/861310/2acf53a0-8840-41c5-a419-8db612c5f474)

Now, with the `.direction-rtl` class applied to the govspeak component, it looks like this:

Before | After
------ | ------
![Screenshot 2024-07-08 at 15 18 54](https://github.com/alphagov/government-frontend/assets/861310/76e5bc39-d801-4ace-aa85-d9cbe41998e2) | ![Screenshot 2024-07-08 at 15 19 00](https://github.com/alphagov/government-frontend/assets/861310/18bfa0bf-8a12-46ec-856d-3c8db620713b)

Trello card: https://trello.com/c/HXiajSKv/183-bullet-points-cut-off-in-html-attachments-in-rtl-languages