### PR TITLE
Use govuk-frontend no print style instead of dont-print class

### DIFF
--- a/app/views/components/_back_to_top.html.erb
+++ b/app/views/components/_back_to_top.html.erb
@@ -2,7 +2,7 @@
 <%
   text ||= t('content_item.contents', default: "Contents")
 %>
-<a class="govuk-link app-c-back-to-top dont-print"
+<a class="govuk-link app-c-back-to-top govuk-!-display-none-print"
     href="<%= href %>">
     <svg class="app-c-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17" aria-hidden="true" focusable="false">
       <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"/>

--- a/app/views/content_items/call_for_evidence.html.erb
+++ b/app/views/content_items/call_for_evidence.html.erb
@@ -164,7 +164,7 @@
     <% end %>
 
     <div class="content-bottom-margin">
-      <div class="dont-print responsive-bottom-margin">
+      <div class="govuk-!-display-none-print responsive-bottom-margin">
         <%= render 'govuk_publishing_components/components/share_links',
           links: @content_item.share_links,
           track_as_sharing: true,

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -192,7 +192,7 @@
     <% end %>
 
     <div class="content-bottom-margin">
-      <div class="dont-print responsive-bottom-margin">
+      <div class="govuk-!-display-none-print responsive-bottom-margin">
         <%= render 'govuk_publishing_components/components/share_links',
           links: @content_item.share_links,
           track_as_sharing: true,

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -36,7 +36,7 @@
         <% end %>
       </div>
 
-      <div class="dont-print responsive-bottom-margin">
+      <div class="govuk-!-display-none-print responsive-bottom-margin">
         <%= render 'govuk_publishing_components/components/share_links',
           links: @content_item.share_links,
           track_as_sharing: true,


### PR DESCRIPTION
## What / Why
Use `govuk-!-display-none-print` print style instead of `dont-print` class
https://trello.com/c/PnEVIZtq/192-review-and-fix-application-component-print-styles


## Tested on
- Consultations: http://127.0.0.1:3090/government/calls-for-evidence/generative-artificial-intelligence-in-education-call-for-evidence - the share links component does not show on print, as expected
- Calls for evidence: https://www.gov.uk/government/consultations/ices-area-7d-and-lyme-bay-king-scallop-dredge-fishery-closure-proposals-summer-2024 - the share links component does not show on print, as expected
- News articles e.g.: http://127.0.0.1:3090/government/news/secretary-of-state-meets-first-and-deputy-first-ministers - the share links component does not show on print, as expected
- "back top to link": http://127.0.0.1:3090/guidance/cost-of-living-payment - it's the "Contents" link that is hidden when printed