### PR TITLE
[WIP] Add search-with-autocomplete JS dependency

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,6 +7,7 @@
 //= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/radio
+//= require govuk_publishing_components/components/search-with-autocomplete
 //= require govuk_publishing_components/components/single-page-notification-button
 //= require govuk_publishing_components/components/step-by-step-nav
 


### PR DESCRIPTION
government-frontend doesn't call search-with-autocomplete directly, but instead calls it via the super navigation header in the layout for public that it injests via static.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
