### PR TITLE
Take down GOV.UK user research banner for MOD

### DIFF
--- a/lib/data/recruitment_banners.yml
+++ b/lib/data/recruitment_banners.yml
@@ -9,12 +9,6 @@
   #     - /foreign-travel-advice
 
 banners:
-- name: MOD banner 20/08/2024
-  suggestion_text: "Help improve GOV.UK"
-  suggestion_link_text: "Take part in user research (opens in a new tab)"
-  survey_url: https://submit.forms.service.gov.uk/form/3874/give-feedback-on-medals-information-on-gov-uk/13188
-  page_paths:
-    - /guidance/medals-campaigns-descriptions-and-eligibility
 - name: HMRC banner 29/08/2024
   suggestion_text: "Help improve GOV.UK"
   suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -5,28 +5,6 @@ class RecruitmentBannerTest < ActionDispatch::IntegrationTest
     "https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_CCG_Compliance"
   end
 
-  test "MOD banner 20/08/2024 is displayed on page of interest" do
-    detailed_guide = GovukSchemas::Example.find("detailed_guide", example_name: "detailed_guide")
-    path = "/guidance/medals-campaigns-descriptions-and-eligibility"
-
-    detailed_guide["base_path"] = path
-    stub_content_store_has_item(detailed_guide["base_path"], detailed_guide.to_json)
-    visit detailed_guide["base_path"]
-
-    assert page.has_css?(".gem-c-intervention")
-    assert page.has_link?("Take part in user research", href: "https://submit.forms.service.gov.uk/form/3874/give-feedback-on-medals-information-on-gov-uk/13188")
-  end
-
-  test "MOD banner 20/08/2024 is not displayed on all pages" do
-    detailed_guide = GovukSchemas::Example.find("detailed_guide", example_name: "detailed_guide")
-    detailed_guide["base_path"] = "/nothing-to-see-here"
-    stub_content_store_has_item(detailed_guide["base_path"], detailed_guide.to_json)
-    visit detailed_guide["base_path"]
-
-    assert_not page.has_css?(".gem-c-intervention")
-    assert_not page.has_link?("Take part in user research", href: "https://submit.forms.service.gov.uk/form/3874/give-feedback-on-medals-information-on-gov-uk/13188")
-  end
-
   test "HMRC banner 29/08/2024 is displayed on detailed guides of interest" do
     detailed_guide = GovukSchemas::Example.find("detailed_guide", example_name: "detailed_guide")
     detailed_guide_paths = [


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Remove UR banner currently live on [https://www.gov.uk/guidance/medals-campaigns-descriptions-and-eligibility](https://www.gov.uk/guidance/medals-campaigns-descriptions-and-eligibility "smartCard-inline")

## Why

[Trello card](https://trello.com/c/p2P3JOzs/2873-take-down-govuk-user-research-banner-for-mod)