### PR TITLE
Do not attempt to show siblings if there aren't any

### DIFF
--- a/app/presenters/hmrc_manual_section_presenter.rb
+++ b/app/presenters/hmrc_manual_section_presenter.rb
@@ -30,6 +30,8 @@ class HmrcManualSectionPresenter < ContentItemPresenter
   end
 
   def previous_and_next_links
+    return unless siblings
+
     siblings = {}
 
     if previous_sibling
@@ -67,6 +69,8 @@ private
     return unless parent_for_section
 
     child_section_groups = parent_for_section.dig("details", "child_section_groups")
+
+    return unless child_section_groups
 
     sibling_child_sections = child_section_groups.map do |group|
       included_section = group["child_sections"].find { |section| section["section_id"].include?(current_section_id) }

--- a/app/presenters/hmrc_manual_section_presenter.rb
+++ b/app/presenters/hmrc_manual_section_presenter.rb
@@ -32,23 +32,23 @@ class HmrcManualSectionPresenter < ContentItemPresenter
   def previous_and_next_links
     return unless siblings
 
-    siblings = {}
+    section_siblings = {}
 
     if previous_sibling
-      siblings[:previous_page] = {
+      section_siblings[:previous_page] = {
         title: I18n.t("manuals.previous_page"),
         url: previous_sibling["base_path"],
       }
     end
 
     if next_sibling
-      siblings[:next_page] = {
+      section_siblings[:next_page] = {
         title: I18n.t("manuals.next_page"),
         url: next_sibling["base_path"],
       }
     end
 
-    siblings
+    section_siblings
   end
 
 private

--- a/test/presenters/hmrc_manual_section_presenter_test.rb
+++ b/test/presenters/hmrc_manual_section_presenter_test.rb
@@ -146,6 +146,19 @@ class HmrcManualSectionPresenterTest
       assert_equal expected_previous_link, presented_manual_section.previous_and_next_links
     end
 
+    test "presents no previous or next links if there is no previous or next section" do
+      manual_base_path = schema_item("vatgpb2000")["details"]["manual"]["base_path"]
+      manual = schema_item("vat-government-public-bodies", "hmrc_manual")
+
+      manual["details"]["child_section_groups"] = []
+
+      stub_content_store_has_item(manual_base_path, manual.to_json)
+
+      expected_links = {}
+
+      assert_equal expected_links, presented_manual_section.previous_and_next_links
+    end
+
     def presented_manual_section(overrides = {})
       presented_item("vatgpb2000", overrides)
     end


### PR DESCRIPTION
When a parent manual has been withdrawn and redirected, we don't get the value for `child_section_groups` as the redirect content item doesn't contain this value.

Therefore not showing any siblings items at all when this is the case, as we can't be sure what the correct parent actually is for this manual section.

This also resolves an issue where there are no breadcrumbs given for an item.

[Trello card](https://trello.com/c/LXBvfN2L)