### PR TITLE
Remove HMRC UR banner

### DIFF
--- a/lib/data/recruitment_banners.yml
+++ b/lib/data/recruitment_banners.yml
@@ -9,13 +9,6 @@
   #     - /foreign-travel-advice
 
 banners:
-- name: HMRC banner 21/10/2024
-  suggestion_text: "Help improve GOV.UK"
-  suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
-  survey_url: https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_PAS_TAD
-  page_paths:
-    - /guidance/keeping-your-hmrc-login-details-safe
-    - /government/collections/hmrc-phishing-and-scams-detailed-information
 - name: AI banner 11/11/2024
   suggestion_text: "Help improve GOV.UK"
   suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,37 +1,6 @@
 require "test_helper"
 
 class RecruitmentBannerTest < ActionDispatch::IntegrationTest
-  test "HMRC banner 21/10/2024 is displayed on detailed guide of interest" do
-    detailed_guide = GovukSchemas::Example.find("detailed_guide", example_name: "detailed_guide")
-
-    detailed_guide["base_path"] = "/guidance/keeping-your-hmrc-login-details-safe"
-    stub_content_store_has_item(detailed_guide["base_path"], detailed_guide.to_json)
-    visit detailed_guide["base_path"]
-
-    assert page.has_css?(".gem-c-intervention")
-    assert page.has_link?("Sign up to take part in user research (opens in a new tab)", href: "https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_PAS_TAD")
-  end
-
-  test "HMRC banner 21/10/2024 is displayed on document collection of interest" do
-    document_collection = GovukSchemas::Example.find("document_collection", example_name: "document_collection")
-
-    document_collection["base_path"] = "/government/collections/hmrc-phishing-and-scams-detailed-information"
-    stub_content_store_has_item(document_collection["base_path"], document_collection.to_json)
-    visit document_collection["base_path"]
-
-    assert page.has_css?(".gem-c-intervention")
-    assert page.has_link?("Sign up to take part in user research (opens in a new tab)", href: "https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_PAS_TAD")
-  end
-
-  test "HMRC banner 21/10/2024 is not displayed on all pages" do
-    detailed_guide = GovukSchemas::Example.find("detailed_guide", example_name: "detailed_guide")
-    detailed_guide["base_path"] = "/nothing-to-see-here"
-    stub_content_store_has_item(detailed_guide["base_path"], detailed_guide.to_json)
-    visit detailed_guide["base_path"]
-
-    assert_not page.has_css?(".gem-c-intervention")
-  end
-
   test "AI banner 11/11/2024 is displayed on guides of interest" do
     guide_paths = [
       "/self-assessment-tax-returns",


### PR DESCRIPTION
Trello card: https://trello.com/c/KGa5vDZ0/3024-take-down-govuk-user-research-banner-hmrc

Preview pages: 
https://government-frontend-pr-3423.herokuapp.com/guidance/keeping-your-hmrc-login-details-safe
https://government-frontend-pr-3423.herokuapp.com/government/collections/hmrc-phishing-and-scams-detailed-information

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
