### PR TITLE
Update URL in GOV.UK Chat promo helper

### DIFF
--- a/app/helpers/govuk_chat_promo_helper.rb
+++ b/app/helpers/govuk_chat_promo_helper.rb
@@ -1,6 +1,6 @@
 module GovukChatPromoHelper
   GOVUK_CHAT_PROMO_BASE_PATHS = %w[
-    /business-support-helpline
+    /business-support-service
     /company-tax-returns
     /corporation-tax
     /pay-corporation-tax


### PR DESCRIPTION
The original URL is actually a redirect, so the promo wouldn't render
after the browser followed the redirect. This updates the helper to
specify the actual URL.