### PR TITLE
Improve print styles for right-to-left (RTL) content.

### DIFF
--- a/app/assets/stylesheets/components/_figure.scss
+++ b/app/assets/stylesheets/components/_figure.scss
@@ -17,7 +17,7 @@
   width: 100%;
 
   @include govuk-media-query($from: tablet) {
-    float: left;
+    float: inline-start;
     width: 50%;
   }
 }
@@ -29,8 +29,8 @@
     display: block;
     vertical-align: top;
     box-sizing: border-box;
-    float: left;
-    padding-left: govuk-spacing(3);
+    float: inline-end;
+    padding-inline-start: govuk-spacing(3);
     width: 50%;
   }
 

--- a/app/assets/stylesheets/components/_published-dates.scss
+++ b/app/assets/stylesheets/components/_published-dates.scss
@@ -4,6 +4,10 @@
   direction: ltr;
   line-height: 1.45em;
   color: govuk-colour("black");
+
+  .direction-rtl & {
+    direction: rtl;
+  }
 }
 
 .app-c-published-dates__toggle {

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -4,7 +4,7 @@
   ) %>
 <% end %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
@@ -20,7 +20,7 @@
   <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 <% end %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds ">
     <div class="content-bottom-margin">
       <div class="responsive-bottom-margin">

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -10,7 +10,7 @@
 
 <%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title } %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title',
       context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
@@ -33,7 +33,7 @@
   <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 <% end %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
     <div class="responsive-bottom-margin">
       <% if @content_item.national_applicability.present? %>

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -4,7 +4,7 @@
   ) %>
 <% end %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
   </div>
@@ -20,7 +20,7 @@
   <%= render 'govuk_publishing_components/components/notice', @content_item.withdrawal_notice_component  %>
 <% end %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
     <div class="content-bottom-margin">
       <div class="responsive-bottom-margin">

--- a/app/views/shared/_publisher_metadata_with_logo.html.erb
+++ b/app/views/shared/_publisher_metadata_with_logo.html.erb
@@ -3,7 +3,7 @@
   metadata_component_options[:margin_bottom] = 3 if @notification_button_visible
 %>
 <div class="govuk-grid-row">
-  <div class="metadata-logo-wrapper<%= ' responsive-bottom-margin' if @content_item.try(:logo) %>">
+  <div class="metadata-logo-wrapper gem-print-columns-none <%= ' responsive-bottom-margin' if @content_item.try(:logo) %>">
     <div class="govuk-grid-column-two-thirds metadata-column">
       <%= render 'govuk_publishing_components/components/metadata', metadata_component_options %>
     </div>


### PR DESCRIPTION
## What
Improvements to components and layouts so that right-to-left (RTL) content renders correctly when printing*. This is part of the work to improve print styles more generally. [Trello](https://trello.com/c/6E5UoTiK/335-rtl-print-styles-have-been-considered-and-implemented-where-required)

_Note:_ This PR depends on https://github.com/alphagov/govuk_publishing_components/pull/4365 and https://github.com/alphagov/collections/pull/3835 and the _After_ screenshots below include those dependecies.

_* Although this PR is specifically about print styles, some fixes also apply to the screen rendering due to problems originating in the screen styles._

## Why
Some pages are broken for foreign languages that read right to left, with styles not set correctly for the changed direction.

## Visual Changes
### Publications Page
| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/772789b4-fe9f-44f0-9efa-e5d99aa2dce7) | ![image](https://github.com/user-attachments/assets/2c207661-4ae9-4842-bb0c-e0f01152026e)  |

### News Article
| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/89010e8f-32e7-4270-8d1b-f3c6de408926) | ![image](https://github.com/user-attachments/assets/09261620-3e16-479e-87fd-9076e02b57c6) |

### Speech
| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/a5e34a35-720a-4011-8271-57dde0057c12) | ![image](https://github.com/user-attachments/assets/30365494-bf04-4168-a384-29b5668abe0e) |
