### PR TITLE
Adjust chat entry component

### DIFF
--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-column-one-third">
   <% if show_govuk_chat_promo?(@content_item.base_path) %>
-    <%= render "govuk_publishing_components/components/chat_entry", { border_top: true } %>
+    <%= render "govuk_publishing_components/components/chat_entry", { margin_top_until_tablet: true } %>
   <% end %>
 
   <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>


### PR DESCRIPTION
## What
This PR removes the blue border top from the chat entry component and adds a margin top on smaller screen sizes as per the design requirements.

Relies on [PR #4417](https://github.com/alphagov/govuk_publishing_components/pull/4417) in the components gem.

## Why
Design requirements - [trello card](https://trello.com/c/iOuUw0vs/2157-entry-banner-tweaks)

## Visual changes
### Before (answer page - desktop)
![image](https://github.com/user-attachments/assets/e77252cd-4473-422d-aa19-f9450e7b19bd)

### After (answer page - desktop)
![image](https://github.com/user-attachments/assets/84a7ab5d-f28a-48fb-b095-c7b78d8ad8dc)

### Before (answer page - mobile)
![image](https://github.com/user-attachments/assets/d0e61755-be6c-43b1-95aa-56fe560caef5)

### After (answer page - mobile)
![image](https://github.com/user-attachments/assets/209fb27f-5309-4bba-8412-490a4fe9d53f)

### Before (guidance page - desktop)
![image](https://github.com/user-attachments/assets/170df614-9f86-43f1-a418-c06da1039815)

### After (guidance page - desktop)
![image](https://github.com/user-attachments/assets/eae308d6-b080-4907-b530-f86087d83043)

### Before (guidance page - mobile)
![image](https://github.com/user-attachments/assets/0dab62b5-703d-403e-92c9-39940221508d)

### After (guidance page - mobile)
![image](https://github.com/user-attachments/assets/a952b95e-0fa9-4210-bb71-5e83d2579567)