### PR TITLE
Fix HTML Publication layout to work with design system columns

### DIFF
--- a/app/assets/stylesheets/views/_html-publication.scss
+++ b/app/assets/stylesheets/views/_html-publication.scss
@@ -30,16 +30,7 @@
     }
   }
 
-  .main-content-container {
-    width: 100%;
-    padding: 0 15px;
-    box-sizing: border-box;
-
-    @include govuk-media-query($from: desktop) {
-      width: 75%;
-      float: right;
-    }
-
+  .contents-container {
     .direction-rtl & {
       float: left;
     }

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -46,7 +46,7 @@
 <% end %>
 
 <div id="contents">
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-row gem-print-columns-none">
     <% if @content_item.contents.any? %>
       <div class="govuk-grid-column-one-quarter-from-desktop contents-list-container">
         <%= render 'govuk_publishing_components/components/contents_list', contents: @content_item.contents, format_numbers: true %>
@@ -64,7 +64,7 @@
       </div>
     </div>
 
-    <div class="main-content-container<% unless @content_item.contents.any? %> offset-empty-contents-list<% end %>">
+    <div class="govuk-grid-column-three-quarters-from-desktop contents-container<% unless @content_item.contents.any? %> offset-empty-contents-list<% end %>">
       <%= render "govuk_publishing_components/components/govspeak_html_publication", { direction: page_text_direction } do %>
         <%= raw(@content_item.govspeak_body[:content]) %>
       <% end %>


### PR DESCRIPTION
## What

Fix the HTML Publication layout so that it uses the grid layout classes supplied by govuk-frontend. [Trello](https://trello.com/c/lCNIkgGw/338-html-publication-layout-should-use-govuk-frontend-grid-classes)

This commit removes some of the rules that were previously set for the `.main-content-container` and instead uses the column rules from `govuk-frontend`.

The `.main-content-container` has now been renamed as `contents-container` to be consistent with the `contents-list-container`. I had hoped to remove this class entirely, but it's required to apply different float rules when in RTL reading mode.

This also adds the new class for collapsing columns to full width when printing.

## Why

HTML Publication uses some custom classes for managing its layout, but these more-or-less replicate what’s already available with the row/grid layout classes from the design system. These differences affect our ability to improve generic print styles for rows/columns, as well as being harder to maintain.
