### PR TITLE
Use type=module for application.js

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (41.1.1)
+    govuk_publishing_components (42.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -9,7 +9,7 @@
 .app-c-published-dates__toggle {
   display: none;
 
-  .js-enabled & {
+  .govuk-frontend-supported & {
     display: inline-block;
   }
 }
@@ -41,7 +41,7 @@
   border-top: 1px solid $govuk-border-colour;
 }
 
-.js-enabled .app-c-published-dates .js-hidden {
+.govuk-frontend-supported .app-c-published-dates .js-hidden {
   display: none;
   visibility: hidden;
 }

--- a/app/assets/stylesheets/helpers/_sticky-element-container.scss
+++ b/app/assets/stylesheets/helpers/_sticky-element-container.scss
@@ -1,4 +1,4 @@
-.js-enabled .sticky-element {
+.govuk-frontend-supported .sticky-element {
   position: absolute;
   bottom: 0;
 

--- a/app/assets/stylesheets/views/_service_manual_guide.scss
+++ b/app/assets/stylesheets/views/_service_manual_guide.scss
@@ -12,7 +12,7 @@
 @import "../modules/sticky";
 @import "../modules/typography";
 
-.js-enabled {
+.govuk-frontend-supported {
   .app-change-history__past {
     &.govuk-list {
       // stylelint-disable-next-line max-nesting-depth

--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -3,7 +3,7 @@
   margin-bottom: govuk-spacing(3);
 }
 
-.js-enabled {
+.govuk-frontend-supported {
   .worldwide-organisation-header {
     .show-other-content {
       all: inherit;

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -9,7 +9,7 @@
 </head>
 <body>
   <div id="wrapper">
-    <main class="govspeak">
+    <main class="govspeak" id="content">
       <%= render 'govuk_publishing_components/components/title', title: 'government-frontend' %>
 
       <% html = capture do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
   <% end %>
 
   <%= stylesheet_link_tag "application", :media => "all", integrity: false %>
-  <%= javascript_include_tag "application", integrity: false %>
+  <%= javascript_include_tag "application", integrity: false, type: "module" %>
   <%= javascript_include_tag 'es6-components', type: "module" %>
   <%= csrf_meta_tags %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item.content_item %>

--- a/app/views/shared/_webchat.html.erb
+++ b/app/views/shared/_webchat.html.erb
@@ -34,4 +34,4 @@
   </span>
 </p>
 <% # This is inline in the source however slimmer will optimize this. %>
-<%= javascript_include_tag "webchat", integrity: false %>
+<%= javascript_include_tag "webchat", integrity: false, type: "module" %>


### PR DESCRIPTION
## What / Why
- Use type=module for this application's JS file
- To coincide with https://github.com/alphagov/govuk_publishing_components/pull/4111
- Has [DO NOT MERGE] as we want the above PR live on `static` first before this is merged.
- We will combine `es6-components.js` again as a separate task unless you disagree with this
- To accurately test this you will need to use local static that is using a local version the `govuk_publishing_components` branch linked above. If you test without this, this app's `application.js` seems to crash.
- Trello card: https://trello.com/c/Hoa45SMD/141-turn-off-javascript-in-legacy-browsers