### PR TITLE
Fix Sass compilation warnings

### DIFF
--- a/app/assets/stylesheets/components/_contents-list-with-body.scss
+++ b/app/assets/stylesheets/components/_contents-list-with-body.scss
@@ -40,7 +40,7 @@
   .app-c-back-to-top {
     margin-bottom: 0;
     padding: govuk-spacing(3);
-    width: percentage(2 / 3);
+    width: 66%;
 
     @include govuk-media-query($from: tablet) {
       padding: govuk-spacing(4);

--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -1,6 +1,6 @@
 .worldwide-organisation-header {
-  margin-top: $govuk-gutter-half;
-  margin-bottom: $govuk-gutter-half;
+  margin-top: govuk-spacing(3);
+  margin-bottom: govuk-spacing(3);
 }
 
 .js-enabled {
@@ -20,12 +20,12 @@
 
 .worldwide-organisation-header__logo {
   @include govuk-media-query($from: tablet) {
-    margin-top: $govuk-gutter-half;
+    margin-top: govuk-spacing(3);
   }
 }
 
 .worldwide-organisation-header__metadata {
-  margin-top: $govuk-gutter / 3;
+  margin-top: govuk-spacing(2);
 
   dl {
     @include govuk-text-colour;


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Remove Sass compilation warnings, specifically:

- remove percentage calculation in contents-list-with-body and replace with a simpler value (it's for the contents list element, which only ever says 'Contents' so limiting it to two thirds of the page seems odd anyway)
- replace use of govuk-gutter in worldwide organisation pages (e.g. https://www.gov.uk/world/organisations/british-embassy-berlin) for the govuk-frontend spacing scale, which fits better and doesn't require any calculations

## Why
Warnings are becoming confusing and need fixing.

## Visual changes
None.

Trello card: https://trello.com/c/gW2NW1sB/239-fix-sass-compilation-warnings
