### PR TITLE
Update Welsh translation of the print_entire_guide key

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -795,7 +795,7 @@ cy:
   multi_page:
     next_page: Nesaf
     previous_page: Blaenorol
-    print_entire_guide: Argraffu'r canllaw cyfan
+    print_entire_guide: Gweld fersiwn argraffadwy o'r canllaw cyfan
     printable_version:
   national_statistics:
     logo_alt_text: Ystadegau swyddogol achrededig


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

A Welsh speaking stakeholder has highlighted the following issue with the translation of page furniture on mainstream content eg [https://www.gov.uk/tax-appeals](https://www.gov.uk/tax-appeals "smartCard-inline")
 
At the bottom of each English mainstream page, it says: "View a printable version of the whole guide"
And at the bottom of the Welsh page it says "Argraffu’r canllaw cyfan". 

> While there is nothing inherently wrong with that (the Welsh says “Print the whole guide”), it is different from the English original, which says “View a printable version of the whole guide”.

## Why

[Trello card](https://trello.com/c/SzRgKgWB/3046-welsh-page-furniture-print-the-whole-guide-s)

## Screenshots

### Before

![Screenshot 2024-11-21 at 16-13-19 Anghytuno â phenderfyniad treth neu gosb Trosolwg - GOV UK](https://github.com/user-attachments/assets/fd75b203-25bf-4013-b9a7-875ef308cb55)

### After

![Screenshot 2024-11-21 at 16-16-07 Anghytuno â phenderfyniad treth neu gosb Trosolwg - GOV UK](https://github.com/user-attachments/assets/5aeb9e15-0602-405b-a09b-12de0c21a6c3)
