### PR TITLE
Improve styling of the intervention banner on tablet

### DIFF
--- a/app/views/shared/_intervention_banner.html.erb
+++ b/app/views/shared/_intervention_banner.html.erb
@@ -1,5 +1,5 @@
 <% if recruitment_banner.present? %>
-  <div class="govuk-width-container govuk-!-margin-top-4">
+  <div class="govuk-!-margin-top-4">
     <%= render "govuk_publishing_components/components/intervention", {
       new_tab: true,
       suggestion_text: recruitment_banner["suggestion_text"],


### PR DESCRIPTION
## What

Remove unnecessary css class which is causing the intervention banner to indent on tablet.

|Before|After|
|-|-|
|<img width="939" alt="Screenshot 2024-08-30 at 10 41 39" src="https://github.com/user-attachments/assets/1c192180-d91b-42c7-a565-64d3d83a4417">|<img width="936" alt="Screenshot 2024-08-30 at 10 42 28" src="https://github.com/user-attachments/assets/5a424c72-ad3f-4630-8983-223a7dd23204">|
