### PR TITLE
Minor bug fixes to HMRC manual layout and breadcrumbs 

### DIFF
--- a/app/views/content_items/manuals/_manual_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_layout.html.erb
@@ -5,27 +5,28 @@
   } %>
   <div id="manuals-frontend" class="manuals-frontend-body">
 
-  <%= machine_readable_metadata(schema: :article) %>
+    <%= machine_readable_metadata(schema: :article) %>
 
-  <div class="manual-body">
-    <% if @content_item.description.present? %>
-      <%= render "govuk_publishing_components/components/lead_paragraph", {
-        text: @content_item.description
-      } %>
-    <% end %>
-    <% if @content_item.body.present? %>
-      <%= render "govuk_publishing_components/components/govspeak", {} do %>
-        <%= raw(@content_item.body) %>
+    <div class="manual-body">
+      <% if @content_item.description.present? %>
+        <%= render "govuk_publishing_components/components/lead_paragraph", {
+          text: @content_item.description
+        } %>
       <% end %>
-    <% end %>
+      <% if @content_item.body.present? %>
+        <%= render "govuk_publishing_components/components/govspeak", {} do %>
+          <%= raw(@content_item.body) %>
+        <% end %>
+      <% end %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("manuals.contents_title"),
-      margin_bottom: 4
-    } %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("manuals.contents_title"),
+        margin_bottom: 4
+      } %>
 
-    <%= yield %>
+      <%= yield %>
 
-    <%= render 'govuk_publishing_components/components/print_link' %>
+      <%= render 'govuk_publishing_components/components/print_link' %>
+    </div>
   </div>
 <% end %>

--- a/app/views/content_items/manuals/_manual_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_layout.html.erb
@@ -1,14 +1,14 @@
 <% content_for :main do %>
-  <%= render "govuk_publishing_components/components/heading", {
-    text: t("manuals.summary_title"),
-    margin_bottom: 4
-  } %>
   <div id="manuals-frontend" class="manuals-frontend-body">
 
     <%= machine_readable_metadata(schema: :article) %>
 
     <div class="manual-body">
       <% if @content_item.description.present? %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t("manuals.summary_title"),
+          margin_bottom: 4
+        } %>
         <%= render "govuk_publishing_components/components/lead_paragraph", {
           text: @content_item.description
         } %>

--- a/app/views/content_items/manuals/_manual_section_layout.html.erb
+++ b/app/views/content_items/manuals/_manual_section_layout.html.erb
@@ -1,10 +1,17 @@
 <% show_contents ||= false %>
 
 <% content_for :main do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    text: t("manuals.breadcrumb_contents"),
