### PR TITLE
Hide email signup button from pages that do not have an :en locale

### DIFF
--- a/app/presenters/content_item/single_page_notification_button.rb
+++ b/app/presenters/content_item/single_page_notification_button.rb
@@ -8,8 +8,12 @@ module ContentItem
       5f9c6c15-7631-11e4-a3cb-005056011aef
     ].freeze
 
-    def has_single_page_notifications?
-      !EXEMPTION_LIST.include? content_item["content_id"]
+    def page_is_on_exemption_list?
+      EXEMPTION_LIST.include? content_item["content_id"]
+    end
+
+    def display_single_page_notification_button?
+      !page_is_on_exemption_list?
     end
   end
 end

--- a/app/presenters/content_item/single_page_notification_button.rb
+++ b/app/presenters/content_item/single_page_notification_button.rb
@@ -13,7 +13,7 @@ module ContentItem
     end
 
     def display_single_page_notification_button?
-      !page_is_on_exemption_list?
+      !page_is_on_exemption_list? && I18n.locale == :en
     end
   end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -47,7 +47,7 @@ class ContentItemPresenter
     false
   end
 
-  def has_single_page_notifications?
+  def display_single_page_notification_button?
     false
   end
 

--- a/app/presenters/document_collection/signup_link.rb
+++ b/app/presenters/document_collection/signup_link.rb
@@ -1,7 +1,7 @@
 module DocumentCollection
   module SignupLink
     def show_email_signup_link?
-      taxonomy_topic_email_override_base_path.present?
+      taxonomy_topic_email_override_base_path.present? && I18n.locale == :en
     end
 
     def taxonomy_topic_email_override_base_path

--- a/app/presenters/document_collection/signup_link.rb
+++ b/app/presenters/document_collection/signup_link.rb
@@ -1,0 +1,11 @@
+module DocumentCollection
+  module SignupLink
+    def show_email_signup_link?
+      taxonomy_topic_email_override_base_path.present?
+    end
+
+    def taxonomy_topic_email_override_base_path
+      content_item.dig("links", "taxonomy_topic_email_override", 0, "base_path")
+    end
+  end
+end

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -5,6 +5,7 @@ class DocumentCollectionPresenter < ContentItemPresenter
   include ContentItem::TitleAndContext
   include ContentItem::ContentsList
   include ContentItem::SinglePageNotificationButton
+  include DocumentCollection::SignupLink
 
   def contents_items
     groups.map do |group|
@@ -52,10 +53,6 @@ class DocumentCollectionPresenter < ContentItemPresenter
       class: "govuk-heading-m govuk-!-font-size-27",
       id: group_title_id(title),
     )
-  end
-
-  def taxonomy_topic_email_override_base_path
-    content_item.dig("links", "taxonomy_topic_email_override", 0, "base_path")
   end
 
 private

--- a/app/views/shared/_document_collections_email_signup.html.erb
+++ b/app/views/shared/_document_collections_email_signup.html.erb
@@ -1,4 +1,4 @@
-<% if @content_item.taxonomy_topic_email_override_base_path.present? %>
+<% if @content_item.show_email_signup_link? %>
   <div
     data-module="ga4-link-tracker"
     data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'

--- a/app/views/shared/_document_collections_email_signup.html.erb
+++ b/app/views/shared/_document_collections_email_signup.html.erb
@@ -10,7 +10,7 @@
       margin_bottom: 6
     } %>
   </div>
-<% else %>
+<% elsif @content_item.display_single_page_notification_button? %>
   <%= render 'shared/single_page_notification_button', {
     content_item: @content_item,
     skip_account: @has_govuk_account ? "false" : "true"

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -10,7 +10,7 @@
 
 <div class="published-dates-button-group">
   <h2 class="govuk-visually-hidden">
-    <% if @content_item.has_single_page_notifications? %>
+    <% if @content_item.display_single_page_notification_button? %>
       <%= I18n.t("common.email_and_print_link") %>
     <% else %>
       <%= I18n.t("common.print_link") %>
@@ -33,7 +33,7 @@
         section: "Footer"
       }
     }
