### PR TITLE
Refactor contents list logic

### DIFF
--- a/app/presenters/content_item/contents_list.rb
+++ b/app/presenters/content_item/contents_list.rb
@@ -1,9 +1,9 @@
 module ContentItem
   module ContentsList
-    CHARACTER_LIMIT = 415
-    CHARACTER_LIMIT_WITH_IMAGE = 224
-    TABLE_ROW_LIMIT = 13
-    TABLE_ROW_LIMIT_WITH_IMAGE = 6
+    MINIMUM_CHARACTER_COUNT = 415
+    MINIMUM_CHARACTER_COUNT_IF_IMAGE_PRESENT = 224
+    MINIMUM_TABLE_ROW_COUNT = 13
+    MINIMUM_TABLE_ROW_COUNT_IF_IMAGE_PRESENT = 6
 
     def contents
       @contents ||=
@@ -40,7 +40,7 @@ module ContentItem
     end
 
     def first_item_has_long_content?
-      first_item_character_count > CHARACTER_LIMIT
+      first_item_character_count > MINIMUM_CHARACTER_COUNT
     end
 
     def first_item_content
@@ -61,7 +61,7 @@ module ContentItem
     end
 
     def first_item_has_long_table?
-      first_item_table_rows > TABLE_ROW_LIMIT
+      first_item_table_rows > MINIMUM_TABLE_ROW_COUNT
     end
 
     def find_first_table
@@ -92,11 +92,11 @@ module ContentItem
     end
 
     def first_item_has_image_and_long_content?
-      first_item_has_image? && first_item_character_count > CHARACTER_LIMIT_WITH_IMAGE
+      first_item_has_image? && first_item_character_count > MINIMUM_CHARACTER_COUNT_IF_IMAGE_PRESENT
     end
 
     def first_item_has_image_and_long_table?
-      first_item_has_image? && first_item_table_rows > TABLE_ROW_LIMIT_WITH_IMAGE
+      first_item_has_image? && first_item_table_rows > MINIMUM_TABLE_ROW_COUNT_IF_IMAGE_PRESENT
     end
 
     def parsed_body

--- a/app/presenters/content_item/contents_list.rb
+++ b/app/presenters/content_item/contents_list.rb
@@ -23,13 +23,22 @@ module ContentItem
       return true if contents_items.count > 2
       return false if no_first_item?
 
-      first_item_has_long_content? ||
-        first_item_has_long_table? ||
-        first_item_has_image_and_long_content? ||
-        first_item_has_image_and_long_table?
+      first_item_size_requirements_met?(character_count, table_row_count)
     end
 
   private
+
+    def first_item_size_requirements_met?(char_count, table_row_count)
+      first_item_character_count > char_count || first_item_table_rows > table_row_count
+    end
+
+    def character_count
+      first_item_has_image? ? MINIMUM_CHARACTER_COUNT_IF_IMAGE_PRESENT : MINIMUM_CHARACTER_COUNT
+    end
+
+    def table_row_count
+      first_item_has_image? ? MINIMUM_TABLE_ROW_COUNT_IF_IMAGE_PRESENT : MINIMUM_TABLE_ROW_COUNT
+    end
 
     def extract_headings_with_ids
       headings = parsed_body.css("h2").map do |heading|
@@ -37,10 +46,6 @@ module ContentItem
         { text: view_context.strip_trailing_colons(heading.text), id: id.value } if id
       end
       headings.compact
-    end
-
-    def first_item_has_long_content?
-      first_item_character_count > MINIMUM_CHARACTER_COUNT
     end
 
     def first_item_content
@@ -58,10 +63,6 @@ module ContentItem
 
     def first_item_character_count
       @first_item_character_count ||= first_item_content.length
-    end
-
-    def first_item_has_long_table?
-      first_item_table_rows > MINIMUM_TABLE_ROW_COUNT
     end
 
     def find_first_table
@@ -89,14 +90,6 @@ module ContentItem
         element = element.next_element
         return false if element.nil?
       end
-    end
-
-    def first_item_has_image_and_long_content?
-      first_item_has_image? && first_item_character_count > MINIMUM_CHARACTER_COUNT_IF_IMAGE_PRESENT
-    end
-
-    def first_item_has_image_and_long_table?
-      first_item_has_image? && first_item_table_rows > MINIMUM_TABLE_ROW_COUNT_IF_IMAGE_PRESENT
     end
 
     def parsed_body

--- a/test/presenters/content_item/contents_list_test.rb
+++ b/test/presenters/content_item/contents_list_test.rb
@@ -17,7 +17,7 @@ class ContentItemContentsListTest < ActiveSupport::TestCase
       end
     end
 
-    @contents_list.expects(:contents_items).returns([{ text: "A heading", id: "custom" }]).once
+    @contents_list.expects(:show_contents_list?).returns(true).once
     @contents_list.contents
     @contents_list.contents
   end


### PR DESCRIPTION
The original implementation could result in the `show_contents_list?` method returning nil
rather than true or false. Which is unexpected, and has been a barrier
to changing when and where we display contents lists ([trello](https://trello.com/c/lT8fhx5Q/2806-display-content-lists-on-publications-even-when-there-are-fewer-than-3-h2s-m-l)) because of confusing
test failures (https://github.com/alphagov/government-frontend/pull/3361).
