### PR TITLE
Replace organisation logos with metadata

### DIFF
--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -4,6 +4,7 @@ class HtmlPublicationPresenter < ContentItemPresenter
   include ContentItem::ContentsList
   include ContentItem::Political
   include ContentItem::NationalApplicability
+  include ContentItem::Metadata
 
   def isbn
     content_item["details"]["isbn"]
@@ -21,17 +22,6 @@ class HtmlPublicationPresenter < ContentItemPresenter
     end
   end
 
-  def last_changed
-    timestamp = display_date(public_timestamp)
-
-    # This assumes that a translation doesn't need the date to come beforehand.
-    if content_item["details"]["first_published_version"]
-      "#{I18n.t('content_item.metadata.published')} #{timestamp}"
-    else
-      "#{I18n.t('content_item.metadata.updated')} #{timestamp}"
-    end
-  end
-
   def organisations
     content_item["links"]["organisations"] || []
   end
@@ -40,6 +30,20 @@ class HtmlPublicationPresenter < ContentItemPresenter
     super.tap do |logo|
       if logo && organisations.count > 1
         logo[:organisation].delete(:image)
+      end
+    end
+  end
+
+  def publisher_metadata
+    super.tap do |m|
+      orgs = organisations.map do |organisation|
+        view_context.link_to(organisation["title"], organisation["base_path"], class: "govuk-link govuk-link--inverse")
+      end
+      m.merge!(from: orgs)
+
+      if content_item["details"]["first_published_version"]
+        m.delete(:see_updates_link)
+        m.delete(:last_updated)
       end
     end
   end

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -9,31 +9,23 @@
   content_for :simple_header, true
 %>
 
-<% if @content_item.organisations %>
-  <div class="publication-external">
-    <ul class="organisation-logos">
-      <% @content_item.organisations.each do |organisation| %>
-        <% logo_attributes = @content_item.organisation_logo(organisation) %>
-        <% next unless logo_attributes %>
-        <li class="organisation-logos__logo">
-          <%= render 'govuk_publishing_components/components/organisation_logo', logo_attributes %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
 
-<%= render 'govuk_publishing_components/components/inverse_header', {} do %>
-  <%= render 'govuk_publishing_components/components/title',
-        title: @content_item.title,
-        context: I18n.t("content_item.schema_name.#{@content_item.format_sub_type}", count: 1),
+<div class="govuk-!-margin-top-5">
+  <%= render 'govuk_publishing_components/components/inverse_header', {} do %>
+    <%= render 'govuk_publishing_components/components/title',
+          title: @content_item.title,
+          context: I18n.t("content_item.schema_name.#{@content_item.format_sub_type}", count: 1),
+          inverse: true,
+          margin_bottom: 0,
+          margin_top: 3
+    %>
+
+    <%= render 'govuk_publishing_components/components/metadata', @content_item.publisher_metadata.merge(
         inverse: true,
-        margin_bottom: 0,
-        margin_top: 3
-  %>
-  <p class="publication-header__last-changed"><%= @content_item.last_changed %></p>
-<% end %>
-
+        inverse_compress: true
+      ) %>
+  <% end %>
+</div>
 <%= render 'shared/history_notice', content_item: @content_item %>
 <% if @content_item.withdrawn? %>
   <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>


### PR DESCRIPTION
This commit is a spike to explore how easy/hard it would be to replace organisation logos on HTML attachments with a call to the metadata component instead:
https://components.publishing.service.gov.uk/component-guide/metadata#on_a_dark_background_without_padding

Some organisations have custom logos, but we only display the logo if it will be the only logo on the page. If it will sit alongside other logos, we hide the custom logo. This behaviour is weird and unexpected.

|Before|After|
|-|-|
|<img width="989" alt="Screenshot 2024-08-27 at 17 17 41" src="https://github.com/user-attachments/assets/33f2e42c-0f46-4261-82a2-570d1678e8d0">|<img width="995" alt="Screenshot 2024-08-27 at 17 18 22" src="https://github.com/user-attachments/assets/66fc9253-2925-4610-9314-d4a7038bcfec">|

[Live site](https://gov.uk/government/publications/keepers-of-time-ancient-and-native-woodland-and-trees-policy-in-england/keepers-of-time-ancient-and-native-woodland-and-trees-policy-in-england)
[Review app](https://government-frontend-pr-3310.herokuapp.com//government/publications/keepers-of-time-ancient-and-native-woodland-and-trees-policy-in-england/keepers-of-time-ancient-and-native-woodland-and-trees-policy-in-england)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Trello: https://trello.com/c/3jez4Zg9/2799-understand-technical-design-and-content-implications-of-removing-org-logos-from-html-attachments
