### PR TITLE
HMRC Manuals: Do not show the title of a section group if the group is empty 

### DIFF
--- a/app/views/content_items/hmrc_manual.html.erb
+++ b/app/views/content_items/hmrc_manual.html.erb
@@ -11,6 +11,7 @@
 
 <%= render "content_items/manuals/manual_layout" do %>
   <% @content_item.section_groups.each do |group| %>
+    <% next unless group["child_sections"].present? %>
     <div class="subsection-collection">
       <%= render "content_items/manuals/hmrc_sections", group: group %>
     </div>

--- a/test/integration/hmrc_manual_test.rb
+++ b/test/integration/hmrc_manual_test.rb
@@ -89,4 +89,32 @@ class HmrcManualTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test "does not render section groups with no sections inside" do
+    content_item_override = {
+      "details" => {
+        "child_section_groups" => [
+          {
+            title: "Some section group title 1",
+            child_sections: [],
+          },
+          {
+            title: "Some section group title 2",
+            child_sections: [
+              {
+                "section_id" => "VATGPB1000",
+                "title" => "Introduction: contents",
+                "description" => "",
+                "base_path" => "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
+              },
+            ],
+          },
+        ],
+      },
+    }
+
+    setup_and_visit_content_item("vat-government-public-bodies", content_item_override)
+    assert page.has_no_text?("Some section group title 1")
+    assert page.has_text?("Some section group title 2")
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

In the [content item](https://www.gov.uk/api/content/hmrc-internal-manuals/capital-gains-manual "‌")  for this page:[https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual](https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual "smartCard-inline") the second `child_section_group` contains a title field, but an empty `child_section_group` array. Which renders a random looking “Updates” heading underneath the list of sections.

## Why

It’s confusing, and probably an accessibility fail.

[Trello ticket](https://trello.com/c/GZmEDmEx/2681-hmrc-manuals-do-not-show-the-title-of-a-section-group-if-its-empty-s-m)