-    href: @content_item.base_path
-  } %>
+  <% if @content_item.breadcrumbs.any? %>
+    <%= render "govuk_publishing_components/components/breadcrumbs", {
+           border: "bottom",
+           breadcrumbs: @content_item.breadcrumbs,
+           collapse_on_mobile: false } %>
+  <% else %>
+    <%= render "govuk_publishing_components/components/back_link", {
+      text: t("manuals.breadcrumb_contents"),
+      href: @content_item.base_path
+    } %>
+  <% end %>
   <div id="manuals-frontend" class="manuals-frontend-body">
     <% if show_contents %>
       <%= render "govuk_publishing_components/components/contents_list", {

--- a/test/integration/hmrc_manual_section_test.rb
+++ b/test/integration/hmrc_manual_section_test.rb
@@ -42,10 +42,16 @@ class HmrcManualSectionTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders back link" do
+  test "renders back link if breadcrumbs are not set" do
     setup_and_visit_manual_section
 
     assert page.has_link?(I18n.t("manuals.breadcrumb_contents"), href: "/hmrc-internal-manuals/vat-government-and-public-bodies")
+  end
+
+  test "renders breadcrumbs if they are set in the content item" do
+    setup_and_visit_manual_section_with_breadcrumbs
+
+    assert page.has_link?("DMBM510000", href: "/hmrc-internal-manuals/debt-management-and-banking/dmbm510000")
   end
 
   test "renders section group" do
@@ -90,6 +96,22 @@ class HmrcManualSectionTest < ActionDispatch::IntegrationTest
     stub_content_store_has_item(manual_base_path, @manual.to_json)
 
     stub_content_store_has_item(@content_item["base_path"], @content_item.to_json)
+    visit_with_cachebust((@content_item["base_path"]).to_s)
+  end
+
+  def setup_and_visit_manual_section_with_breadcrumbs(content_item = get_content_example("vatgpb2000"))
+    @manual = get_content_example_by_schema_and_name("hmrc_manual", "vat-government-public-bodies")
+    @content_item = content_item
+    first_crumb = { "base_path" => "/hmrc-internal-manuals/debt-management-and-banking/dmbm510000", "section_id" => "DMBM510000" }
+    last_crumb = { "base_path" => "/hmrc-internal-manuals/vat-government-public-bodiesg/dmbm510100", "section_id" => "DMBM510100" }
+
+    @content_item["details"]["breadcrumbs"].push(first_crumb, last_crumb)
+    manual_base_path = @content_item["details"]["manual"]["base_path"]
+
+    stub_content_store_has_item(manual_base_path, @manual.to_json)
+
+    stub_content_store_has_item(@content_item["base_path"], @content_item.to_json)
+    stub_content_store_has_item(@content_item["details"]["breadcrumbs"].last["base_path"], @content_item.to_json)
     visit_with_cachebust((@content_item["base_path"]).to_s)
   end
 end

--- a/test/integration/hmrc_manual_test.rb
+++ b/test/integration/hmrc_manual_test.rb
@@ -42,7 +42,7 @@ class HmrcManualTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders about title" do
+  test "renders 'Summary' title if description field is present" do
     setup_and_visit_content_item("vat-government-public-bodies")
 
     assert page.has_text?(I18n.t("manuals.summary_title"))


### PR DESCRIPTION
https://trello.com/c/DwMxfbuf/1145-breadcrumb-issues-in-hmrc-internal-manuals

#### 1. Don't display the "Summary" heading if there's no content below it.

Eg on https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual 

|Before|After|
|-|-|
|<img width="889" alt="Screenshot 2024-07-29 at 22 58 32" src="https://github.com/user-attachments/assets/cc455ac9-ae07-479d-93ca-853af0a82f8f">|<img width="1021" alt="Screenshot 2024-07-29 at 22 57 53" src="https://github.com/user-attachments/assets/6ff2281b-6d55-45ce-abfd-b81dfc814e20">|

Here's a page that has a populated description [on live](https://www.gov.uk/hmrc-internal-manuals/debt-management-and-banking) and [on the review app](https://government-frontend-pr-3284.herokuapp.com//hmrc-internal-manuals/debt-management-and-banking) to show that there's no visible change.

#### 2. If breadcrumbs are present, display them

Eg debt management and banking manual
- [missing on live](https://www.gov.uk/hmrc-internal-manuals/debt-management-and-banking/dmbm510110)
- [present on review app](https://government-frontend-pr-3284.herokuapp.com/hmrc-internal-manuals/debt-management-and-banking/dmbm510110)

Eg capital gains manual
- [missing on live](https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual/cg40432)
- [present on review app]( https://government-frontend-pr-3284.herokuapp.com/hmrc-internal-manuals/capital-gains-manual/cg40432)

|Before|After|
|-|-|
|<img width="901" alt="Screenshot 2024-07-29 at 23 00 16" src="https://github.com/user-attachments/assets/da7c4663-bf62-4732-b7ef-9eef6cc6e72d">|<img width="992" alt="Screenshot 2024-07-29 at 23 01 51" src="https://github.com/user-attachments/assets/0f5db410-f0a7-4656-898f-8da522b595f9">|


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
