### PR TITLE
Fix bugs in historical mode banner translations

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -33,14 +33,14 @@ ja:
     visit: 訪問：
   components:
     figure:
-      image_credit: 画像著作権：％{credit}
+      image_credit: 画像著作権：%{credit}
     print_link:
       text:
     published_dates:
       hidden_heading:
       hide_all_updates: すべての更新を非表示
       last_updated: 最終更新日：%{date}
-      published: 公開日：％{date}
+      published: 公開日：%{date}
       see_all_updates: すべての更新を見る
       show_all_updates: すべての更新を表示
     share_links:
@@ -48,7 +48,7 @@ ja:
   consultation:
     analysing_feedback:
     and: および
-    another_website_html: この審議％{closed}は、<ahref = "％{url}">別のウェブサイト</a>で行われました
+    another_website_html: この審議%{closed}は、<ahref = "%{url}">別のウェブサイト</a>で行われました
     at: 時間：
     closes: 終了時間：
     closes_at: 審議終了時間：
@@ -244,7 +244,7 @@ ja:
       written_statement:
         other: 議会への書面による声明
   corporate_information_page:
-    about_our_services_html: "％{link} をご覧ください。"
+    about_our_services_html: "%{link} をご覧ください。"
     corporate_information: 各種情報
     personal_information_charter_html: 個人情報の取り扱いについては %{link} をご覧下さい。
     publication_scheme_html: 情報公開の種類については %{link} をご覧下さい。
@@ -259,7 +259,7 @@ ja:
     alt_text: 国防省の紋章
     field_of_operation: 運用分野
     none_added: この活動分野での死亡通知はまだ追加されていません。
-    operations_in: "％{location} での操作"
+    operations_in: "%{location} での操作"
   field_of_operation:
     context:
     title:
@@ -315,7 +315,7 @@ ja:
     skip_contents:
   html_publication:
     print_meta_data:
-      available_at: この出版物は％{url}で入手できます
+      available_at: この出版物は%{url}で入手できます
       copyright: "© Crown copyright %{year}"
       isbn: ISBN：
       licence_html: 本書は、特に明記されていない限り、Open Government License v 3.0の条件に基づいてライセンスされています。このライセンスを確認するには、<a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a> にアクセスするか、Information Policy Team、The National Archives、Kew、London TW 9 4 DU、またはEメールにて <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>までお問い合わせください。
@@ -424,7 +424,7 @@ ja:
       option: オプションを択してください
       title: オプションを選択していません
   shared:
-    historically_political: 本件は、％{government}で公開されました
+    historically_political: 本件は、%{government}で公開されました
     webchat:
       available: アドバイザーのチャットがご利用いただけます。
       busy: 現在、すべてのウェブチャットアドバイザーはビジーです。
@@ -467,11 +467,11 @@ ja:
     policies: 方針
   worldwide_organisation:
     corporate_information:
-      about_our_services_html: "％{link} をご覧ください。"
-      personal_information_charter_html: "％{link} で、お客様の個人情報の取り扱いについて説明しています。"
-      publication_scheme_html: "％{link} で、定期的に公開している情報の種類についてご覧ください。"
-      social_media_use_html: "％{link} に関する方針をご覧ください。"
-      welsh_language_scheme_html: "％{link} への取り組みについてご覧ください。"
+      about_our_services_html: "%{link} をご覧ください。"
+      personal_information_charter_html: "%{link} で、お客様の個人情報の取り扱いについて説明しています。"
+      publication_scheme_html: "%{link} で、定期的に公開している情報の種類についてご覧ください。"
+      social_media_use_html: "%{link} に関する方針をご覧ください。"
+      welsh_language_scheme_html: "%{link} への取り組みについてご覧ください。"
     find_out_more: プロフィール全体とすべての連絡先の詳細を見る
     headings:
       contact_us: お問い合わせ

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -33,14 +33,14 @@ pa-pk:
     visit: 'ویکھو:'
   components:
     figure:
-      image_credit: 'امیج کریڈٹ: {credit} %'
+      image_credit: 'امیج کریڈٹ: %{credit}'
     print_link:
       text:
     published_dates:
       hidden_heading:
       hide_all_updates: سارے تازہ ترین حالات نوں لُکا لوؤ
-      last_updated: اخری وار تازہ ترین بنایا {date} %
-      published: شائع ہویا {date} %
+      last_updated: اخری وار تازہ ترین بنایا %{date}
+      published: شائع ہویا %{date}
       see_all_updates: ساری تازہ ترین صورتِ حال
       show_all_updates: ساری تازہ ترین صورتِ حال وکھاؤ
     share_links:
@@ -48,7 +48,7 @@ pa-pk:
   consultation:
     analysing_feedback:
     and: ہور
-    another_website_html: ایہ مشورہ  {closed} %ایندے تے وقوعہ ہویا <a href="%{url}">دُوسری ویب سائٹ</a>
+    another_website_html: ایہ مشورہ  %{closed}ایندے تے وقوعہ ہویا <a href="%{url}">دُوسری ویب سائٹ</a>
     at: ایندے تے
     closes: ایہ ایندے تے بند ہوندا اے
     closes_at: ایہ مشاورت ایندے تے بند ہوندی اے
@@ -321,12 +321,12 @@ pa-pk:
         one: قومی مجلس دے سامنے تحریری بیان
         other: قومی مجلس دے سامنے تحریری بیانات
   corporate_information_page:
-    about_our_services_html: اینوں لبھو {link}%.
+    about_our_services_html: اینوں لبھو %{link}.
     corporate_information: کاروبار دی معلومات
