### PR TITLE
Add a noindex metatag to specific publication

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -25,4 +25,9 @@ class PublicationPresenter < ContentItemPresenter
   def dataset?
     %(national_statistics official_statistics transparency).include? document_type
   end
+
+  # this is a temporary hack and should be removed in approx 3 months
+  def hide_from_search_engines?
+    content_item["base_path"] == "/government/publications/pension-credit-claim-form--2"
+  end
 end

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -2,6 +2,10 @@
   <%= machine_readable_metadata(
     schema: (@content_item.dataset? ? :dataset : :article)
   ) %>
+
+  <% if @content_item.hide_from_search_engines? %>
+    <meta name="robots" content="noindex">
+  <% end %>
 <% end %>
 
 <%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title } %>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 #
 # To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-agent: *
+Disallow: /government/publications/pension-credit-claim-form--2

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -288,4 +288,10 @@ class PublicationTest < ActionDispatch::IntegrationTest
     setup_and_visit_notification_exempt_page("publication")
     assert_not page.has_css?(".gem-c-single-page-notification-button")
   end
+
+  test "adds the noindex meta tag to '/government/publications/pension-credit-claim-form--2'" do
+    overrides = { "base_path" => "/government/publications/pension-credit-claim-form--2" }
+    setup_and_visit_content_item("publication-with-featured-attachments", overrides)
+    assert page.has_css?('meta[name="robots"][content="noindex"]', visible: false)
+  end
 end

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -78,4 +78,18 @@ class PublicationPresenterTest < PresenterTestCase
     presented = presented_item("statistics_publication")
     assert presented.has_single_page_notifications?
   end
+
+  test "hide_from_search_engines? returns false" do
+    presented = presented_item("publication-with-featured-attachments")
+
+    assert_not(presented.hide_from_search_engines?)
+  end
+
+  test "hide_from_search_engines? returns true if the page is '/government/publications/pension-credit-claim-form--2'" do
+    schema_example = schema_item("publication-with-featured-attachments")
+    schema_example["base_path"] = "/government/publications/pension-credit-claim-form--2"
+    presented = presented_item("publication", schema_example)
+
+    assert presented.hide_from_search_engines?
+  end
 end


### PR DESCRIPTION
As requested by DWP and senior leadership
This is a temporary fix and should be removed within 3 months

This is an existing pattern see [other examples in this application](https://github.com/search?q=repo%3Aalphagov%2Fgovernment-frontend+%3Cmeta+name%3D%22robots%22+content%3D%22noindex%2C+nofollow%22%3E&type=code)

[Trello](https://trello.com/c/fTPduo3e/2830-insert-a-noindex-meta-tag-to-pension-credit-claim-form-government-publications-pension-credit-claim-form-2)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
