### PR TITLE
Fix translation typo in Latin American locale

### DIFF
--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -76,7 +76,7 @@ es-419:
     ways_to_respond: Formas de responder
     write_to: 'Escriba a:'
   contact:
-    access_and_opening_times: Acceso y horarios de aperturaAcceso y inicio
+    access_and_opening_times: Acceso y horarios de apertura
     contact_form: Formulario de contacto
     email: Email
     find_call_charges: Conozca las tarifas de las llamadas


### PR DESCRIPTION
This is pretty clearly a typo when the key/values were first put in: https://github.com/alphagov/government-frontend/commit/34c297265c005b8cdf5348b874b524297b4bd072#diff-7110365887255a0b6cf4bd5f866f9cdcfa187ee3844e45aa8b7033d30c135189R45-R51

Correct value is the first half, as confirmed in the card/zendesk ticket:
https://trello.com/c/DWS19aem/30-issue-with-access-and-opening-times-latin-american-spanish-translation-text

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
