### PR TITLE
Remove ICS link

### DIFF
--- a/app/views/content_items/get_involved.html.erb
+++ b/app/views/content_items/get_involved.html.erb
@@ -202,7 +202,6 @@
 
   <%= render "govuk_publishing_components/components/list", {
     items: [
-      sanitize("<a href=\"http://www.volunteerics.org/\" class=\"govuk-link\">#{t('get_involved.join_ics')}</a>"),
       sanitize("<a href=\"http://www.ourwatch.org.uk/knowledge-base-category/how-to-get-involved/\" class=\"govuk-link\">#{t('get_involved.neighbourhood_watch')}</a>"),
       sanitize("<a href=\"/donating-to-charity\" class=\"govuk-link\">#{t('get_involved.make_donation')}</a>"),
       sanitize("<a href=\"https://schoolsonline.britishcouncil.org/about-schools-online/about-programmes/connecting-classrooms\" rel=\"noopener\" class=\"govuk-link\">#{t('get_involved.school_overseas')}</a>"),


### PR DESCRIPTION
Remove link to International Citizen Service, as the link is broken and the service is no longer running.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
