### PR TITLE
Fix markup (and therefore styling) of RTL history mode banner

### DIFF
--- a/app/views/shared/_history_notice.html.erb
+++ b/app/views/shared/_history_notice.html.erb
@@ -1,5 +1,8 @@
 <% if content_item.historically_political? %>
   <%= render "govuk_publishing_components/components/notice", {
-    title: t("shared.historically_political", government: content_item.publishing_government),
+    title: sanitize(
+      t("shared.historically_political", government: "<span lang='en' dir='ltr'>#{content_item.publishing_government}</span>"),
+      attributes: %w(lang dir),
+    ),
   } %>
 <% end %>

--- a/test/integration/news_article_test.rb
+++ b/test/integration/news_article_test.rb
@@ -42,6 +42,14 @@ class NewsArticleTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "marks up government name correctly" do
+    setup_and_visit_content_item("news_article_history_mode_translated_arabic")
+
+    within ".govuk-notification-banner__content" do
+      assert page.has_css?("span[lang='en'][dir='ltr']", text: "2022 to 2024 Sunak Conservative government")
+    end
+  end
+
   test "does not render with the single page notification button" do
     setup_and_visit_content_item("news_article")
     assert_not page.has_css?(".gem-c-single-page-notification-button")


### PR DESCRIPTION
Depends on https://github.com/alphagov/publishing-api/pull/2901.

Right-to-left languages were displaying the government name in an unusual way, treating the government name as translated text even though it is still English. This commit fixes the text direction, as well as setting the correct language for the text snippet.

Before:
![to 2024 Sunak Conservative government 2022](https://github.com/user-attachments/assets/999781ba-8f6e-4c03-8f6d-00d9b8921c4c)

After:
![2022 to 2024 Sunak Conservative government](https://github.com/user-attachments/assets/d94c7979-03f3-46ca-bc97-4a86951a8b31)

Trello: https://trello.com/c/dyyPjZxD/2870-history-mode-banners-in-foreign-languages-govt-agency-general-issue

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
