### PR TITLE
Apply 'no columns' print style to Guide/Detailed Guide

### DIFF
--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -7,7 +7,7 @@
 
 <%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title_and_context[:title] } %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
@@ -23,7 +23,7 @@
 <% if @content_item.withdrawn? %>
   <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 <% end %>
-<div class="govuk-grid-row">
+<div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
     <% if @content_item.national_applicability.present? %>
       <%= render "govuk_publishing_components/components/devolved_nations", {

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -6,7 +6,7 @@
   <meta name="robots" content="noindex, nofollow">
 <% end %>
 
-<div class="govuk-grid-row" id="guide-print">
+<div class="govuk-grid-row gem-print-columns-none" id="guide-print">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', {
       margin_bottom: 6,

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -19,7 +19,7 @@
 
 <%= render 'shared/intervention_banner' %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', { title: @content_item.content_title } %>
 


### PR DESCRIPTION
## What
Add the new `gem-print-columns-none` print class to the layouts in Guides and Detailed Guides, to collapse columns on print. [Trello](https://trello.com/c/J1FtkA7Q/344-add-generic-print-styles-to-guide-and-detailed-guide)

## Why
When printing various page types, the 2/3rds + 1/3rds column layout causes issues with cropped content and a generally poor printing experience because the full page isn't used. By selectively collapsing floated columns, we can avoid most of these issues and improve the printing experience by using the full width of the page.

### Visual Changes: GUIDE (Portrait)
| Before    | After |
| -------- | ------- |
|![image](https://github.com/user-attachments/assets/fdd49449-0c43-4cff-a33f-46627c366317)|![image](https://github.com/user-attachments/assets/bc236d30-eca6-4f5c-aa3c-d886a5001d9e)|

### Visual Changes: GUIDE (Landscape)
| Before    | After |
| -------- | ------- |
|![image](https://github.com/user-attachments/assets/5ba82c31-ccd1-40e7-b13e-91b5a3a02fc5)|![image](https://github.com/user-attachments/assets/b3203637-4f51-424c-a026-bebe5f0c013e)|

### Visual Changes: DETAILED GUIDE (Portrait)
| Before    | After |
| -------- | ------- |
|![image](https://github.com/user-attachments/assets/68fe6315-6214-4196-b9bf-c47a65fe7daf)|![image](https://github.com/user-attachments/assets/5670183c-27e2-4486-8153-fff72e124683)|

### Visual Changes: DETAILED GUIDE (Landscape)
| Before    | After |
| -------- | ------- |
|![image](https://github.com/user-attachments/assets/2ebe9c30-b7a2-4cb1-a596-13fc7efa85bc)|![image](https://github.com/user-attachments/assets/76144185-746e-4de5-b692-a54bb8bb75bb)|
