### PR TITLE
Translate "Skip contents" link to Welsh

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -697,7 +697,7 @@ cy:
     title: Dydy'r dudalen rydych chi'n chwilio amdani ddim ar gael mwyach
   guide:
     pages_in_guide: Tudalennau yn y canllaw hwn
-    skip_contents:
+    skip_contents: Sgipio cynnwys
   html_publication:
     print_meta_data:
       available_at: Mae'r cyhoeddiad hwn ar gael yn %{url}

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -16,6 +16,18 @@ class GuideTest < ActionDispatch::IntegrationTest
     assert page.has_css?(".govuk-link.govuk-link--no-visited-state[href$='/print']", text: "View a printable version of the whole guide")
   end
 
+  test "skip link in English" do
+    setup_and_visit_content_item("guide")
+
+    assert page.has_css?(".gem-c-skip-link", text: "Skip contents")
+  end
+
+  test "translated skip link" do
+    setup_and_visit_content_item("guide", { "locale" => "cy" })
+
+    assert page.has_css?(".gem-c-skip-link", text: "Sgipio cynnwys")
+  end
+
   test "draft access tokens are appended to part links within navigation" do
     setup_and_visit_content_item_with_params("guide", "?token=some_token")
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Translate "Skip contents" link to Welsh.

## Why

[Trello card](https://trello.com/c/sLfqPAYv/3074-confusing-skip-link-text-on-guides-for-welsh-translation-only)
