### PR TITLE
Fix Arabic translation for 'Published' and 'Policy paper'

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -86,7 +86,7 @@ ar:
   content_item:
     contents: المحتويات
     metadata:
-      published: منشورة
+      published: تاريخ النشر
       updated: تاريخ التحديث
     schema_name:
       aaib_report:
@@ -456,8 +456,8 @@ ar:
       policy_paper:
         few:
         many:
-        one: ورقة السياسة
-        other: أوراق السياسة
+        one: ورقة تتعلق بالسياسات
+        other: أوراق تتعلق بالسياسات
         two:
         zero:
       press_release:


### PR DESCRIPTION
The translations for "Policy paper" and "Publish" are incorrect in Arabic.
Page example: https://www.gov.uk/government/publications/uk-candidate-for-the-international-court-of-justice-election-2026-professor-dapo-akande-election-brochure.ar

Before:
<img width="696" alt="Screenshot 2025-01-17 at 11 09 28" src="https://github.com/user-attachments/assets/6bcfbed9-e199-467a-a207-7e9b66f16b32" />


After:
<img width="691" alt="Screenshot 2025-01-17 at 11 09 17" src="https://github.com/user-attachments/assets/5b210e69-3429-4011-b420-bb0d491aa97c" />



Trello card: https://trello.com/c/NkLPasOt/3166-fix-arabic-translation-in-government-frontend
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
