### PR TITLE
Display an H1 of the page title on some worldwide org pages

### DIFF
--- a/app/presenters/worldwide_corporate_information_page_presenter.rb
+++ b/app/presenters/worldwide_corporate_information_page_presenter.rb
@@ -11,6 +11,10 @@ class WorldwideCorporateInformationPagePresenter < ContentItemPresenter
     false
   end
 
+  def display_page_title?
+    false
+  end
+
   def worldwide_organisation
     return unless content_item.dig("links", "worldwide_organisation")
 

--- a/app/presenters/worldwide_office_presenter.rb
+++ b/app/presenters/worldwide_office_presenter.rb
@@ -6,6 +6,10 @@ class WorldwideOfficePresenter < ContentItemPresenter
     worldwide_organisation&.formatted_title
   end
 
+  def display_page_title?
+    false
+  end
+
   def body
     content_item.dig("details", "access_and_opening_times")
   end

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -2,11 +2,21 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
   include ContentItem::Body
   include WorldwideOrganisation::Branding
   include ActionView::Helpers::UrlHelper
+  include ActionView::Helpers::SanitizeHelper
 
   WorldwideOffice = Struct.new(:contact, :has_access_and_opening_times?, :public_url, keyword_init: true)
 
   def formatted_title
     content_item.dig("details", "logo", "formatted_title")
+  end
+
+  def display_page_title?
+    return if sponsoring_organisations.empty?
+    return if formatted_title.nil? || content_item["title"].nil?
+
+    logo_formatted_title = strip_tags(formatted_title).gsub(/\s+/, "")
+    page_title = content_item["title"].gsub(/\s+/, "")
+    logo_formatted_title != page_title
   end
 
   def sponsoring_organisation_links

--- a/app/views/content_items/worldwide_organisation/_header.html.erb
+++ b/app/views/content_items/worldwide_organisation/_header.html.erb
@@ -1,12 +1,22 @@
+<% locals = { organisation: @content_item.organisation_logo, inline: true, heading_level: 1 }
+    if @content_item.display_page_title?
+      locals.merge!(margin_bottom: 9)
+      locals.delete(:heading_level)
+    end
+%>
+
 <header class="worldwide-organisation-header govuk-grid-row">
   <div class="govuk-grid-column-two-thirds worldwide-organisation-header__logo">
-    <%= render "govuk_publishing_components/components/organisation_logo", {
-      organisation: @content_item.organisation_logo,
-      heading_level: 1,
-      inline: true,
-    } %>
+    <%= render "govuk_publishing_components/components/organisation_logo", locals %>
+     <% if @content_item.display_page_title? %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: @content_item.title,
+          heading_level: 1,
+          font_size: "l",
+          margin_bottom: 5,
+        } %>
+      <% end %>
   </div>
-
   <div class="govuk-grid-column-one-third govuk-!-padding-top-2">
     <% if @content_item.available_translations.length > 1 %>
       <%= render 'govuk_publishing_components/components/translation_nav',

--- a/test/integration/worldwide_organisation_test.rb
+++ b/test/integration/worldwide_organisation_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class WorldwideOrganisationTest < ActionDispatch::IntegrationTest
   test "renders basic worldwide organisation page" do
     setup_and_visit_content_item("worldwide_organisation")
-    assert_has_component_title("British Deputy High Commission\nHyderabad")
+    assert_has_component_title("UK Embassy in Country")
     assert page.has_text?(@content_item["description"])
   end
 

--- a/test/presenters/worldwide_corporate_information_page_presenter_test.rb
+++ b/test/presenters/worldwide_corporate_information_page_presenter_test.rb
@@ -46,6 +46,10 @@ class WorldwideCorporateInformationPagePresenterTest < PresenterTestCase
     assert_equal expected, presented.organisation_logo
   end
 
+  test "#display_page_title? returns false" do
+    assert_not presented_item.display_page_title?
+  end
+
 private
 
   def first_sponsoring_organisation(item)

--- a/test/presenters/worldwide_office_presenter_test.rb
+++ b/test/presenters/worldwide_office_presenter_test.rb
@@ -50,6 +50,10 @@ class WorldwideOfficePresenterTest < PresenterTestCase
     assert_equal expected, presented.organisation_logo
   end
 
+  test "#display_page_title? returns false" do
+    assert_not presented_item.display_page_title?
+  end
+
 private
 
   def first_sponsoring_organisation(item)

--- a/test/presenters/worldwide_organisation_presenter_test.rb
+++ b/test/presenters/worldwide_organisation_presenter_test.rb
@@ -172,4 +172,22 @@ class WorldwideOrganisationPresenterTest < PresenterTestCase
 
     assert_equal [], presented.home_page_offices
   end
+
+  test "#display_page_title? returns true if the formatted logo title is different to the page title" do
+    content_item = schema_item
+    content_item["title"] = "Department for Business and Trade Paraguay"
+    content_item["details"]["logo"]["formatted_title"] = "Department for Business and Trade"
+
+    presented = create_presenter(WorldwideOrganisationPresenter, content_item: content_item)
+    assert presented.display_page_title?
+  end
+
+  test "#display_page_title? returns false if the formatted logo has the same text as the page title" do
+    content_item = schema_item
+    content_item["title"] = "Department for Business and Trade Paraguay"
+    content_item["details"]["logo"]["formatted_title"] = "Department for Business and Trade<br/>Paraguay"
+
+    presented = create_presenter(WorldwideOrganisationPresenter, content_item: content_item)
+    assert_not presented.display_page_title?
+  end
 end


### PR DESCRIPTION
## What

|Before|After|
|-|-|
|<img width="995" alt="Screenshot 2025-01-17 at 14 59 20" src="https://github.com/user-attachments/assets/fada8b04-2d31-453e-a802-9cc860b50ffa" />|<img width="1100" alt="Screenshot 2025-01-17 at 14 58 02" src="https://github.com/user-attachments/assets/1580a802-2399-4669-81e8-605241fd60bc" />|

## How

Current behaviour: The logo is wrapped in an H1
New behaviour: If the logo text and the page title is the same, the logo is wrapped in an H1, if it's not, the page title is added as an H1

Review apps:

- [British Embassy Madrid](https://government-frontend-pr-3525.herokuapp.com/world/organisations/british-embassy-madrid)
- [British Embassy Abu Dhabi](https://government-frontend-pr-3525.herokuapp.com/world/organisations/british-embassy-abu-dhabi)
- [Department for Business and Trade Paraguay](https://government-frontend-pr-3525.herokuapp.com/world/organisations/department-for-business-and-trade-paraguay)
- [UK Mission to the UN](https://government-frontend-pr-3525.herokuapp.com/world/organisations/united-kingdom-mission-to-the-united-nations)


[Trello](https://trello.com/c/sMTxi5QB/3153-h1-issue-with-world-organisation-template)