### PR TITLE
Unsubscribe button on document collection pages

### DIFF
--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -3,6 +3,9 @@
     schema: :article
   ) %>
 <% end %>
+
+<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title_and_context[:title] } %>
+
 <%= render 'shared/intervention_banner' %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/shared/_document_collections_email_signup.html.erb
+++ b/app/views/shared/_document_collections_email_signup.html.erb
@@ -11,5 +11,8 @@
     } %>
   </div>
 <% else %>
-  <%= render 'shared/single_page_notification_button', content_item: @content_item, skip_account: "true" %>
+  <%= render 'shared/single_page_notification_button', {
+    content_item: @content_item,
+    skip_account: @has_govuk_account ? "false" : "true"
+    } %>
 <% end %>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -310,7 +310,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert response.headers["Vary"].include?("GOVUK-Account-Session-Flash")
   end
 
-  %w[publication consultation detailed_guide call_for_evidence].each do |schema_name|
+  %w[publication consultation detailed_guide call_for_evidence document_collection].each do |schema_name|
     test "#{schema_name} displays the subscription success banner when the 'email-subscription-success' flash is present" do
       example_name = %w[consultation call_for_evidence].include?(schema_name) ? "open_#{schema_name}" : schema_name
       content_item = content_store_has_schema_example(schema_name, example_name)

--- a/test/integration/document_collection/email_notifications_test.rb
+++ b/test/integration/document_collection/email_notifications_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+module DocumentCollection
+  class EmailNotificationsTest < ActionDispatch::IntegrationTest
+    include GovukPersonalisation::TestHelpers::Features
+
+    def schema_type
+      "document_collection"
+    end
+
+    def taxonomy_topic_base_path
+      "/taxonomy_topic_base_path"
+    end
+
+    def email_alert_frontend_signup_endpoint_no_account
+      "/email-signup"
+    end
+
+    def email_alert_frontend_signup_endpoint_enforce_account
+      "/email/subscriptions/single-page/new"
+    end
+
+    test "renders a signup link if the document collection has a taxonomy topic email override" do
+      content_item = get_content_example("document_collection")
+      content_item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
+      stub_content_store_has_item(content_item["base_path"], content_item)
+      visit_with_cachebust(content_item["base_path"])
+      assert page.has_css?(".gem-c-signup-link")
+      assert page.has_link?(href: "/email-signup/confirm?topic=#{taxonomy_topic_base_path}")
+      assert_not page.has_css?(".gem-c-single-page-notification-button")
+    end
+
+    test "renders the single page notification button with a form action of email-alert-frontend's non account signup endpoint" do
+      setup_and_visit_content_item("document_collection")
+
+      form = page.find("form.gem-c-single-page-notification-button")
+      assert_match(email_alert_frontend_signup_endpoint_no_account, form["action"])
+
+      button = page.find(:button, class: "gem-c-single-page-notification-button__submit")
+
+      expected_tracking = {
+        "event_name" => "navigation",
+        "type" => "subscribe",
+        "index_link" => 1,
+        "index_total" => 2,
+        "section" => "Top",
+        "url" => email_alert_frontend_signup_endpoint_no_account,
+      }
+      actual_tracking = JSON.parse(button["data-ga4-link"])
+
+      assert_equal expected_tracking, actual_tracking
+    end
+
+    test "renders the single page notification button with a form action of EmailAlertAPI's account-only endpoint for users logged into their gov.uk account" do
+      # Need to use Rack as Selenium, the default driver, doesn't provide header access, and we need to set a govuk_account_session header
+      Capybara.current_driver = :rack_test
+      mock_logged_in_session
+      setup_and_visit_content_item("document_collection")
+
+      form = page.find("form.gem-c-single-page-notification-button")
+      assert_match(email_alert_frontend_signup_endpoint_enforce_account, form["action"])
+
+      button = page.find(:button, class: "gem-c-single-page-notification-button__submit")
+
+      expected_tracking = {
+        "event_name" => "navigation",
+        "type" => "subscribe",
+        "index_link" => 1,
+        "index_total" => 2,
+        "section" => "Top",
+        "url" => "/email/subscriptions/single-page/new",
+      }
+
+      actual_tracking = JSON.parse(button["data-ga4-link"])
+
+      assert_equal expected_tracking, actual_tracking
+
+      # reset back to default driver
+      Capybara.use_default_driver
+    end
+  end
+end

--- a/test/integration/document_collection_test.rb
+++ b/test/integration/document_collection_test.rb
@@ -132,17 +132,4 @@ class DocumentCollectionTest < ActionDispatch::IntegrationTest
       assert page.has_text?("This was published under the 2010 to 2015 Conservative and Liberal Democrat coalition government")
     end
   end
-
-  test "renders with the single page notification button" do
-    setup_and_visit_content_item("document_collection")
-    assert page.has_css?(".gem-c-single-page-notification-button")
-    assert_not page.has_css?(".gem-c-signup-link")
-  end
-
-  test "renders with the taxonomy subscription button" do
-    setup_and_visit_content_item_with_taxonomy_topic_email_override("document_collection")
-    assert page.has_css?(".gem-c-signup-link")
-    assert page.has_link?(href: "/email-signup/confirm?topic=/testpath")
-    assert_not page.has_css?(".gem-c-single-page-notification-button")
-  end
 end


### PR DESCRIPTION
## What

Fix two issues with the email subscription signup process on Document Collection pages.

#### [First commit](https://github.com/alphagov/government-frontend/pull/3409/commits/dbb589261a7aded797c4888cc59127b42f5cd3c5): Display a flash message to confirm subscription. 

This should have been added in https://github.com/alphagov/government-frontend/pull/2535

|Before|After|
|-|-|
|<img width="876" alt="Screenshot 2024-11-12 at 22 28 09" src="https://github.com/user-attachments/assets/a7265f7d-96a4-4ea0-bd5b-b8203aba8ba9">|<img width="816" alt="Screenshot 2024-11-12 at 22 26 38" src="https://github.com/user-attachments/assets/eaee1c16-1230-46ce-a15f-eae93b81e733">|

#### [Second commit](https://github.com/alphagov/government-frontend/pull/3409/commits/c53a9076621824936caea4c7c779df23a2706851): Fix unsubscribe button

Allow users with a gov.uk account to unsubscribe from a document collection via the single page notification button. See commit message for full explanation and links to documentation. 

[Trello](https://trello.com/c/qCUfi1lj/2917-bug-single-page-notification-button-unsubscribe-button-broken-on-document-collections-for-users-with-a-govuk-account)
