### PR TITLE
Change option on devolved nations component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
+    connection_pool (2.5.0)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -131,10 +131,10 @@ GEM
       rest-client (~> 2.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (4.29.2)
+    google-protobuf (4.29.3)
       bigdecimal
       rake (>= 13)
-    googleapis-common-protos-types (1.16.0)
+    googleapis-common-protos-types (1.17.0)
       google-protobuf (>= 3.18, < 5.a)
     govspeak (8.8.3)
       actionview (>= 6, < 8.0.2)
@@ -162,7 +162,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (47.0.0)
+    govuk_publishing_components (48.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -216,7 +216,7 @@ GEM
       rexml (>= 3.3.9)
     language_server-protocol (3.17.0.3)
     link_header (0.0.8)
-    logger (1.6.4)
+    logger (1.6.5)
     logstasher (2.1.5)
       activesupport (>= 5.2)
       request_store
@@ -291,7 +291,7 @@ GEM
     opentelemetry-instrumentation-active_job (0.7.8)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
-    opentelemetry-instrumentation-active_model_serializers (0.21.0)
+    opentelemetry-instrumentation-active_model_serializers (0.21.1)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-active_support (>= 0.7.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
@@ -383,7 +383,7 @@ GEM
     opentelemetry-instrumentation-http_client (0.22.8)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
-    opentelemetry-instrumentation-koala (0.20.5)
+    opentelemetry-instrumentation-koala (0.20.6)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
     opentelemetry-instrumentation-lmdb (0.22.3)
@@ -400,7 +400,7 @@ GEM
     opentelemetry-instrumentation-net_http (0.22.8)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
-    opentelemetry-instrumentation-pg (0.29.1)
+    opentelemetry-instrumentation-pg (0.29.2)
       opentelemetry-api (~> 1.0)
       opentelemetry-helpers-sql-obfuscation
       opentelemetry-instrumentation-base (~> 0.22.1)
@@ -425,7 +425,7 @@ GEM
     opentelemetry-instrumentation-rake (0.2.2)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
-    opentelemetry-instrumentation-rdkafka (0.4.8)
+    opentelemetry-instrumentation-rdkafka (0.4.9)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
     opentelemetry-instrumentation-redis (0.25.7)

--- a/app/views/content_items/call_for_evidence.html.erb
+++ b/app/views/content_items/call_for_evidence.html.erb
@@ -24,7 +24,7 @@
     <% if @content_item.national_applicability.present? %>
       <%= render "govuk_publishing_components/components/devolved_nations", {
         national_applicability: @content_item.national_applicability,
-        type: @content_item.schema_name,
+        content_type: @content_item.schema_name,
       } %>
     <% end %>
 

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -25,7 +25,7 @@
     <% if @content_item.national_applicability.present? %>
       <%= render "govuk_publishing_components/components/devolved_nations", {
         national_applicability: @content_item.national_applicability,
-        type: @content_item.schema_name,
+        content_type: @content_item.schema_name,
       } %>
     <% end %>
 

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -27,7 +27,7 @@
     <% if @content_item.national_applicability.present? %>
       <%= render "govuk_publishing_components/components/devolved_nations", {
         national_applicability: @content_item.national_applicability,
-        type: @content_item.schema_name,
+        content_type: @content_item.schema_name,
       } %>
     <% end %>
 

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -41,7 +41,7 @@
 <% if @content_item.national_applicability.present? %>
   <%= render "govuk_publishing_components/components/devolved_nations", {
     national_applicability: @content_item.national_applicability,
-    type: @content_item.schema_name,
+    content_type: @content_item.schema_name,
   } %>
 <% end %>
 

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -39,7 +39,7 @@
       <% if @content_item.national_applicability.present? %>
         <%= render "govuk_publishing_components/components/devolved_nations", {
           national_applicability: @content_item.national_applicability,
-          type: @content_item.schema_name,
+          content_type: @content_item.schema_name,
         } %>
       <% end %>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Update instances of the [devolved nations component](https://components.publishing.service.gov.uk/component-guide/devolved_nations) to use a different option name. The option has changed from 'type' to 'content_type'.

Note that this PR will probably fail tests until the change to the component is included in this PR.

## Why

The option is changing in https://github.com/alphagov/govuk_publishing_components/pull/4535

## Visual changes
None.

Trello card: https://trello.com/c/hUDC8lzz/418-add-component-wrapper-helper-to-button-component
