### PR TITLE
Enable headings in body text on document collections to appear in contents section 

### DIFF
--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -8,7 +8,7 @@ class DocumentCollectionPresenter < ContentItemPresenter
   include DocumentCollection::SignupLink
 
   def contents_items
-    groups.map do |group|
+    super + groups.map do |group|
       title = group["title"]
       { text: title, id: group_title_id(title) }
     end

--- a/test/presenters/document_collection_presenter_test.rb
+++ b/test/presenters/document_collection_presenter_test.rb
@@ -41,6 +41,15 @@ class DocumentCollectionPresenterTest
       assert_equal contents, presented_item.contents
     end
 
+    test "presents a contents list based on body h2 headers and collection groups" do
+      contents = [
+        { text: "Consolidated list", id: "consolidated-list", href: "#consolidated-list" },
+        { text: "Documents", id: "documents", href: "#documents" },
+      ]
+
+      assert_equal contents, presented_item("document_collection_with_body").contents
+    end
+
     test "presents a group heading with generated ID" do
       heading = '<h3 class="govuk-heading-m govuk-!-font-size-27" id="heading-with-spaces">Heading with Spaces</h3>'
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Investigate whether we can enable headings in the body text to be included in the contents section, and if possible make it happen.

## Why

The 'Contents' section of a document collection page is created automatically from the 'groups' of documents on the page. That works fine the majority of the time.

However, sometimes departments need to also link to documents or webpages that are relevant, but hosted off [GOV.UK](http://GOV.UK "‌").

Because Whitehall doesn't let them add such links off the [GOV.UK](http://GOV.UK "‌") domain to 'groups', they have to add these to the body content of a page in the conventional way, under headings.

However, the H2s in the body content of a collection page are not made part of the 'Contents' list. This means that the contents list doesn't properly reflect the structure of the webpage.

Having the contents list reflect all of the page's H2s would make the collection page template consistent with detailed guides and publications.

Examples

- [https://www.gov.uk/government/collections/technical-guidance-for-regulated-industry-sectors-environmental-permitting](https://www.gov.uk/government/collections/technical-guidance-for-regulated-industry-sectors-environmental-permitting "smartCard-inline") (The H2s on ‘Combustion activities’, ‘Food and drink’ and ‘Paper, pulp and cardboard manufacturing’ aren’t in the contents because they’re in the body text to link to material published off the [GOV.UK](http://GOV.UK "‌") domain.)
- [https://whitehall-admin.publishing.service.gov.uk/government/admin/collections/1381479](https://whitehall-admin.publishing.service.gov.uk/government/admin/collections/1381479 "‌") (currently in draft)

[Trello card](https://trello.com/c/FcmfMALh/3148-enable-headings-in-body-text-on-document-collections-to-appear-in-contents-section-m)