-  } if @content_item.has_single_page_notifications? %>
+  } if @content_item.display_single_page_notification_button? %>
   <%= render "govuk_publishing_components/components/print_link", {
     margin_top: 0,
     margin_bottom: 8,

--- a/app/views/shared/_single_page_notification_button.html.erb
+++ b/app/views/shared/_single_page_notification_button.html.erb
@@ -1,24 +1,26 @@
-<%
-  default_ga4_data_attributes = {
-    module: "ga4-link-tracker",
-    ga4_link: {
-      event_name: "navigation",
-      type: "subscribe",
-      index_link: 1,
-      index_total: 2,
-      section: "Top"
+<% if @content_item.display_single_page_notification_button? %>
+  <%
+    default_ga4_data_attributes = {
+      module: "ga4-link-tracker",
+      ga4_link: {
+        event_name: "navigation",
+        type: "subscribe",
+        index_link: 1,
+        index_total: 2,
+        section: "Top"
+      }
     }
-  }
-%>
+  %>
 
-<% ga4_data_attributes = ga4_data_attributes || default_ga4_data_attributes %>
-<% skip_account = skip_account || "false" %>
+  <% ga4_data_attributes = ga4_data_attributes || default_ga4_data_attributes %>
+  <% skip_account = skip_account || "false" %>
 
-<%= render 'govuk_publishing_components/components/single_page_notification_button', {
-  base_path: @content_item.base_path,
-  js_enhancement: @has_govuk_account,
-  ga4_data_attributes: ga4_data_attributes,
-  margin_bottom: 6,
-  button_location: "top",
-  skip_account: skip_account,
-} if @content_item.display_single_page_notification_button? %>
+  <%= render 'govuk_publishing_components/components/single_page_notification_button', {
+    base_path: @content_item.base_path,
+    js_enhancement: @has_govuk_account,
+    ga4_data_attributes: ga4_data_attributes,
+    margin_bottom: 6,
+    button_location: "top",
+    skip_account: skip_account,
+  } %>
+<% end %>

--- a/app/views/shared/_single_page_notification_button.html.erb
+++ b/app/views/shared/_single_page_notification_button.html.erb
@@ -21,4 +21,4 @@
   margin_bottom: 6,
   button_location: "top",
   skip_account: skip_account,
-} if @content_item.has_single_page_notifications? %>
+} if @content_item.display_single_page_notification_button? %>

--- a/test/integration/call_for_evidence_test.rb
+++ b/test/integration/call_for_evidence_test.rb
@@ -371,9 +371,14 @@ class CallForEvidenceTest < ActionDispatch::IntegrationTest
     assert page.has_css?("a", text: "Twitter")
   end
 
-  test "renders with the single page notification button" do
+  test "renders with the single page notification button on English language pages" do
     setup_and_visit_content_item("open_call_for_evidence")
     assert page.has_css?(".gem-c-single-page-notification-button")
+  end
+
+  test "does not render the single page notification button on foreign language pages" do
+    setup_and_visit_content_item("open_call_for_evidence", "locale" => "cy")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
   end
 
   test "does not render the single page notification button on exempt pages" do

--- a/test/integration/consultation_test.rb
+++ b/test/integration/consultation_test.rb
@@ -372,7 +372,7 @@ class ConsultationTest < ActionDispatch::IntegrationTest
     assert page.has_css?("a", text: "Twitter")
   end
 
-  test "renders with the single page notification button" do
+  test "renders with the single page notification button on English language pages" do
     setup_and_visit_content_item("open_consultation")
     assert page.has_css?(".gem-c-single-page-notification-button")
 
@@ -389,6 +389,11 @@ class ConsultationTest < ActionDispatch::IntegrationTest
 
   test "does not render the single page notification button on exempt pages" do
     setup_and_visit_notification_exempt_page("open_consultation")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
