### PR TITLE
Style organisation logos with flex-basis on desktop only

### DIFF
--- a/app/assets/stylesheets/helpers/_organisation-logos.scss
+++ b/app/assets/stylesheets/helpers/_organisation-logos.scss
@@ -1,16 +1,12 @@
 .organisation-logos {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: flex-start;
   list-style-type: none;
   margin-top: govuk-spacing(2);
   padding: 0;
 }
 
 .organisation-logos__logo {
+  display: inline-block;
+  vertical-align: top;
   padding-bottom: govuk-spacing(3);
-  margin-right: govuk-spacing(3);
-  flex-basis: 25%;
-  min-width: 130px;
+  margin-right: govuk-spacing(6);
 }


### PR DESCRIPTION
## What / Why
- On HTML publications such as https://www.gov.uk/government/publications/dvsa-sustainability-strategy/dvsa-sustainability-strategy, if you resize down to mobile, the organisation logo's name will wrap the text when it does not need to
- This is because of `flex-basis: 25%`, which restricts the width of the logo
- It seems like this `flex-basis` exists because some publications have more than one organisation logo on the page. For example: https://www.gov.uk/government/publications/10-downing-street-correspondence-communications-gifts-and-hospitality-privacy-notice/10-downing-street-correspondence-communications-gifts-and-hospitality-privacy-notice
- It seems like `flex-basis` is only needed on desktop, since the logos will stack on tablet / mobile. Therefore I have wrapped the `flex-basis` in a desktop-only media query.
- I have also increased the `flex-basis` to `30%`, as the `Prime Minister's Office` text was still wrapping while the screen size was within our `desktop` width boundary.


## Visual Changes 

### Before (one logo example)
<img width="335" alt="image" src="https://github.com/user-attachments/assets/1c2301ab-64f3-4e50-bc05-27127a30b8ae">


### After (one logo example)

<img width="335" alt="image" src="https://github.com/user-attachments/assets/521a7489-439e-47a4-8c78-9bee22d53abb">

### Before (multiple logo example)

<img width="397" alt="image" src="https://github.com/user-attachments/assets/9acbe4f2-d798-4eb6-8a61-79887f6adee2">


### After (multiple logo example)

<img width="397" alt="image" src="https://github.com/user-attachments/assets/efeb3a15-8faf-4e15-8aa2-9c3e4609d23c">




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
