### PR TITLE
Remove org sort by title from html publications

### DIFF
--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -33,8 +33,7 @@ class HtmlPublicationPresenter < ContentItemPresenter
   end
 
   def organisations
-    orgs = content_item["links"]["organisations"] || []
-    orgs.sort_by { |o| o["title"] }
+    content_item["links"]["organisations"] || []
   end
 
   def organisation_logo(organisation)


### PR DESCRIPTION
We're currently sorting organisations by their title for the header, but this erases information from the content item, namely the ordering of organisations. Until now that hasn't been useful information (because it was the database natural ordering of the organisations involved). But now it's the lead organisations followed by the supporting organisations, so we shouldn't resort. This will bring the order of organisations in HTML attachments into line with the order presented in the item they're attached to.

Before Merging:

- [x] Ensure that the [republish task](https://docs.publishing.service.gov.uk/manual/republishing-content.html#to-republish-all-documents-of-a-specific-type) has been run for: Consultations, and Calls for Evidence in production.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/7d3ERApJ/23-lead-organisation-logos-in-html-publications