+
+  test "does not render the single page notification button on foreign language pages" do
+    setup_and_visit_notification_exempt_page("open_consultation", "locale" => "cy")
     assert_not page.has_css?(".gem-c-single-page-notification-button")
   end
 end

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -82,7 +82,7 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
     assert_not_equal faq_schema["mainEntity"], []
   end
 
-  test "renders with the single page notification button" do
+  test "renders with the single page notification button on English language pages" do
     setup_and_visit_content_item("detailed_guide")
     assert page.has_css?(".gem-c-single-page-notification-button")
 
@@ -99,6 +99,11 @@ class DetailedGuideTest < ActionDispatch::IntegrationTest
 
   test "does not render the single page notification button on exempt pages" do
     setup_and_visit_notification_exempt_page("detailed_guide")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
+
+  test "does not render the single page notification button on foreign language pages" do
+    setup_and_visit_notification_exempt_page("detailed_guide", "locale" => "cy")
     assert_not page.has_css?(".gem-c-single-page-notification-button")
   end
 end

--- a/test/integration/document_collection/email_notifications_test.rb
+++ b/test/integration/document_collection/email_notifications_test.rb
@@ -20,8 +20,9 @@ module DocumentCollection
       "/email/subscriptions/single-page/new"
     end
 
-    test "renders a signup link if the document collection has a taxonomy topic email override" do
+    test "renders a signup link if the document collection has a taxonomy topic email override and the page is in English" do
       content_item = get_content_example("document_collection")
+      content_item["locale"] = "en"
       content_item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
       stub_content_store_has_item(content_item["base_path"], content_item)
       visit_with_cachebust(content_item["base_path"])
@@ -31,7 +32,7 @@ module DocumentCollection
     end
 
     test "renders the single page notification button with a form action of email-alert-frontend's non account signup endpoint" do
-      setup_and_visit_content_item("document_collection")
+      setup_and_visit_content_item("document_collection", "locale" => "en")
 
       form = page.find("form.gem-c-single-page-notification-button")
       assert_match(email_alert_frontend_signup_endpoint_no_account, form["action"])
@@ -55,7 +56,7 @@ module DocumentCollection
       # Need to use Rack as Selenium, the default driver, doesn't provide header access, and we need to set a govuk_account_session header
       Capybara.current_driver = :rack_test
       mock_logged_in_session
-      setup_and_visit_content_item("document_collection")
+      setup_and_visit_content_item("document_collection", "locale" => "en")
 
       form = page.find("form.gem-c-single-page-notification-button")
       assert_match(email_alert_frontend_signup_endpoint_enforce_account, form["action"])
@@ -77,6 +78,11 @@ module DocumentCollection
 
       # reset back to default driver
       Capybara.use_default_driver
+    end
+
+    test "does not render the single page notification button if the page is in a foreign language" do
+      setup_and_visit_content_item("document_collection", "locale" => "cy")
+      assert_not page.has_css?(".gem-c-single-page-notification-button")
     end
   end
 end

--- a/test/integration/document_collection/email_notifications_test.rb
+++ b/test/integration/document_collection/email_notifications_test.rb
@@ -84,5 +84,14 @@ module DocumentCollection
       setup_and_visit_content_item("document_collection", "locale" => "cy")
       assert_not page.has_css?(".gem-c-single-page-notification-button")
     end
+
+    test "does not render the email signup link if the page is in a foreign language" do
+      content_item = get_content_example("document_collection")
+      content_item["links"]["taxonomy_topic_email_override"] = [{ "base_path" => taxonomy_topic_base_path.to_s }]
+      content_item["locale"] = "cy"
+      stub_content_store_has_item(content_item["base_path"], content_item)
+      visit_with_cachebust(content_item["base_path"])
+      assert_not page.has_css?(".gem-c-signup-link")
+    end
   end
 end

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -269,7 +269,7 @@ class PublicationTest < ActionDispatch::IntegrationTest
     ])
   end
 
