### PR TITLE
Fix: service manual mobile/tablet alignment

### DIFF
--- a/app/views/content_items/service_manual_topic.html.erb
+++ b/app/views/content_items/service_manual_topic.html.erb
@@ -4,7 +4,6 @@
 <% content_for :phase_message do %>
   <%= render 'shared/custom_phase_message', phase: @content_item.phase %>
 <% end %>
-<div class="govuk-width-container">
 
   <%= render "govuk_publishing_components/components/breadcrumbs", {
     breadcrumbs: @content_item.breadcrumbs,
@@ -89,4 +88,3 @@
     </div>
 
   </div>
-</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,9 +10,7 @@
       <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase %>
     <% end %>
     <% if @content_item.service_manual? %>
-      <div class="govuk-width-container">
         <%= render_phase_label @content_item, content_for(:phase_message) %>
-      </div>
     <% end %>
 
     <% if @content_item.show_default_breadcrumbs? %>

--- a/test/integration/service_manual_phase_label_test.rb
+++ b/test/integration/service_manual_phase_label_test.rb
@@ -29,7 +29,9 @@ class ServiceManualPhaseLabelTest < ActionDispatch::IntegrationTest
     stub_content_store_has_item(guide["base_path"], guide)
     visit guide["base_path"]
 
-    assert_text("Alpha")
+    phase_label = find("strong.govuk-tag.govuk-phase-banner__content__tag").text
+
+    assert_match(/alpha/i, phase_label.strip)
   end
 
   test "No phase label is displayed for a guide without a phase field" do


### PR DESCRIPTION
## What

[Trello card](https://trello.com/c/SHt2Y8Uu/2767-service-manual-pages-not-aligned-correctly-on-mobile-and-tablet)

This PR addresses alignment issues in the service manual pages across mobile and tablet views which was identified in this GitHub issue: https://github.com/alphagov/government-frontend/issues/3250 

#### Changes made:
- Removed `govuk-width-container` div from `service_manual_topic.html.erb`: This change fixes the alignment issue of the content of the page.
- Removed `govuk-width-container` div from `application.html.erb`: this adjustment ensures proper alignment of the phase banner with the content in various views.

#### Additional Updates:
- Improved `service_manual_phase_label` test: enhanced the test to handle case sensitivity for the "Alpha" phase label, ensuring Capybara correctly identifies the label regardless of its case. This resolves the previous test error where it said it found an instance `it was found 1 time using a case insensitive search and it was found 1 time including non-visible text.)`.

## Screenshots:

Service manual page: https://www.gov.uk/service-manual/helping-people-to-use-your-service

#### Desktop

No change.

#### Tablet:

| Before | After |
|--------|--------|
| <img width="1052" alt="image" src="https://github.com/user-attachments/assets/daeafffb-0800-4408-bef4-e71a10670175"> | <img width="890" alt="image" src="https://github.com/user-attachments/assets/90ef235a-dbb1-4d32-8e5f-d09dd43fae8d"> |


#### Mobile:
| Before | After |
|--------|--------|
|<img width="587" alt="image" src="https://github.com/user-attachments/assets/1e4c2a9e-3810-4316-9cde-a8c4c7a4cc41">| <img width="491" alt="image" src="https://github.com/user-attachments/assets/703af7ba-d83b-4650-9b82-a72414c09638"> | 

I noticed this PR https://github.com/alphagov/government-frontend/pull/2988 which also looked at fixing the spacing of the phase banner in HMRC internal manuals. The below shows this is _not_ affected:

HMRC internal manual: https://www.gov.uk/hmrc-internal-manuals/air-passenger-duty/updates

#### Desktop

No change

#### Tablet (no change but to show it too)

| Before | After |
|--------|--------|
| <img width="871" alt="image" src="https://github.com/user-attachments/assets/aa56de60-ad69-4d81-bbcb-c8899a9289e6"> | <img width="878" alt="image" src="https://github.com/user-attachments/assets/21e631e1-4b19-40c7-91a8-6b48fca4c13d"> |

#### Mobile (no change but to show it too:
| Before | After |
|--------|--------|
|<img width="427" alt="image" src="https://github.com/user-attachments/assets/31fbbabe-76a9-44c2-aded-016c9c798f88">| <img width="419" alt="image" src="https://github.com/user-attachments/assets/c5aae438-ebe3-4148-a7b3-ad4b863fd26c"> | 