### PR TITLE
Add flash success banner to document collection pages

### DIFF
--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -3,6 +3,9 @@
     schema: :article
   ) %>
 <% end %>
+
+<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title_and_context[:title] } %>
+
 <%= render 'shared/intervention_banner' %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -310,7 +310,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert response.headers["Vary"].include?("GOVUK-Account-Session-Flash")
   end
 
-  %w[publication consultation detailed_guide call_for_evidence].each do |schema_name|
+  %w[publication consultation detailed_guide call_for_evidence document_collection].each do |schema_name|
     test "#{schema_name} displays the subscription success banner when the 'email-subscription-success' flash is present" do
       example_name = %w[consultation call_for_evidence].include?(schema_name) ? "open_#{schema_name}" : schema_name
       content_item = content_store_has_schema_example(schema_name, example_name)


### PR DESCRIPTION
This was missing from https://github.com/alphagov/government-frontend/pull/2535