### PR TITLE
Fix hmrc manuals heading

### DIFF
--- a/app/views/content_items/hmrc_manual.html.erb
+++ b/app/views/content_items/hmrc_manual.html.erb
@@ -13,7 +13,7 @@
   <% @content_item.section_groups.each do |group| %>
     <% next unless group["child_sections"].present? %>
     <div class="subsection-collection">
-      <%= render "content_items/manuals/hmrc_sections", group: group %>
+      <%= render "content_items/manuals/hmrc_sections", group: group, heading_level: 3 %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/content_items/hmrc_manual_section.html.erb
+++ b/app/views/content_items/hmrc_manual_section.html.erb
@@ -21,7 +21,7 @@
 
   <% @content_item.section_groups.each do | group | %>
     <div class="subsection-collection govuk-grid-column-full">
-      <%= render "content_items/manuals/hmrc_sections", group: group %>
+      <%= render "content_items/manuals/hmrc_sections", group: group, heading_level: 2 %>
     </div>
   <% end %>
 

--- a/app/views/content_items/manuals/_hmrc_sections.html.erb
+++ b/app/views/content_items/manuals/_hmrc_sections.html.erb
@@ -1,5 +1,10 @@
 <% if group["title"] %>
-  <%= group["title"] %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: group["title"],
+    font_size: "m",
+    heading_level:,
+    margin_bottom: 4,
+  } %>
 <% end %>
 
 <ol class="section-list hmrc">

--- a/test/integration/hmrc_manual_test.rb
+++ b/test/integration/hmrc_manual_test.rb
@@ -54,6 +54,12 @@ class HmrcManualTest < ActionDispatch::IntegrationTest
     assert page.has_selector?("h2", text: I18n.t("manuals.contents_title"))
   end
 
+  test "renders sections title heading" do
+    setup_and_visit_content_item("vat-government-public-bodies")
+
+    assert page.has_selector?("h3", text: "Historic updates")
+  end
+
   test "renders section groups" do
     setup_and_visit_content_item("vat-government-public-bodies")
 


### PR DESCRIPTION
**Example of HMRC manual section pages:** 
- https://government-frontend-pr-3464.herokuapp.com/hmrc-internal-manuals/inheritance-tax-manual/ihtm35000

Before:
![Screenshot 2025-01-16 at 09 35 02](https://github.com/user-attachments/assets/726e27b4-13d7-404b-9512-00e4262c6e81)

After:
![Screenshot 2025-01-16 at 09 34 48](https://github.com/user-attachments/assets/279a8dae-31f5-4d17-8d36-035be325a8ce)

**Example of HMRC manual pages:**
- https://government-frontend-pr-3464.herokuapp.com/hmrc-internal-manuals/paye-manual
- https://government-frontend-pr-3464.herokuapp.com/hmrc-internal-manuals/cotax-manual

 Before:
![Screenshot 2025-01-16 at 09 35 25](https://github.com/user-attachments/assets/808ff0e3-a08c-4d4a-ae50-49df321ec7a1)

After:
![Screenshot 2025-01-16 at 09 35 11](https://github.com/user-attachments/assets/35f98979-7e7d-479e-9631-1eeaad528d86)



Trello card: https://trello.com/c/siEO6N64/3097-hmrc-manuals-api-section-headings-issue-l#