### PR TITLE
Memoize manual section presenter

### DIFF
--- a/app/presenters/manual_section_presenter.rb
+++ b/app/presenters/manual_section_presenter.rb
@@ -11,9 +11,9 @@ class ManualSectionPresenter < ContentItemPresenter
   end
 
   def intro
-    @intro ||= begin
-      return nil unless details["body"]
+    return nil unless details["body"]
 
+    @intro ||= begin
       intro = Nokogiri::HTML::DocumentFragment.parse(details["body"])
 
       # Strip all content following and including h2
@@ -29,9 +29,9 @@ class ManualSectionPresenter < ContentItemPresenter
   end
 
   def main
-    @main ||= begin
-      return nil unless details["body"]
+    return nil unless details["body"]
 
+    @main ||= begin
       document = Nokogiri::HTML::DocumentFragment.parse(details["body"])
 
       # Identifies all h2's and creates an array of objects from the heading and

--- a/app/presenters/manual_section_presenter.rb
+++ b/app/presenters/manual_section_presenter.rb
@@ -11,15 +11,17 @@ class ManualSectionPresenter < ContentItemPresenter
   end
 
   def intro
-    return nil unless details["body"]
+    @intro ||= begin
+      return nil unless details["body"]
 
-    intro = Nokogiri::HTML::DocumentFragment.parse(details["body"])
+      intro = Nokogiri::HTML::DocumentFragment.parse(details["body"])
 
-    # Strip all content following and including h2
-    intro.css("h2").xpath("following-sibling::*").remove
-    intro.css("h2").remove
+      # Strip all content following and including h2
+      intro.css("h2").xpath("following-sibling::*").remove
+      intro.css("h2").remove
 
-    intro.text.squeeze == "\n" ? "" : intro
+      intro.text.squeeze == "\n" ? "" : intro
+    end
   end
 
   def visually_expanded?

--- a/app/presenters/manual_section_presenter.rb
+++ b/app/presenters/manual_section_presenter.rb
@@ -27,30 +27,32 @@ class ManualSectionPresenter < ContentItemPresenter
   end
 
   def main
-    return nil unless details["body"]
+    @main ||= begin
+      return nil unless details["body"]
 
-    document = Nokogiri::HTML::DocumentFragment.parse(details["body"])
+      document = Nokogiri::HTML::DocumentFragment.parse(details["body"])
 
-    # Identifies all h2's and creates an array of objects from the heading and
-    # its proceeding content up to the next heading. This is so that it can be
-    # consumed by accordion components in the template.
-    document.css("h2").map do |heading|
-      content = []
-      heading.xpath("following-sibling::*").each do |element|
-        if element.name == "h2"
-          break
-        else
-          content << element.to_html
+      # Identifies all h2's and creates an array of objects from the heading and
+      # its proceeding content up to the next heading. This is so that it can be
+      # consumed by accordion components in the template.
+      document.css("h2").map do |heading|
+        content = []
+        heading.xpath("following-sibling::*").each do |element|
+          if element.name == "h2"
+            break
+          else
+            content << element.to_html
+          end
         end
-      end
 
-      {
-        heading: {
-          text: heading.text,
-          id: heading[:id],
-        },
-        content: content.join,
-      }
+        {
+          heading: {
+            text: heading.text,
+            id: heading[:id],
+          },
+          content: content.join,
+        }
+      end
     end
   end
 


### PR DESCRIPTION
We're currently calling the main method, and then looping over the result. In each loop, we call the method again so that we can get the length. See manual_section.html.erb, which does roughly:

    @content_item.main.each.with_index do |item, index|
     # ...
     {
       data_attributes: {
         ga4_event: {
           # ...
           index: index,
           index_total: @content_item.main.length,

... the effect of this is that we run the main method n times, where n is the number of `<h2>` elements in the body. This results in us spending a lot of time parsing the same document and running the same CSS / XPath selectors on it, which adds up to a lot of time.

Memoizing the result of the main method shaves several seconds off the time to render www.gov.uk/guidance/complete-the-school-census/data-items-2024-to-2025 on my machine.

The flamegraph before these changes (using the wonderful rack-mini-profiler) shows manual_section.html.erb taking over 2 seconds to render:

<img width="1792" alt="flamegraph before changes" src="https://github.com/user-attachments/assets/fd54ea07-6200-4a3d-bc48-adf808fb0904" />

Note that `ManualSectionPresenter#main` is called many times.

After the changes in this PR, this reduces to 186ms:

<img width="1792" alt="flamegraph after changes" src="https://github.com/user-attachments/assets/7ab372cd-cde6-421d-b291-e94083d9c615" />

These flamegraphs also identified a further ~70ms we could save by memoizing the intro method, so I've done that too.

I did look at some other optimizations (e.g. traversing the nokogiri document manually, instead of using css / xpaths), but once it's memoized those only save microseconds so it's not worth it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
