### PR TITLE
Fix sass warnings

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,13 +1,13 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .app-c-banner {
-  @include responsive-bottom-margin;
-  @include govuk-font(19);
   direction: ltr;
   background: $govuk-brand-colour;
   color: govuk-colour("white");
   padding: govuk-spacing(3);
   clear: both;
+  @include responsive-bottom-margin;
+  @include govuk-font(19);
 
   @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(4) govuk-spacing(6);
@@ -30,13 +30,13 @@
 }
 
 .app-c-banner__title {
-  @include govuk-font(27, $weight: bold);
   margin-bottom: govuk-spacing(2);
+  @include govuk-font(27, $weight: bold);
 }
 
 .app-c-banner__desc {
-  @include govuk-font(19);
   // Ensure the text has a line-length of around 60 characters
   max-width: 30em;
   padding-top: govuk-spacing(2);
+  @include govuk-font(19);
 }

--- a/app/assets/stylesheets/components/_download-link.scss
+++ b/app/assets/stylesheets/components/_download-link.scss
@@ -2,9 +2,9 @@
 
 .app-c-download-link {
   display: inline-block;
-  @include govuk-font(19, $weight: bold);
   margin-top: govuk-spacing(3);
   margin-bottom: govuk-spacing(3);
+  @include govuk-font(19, $weight: bold);
 
   @include govuk-media-query($from: tablet) {
     margin-top: govuk-spacing(6);

--- a/app/assets/stylesheets/components/_figure.scss
+++ b/app/assets/stylesheets/components/_figure.scss
@@ -1,12 +1,11 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .app-c-figure {
-  @include govuk-clearfix;
-
   border-top: 1px solid $govuk-border-colour;
   padding-top: govuk-spacing(3);
   margin: 0;
   margin-bottom: govuk-spacing(8);
+  @include govuk-clearfix;
 
   @include govuk-media-query($until: tablet) {
     margin-bottom: govuk-spacing(6);
@@ -41,7 +40,7 @@
 }
 
 .app-c-figure__figcaption-text {
-  @include govuk-font(16);
   margin: 0;
   margin-bottom: govuk-spacing(2);
+  @include govuk-font(16);
 }

--- a/app/assets/stylesheets/helpers/_parts.scss
+++ b/app/assets/stylesheets/helpers/_parts.scss
@@ -21,9 +21,9 @@
   }
 
   .part-title {
-    @include govuk-font(27, $weight: bold);
     margin-bottom: govuk-spacing(3);
     margin-top: govuk-spacing(3);
+    @include govuk-font(27, $weight: bold);
 
     @include govuk-media-query($from: tablet) {
       margin-bottom: govuk-spacing(4);

--- a/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
+++ b/app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
@@ -2,10 +2,10 @@
 // roll out the combination of metadata + logo across
 // formats so they may ultimately become component styles.
 .metadata-logo-wrapper {
-  @include govuk-clearfix;
   border-top: 1px solid $govuk-border-colour;
   margin-left: govuk-spacing(3);
   margin-right: govuk-spacing(3);
+  @include govuk-clearfix;
 
   .metadata-column {
     padding-left: 0;

--- a/app/assets/stylesheets/modules/_notice.scss
+++ b/app/assets/stylesheets/modules/_notice.scss
@@ -1,17 +1,16 @@
 .notice {
   clear: both;
-  @include responsive-bottom-margin;
   padding: govuk-spacing(3);
-
   border: 5px solid $govuk-brand-colour;
+  @include responsive-bottom-margin;
 
   @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(4);
   }
 
   &__title {
-    @include govuk-font(36, $weight: bold);
     margin-bottom: govuk-spacing(2);
+    @include govuk-font(36, $weight: bold);
   }
 
   &__description {

--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -12,8 +12,8 @@
   }
 
   .publication-header__last-changed {
-    @include govuk-font(19);
     margin-top: govuk-spacing(3);
+    @include govuk-font(19);
   }
 
   .contents-list-container {

--- a/app/assets/stylesheets/views/_manual.scss
+++ b/app/assets/stylesheets/views/_manual.scss
@@ -5,14 +5,13 @@
 }
 
 .manuals-header {
-  @include govuk-font(16);
-  @include govuk-clearfix;
-
   background: $govuk-brand-colour;
   color: govuk-colour("white");
   margin: 0;
   padding-bottom: govuk-spacing(6);
   padding-top: govuk-spacing(6);
+  @include govuk-font(16);
+  @include govuk-clearfix;
 
   @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(6) govuk-spacing(3);
@@ -23,8 +22,8 @@
   }
 
   h1 {
-    @include govuk-font(36, $weight: bold);
     padding: 0 0 govuk-spacing(3);
+    @include govuk-font(36, $weight: bold);
 
     @include govuk-media-query($from: tablet) {
       padding: 0 0 govuk-spacing(6);
@@ -54,11 +53,10 @@
 }
 
 .section-list-item {
-  @include govuk-font(19);
-
   border-top: 1px solid $govuk-border-colour;
   cursor: pointer;
   list-style: none;
+  @include govuk-font(19);
 
   &:hover {
     background-color: govuk-colour("light-grey");
@@ -83,9 +81,9 @@
   }
 
   .subsection-title-text {
+    display: block;
     @include govuk-typography-weight-bold;
     @include govuk-link-decoration;
-    display: block;
   }
 
   .subsection-summary {

--- a/app/assets/stylesheets/views/_travel-advice.scss
+++ b/app/assets/stylesheets/views/_travel-advice.scss
@@ -11,9 +11,8 @@
   // TODO: Remove this when components can accept variable unidirectional spacing,
   // the component above should have a bigger margin-bottom.
   .map {
-    @include responsive-bottom-margin;
-
     margin-top: govuk-spacing(6);
+    @include responsive-bottom-margin;
 
     .map-image {
       max-width: 100%;

--- a/app/assets/stylesheets/views/_worldwide-organisation.scss
+++ b/app/assets/stylesheets/views/_worldwide-organisation.scss
@@ -28,6 +28,7 @@
   margin-top: govuk-spacing(2);
 
   dl {
+    margin: 0;
     @include govuk-text-colour;
     @include govuk-font($size: 16);
     @include govuk-responsive-margin(4, "bottom");
@@ -37,8 +38,6 @@
       grid-template-columns: auto 1fr;
       grid-gap: govuk-spacing(2);
     }
-
-    margin: 0;
 
     dt,
     dd {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fixes some Sass compilation warnings, that look like this:

```
13:28:45 css.1  |    ┌──> app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss
13:28:45 css.1  | 7  │     margin-left: govuk-spacing(3);
13:28:45 css.1  |    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
13:28:45 css.1  |    ╵
13:28:45 css.1  |    ┌──> ../../../.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/govuk_publishing_components-43.0.2/node_modules/govuk-frontend/dist/govuk/helpers/_clearfix.scss
13:28:45 css.1  | 10 │ ┌   &::after {
13:28:45 css.1  | 11 │ │     content: "";
13:28:45 css.1  | 12 │ │     display: block;
13:28:45 css.1  | 13 │ │     clear: both;
13:28:45 css.1  | 14 │ │   }
13:28:45 css.1  |    │ └─── nested rule
13:28:45 css.1  |    ╵
13:28:45 css.1  |     app/assets/stylesheets/helpers/_publisher-metadata-with-logo.scss 7:3  @import
13:28:45 css.1  |     app/assets/stylesheets/application.scss 19:9                           root stylesheet
```

## Why
There was a change to a dependency recently where this arrangement of selectors was suddenly required, so we're having to update quite a few Sass files to silence these warnings.

## Visual changes
None.
