### PR TITLE
Render news articles using GraphQL

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -136,15 +136,45 @@ private
   end
 
   def load_content_item
+    @content_item = if use_graphql?
+                      graphql_response = Services
+                        .publishing_api
+                        .graphql_content_item(Graphql::NewsArticleQuery.new(content_item_path).query)
+
+                      if graphql_response["schema_name"] == "news_article"
+                        PresenterBuilder.new(
+                          graphql_response,
+                          content_item_path,
+                          view_context,
+                        ).presenter
+                      else
+                        load_content_item_from_content_store
+                      end
+                    else
+                      load_content_item_from_content_store
+                    end
+  end
+
+  def load_content_item_from_content_store
     content_item = Services.content_store.content_item(content_item_path)
 
     content_item["links"]["ordered_related_items"] = ordered_related_items(content_item["links"]) if content_item["links"]
 
-    @content_item = PresenterBuilder.new(
+    PresenterBuilder.new(
       content_item,
       content_item_path,
       view_context,
     ).presenter
+  end
+
+  def use_graphql?
+    if params.include?(:graphql) && params[:graphql] == "true"
+      true
+    elsif params.include?(:graphql) && params[:graphql] == "false"
+      false
+    else
+      Features.graphql_feature_enabled?
+    end
   end
 
   def ordered_related_items(links)

--- a/app/lib/features.rb
+++ b/app/lib/features.rb
@@ -1,0 +1,5 @@
+class Features
+  def self.graphql_feature_enabled?
+    ENV["GRAPHQL_FEATURE_FLAG"]
+  end
+end

--- a/app/queries/graphql/news_article_query.rb
+++ b/app/queries/graphql/news_article_query.rb
@@ -1,0 +1,75 @@
+class Graphql::NewsArticleQuery
+  def initialize(base_path)
+    @base_path = base_path
+  end
+
+  def query
+    <<-QUERY
+        {
+          edition(
+            base_path: "#{@base_path}",
+            content_store: "live",
+          ) {
+            ... on NewsArticle {
+              base_path
+              description
+              details
+              document_type
+              first_published_at
+              links {
+                available_translations {
+                  base_path
+                  locale
+                }
+                government {
+                  details {
+                    current
+                  }
+                  title
+                }
+                organisations {
+                  base_path
+                  content_id
+                  title
+                }
+                people {
+                  base_path
+                  content_id
+                  title
+                }
+                taxons {
+                  base_path
+                  content_id
+                  document_type
+                  phase
+                  title
+                  links {
+                    parent_taxons {
+                      base_path
+                      content_id
+                      document_type
+                      phase
+                      title
+                    }
+                  }
+                }
+                topical_events {
+                  base_path
+                  content_id
+                  title
+                }
+                world_locations {
+                  base_path
+                  content_id
+                  title
+                }
+              }
+              locale
+              schema_name
+              title
+            }
+          }
+        }
+    QUERY
+  end
+end

--- a/test/fixtures/graphql/news_article.json
+++ b/test/fixtures/graphql/news_article.json
@@ -1,0 +1,74 @@
+{
+  "data":
+  {
+    "edition":
+    {
+      "base_path": "/government/news/announcement",
+      "description": "Summary of the news",
+      "details": {
+        "body": "Some text",
+        "political": "true"
+      },
+      "document_type": "news_story",
+      "first_published_at": "2016-12-25T01:02:03+00:00",
+      "links": {
+        "available_translations": [
+          {
+            "base_path": "/government/news/announcement",
+            "locale": "en"
+          }
+        ],
+        "government": [
+          {
+            "details": {
+              "current": false
+            },
+            "title": "A government"
+          }
+        ],
+        "organisations": [
+          {
+            "base_path": "/organisation-1",
+            "title": "An organisation"
+          }
+        ],
+        "people": [
+          {
+            "base_path": "/person-1",
+            "title": "A person"
+          }
+        ],
+        "taxons": [
+          {
+            "base_path": "/taxon-2",
+            "content_id": "8fa1fa2f-bcce-4cde-98fb-308514c35c63",
+            "title": "Taxon 2",
+            "links": {
+              "parent_taxons": [
+                {
+                  "base_path": "/taxon-1",
+                  "content_id": "9de167ce-6c4f-40b1-a45e-e3160d75556e",
+                  "title": "Taxon 1"
+                }
+              ]
+            }
+          }
+        ],
+        "topical_events": [
+          {
+            "base_path": "/topical-event-1",
+            "title": "A topical event"
+          }
+        ],
+        "world_locations": [
+          {
+            "base_path": "/world-location-1",
+            "title": "A world location"
+          }
+        ]
+      },
+      "schema_name": "news_article",
+      "title": "Generic news article"
+    }
+  }
+}

--- a/test/presenter_test_helper.rb
+++ b/test/presenter_test_helper.rb
@@ -28,3 +28,17 @@ class PresenterTestCase < ActiveSupport::TestCase
     govuk_content_schema_example(schema, type)
   end
 end
+
+class GraphqlPresenterTestCase < PresenterTestCase
+  def create_presenter(presenter_class,
+                       content_item: fetch_graphql_content_item("news_article"),
+                       requested_path: "/test-content-item",
+                       view_context: ApplicationController.new.view_context)
+    presenter_class.new(content_item, requested_path, view_context)
+  end
+
+  def presented_item(type = schema_name, overrides = {})
+    example = fetch_graphql_content_item(type)
+    present_example(example.merge(overrides))
+  end
+end

--- a/test/presenters/news_article_graphql_presenter_test.rb
+++ b/test/presenters/news_article_graphql_presenter_test.rb
@@ -1,0 +1,33 @@
+require "presenter_test_helper"
+
+class NewsArticleGraphqlPresenterTest
+  class NewsArticleGraphqlPresenterTestCase < GraphqlPresenterTestCase
+    attr_accessor :example_schema_name
+
+    def schema_name
+      "news_article"
+    end
+  end
+
+  class PresentedNewsArticleGraphqlTest < NewsArticleGraphqlPresenterTestCase
+    test "presents a description" do
+      assert_equal "Summary of the news", presented_item.description
+    end
+
+    test "presents a body" do
+      assert_equal "Some text", presented_item.body
+    end
+
+    test "presents a readable first published date" do
+      assert_equal "25 December 2016", presented_item.published
+    end
+
+    test "presents the locale" do
+      assert_equal "en", presented_item.locale
+    end
+
+    test "presents historically political" do
+      assert presented_item.historically_political?
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -280,3 +280,14 @@ class ActionDispatch::IntegrationTest
     }
   end
 end
+
+def fetch_graphql_fixture(filename)
+  json = File.read(
+    Rails.root.join("test", "fixtures", "graphql", "#{filename}.json"),
+  )
+  JSON.parse(json)
+end
+
+def fetch_graphql_content_item(filename)
+  fetch_graphql_fixture(filename).dig("data", "edition")
+end


### PR DESCRIPTION
This switches the rendering of news articles to use Publishing API's GraphQL endpoint, only when the feature flag is enabled.

The code here (and in the associated Publishing API PR: https://github.com/alphagov/publishing-api/pull/3008) has been written in such a way that the least number of changes have been needed in this app, as this is only a proof of concept for now.  If we decide to use GraphQL for everything going forward, we should revisit the structure of content returned by GraphQL.

Also note that GraphQL powered queries rely on an initial request to Content Store, since we need to know the content type before deciding whether to use GraphQL.

Furthermore it only renders one level of parent taxon.  We will have follow-up work to change how the taxonomy is presented by GraphQL, as it's recursive nature doesn't fit the current implementation.

[Trello card](https://trello.com/c/RMkMvY8b)