-  test "renders with the single page notification button" do
+  test "renders with the single page notification button on English language pages" do
     setup_and_visit_content_item("publication")
     assert page.has_css?(".gem-c-single-page-notification-button")
 
@@ -286,6 +286,11 @@ class PublicationTest < ActionDispatch::IntegrationTest
 
   test "does not render the single page notification button on exempt pages" do
     setup_and_visit_notification_exempt_page("publication")
+    assert_not page.has_css?(".gem-c-single-page-notification-button")
+  end
+
+  test "does not render the single page notification button on foreign language pages" do
+    setup_and_visit_content_item("publication", "locale" => "cy")
     assert_not page.has_css?(".gem-c-single-page-notification-button")
   end
 

--- a/test/presenters/call_for_evidence_presenter_test.rb
+++ b/test/presenters/call_for_evidence_presenter_test.rb
@@ -156,7 +156,7 @@ class CallForEvidencePresenterTest
       schema = schema_item("open_call_for_evidence")
       presented = presented_item("open_call_for_evidence", schema)
 
-      assert presented.has_single_page_notifications?
+      assert presented.display_single_page_notification_button?
     end
   end
 end

--- a/test/presenters/call_for_evidence_presenter_test.rb
+++ b/test/presenters/call_for_evidence_presenter_test.rb
@@ -152,11 +152,22 @@ class CallForEvidencePresenterTest
       assert_equal "https://twitter.com/share?url=https%3A%2F%2Fwww.test.gov.uk%2Fgovernment%2Fcall_for_evidence%2Fyouth-vaping-call-for-evidence&text=Youth%20Vaping", presented_item("open_call_for_evidence").share_links[1][:href]
     end
 
-    test "presents the single page notification button" do
-      schema = schema_item("open_call_for_evidence")
-      presented = presented_item("open_call_for_evidence", schema)
+    test "displays the single page notification button on English pages" do
+      I18n.with_locale("en") do
+        schema = schema_item("open_call_for_evidence")
+        presented = presented_item("open_call_for_evidence", schema)
 
-      assert presented.display_single_page_notification_button?
+        assert presented.display_single_page_notification_button?
+      end
+    end
+
+    test "does not display the single page notification button on foreign language pages" do
+      I18n.with_locale("fr") do
+        schema = schema_item("open_call_for_evidence")
+        presented = presented_item("open_call_for_evidence", schema)
+
+        assert_not presented.display_single_page_notification_button?
+      end
     end
   end
 end

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -175,7 +175,7 @@ class ConsultationPresenterTest
       schema = schema_item("open_consultation")
       presented = presented_item("open_consultation", schema)
 
-      assert presented.has_single_page_notifications?
+      assert presented.display_single_page_notification_button?
     end
   end
 end

--- a/test/presenters/consultation_presenter_test.rb
+++ b/test/presenters/consultation_presenter_test.rb
@@ -171,11 +171,20 @@ class ConsultationPresenterTest
       assert_equal "https://twitter.com/share?url=https%3A%2F%2Fwww.test.gov.uk%2Fgovernment%2Fconsultations%2Fpostgraduate-doctoral-loans&text=Postgraduate%20doctoral%20loans", presented_item("open_consultation").share_links[1][:href]
     end
 
-    test "presents the single page notification button" do
-      schema = schema_item("open_consultation")
-      presented = presented_item("open_consultation", schema)
+    test "displays the single page notification button on English pages" do
+      I18n.with_locale("en") do
+        schema = schema_item("open_consultation")
+        presented = presented_item("open_consultation", schema)
+        assert presented.display_single_page_notification_button?
+      end
+    end
 
-      assert presented.display_single_page_notification_button?
+    test "does not display the single page notification button on foreign language pages" do
+      I18n.with_locale("fr") do
+        schema = schema_item("open_consultation")
+        presented = presented_item("open_consultation", schema)
+        assert_not presented.display_single_page_notification_button?
+      end
     end
   end
 end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -86,6 +86,6 @@ class DetailedGuidePresenterTest < PresenterTestCase
 
   test "presents the single page notification button" do
     presented = presented_item("national_applicability_detailed_guide")
