### PR TITLE
Display an H1 of the page title of all worldwide org pages

### DIFF
--- a/app/views/content_items/worldwide_corporate_information_page.html.erb
+++ b/app/views/content_items/worldwide_corporate_information_page.html.erb
@@ -1,5 +1,6 @@
 <%= render partial: "content_items/worldwide_organisation/header", locals: {
   worldwide_organisation: @content_item.worldwide_organisation,
+  show_header_title: false,
 } %>
 
 <article class="govuk-grid-row">

--- a/app/views/content_items/worldwide_office.html.erb
+++ b/app/views/content_items/worldwide_office.html.erb
@@ -1,5 +1,6 @@
 <%= render partial: "content_items/worldwide_organisation/header", locals: {
   worldwide_organisation: @content_item.worldwide_organisation,
+  show_header_title: false,
 } %>
 
 <article class="govuk-grid-row">

--- a/app/views/content_items/worldwide_organisation.html.erb
+++ b/app/views/content_items/worldwide_organisation.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: "content_items/worldwide_organisation/header", locals: { worldwide_organisation: @content_item } %>
+<%= render partial: "content_items/worldwide_organisation/header", locals: { worldwide_organisation: @content_item, show_header_title: true } %>
 
 <section class="govuk-grid-row" id="about-us">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/worldwide_organisation/_header.html.erb
+++ b/app/views/content_items/worldwide_organisation/_header.html.erb
@@ -1,10 +1,20 @@
 <header class="worldwide-organisation-header govuk-grid-row">
   <div class="govuk-grid-column-two-thirds worldwide-organisation-header__logo">
-    <%= render "govuk_publishing_components/components/organisation_logo", {
-      organisation: @content_item.organisation_logo,
-      heading_level: 1,
-      inline: true,
-    } %>
+    <% locals = { organisation: @content_item.organisation_logo, inline: true, heading_level: 1 } %>
+      <% if show_header_title
+        locals.merge!(margin_bottom: 8)
+        locals.delete(:heading_level) %>
+        <%= render "govuk_publishing_components/components/organisation_logo", locals %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: @content_item.title,
+          heading_level: 1,
+          inline: true,
+          font_size: "l",
+          margin_bottom: 5,
+        } %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/organisation_logo", locals %>
+      <% end %>
   </div>
 
   <div class="govuk-grid-column-one-third govuk-!-padding-top-2">

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -3,7 +3,8 @@ require "test_helper"
 class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
   test "renders basic worldwide organisation page" do
     setup_and_visit_content_item("worldwide_organisation")
-    assert_has_component_title("British Deputy High Commission\nHyderabad")
+    assert_has_component_title("UK Embassy in Country")
+    assert page.has_css?(".gem-c-organisation-logo__name")
     assert page.has_text?(@content_item["description"])
   end
 


### PR DESCRIPTION
## What

Add the page title as an H1 on worldwide organisation pages

## Screenshots

|Before|After|
|-|-|
|<img width="995" alt="Screenshot 2025-01-17 at 14 59 20" src="https://github.com/user-attachments/assets/fada8b04-2d31-453e-a802-9cc860b50ffa" />|<img width="1100" alt="Screenshot 2025-01-17 at 14 58 02" src="https://github.com/user-attachments/assets/1580a802-2399-4669-81e8-605241fd60bc" />|

Old behaviour: The logo is wrapped in an H1
New behaviour: Logo is not wrapped in an H1, new H1 is added beneath containing page title

Review apps:

- [British Embassy Madrid](https://government-frontend-pr-3510.herokuapp.com/world/organisations/british-embassy-madrid)
- [British Embassy Abu Dhabi](https://government-frontend-pr-3510.herokuapp.com/world/organisations/british-embassy-abu-dhabi)
- [Department for Business and Trade Paraguay](https://government-frontend-pr-3510.herokuapp.com/world/organisations/department-for-business-and-trade-paraguay)
- [UK Mission to the UN](https://government-frontend-pr-3510.herokuapp.com/world/organisations/united-kingdom-mission-to-the-united-nations)

[Trello](https://trello.com/c/sMTxi5QB/3153-h1-issue-with-world-organisation-template)
trello card: https://trello.com/c/sMTxi5QB/3153-needed-by-15-jan-h1-issue-with-world-organisation-template
