### PR TITLE
Add warning about migrating routes to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
 ⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
 
 Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
+
+Routes in this application are being migrated to another application, please check with #govuk-patterns-and-pages when making changes.


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Update the pull request template to include a warning about route migration.

## Why
The Patterns and Pages team are currently migrating routes out of this application and into `frontend`. Any devs unaware of this could be making necessary changes to code that has already been copied across, but not yet in use.

## Visual changes
None.
