### PR TITLE
Fix oversized images

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,3 +54,7 @@ $govuk-include-default-font-face: false;
     text-align: start;
   }
 }
+
+.constrained-image {
+  max-width: 100%;
+}

--- a/app/views/content_items/how_government_works.html.erb
+++ b/app/views/content_items/how_government_works.html.erb
@@ -103,9 +103,9 @@
           </p>
 
           <% if @content_item.prime_minister.present? && @content_item.prime_minister_image_url.present? %>
-            <%= image_tag @content_item.prime_minister_image_url, { alt:  @content_item.prime_minister_image_alt_text, width: '465', height: '310' } %>
+            <%= image_tag @content_item.prime_minister_image_url, { class: 'constrained-image', alt:  @content_item.prime_minister_image_alt_text } %>
           <% else %>
-            <%= image_tag 'how-gov-works/10_downing_street.jpg', alt: '10 Downing Street', width: '465', height: '310' %>
+            <%= image_tag 'how-gov-works/10_downing_street.jpg', class: 'constrained-image', alt: '10 Downing Street' %>
           <% end %>
         </section>
 
@@ -120,7 +120,7 @@
           <p class="govuk-body">The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government.</p>
           <p class="govuk-body govuk-!-margin-bottom-8"><%= link_to("See who is in the Cabinet", "/government/ministers", class: "govuk-link") %></p>
 
-          <%= image_tag 'how-gov-works/cabinet_01.jpg', alt: '', width: '465', height: '310' %>
+          <%= image_tag 'how-gov-works/cabinet_01.jpg', class: 'constrained-image', alt: '' %>
         </section>
       </section>
     </div>
@@ -517,7 +517,7 @@
         <p class="govuk-body">Read about past Prime Ministers, Chancellors and Foreign Secretaries in <%= link_to "notable people", "/government/history#notable-people", class: "govuk-link" %>. Learn more about historic <%= link_to "government buildings", "/government/history#government-buildings", class: "govuk-link" %> on Whitehall and around the UK.</p>
         <p class="govuk-body govuk-!-margin-bottom-8">You can also find links to <%= link_to "historical research", "/government/history#historical-research", class: "govuk-link" %>, documents and records.</p>
 
-        <%= image_tag 'how-gov-works/churchill_01.jpg', alt: '', width: '465', height: '310' %>
+        <%= image_tag 'how-gov-works/churchill_01.jpg', class: 'constrained-image', alt: '' %>
       </section>
     </div>
   </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- fix oversized images on the 'how government works' page https://www.gov.uk/government/how-government-works
- remove hard coded image dimensions and add a class that sets `max-width: 100%`
- was causing the images to overlap the width of the screen at small screen sizes, causing a horizontal scroll bar and a broken layout
- only adding the class or only removing the width/height don't fix the problem, because width/height as inline attributes override CSS
- was hoping to be able to leave the width/height to reduce cumulative layout shift when loading, but this is a small loss compared to fixing the general appearance
- surprised we don't have a general class to have all `img` tags with `max-width: 100%` but since there isn't one I don't want to try introducing one here as proving it's fine on every page is a much bigger task (although logically it should be... right?)

Page with the problem: https://www.gov.uk/government/how-government-works

(I've checked for other image tags within `government-frontend` and this seems to be the only instance of this problem)

Example of the problem:

![Screenshot 2024-07-08 at 16 03 56](https://github.com/alphagov/government-frontend/assets/861310/c78ecb52-210f-465f-b94c-2f37cb019502)

## Visual changes

Before | After
----- | -----
![Screenshot 2024-07-08 at 16 01 01](https://github.com/alphagov/government-frontend/assets/861310/3497ecd7-e2c5-410d-a992-00fad2aa52a9) | ![Screenshot 2024-07-08 at 16 03 00](https://github.com/alphagov/government-frontend/assets/861310/fbd7a46f-3cdc-4b6d-af60-ee39d1ba01a8)




Trello card: https://trello.com/c/USYdcgFe/235-image-off-the-right-hand-side-of-the-screen