### PR TITLE
Translate correctly Welsh published date

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -126,7 +126,7 @@ private
   end
 
   def display_date(timestamp, format = "%-d %B %Y")
-    I18n.l(Time.zone.parse(timestamp), format:, locale: "en") if timestamp
+    I18n.l(Time.zone.parse(timestamp), format:, locale:) if timestamp
   end
 
   def sorted_locales(translations)

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -294,4 +294,18 @@ class PublicationTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item("publication-with-featured-attachments", overrides)
     assert page.has_css?('meta[name="robots"][content="noindex"]', visible: false)
   end
+
+  test "translates Welsh published date correctly" do
+    setup_and_visit_content_item("publication", { "locale" => "cy" })
+
+    assert_has_metadata({
+      published: "3 Mai 2016",
+      from: {
+        "Environment Agency": "/government/organisations/environment-agency",
+        "The Rt Hon Sir Eric Pickles MP": "/government/people/eric-pickles",
+      },
+    })
+
+    assert_footer_has_published_dates("Cyhoeddwyd ar 3 Mai 2016")
+  end
 end


### PR DESCRIPTION
All months in the published date component need to be translated.

<img width="355" alt="Screenshot 2024-11-27 at 11 48 39" src="https://github.com/user-attachments/assets/09cac790-e141-487b-93e2-9bf2b5e15bda">

Trello card: https://trello.com/c/12ai7KMg/3072-allow-months-to-be-translated-in-the-published-dates-field-in-government-frontend-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
