### PR TITLE
DAC audit fix: Add hidden heading above email sign up and print link

### DIFF
--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -9,6 +9,14 @@
   } %>
 
 <div class="published-dates-button-group">
+  <h2 class="govuk-visually-hidden">
+    <% if @content_item.has_single_page_notifications? %>
+      <%= I18n.t("common.email_and_print_link") %>
+    <% else %>
+      <%= I18n.t("common.print_link") %>
+    <% end %>
+  </h2>
+
   <%= render 'govuk_publishing_components/components/single_page_notification_button', {
     base_path: @content_item.base_path,
     js_enhancement: @has_govuk_account,

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -28,6 +28,8 @@ ar:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'تفضّل بزيارة:'
   components:
     figure:
@@ -772,7 +774,6 @@ ar:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -783,6 +784,7 @@ ar:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -28,6 +28,8 @@ az:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Baş çəkin:'
   components:
     figure:
@@ -464,7 +466,6 @@ az:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ az:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -28,6 +28,8 @@ be:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Наведайце:'
   components:
     figure:
@@ -618,7 +620,6 @@ be:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -629,6 +630,7 @@ be:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -28,6 +28,8 @@ bg:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Посетете:'
   components:
     figure:
@@ -464,7 +466,6 @@ bg:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ bg:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -28,6 +28,8 @@ bn:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'ভিজিট করুন:'
   components:
     figure:
@@ -464,7 +466,6 @@ bn:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ bn:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -28,6 +28,8 @@ cs:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Navštivte:'
   components:
     figure:
@@ -541,7 +543,6 @@ cs:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -552,6 +553,7 @@ cs:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -28,6 +28,8 @@ cy:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Ymweld:'
   components:
     figure:
@@ -772,7 +774,6 @@ cy:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -783,6 +784,7 @@ cy:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -28,6 +28,8 @@ da:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Besøge:'
   components:
     figure:
@@ -476,7 +478,6 @@ da:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -487,6 +488,7 @@ da:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -28,6 +28,8 @@ de:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Besuchen Sie:'
   components:
     figure:
@@ -464,7 +466,6 @@ de:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ de:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -28,6 +28,8 @@ dr:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'بازدید:'
   components:
     figure:
@@ -467,7 +469,6 @@ dr:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -478,6 +479,7 @@ dr:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -28,6 +28,8 @@ el:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Επίσκεψη:'
   components:
     figure:
@@ -464,7 +466,6 @@ el:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ el:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,8 @@ en:
     write_to: 'Write to:'
   common:
     visit: 'Visit:'
+    email_and_print_link: Sign up for emails or print this page
+    print_link: Print this page
   components:
     figure:
       image_credit: 'Image credit: %{credit}'

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -28,6 +28,8 @@ es-419:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Visite:'
   components:
     figure:
@@ -464,7 +466,6 @@ es-419:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ es-419:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -28,6 +28,8 @@ es:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Visite:'
   components:
     figure:
@@ -464,7 +466,6 @@ es:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ es:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -28,6 +28,8 @@ et:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Külastus:'
   components:
     figure:
@@ -464,7 +466,6 @@ et:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ et:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -28,6 +28,8 @@ fa:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'بازدید کنید:'
   components:
     figure:
@@ -464,7 +466,6 @@ fa:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ fa:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -28,6 +28,8 @@ fi:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Vierailla:'
   components:
     figure:
@@ -464,7 +466,6 @@ fi:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ fi:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -28,6 +28,8 @@ fr:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Visiter:'
   components:
     figure:
@@ -464,7 +466,6 @@ fr:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ fr:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -28,6 +28,8 @@ gd:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Cuairt:'
   components:
     figure:
@@ -618,7 +620,6 @@ gd:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -629,6 +630,7 @@ gd:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -28,6 +28,8 @@ gu:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'મુલાકાત લો:'
   components:
     figure:
@@ -464,7 +466,6 @@ gu:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ gu:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -28,6 +28,8 @@ he:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'בקר:'
   components:
     figure:
@@ -464,7 +466,6 @@ he:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ he:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -28,6 +28,8 @@ hi:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'इस पर जाएं:'
   components:
     figure:
@@ -464,7 +466,6 @@ hi:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ hi:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -28,6 +28,8 @@ hr:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Posjetite:'
   components:
     figure:
@@ -541,7 +543,6 @@ hr:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -552,6 +553,7 @@ hr:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -28,6 +28,8 @@ hu:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Látogassa meg:'
   components:
     figure:
@@ -464,7 +466,6 @@ hu:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ hu:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -28,6 +28,8 @@ hy:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: Այցելել՝
   components:
     figure:
@@ -464,7 +466,6 @@ hy:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ hy:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -28,6 +28,8 @@ id:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Kunjungan:'
   components:
     figure:
@@ -387,7 +389,6 @@ id:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -398,6 +399,7 @@ id:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -28,6 +28,8 @@ is:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Heimsæktu:'
   components:
     figure:
@@ -464,7 +466,6 @@ is:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ is:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -28,6 +28,8 @@ it:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Visita:'
   components:
     figure:
@@ -464,7 +466,6 @@ it:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ it:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -28,6 +28,8 @@ ja:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 訪問：
   components:
     figure:
@@ -387,7 +389,6 @@ ja:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -398,6 +399,7 @@ ja:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -28,6 +28,8 @@ ka:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'ეწვიეთ:'
   components:
     figure:
@@ -464,7 +466,6 @@ ka:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ ka:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -28,6 +28,8 @@ kk:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Мұнда өтіңіз:'
   components:
     figure:
@@ -464,7 +466,6 @@ kk:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ kk:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -28,6 +28,8 @@ ko:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: '방문:'
   components:
     figure:
@@ -387,7 +389,6 @@ ko:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -398,6 +399,7 @@ ko:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -28,6 +28,8 @@ lt:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Apsilankykite:'
   components:
     figure:
@@ -541,7 +543,6 @@ lt:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -552,6 +553,7 @@ lt:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -28,6 +28,8 @@ lv:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Apmeklējiet:'
   components:
     figure:
@@ -464,7 +466,6 @@ lv:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ lv:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -28,6 +28,8 @@ ms:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Lawati:'
   components:
     figure:
@@ -387,7 +389,6 @@ ms:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -398,6 +399,7 @@ ms:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -28,6 +28,8 @@ mt:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Żur:'
   components:
     figure:
@@ -618,7 +620,6 @@ mt:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -629,6 +630,7 @@ mt:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -28,6 +28,8 @@ ne:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'भ्रमण:'
   components:
     figure:
@@ -464,7 +466,6 @@ ne:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ ne:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -28,6 +28,8 @@ nl:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Bezoek:'
   components:
     figure:
@@ -464,7 +466,6 @@ nl:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ nl:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -28,6 +28,8 @@
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Besøk:'
   components:
     figure:
@@ -464,7 +466,6 @@
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -28,6 +28,8 @@ pa-pk:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'ویکھو:'
   components:
     figure:
@@ -464,7 +466,6 @@ pa-pk:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ pa-pk:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -28,6 +28,8 @@ pa:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'ਮੁਲਾਕਾਤ:'
   components:
     figure:
@@ -464,7 +466,6 @@ pa:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ pa:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -28,6 +28,8 @@ pl:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Odwiedź:'
   components:
     figure:
@@ -618,7 +620,6 @@ pl:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -629,6 +630,7 @@ pl:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -28,6 +28,8 @@ ps:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'لیدنه:'
   components:
     figure:
@@ -464,7 +466,6 @@ ps:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ ps:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -28,6 +28,8 @@ pt:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Visite:'
   components:
     figure:
@@ -464,7 +466,6 @@ pt:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ pt:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -28,6 +28,8 @@ ro:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Accesați:'
   components:
     figure:
@@ -541,7 +543,6 @@ ro:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -552,6 +553,7 @@ ro:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -28,6 +28,8 @@ ru:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Посетите:'
   components:
     figure:
@@ -618,7 +620,6 @@ ru:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -629,6 +630,7 @@ ru:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -28,6 +28,8 @@ si:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'පිවිසෙන්න:'
   components:
     figure:
@@ -464,7 +466,6 @@ si:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ si:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -28,6 +28,8 @@ sk:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Navštívte:'
   components:
     figure:
@@ -541,7 +543,6 @@ sk:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -552,6 +553,7 @@ sk:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -28,6 +28,8 @@ sl:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Obiščite:'
   components:
     figure:
@@ -618,7 +620,6 @@ sl:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -629,6 +630,7 @@ sl:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -28,6 +28,8 @@ so:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Booqo:'
   components:
     figure:
@@ -464,7 +466,6 @@ so:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ so:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -28,6 +28,8 @@ sq:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Vizitoni:'
   components:
     figure:
@@ -464,7 +466,6 @@ sq:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ sq:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -28,6 +28,8 @@ sr:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Posetite:'
   components:
     figure:
@@ -541,7 +543,6 @@ sr:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -552,6 +553,7 @@ sr:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -28,6 +28,8 @@ sv:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Besök:'
   components:
     figure:
@@ -464,7 +466,6 @@ sv:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ sv:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -28,6 +28,8 @@ sw:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Tembelea:'
   components:
     figure:
@@ -464,7 +466,6 @@ sw:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ sw:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -28,6 +28,8 @@ ta:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'வருகை:'
   components:
     figure:
@@ -464,7 +466,6 @@ ta:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ ta:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -28,6 +28,8 @@ th:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'เยี่ยมชม:'
   components:
     figure:
@@ -387,7 +389,6 @@ th:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -398,6 +399,7 @@ th:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -28,6 +28,8 @@ tk:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Serediň:'
   components:
     figure:
@@ -464,7 +466,6 @@ tk:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ tk:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -28,6 +28,8 @@ tr:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Ziyaret et:'
   components:
     figure:
@@ -464,7 +466,6 @@ tr:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ tr:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -28,6 +28,8 @@ uk:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Відвідайте:'
   components:
     figure:
@@ -618,7 +620,6 @@ uk:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -629,6 +630,7 @@ uk:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -28,6 +28,8 @@ ur:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'ملاحظہ کریں:'
   components:
     figure:
@@ -464,7 +466,6 @@ ur:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ ur:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -28,6 +28,8 @@ uz:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Ташриф буюринг:'
   components:
     figure:
@@ -464,7 +466,6 @@ uz:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ uz:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -28,6 +28,8 @@ vi:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 'Truy cập:'
   components:
     figure:
@@ -387,7 +389,6 @@ vi:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -398,6 +399,7 @@ vi:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -28,6 +28,8 @@ yi:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit:
   components:
     figure:
@@ -464,7 +466,6 @@ yi:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -475,6 +476,7 @@ yi:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -28,6 +28,8 @@ zh-hk:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 訪問：
   components:
     figure:
@@ -387,7 +389,6 @@ zh-hk:
     zh-hk: 中文
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -398,6 +399,7 @@ zh-hk:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -28,6 +28,8 @@ zh-tw:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 探訪：
   components:
     figure:
@@ -387,7 +389,6 @@ zh-tw:
     zh-hk:
     zh-tw: 繁體中文
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -398,6 +399,7 @@ zh-tw:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -28,6 +28,8 @@ zh:
     ways_to_respond:
     write_to:
   common:
+    email_and_print_link:
+    print_link:
     visit: 访问：
   components:
     figure:
@@ -387,7 +389,6 @@ zh:
     zh-hk:
     zh-tw:
   manuals:
-    summary_title:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:
     contents_title:
@@ -398,6 +399,7 @@ zh:
     previous_page:
     search_this_manual:
     see_all_updates:
+    summary_title:
     title:
     updated:
     updates_amendments:


### PR DESCRIPTION
## What

Add a hidden H2 above the email signup and or print link on many page types. 

## Why

To fix an accessibility fail

[Trello](https://trello.com/c/CTIcMi1r/2623-section-under-main-content-without-heading-m)

### Review app links:
Guidance (without an email signup button) https://government-frontend-pr-3261.herokuapp.com/guidance/dvsa-email-alerts
Guides (schema: publication): [Who can get a Blue Badge](https://government-frontend-pr-3261.herokuapp.com//government/publications/blue-badge-can-i-get-one)
Detailed guides: [Online immigration status (eVisa)](https://government-frontend-pr-3261.herokuapp.com/guidance/online-immigration-status-evisa)
Consultations: [Smarter regulation: deregulating the commercial agents regulations](https://government-frontend-pr-3261.herokuapp.com/government/consultations/smarter-regulation-deregulating-the-commercial-agents-regulations)
Call for Evidence: [CyberFirst programme: call for views](https://government-frontend-pr-3261.herokuapp.com/government/calls-for-evidence/call-for-views-on-the-cyberfirst-programme)