### PR TITLE
Make contact_for_office tolerant of missing data

### DIFF
--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -134,15 +134,17 @@ private
   end
 
   def contact_for_office(office_content_id)
-    contact_mapping = content_item.dig("details", "office_contact_associations").select { |office_contact_association|
-      office_contact_association["office_content_id"] == office_content_id
-    }.first
+    contact_mapping = content_item.to_hash
+      .fetch("details")
+      .fetch("office_contact_associations", [])
+      .find { |office_contact_association| office_contact_association["office_content_id"] == office_content_id }
 
-    return unless contact_mapping
+    return if contact_mapping.nil?
 
-    content_item.dig("links", "contacts").select { |contact|
-      contact["content_id"] == contact_mapping["contact_content_id"]
-    }.first
+    content_item.to_hash
+      .fetch("links")
+      .fetch("contacts", [])
+      .find { |contact| contact["content_id"] == contact_mapping["contact_content_id"] }
   end
 
   def presented_title_for_roles(roles)

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -112,6 +112,14 @@ class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "does not render the main office contact if the contact link is missing" do
+    setup_and_visit_content_item("worldwide_organisation") do |item|
+      item["links"].delete("contacts")
+    end
+
+    assert_not page.has_text?("Contact us")
+  end
+
   test "renders the main office contact without a link to the office page when the office has no access details" do
     setup_and_visit_content_item(
       "worldwide_organisation",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -161,6 +161,7 @@ class ActionDispatch::IntegrationTest
   def setup_and_visit_content_item(name, overrides = {}, parameter_string = "")
     @content_item = get_content_example(name).tap do |item|
       content_item = item.deep_merge(overrides)
+      yield content_item if block_given?
       setup_and_visit_content_item_by_example(content_item, parameter_string)
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ require "minitest/reporters"
 
 Dir[Rails.root.join("test/support/*.rb")].sort.each { |f| require f }
 
-Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new unless ENV["RM_INFO"]
 
 GovukTest.configure
 


### PR DESCRIPTION
**NOTE: not sure this is the right thing to do - we should probably fix the data in content-store rather than patching the frontend to be tolerant of bad data. Raising this as a suggestion.**

Worldwide organisation content items should have both office_contact_associations and a link to contacts.

If they don't have both, we can either error (what the code used to do), or just skip the contact section (what this PR does).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

