### PR TITLE
Update GraphQL query to use generic edition type

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -139,7 +139,7 @@ private
     @content_item = if use_graphql?
                       graphql_response = Services
                         .publishing_api
-                        .graphql_content_item(Graphql::NewsArticleQuery.new(content_item_path).query)
+                        .graphql_content_item(Graphql::EditionQuery.new(content_item_path).query)
 
                       if graphql_response["schema_name"] == "news_article"
                         PresenterBuilder.new(

--- a/app/queries/graphql/edition_query.rb
+++ b/app/queries/graphql/edition_query.rb
@@ -1,4 +1,4 @@
-class Graphql::NewsArticleQuery
+class Graphql::EditionQuery
   def initialize(base_path)
     @base_path = base_path
   end
@@ -10,10 +10,25 @@ class Graphql::NewsArticleQuery
             base_path: "#{@base_path}",
             content_store: "live",
           ) {
-            ... on NewsArticle {
+            ... on Edition {
               base_path
               description
-              details
+              details {
+              body
+                change_history
+                default_news_image {
+                  alt_text
+                  url
+                }
+                display_date
+                emphasised_organisations
+                first_public_at
+                image {
+                  alt_text
+                  url
+                }
+                political
+              }
               document_type
               first_published_at
               links {

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -110,7 +110,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     base_path = "content-item"
 
     graphql_fixture = fetch_graphql_fixture("news_article")
-    stub_publishing_api_graphql_content_item(Graphql::NewsArticleQuery.new("/#{base_path}").query, graphql_fixture)
+    stub_publishing_api_graphql_content_item(Graphql::EditionQuery.new("/#{base_path}").query, graphql_fixture)
 
     get :show,
         params: {
@@ -118,7 +118,7 @@ class ContentItemsControllerTest < ActionController::TestCase
         }
 
     assert_requested :post, "#{PUBLISHING_API_ENDPOINT}/graphql",
-                     body: { query: Graphql::NewsArticleQuery.new("/#{base_path}").query },
+                     body: { query: Graphql::EditionQuery.new("/#{base_path}").query },
                      times: 1
 
     assert_not_requested :get, "#{content_store_endpoint}/content/#{base_path}"
@@ -134,7 +134,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
     graphql_fixture = fetch_graphql_fixture("news_article")
     graphql_fixture["data"]["edition"]["schema_name"] = "case_study"
-    stub_publishing_api_graphql_content_item(Graphql::NewsArticleQuery.new("/#{base_path}").query, graphql_fixture)
+    stub_publishing_api_graphql_content_item(Graphql::EditionQuery.new("/#{base_path}").query, graphql_fixture)
 
     get :show,
         params: {
@@ -142,7 +142,7 @@ class ContentItemsControllerTest < ActionController::TestCase
         }
 
     assert_requested :post, "#{PUBLISHING_API_ENDPOINT}/graphql",
-                     body: { query: Graphql::NewsArticleQuery.new("/#{base_path}").query }
+                     body: { query: Graphql::EditionQuery.new("/#{base_path}").query }
 
     assert_requested :get, "#{content_store_endpoint}/content/#{base_path}",
                      times: 1


### PR DESCRIPTION
Publishing API was updated in https://github.com/alphagov/publishing-api/pull/3063 to have a single edition type for most content, instead of a specific type for news articles.

Updating the query used by this application in making such requests to Publishing API.

[Trello card](https://trello.com/c/MSjuzc9M)