-    assert presented.has_single_page_notifications?
+    assert presented.display_single_page_notification_button?
   end
 end

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -84,8 +84,17 @@ class DetailedGuidePresenterTest < PresenterTestCase
     assert_equal presented.logo, expected
   end
 
-  test "presents the single page notification button" do
-    presented = presented_item("national_applicability_detailed_guide")
-    assert presented.display_single_page_notification_button?
+  test "displays the single page notification button on English pages" do
+    I18n.with_locale("en") do
+      presented = presented_item("national_applicability_detailed_guide")
+      assert presented.display_single_page_notification_button?
+    end
+  end
+
+  test "does not display the single page notification button on foreign language pages" do
+    I18n.with_locale("fr") do
+      presented = presented_item("national_applicability_detailed_guide")
+      assert_not presented.display_single_page_notification_button?
+    end
   end
 end

--- a/test/presenters/document_collection/signup_link_test.rb
+++ b/test/presenters/document_collection/signup_link_test.rb
@@ -21,13 +21,27 @@ class DocumentCollectionSignupLinkTest < ActiveSupport::TestCase
     assert_equal false, item.show_email_signup_link?
   end
 
-  test "show_email_signup_link? returns true if there is a linked taxonomy_topic_email_override" do
-    item = DummyContentItem.new
-    item.content_item["links"]["taxonomy_topic_email_override"] = [
-      {
-        "base_path" => "/a-taxonomy-topic",
-      },
-    ]
-    assert item.show_email_signup_link?
+  test "show_email_signup_link? returns false if the locale is not en" do
+    I18n.with_locale("fr") do
+      item = DummyContentItem.new
+      item.content_item["links"]["taxonomy_topic_email_override"] = [
+        {
+          "base_path" => "/a-taxonomy-topic",
+        },
+      ]
+      assert_equal false, item.show_email_signup_link?
+    end
+  end
+
+  test "show_email_signup_link? returns true if there is a linked taxonomy_topic_email_override and the locale is en" do
+    I18n.with_locale("en") do
+      item = DummyContentItem.new
+      item.content_item["links"]["taxonomy_topic_email_override"] = [
+        {
+          "base_path" => "/a-taxonomy-topic",
+        },
+      ]
+      assert item.show_email_signup_link?
+    end
   end
 end

--- a/test/presenters/document_collection/signup_link_test.rb
+++ b/test/presenters/document_collection/signup_link_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class DocumentCollectionSignupLinkTest < ActiveSupport::TestCase
+  class DummyContentItem
+    include DocumentCollection::SignupLink
+    attr_accessor :content_item
+
+    def initialize
+      @content_item = {}
+      @content_item["links"] = {}
+    end
+  end
+
+  test "taxonomy_topic_email_override_base_path returns nil if field is empty" do
+    item = DummyContentItem.new
+    assert_nil item.taxonomy_topic_email_override_base_path
+  end
+
+  test "show_email_signup_link? returns false if there is no linked taxonomy_topic_email_override" do
+    item = DummyContentItem.new
+    assert_equal false, item.show_email_signup_link?
+  end
+
+  test "show_email_signup_link? returns true if there is a linked taxonomy_topic_email_override" do
+    item = DummyContentItem.new
+    item.content_item["links"]["taxonomy_topic_email_override"] = [
+      {
+        "base_path" => "/a-taxonomy-topic",
+      },
+    ]
+    assert item.show_email_signup_link?
+  end
+end

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -120,8 +120,16 @@ class DocumentCollectionPresenterTest
       end
     end
 
-    test "renders with the single page notification button" do
-      assert presented_item.display_single_page_notification_button?
+    test "displays the single page notification button on English pages" do
+      I18n.with_locale("en") do
+        assert presented_item.display_single_page_notification_button?
+      end
+    end
+
+    test "does not display the single page notification button on foreign language pages" do
+      I18n.with_locale("fr") do
+        assert_not presented_item.display_single_page_notification_button?
+      end
     end
   end
 

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -119,6 +119,10 @@ class DocumentCollectionPresenterTest
         assert_nil nil, public_updated_at
       end
     end
