### PR TITLE
Align phase banner on service manual homepage

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -97,6 +97,10 @@ class ContentItemPresenter
     false
   end
 
+  def service_manual_homepage?
+    false
+  end
+
   def render_guide_as_single_page?
     # /how-to-vote
     content_id == "9315bc67-33e7-42e9-8dea-e022f56dabfa" && voting_is_open?

--- a/app/presenters/service_manual_presenter.rb
+++ b/app/presenters/service_manual_presenter.rb
@@ -15,6 +15,10 @@ class ServiceManualPresenter < ContentItemPresenter
     true
   end
 
+  def service_manual_homepage?
+    content_item["document_type"] == "service_manual_homepage"
+  end
+
   def show_phase_banner?
     false
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,13 @@
       <%= render 'govuk_publishing_components/components/phase_banner', phase: @content_item.phase %>
     <% end %>
     <% if @content_item.service_manual? %>
+      <% if @content_item.service_manual_homepage? %>
+        <div class="govuk-width-container">
+          <%= render_phase_label @content_item, content_for(:phase_message) %>
+        </div>
+      <% else %>
         <%= render_phase_label @content_item, content_for(:phase_message) %>
+      <% end %>
     <% end %>
 
     <% if @content_item.show_default_breadcrumbs? %>


### PR DESCRIPTION
## What
- Align phase banner on service manual homepage
- Add new `service_manual_homepage?` presenter method

## Why
When on the service_manual_homepage, the phase banner will be wrapped in a div element with the `govuk-width-container` class to align it with the rest of the content on the page.

The service manual homepage layout is different from the rest of the service manual as it contains an app-hero banner that needs to span the full width of the page with a blue background, but we still want the phase banner to be contained.

## Visual changes

### Service manual homepage

| Before | After |
| --- | --- |
| <img width="801" alt="Screenshot 2024-08-09 at 13 56 22" src="https://github.com/user-attachments/assets/1c851b16-049a-4d3e-ba90-4aa6a30c0e0f"> | <img width="720" alt="Screenshot 2024-08-09 at 13 56 58" src="https://github.com/user-attachments/assets/dfe94436-d4d3-4e1b-956c-b3aaff497e77"> |