### PR TITLE
Upgrade heroku dyno plan for review apps from default (eco) to basic

### DIFF
--- a/app.json
+++ b/app.json
@@ -43,5 +43,11 @@
       "url": "https://github.com/heroku/heroku-buildpack-ruby"
     }
   ],
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "basic"
+    }
+  },
   "addons": []
 }


### PR DESCRIPTION
Upgrade heroku dyno plan for review apps from default (eco) to basic

https://devcenter.heroku.com/articles/app-json-schema#formation