+
+    test "renders with the single page notification button" do
+      assert presented_item.display_single_page_notification_button?
+    end
   end
 
   class GroupWithMissingDocument < TestCase

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -74,9 +74,18 @@ class PublicationPresenterTest < PresenterTestCase
     assert_equal(presented.national_applicability[:wales][:alternative_url], "http://wales.gov.uk/topics/statistics/headlines/housing2012/121025/?lang=en")
   end
 
-  test "presents the single page notification button" do
-    presented = presented_item("statistics_publication")
-    assert presented.display_single_page_notification_button?
+  test "displays the single page notification button on English pages" do
+    I18n.with_locale("en") do
+      presented = presented_item("statistics_publication")
+      assert presented.display_single_page_notification_button?
+    end
+  end
+
+  test "does not display the single page notification button on foreign language pages" do
+    I18n.with_locale("fr") do
+      presented = presented_item("statistics_publication")
+      assert_not presented.display_single_page_notification_button?
+    end
   end
 
   test "hide_from_search_engines? returns false" do

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -76,7 +76,7 @@ class PublicationPresenterTest < PresenterTestCase
 
   test "presents the single page notification button" do
     presented = presented_item("statistics_publication")
-    assert presented.has_single_page_notifications?
+    assert presented.display_single_page_notification_button?
   end
 
   test "hide_from_search_engines? returns false" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -194,8 +194,9 @@ class ActionDispatch::IntegrationTest
     end
   end
 
-  def setup_and_visit_notification_exempt_page(name)
+  def setup_and_visit_notification_exempt_page(name, overrides = {})
     @content_item = get_content_example(name).tap do |item|
+      item.deep_merge(overrides)
       item["content_id"] = ContentItem::SinglePageNotificationButton::EXEMPTION_LIST[0]
       stub_content_store_has_item(item["base_path"], item.to_json)
       visit_with_cachebust((item["base_path"]).to_s)


### PR DESCRIPTION
## What
Hide the single page notification button from pages that are not published in English. 

## Why
GOV.UK does not support email subscriptions to foreign language content. The single page notification button was added to all pages (English and foreign language). The consequence has been users signing up to an email subscription that will [never match a content change](https://github.com/alphagov/email-alert-service/blob/main/email_alert_service/models/major_change_message_processor.rb#L23-L26).

We _could_ make the button work so that clicking the button on eg a welsh page results
in the user signing up to the equivalent content in English. But we decided against this for the following reasons:

1. There is no indication that there is a user need for that behaviour
2. The code to fetch the english base-path would be added to the button component in the
gem. The logic for this button is already very complicated, and adding further complexity
feels like a bad idea.
3. Not all our publishing applications create foreign content with a link back to the english
version. So if the button was added to other content types in the future it wouldn't work as
expected eg https://www.gov.uk/api/content/budd-dal-plant-16-19
4. Hiding the signup button is the same approach used [elsewhere](https://github.com/alphagov/collections/blob/ea307473313aa5138e6db6dd16eb26f1bf453bfd/app/views/world_location_news/show.html.erb#L56-L86).

|Before|After|
|--|--|
|<img width="1080" alt="Screenshot 2024-12-06 at 16 50 52" src="https://github.com/user-attachments/assets/bf3abbfe-2233-4397-9605-ed453b8c363c">|<img width="985" alt="Screenshot 2024-12-06 at 16 50 21" src="https://github.com/user-attachments/assets/8f27c3a8-3521-4af4-b2f2-03ab91d8c932">|

[Review app](https://government-frontend-pr-3467.herokuapp.com/government/publications/investigation-of-building-control-professionals.cy)


[Trello](https://trello.com/c/24HBupfM/3107-hide-single-page-notification-button-on-welsh-pages) 