-    personal_information_charter_html: ساڈا {link}% ایہ وضاحت کر دا اے کہ اسی ذاتی معلومات نال کی سلوک کرنے آں۔
-    publication_scheme_html: ایس تے ایہ پڑھو کہ اسی رضاکارانہ طور تے کیس طراں دی معلومات شائع کرنے آں {link}%.
-    social_media_use_html: ایندے تے ساڈی حکمتِ عملی بارے پڑھو {link}%.
-    welsh_language_scheme_html: ساڈی وابستگی دے بارے جانو {link}%.
+    personal_information_charter_html: ساڈا %{link} ایہ وضاحت کر دا اے کہ اسی ذاتی معلومات نال کی سلوک کرنے آں۔
+    publication_scheme_html: ایس تے ایہ پڑھو کہ اسی رضاکارانہ طور تے کیس طراں دی معلومات شائع کرنے آں %{link}.
+    social_media_use_html: ایندے تے ساڈی حکمتِ عملی بارے پڑھو %{link}.
+    welsh_language_scheme_html: ساڈی وابستگی دے بارے جانو %{link}.
   email:
     already_subscribed_title:
     description:
@@ -336,7 +336,7 @@ pa-pk:
     alt_text: وزارتِ دفاع کریسٹ
     field_of_operation: عمل کرن دا حلقہ
     none_added: موت دی کوئی وی اطلاع شامل نئیں کیتی گئی ایس تھاں تے کم کرن لئی
-    operations_in: ایندے بارے عمل {location}%
+    operations_in: ایندے بارے عمل %{location}
   field_of_operation:
     context:
     title:
@@ -392,7 +392,7 @@ pa-pk:
     skip_contents:
   html_publication:
     print_meta_data:
-      available_at: ایہ اشاعت ایتھے موجود اے {url}%
+      available_at: ایہ اشاعت ایتھے موجود اے %{url}
       copyright: "%{year}© کراؤن کاپی رائٹ"
       isbn: 'ISBN:'
       licence_html: 'ایہ اشاعت نوں حکومت دے لائسنس  وی 3۔0 دی شرائط دے تحت لائسنس ملیا اے سوائے اُس تھاں جتھے ایس توں علاوہ ہور کُج لکھیا اے۔ ایس لائسنس نوں ویکھن لئی ایہ ملاحظہ کرو۔ , visit <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">nationalarchives.gov.uk/doc/open-government-licence/version/3</a> or write to the Information Policy Team, The National Archives, Kew, London TW9 4DU, or email: <a href="mailto:psi@nationalarchives.gov.uk">psi@nationalarchives.gov.uk</a>.'
@@ -502,7 +502,7 @@ pa-pk:
       option: برائے مہربانی اک نوں چُنو
       title: تُسی کسے دا چناؤ نئیں کیتا
   shared:
-    historically_political: اینوں ایس دے تحت شائع کیتا گیا {government}%
+    historically_political: اینوں ایس دے تحت شائع کیتا گیا %{government}
     webchat:
       available: مشیر گل بات کرن لئی موجود نیں۔
       busy: ویب چیٹ دے سارے مشیر ایس ویلے مصروف نیں۔
@@ -545,11 +545,11 @@ pa-pk:
     policies: حکمت عملی دا کاغذ
   worldwide_organisation:
     corporate_information:
-      about_our_services_html: ایندے وچوں لبھو {link}%.
-      personal_information_charter_html: ساڈا {link}%  ایہ وضاحت کردا اے کہ تہاڈی ذاتی معلومات نال کس طراں سلوک کردے آں
-      publication_scheme_html: ایہ پڑھو کہ کیس طراں دی معلومات عام طور پر  اسی شائع کرنے آں {link}%.
-      social_media_use_html: ایندے تے ساڈی پالیسی پڑھو {link}%.
-      welsh_language_scheme_html: ساڈی وابستگی دے بارے جانو {link}%.
+      about_our_services_html: ایندے وچوں لبھو %{link}.
+      personal_information_charter_html: ساڈا %{link}  ایہ وضاحت کردا اے کہ تہاڈی ذاتی معلومات نال کس طراں سلوک کردے آں
+      publication_scheme_html: ایہ پڑھو کہ کیس طراں دی معلومات عام طور پر  اسی شائع کرنے آں %{link}.
+      social_media_use_html: ایندے تے ساڈی پالیسی پڑھو %{link}.
+      welsh_language_scheme_html: ساڈی وابستگی دے بارے جانو %{link}.
     find_out_more: ساری تصویر تے رابطہ دی تفصیلات ویکھو
     headings:
       contact_us: ساڈے نال رابطہ کرو


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

There are rendering anomalies in history mode notification banners for some foreign language pages. Placeholder text is not replaced and some strings are rendered out of the expected order. Examples:

https://www.gov.uk/government/news/uk-and-us-sanction-key-houthi-figures-to-protect-maritime-security-in-the-red-sea.ar

https://www.gov.uk/government/news/his-majesty-the-king-honours-mr-makoto-uchida-president-and-chief-executive-officer-nissan-motor-corporation.ja

This PR fixes the second issue and a similar issue in a different language, but not the first issue as it would require a completely new functionality to be added to whitehall publisher.

[The same Japanese page after the change](https://government-frontend-pr-3287.herokuapp.com/government/news/his-majesty-the-king-honours-mr-makoto-uchida-president-and-chief-executive-officer-nissan-motor-corporation.ja)

## Why

[Trello ticket](https://trello.com/c/WzkmRlRU/2732-history-mode-banners-in-foreign-languages)