### PR TITLE
Update app.json used by heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -40,6 +40,9 @@
   "image": "heroku/ruby",
   "buildpacks": [
     {
+      "url": "https://github.com/heroku/heroku-buildpack-nodejs"
+    },
+    {
       "url": "https://github.com/heroku/heroku-buildpack-ruby"
     }
   ],


### PR DESCRIPTION
Our review apps were failing at the line `Installing yarn-v1.22.22`. The error message from Heroku suggested specifically adding a buildpack for node.js before the ruby buildpack is fetched. See logs [here](https://dashboard.heroku.com/pipelines/9af8998d-0da3-4a5f-bd82-ac366adac06f/app-setup/abdac96e-7334-42b5-887f-452e81172b98).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
