### PR TITLE
Handle nested divs in first_item_content

### DIFF
--- a/app/presenters/content_item/contents_list.rb
+++ b/app/presenters/content_item/contents_list.rb
@@ -46,15 +46,33 @@ module ContentItem
 
     def first_item_content
       element = first_item
-      first_item_text = ""
-      allowed_elements = %w[p ul ol]
+      return "" unless element
 
-      until element.name == "h2"
-        first_item_text += element.text if element.name.in?(allowed_elements)
+      content = ""
+
+      until element.nil? || element.name == "h2"
+        content += extract_content_from_element(element)
         element = element.next_element
-        break if element.nil?
       end
-      first_item_text
+
+      content.strip
+    end
+
+    def extract_content_from_element(element)
+      case element.name
+      when "div"
+        extract_nested_content(element)
+      when "p", "ul", "ol"
+        element.text
+      else
+        ""
+      end
+    end
+
+    def extract_nested_content(element)
+      element.children.each_with_object("") do |child, content|
+        content << extract_content_from_element(child)
+      end
     end
 
     def first_item_character_count


### PR DESCRIPTION
## What
[Trello card](https://trello.com/c/lT8fhx5Q/2806-display-content-lists-on-publications-even-when-there-are-fewer-than-3-h2s-m-l)

This PR addresses an issue where the content list was not displayed on some publication pages due to the way nested content elements were handled in the `show_contents_list?` method.

## Context:
The `show_contents_list?` method uses various conditions to determine whether to display a content list. These rules were first introduced in PR #719.

Recently, a Zendesk ticket reported that the content list was missing from the [DVSA Earned Recognition page](https://www.gov.uk/government/publications/dvsa-earned-recognition-it-or-software-you-need/vehicle-operator-it-systems-and-software-that-work-with-dvsa-earned-recognition) page, resulting in an empty block of space on the left side of the publication. 

The issue was traced to the method's ability to handle deeply nested content inside `div` elements.

### Debugging:
During investigation, the following issues were identified on that page:
```
- first_item_content.length = 0 was inaccurately evaluated as 0
- first_item_has_long_content? = false
- first_item_content = "" was empty
```

However, this is not accurate, because the content includes multiple headings and subsections:
- An `h2` section for "Driver system providers"
- Multiple `h3` subsections like "A", "B", and "C", each containing `p` elements with contact details, all wrapped inside nested `div` tags.

The `show_contents_list?` method wasn't picking up this content due to the nested structure. As a result, the conditions returned `false`, causing the content list to be omitted.

### Solution:

I updated the `first_item_content` method in `contents_list.rb` to handle nested `divs` and introduced other methods to extract valid elements `p`, `ul`, and `ol` inside a nested `div` element, ensuring that all content is considered.

### Tests:

Several test cases have been added:
1. Test case for long content in nested elements: It shows the content list when the first item contains long content inside nested `div` elements.
2. Test case for short content in nested elements: Ensures that the content list is not shown when the first item contains short content, even if it is nested inside `divs`.
3. Deep div nesting: This tests that the method correctly extracts text from deeply nested divs while ignoring allowed elements

### Testing:

The [page](https://government-frontend-pr-3348.herokuapp.com/government/publications/dvsa-earned-recognition-it-or-software-you-need/vehicle-operator-it-systems-and-software-that-work-with-dvsa-earned-recognition) now correctly renders the content list:
- first_item_content.length: 2817
- first_item_has_long_content? true
- first_item_content now captures the actual content.

## Why
Without this fix, pages with only two content items and no recognised long content could fail to render the content list, leaving an empty whitespace that negatively impacts user experience.

## Visual Changes
| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/629524af-077d-4ce1-a032-89becfd78d09) | <img width="1068" alt="image" src="https://github.com/user-attachments/assets/8010f50c-d38e-4b3c-ad95-d842c807eb59"> |

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
