### PR TITLE
Add user research banner

### DIFF
--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -3,6 +3,7 @@
     schema: :faq
   ) %>
 <% end %>
+<%= render 'shared/intervention_banner' %>
 
 <%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title_and_context[:title] } %>
 

--- a/lib/data/recruitment_banners.yml
+++ b/lib/data/recruitment_banners.yml
@@ -4,8 +4,14 @@
   #   suggestion_text: "Help improve GOV.UK"
   #   suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
   #   survey_url: https://google.com
-  #   page_paths: 
+  #   page_paths:
   #     - /
   #     - /foreign-travel-advice
 
 banners:
+- name: MOD banner 20/08/2024
+  suggestion_text: "Help improve GOV.UK"
+  suggestion_link_text: "Take part in user research (opens in a new tab)"
+  survey_url: https://submit.forms.service.gov.uk/form/3874/give-feedback-on-medals-information-on-gov-uk/13188
+  page_paths:
+    - /guidance/medals-campaigns-descriptions-and-eligibility

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  test "MOD banner 20/08/2024 is displayed on page of interest" do
+    detailed_guide = GovukSchemas::Example.find("detailed_guide", example_name: "detailed_guide")
+    path = "/guidance/medals-campaigns-descriptions-and-eligibility"
+
+    detailed_guide["base_path"] = path
+    stub_content_store_has_item(detailed_guide["base_path"], detailed_guide.to_json)
+    visit detailed_guide["base_path"]
+
+    assert page.has_css?(".gem-c-intervention")
+    assert page.has_link?("Take part in user research", href: "https://submit.forms.service.gov.uk/form/3874/give-feedback-on-medals-information-on-gov-uk/13188")
+  end
+
+  test "MOD banner 20/08/2024 is not displayed on all pages" do
+    detailed_guide = GovukSchemas::Example.find("detailed_guide", example_name: "detailed_guide")
+    detailed_guide["base_path"] = "/nothing-to-see-here"
+    stub_content_store_has_item(detailed_guide["base_path"], detailed_guide.to_json)
+    visit detailed_guide["base_path"]
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research", href: "https://submit.forms.service.gov.uk/form/3874/give-feedback-on-medals-information-on-gov-uk/13188")
+  end
+end


### PR DESCRIPTION
As requested by MOD via our normal processes
https://trello.com/c/2RgPDQf8/2800-govuk-user-research-banner-requests-mod

|Before|After|
|-|-|
|<img width="817" alt="Screenshot 2024-08-20 at 12 52 38" src="https://github.com/user-attachments/assets/9946b3d1-67ff-4052-ad30-678398b7c565">|<img width="825" alt="Screenshot 2024-08-20 at 12 52 06" src="https://github.com/user-attachments/assets/30519d34-7f9b-4070-a90c-3d300e656128">|

Trello: https://trello.com/c/2RgPDQf8/2800-govuk-user-research-banner-requests-mod
Review app: https://government-frontend-pr-3304.herokuapp.com/guidance/medals-campaigns-descriptions-and-eligibility