### PR TITLE
Display GOV.UK Chat promo on certain pages

### DIFF
--- a/app/helpers/govuk_chat_promo_helper.rb
+++ b/app/helpers/govuk_chat_promo_helper.rb
@@ -1,0 +1,17 @@
+module GovukChatPromoHelper
+  GOVUK_CHAT_PROMO_BASE_PATHS = %w[
+    /business-support-helpline
+    /company-tax-returns
+    /corporation-tax
+    /pay-corporation-tax
+    /pay-vat
+    /search-for-trademark
+    /set-up-business
+    /submit-vat-return
+    /write-business-plan
+  ].freeze
+
+  def show_govuk_chat_promo?(base_path)
+    ENV["GOVUK_CHAT_PROMO_ENABLED"] == "true" && GOVUK_CHAT_PROMO_BASE_PATHS.include?(base_path)
+  end
+end

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -1,5 +1,9 @@
 <% content_item = @content_item.content_item.parsed_content %>
 
 <div class="govuk-grid-column-one-third">
+  <% if show_govuk_chat_promo?(@content_item.base_path) %>
+    <%= render "govuk_publishing_components/components/chat_entry", { border_top: true } %>
+  <% end %>
+
   <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
 </div>

--- a/test/helpers/govuk_chat_promo_helper_test.rb
+++ b/test/helpers/govuk_chat_promo_helper_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class GovukChatPromoHelperTest < ActionView::TestCase
+  test "show_govuk_chat_promo? when configuration disabled" do
+    assert_not show_govuk_chat_promo?(GOVUK_CHAT_PROMO_BASE_PATHS.first)
+  end
+
+  test "show_govuk_chat_promo? when base_path not in configuration" do
+    ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+      assert_not show_govuk_chat_promo?("/non-matching-path")
+    end
+  end
+
+  test "show_govuk_chat_promo? when base_path is in configuration" do
+    ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+      assert show_govuk_chat_promo?(GOVUK_CHAT_PROMO_BASE_PATHS.first)
+    end
+  end
+end

--- a/test/integration/govuk_chat_promo_test.rb
+++ b/test/integration/govuk_chat_promo_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class GovukChatPromoTest < ActionDispatch::IntegrationTest
+  test "renders GOV.UK chat promo for matching content type and base path" do
+    ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+      setup_and_visit_a_page_with_specific_base_path("answer", GovukChatPromoHelper::GOVUK_CHAT_PROMO_BASE_PATHS.first)
+
+      assert page.has_css?(".gem-c-chat-entry")
+    end
+  end
+
+  def schema_type
+    "answer"
+  end
+end


### PR DESCRIPTION
**Note: this is a draft and an incomplete implementation. I'm just looking for feedback for the approach taken.**

We want to show a promo to the new GOV.UK Chat application on certain pages on GOV.UK. It's a CTA pointing users to the chat app.

The list of URLs we want the promo to appear on is quite short and cover only `answer` and `guide` content types from this codebase.

The CTA is to be shown in the sidebar on the right of the relevant pages.

<img width="1048" alt="Screenshot 2024-08-27 at 09 49 23" src="https://github.com/user-attachments/assets/9428ce6f-5a94-4fae-a656-63ca0682e7bc">

