### PR TITLE
Fix GOV.UK Chat promo on pages with multiple path segments

### DIFF
--- a/app/helpers/govuk_chat_promo_helper.rb
+++ b/app/helpers/govuk_chat_promo_helper.rb
@@ -1,5 +1,5 @@
 module GovukChatPromoHelper
-  GOVUK_CHAT_PROMO_BASE_PATHS = %w[
+  GOVUK_CHAT_PROMO_PATHS = %w[
     /business-asset-disposal-relief
     /business-support-service
     /capital-gains-tax
@@ -65,7 +65,7 @@ module GovukChatPromoHelper
     /write-business-plan
   ].freeze
 
-  def show_govuk_chat_promo?(base_path)
-    ENV["GOVUK_CHAT_PROMO_ENABLED"] == "true" && GOVUK_CHAT_PROMO_BASE_PATHS.include?(base_path)
+  def show_govuk_chat_promo?(path)
+    ENV["GOVUK_CHAT_PROMO_ENABLED"] == "true" && GOVUK_CHAT_PROMO_PATHS.include?(path)
   end
 end

--- a/app/views/shared/_sidebar_navigation.html.erb
+++ b/app/views/shared/_sidebar_navigation.html.erb
@@ -1,7 +1,7 @@
 <% content_item = @content_item.content_item.parsed_content %>
 
 <div class="govuk-grid-column-one-third">
-  <% if show_govuk_chat_promo?(@content_item.base_path) %>
+  <% if show_govuk_chat_promo?(@content_item.requested_path) %>
     <%= render "govuk_publishing_components/components/chat_entry", { margin_top_until_tablet: true } %>
   <% end %>
 

--- a/test/helpers/govuk_chat_promo_helper_test.rb
+++ b/test/helpers/govuk_chat_promo_helper_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class GovukChatPromoHelperTest < ActionView::TestCase
   test "show_govuk_chat_promo? when configuration disabled" do
-    assert_not show_govuk_chat_promo?(GOVUK_CHAT_PROMO_BASE_PATHS.first)
+    assert_not show_govuk_chat_promo?(GOVUK_CHAT_PROMO_PATHS.first)
   end
 
   test "show_govuk_chat_promo? when base_path not in configuration" do
@@ -13,7 +13,7 @@ class GovukChatPromoHelperTest < ActionView::TestCase
 
   test "show_govuk_chat_promo? when base_path is in configuration" do
     ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
-      assert show_govuk_chat_promo?(GOVUK_CHAT_PROMO_BASE_PATHS.first)
+      assert show_govuk_chat_promo?(GOVUK_CHAT_PROMO_PATHS.first)
     end
   end
 end

--- a/test/integration/govuk_chat_promo_test.rb
+++ b/test/integration/govuk_chat_promo_test.rb
@@ -1,15 +1,31 @@
 require "test_helper"
 
 class GovukChatPromoTest < ActionDispatch::IntegrationTest
-  test "renders GOV.UK chat promo for matching content type and base path" do
+  test "renders GOV.UK chat promo for matching content type and requested path" do
     ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
-      setup_and_visit_a_page_with_specific_base_path("answer", GovukChatPromoHelper::GOVUK_CHAT_PROMO_BASE_PATHS.first)
+      setup_and_visit_a_page_with_specific_base_path("guide", "/contracted-out")
 
       assert page.has_css?(".gem-c-chat-entry")
     end
   end
 
+  test "renders GOV.UK chat promo when requested path contains multiple parts" do
+    ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+      setup_and_visit_a_page_with_specific_base_path("guide", "/contracted-out/how-contracting-out-affects-your-amount")
+
+      assert page.has_css?(".gem-c-chat-entry")
+    end
+  end
+
+  test "does not render GOV.UK chat promo when base path is in allow list but actual path is not" do
+    ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+      setup_and_visit_a_page_with_specific_base_path("guide", "/contracted-out/check-if-you-were-contracted-out")
+
+      assert_not page.has_css?(".gem-c-chat-entry")
+    end
+  end
+
   def schema_type
-    "answer"
+    "guide"
   end
 end


### PR DESCRIPTION
We have an allow list of URLs on which we want to render the GOV.UK Chat
promo, which we compare the content item's `base_path` against to
determine whether to show the promo or not.

This results in a bug in some guide pages where we only want to show the
promo on certain steps of the guide.

Let's consider the "/contracted-out" URL. This guide has 3 steps, and so
3 URLs

1. /contracted-out
2. /contracted-out/how-contracting-out-affects-your-amount
3. /contracted-out/check-if-you-were-contracted-out

We only want to show the promo on URL 1 and 3 in the list above, but not
the second one.

With the current logic, we're showing the promo on all of these URLs.
That's because we're looking at the `content_item.base_path` property,
which is "/contracted-out" for all of those URLs.

Instead we should do the comparison on the `requested_path` method,
which is the full path.

It also fixes a bug in a similar vein where we want to show the promo on
only one of the sub-pages in a guide (e.g. URL 2 above), but because
we're comparing against the `base_path`, we end up showing it on all
pages of the guide.