### PR TITLE
Remove margin tops and replace titles with headings

### DIFF
--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -33,7 +33,6 @@
 
     <%= render "components/contents_list_with_body", contents: @content_item.contents do %>
       <%= render "govuk_publishing_components/components/print_link", {
-        margin_top: 0,
         margin_bottom: 6,
       } %>
 

--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -52,7 +52,6 @@
         <%= render 'govuk_publishing_components/components/contents_list', contents: @content_item.contents, format_numbers: true %>
 
         <%= render 'govuk_publishing_components/components/print_link', {
-          margin_top: 0,
           margin_bottom: 6,
         } %>
       </div>

--- a/app/views/content_items/service_manual_homepage.html.erb
+++ b/app/views/content_items/service_manual_homepage.html.erb
@@ -11,10 +11,11 @@
     <div class="govuk-main-wrapper">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <%= render "govuk_publishing_components/components/title", {
-            title: "Service Manual",
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Service Manual",
+            font_size: "xl",
+            heading_level: 1,
             inverse: true,
-            margin_top: 0,
             margin_bottom: 6,
           } %>
           <p class="govuk-body-lead app-hero-lead app-hero__body--inverse govuk-!-padding-bottom-1">

--- a/app/views/content_items/service_manual_service_toolkit.html.erb
+++ b/app/views/content_items/service_manual_service_toolkit.html.erb
@@ -8,10 +8,11 @@
     <div class="govuk-main-wrapper">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <%= render "govuk_publishing_components/components/title", {
-            title: "Design and build government services",
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Design and build government services",
+            font_size: "xl",
+            heading_level: 1,
             inverse: true,
-            margin_top: 0,
             margin_bottom: 6,
           } %>
           <p class="app-hero__description govuk-body-l govuk-!-margin-bottom-3 app-hero__body--inverse">

--- a/app/views/histories/10_downing_street.html.erb
+++ b/app/views/histories/10_downing_street.html.erb
@@ -4,10 +4,12 @@
 
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/title", {
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "10 Downing Street",
       context: "History",
-      title: "10 Downing Street",
-      margin_top: 0,
+      font_size: "xl",
+      heading_level: 1,
+      margin_bottom: 8,
     } %>
   </div>
 </header>

--- a/app/views/histories/11_downing_street.html.erb
+++ b/app/views/histories/11_downing_street.html.erb
@@ -4,10 +4,12 @@
 
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/title", {
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "11 Downing Street",
       context: "History",
-      title: "11 Downing Street",
-      margin_top: 0,
+      font_size: "xl",
+      heading_level: 1,
+      margin_bottom: 8,
     } %>
   </div>
 </header>

--- a/app/views/histories/1_horse_guards_road.html.erb
+++ b/app/views/histories/1_horse_guards_road.html.erb
@@ -4,10 +4,12 @@
 
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/title", {
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "1 Horse Guards Road",
       context: "History",
-      title: "1 Horse Guards Road",
-      margin_top: 0,
+      font_size: "xl",
+      heading_level: 1,
+      margin_bottom: 8,
     } %>
   </div>
 </header>

--- a/app/views/histories/king_charles_street.html.erb
+++ b/app/views/histories/king_charles_street.html.erb
@@ -4,10 +4,12 @@
 
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/title", {
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "King Charles Street",
       context: "History",
-      title: "King Charles Street",
-      margin_top: 0,
+      font_size: "xl",
+      heading_level: 1,
+      margin_bottom: 8,
     } %>
   </div>
 </header>

--- a/app/views/histories/lancaster_house.html.erb
+++ b/app/views/histories/lancaster_house.html.erb
@@ -4,10 +4,12 @@
 
 <header class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/title", {
-      context:"History",
-      title: "Lancaster House",
-      margin_top: 0,
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Lancaster House",
+      context: "History",
+      font_size: "xl",
+      heading_level: 1,
+      margin_bottom: 8,
     } %>
   </div>
 </header>

--- a/app/views/shared/_published_dates_with_notification_button.html.erb
+++ b/app/views/shared/_published_dates_with_notification_button.html.erb
@@ -35,7 +35,6 @@
     }
   } if @content_item.display_single_page_notification_button? %>
   <%= render "govuk_publishing_components/components/print_link", {
-    margin_top: 0,
     margin_bottom: 8,
   } %>
 </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Firstly, remove the options to pass a `margin_top` attribute to the print link component, as this option was [removed in a previous PR](https://github.com/alphagov/govuk_publishing_components/pull/4577).

Secondly, replace instances of the title component with the heading component. These are instances where the `margin_top` option is used, and we're removing that from the component (and ultimately working towards retiring the title component). Note that this does not include the HTML publication pages as this is handled in a separate PR: https://github.com/alphagov/government-frontend/pull/3534

Pages where we're replacing the title:

- [service manual](https://www.gov.uk/service-manual)
- [service toolkit](https://www.gov.uk/service-toolkit)
- [1 horse guards](https://www.gov.uk/government/history/1-horse-guards-road)
- [10 downing street](https://www.gov.uk/government/history/10-downing-street)
- [11 downing street](https://www.gov.uk/government/history/11-downing-street)
- [king charles street](https://www.gov.uk/government/history/king-charles-street)
- [lancaster house](https://www.gov.uk/government/history/lancaster-house)

## Visual changes
None.

Trello card: https://trello.com/c/ELvrt0ra/456-replace-title-with-heading-in-government-frontend