### PR TITLE
Add AB test for showing Contents list on step nav guide pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,12 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Template
+  include ContentsListAbTestable
+
   slimmer_template "gem_layout"
+
+  helper_method :contents_list_variant
+  helper_method :step_by_step_page_under_test?
+
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery except: :service_sign_in_options

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,6 +1,7 @@
 require "slimmer/headers"
 
 class ContentItemsController < ApplicationController
+  include ContentsListAbTestable
   include GovukPersonalisation::ControllerConcern
   include Slimmer::Headers
   include Slimmer::Template
@@ -32,6 +33,11 @@ class ContentItemsController < ApplicationController
     elsif is_history_page?
       show_history_page
     else
+      if step_by_step_page_under_test?
+        set_contents_list_response_header
+        set_ab_test_show_contents_list
+      end
+
       set_guide_draft_access_token if @content_item.is_a?(GuidePresenter)
       render_template
     end
@@ -290,5 +296,9 @@ private
     return if !@content_item || !@content_item.respond_to?(:csp_connect_src)
 
     @content_item.csp_connect_src
+  end
+
+  def set_ab_test_show_contents_list
+    @content_item.ab_test_show_contents_list = contents_list_variant_b?
   end
 end

--- a/app/controllers/contents_list_ab_testable.rb
+++ b/app/controllers/contents_list_ab_testable.rb
@@ -1,0 +1,61 @@
+module ContentsListAbTestable
+  ALLOWED_VARIANTS = %w[A B Z].freeze
+
+  AB_TEST_PAGES = [
+    # Help paying for childcare
+    "/help-with-childcare-costs",
+    "/help-with-childcare-costs/free-childcare-and-education-for-3-to-4-year-olds",
+    "/help-with-childcare-costs/free-childcare-2-year-olds-claim-benefits",
+    "/help-with-childcare-costs/tax-credits",
+    "/help-with-childcare-costs/universal-credit",
+    "/help-with-childcare-costs/childcare-vouchers",
+    "/help-with-childcare-costs/support-while-you-study",
+    # What to do after someone dies
+    "/after-a-death",
+    "/after-a-death/when-a-death-is-reported-to-a-coroner",
+    "/after-a-death/death-abroad",
+    "/after-a-death/organisations-you-need-to-contact-and-tell-us-once",
+    "/after-a-death/report-without-tell-us-once",
+    "/after-a-death/arrange-the-funeral",
+    "/after-a-death/if-a-child-or-baby-dies",
+    "/after-a-death/bereavement-help-and-support",
+    # Become a sole trader
+    "/become-sole-trader",
+    "/become-sole-trader/choose-your-business-name",
+    "/become-sole-trader/register-sole-trader",
+    # Set up a private limited company
+    "/limited-company-formation",
+    "/limited-company-formation/choose-company-name",
+    "/limited-company-formation/company-address",
+    "/limited-company-formation/appoint-directors-and-company-secretaries",
+    "/limited-company-formation/shareholders",
+    "/limited-company-formation/memorandum-and-articles-of-association",
+    "/limited-company-formation/register-your-company",
+    "/limited-company-formation/add-corporation-tax-services-to-business-tax-account",
+  ].freeze
+
+  def contents_list_test
+    @contents_list_test ||= GovukAbTesting::AbTest.new(
+      "ContentsList",
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+    )
+  end
+
+  def contents_list_variant
+    contents_list_test.requested_variant(request.headers)
+  end
+
+  def set_contents_list_response_header
+    contents_list_variant.configure_response(response)
+  end
+
+  def contents_list_variant_b?
+    var_b = contents_list_variant.variant?("B")
+    step_by_step_page_under_test? && var_b
+  end
+
+  def step_by_step_page_under_test?
+    AB_TEST_PAGES.include? request.path
+  end
+end

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -1,7 +1,7 @@
 class GuidePresenter < ContentItemPresenter
   include ContentItem::Parts
 
-  attr_accessor :draft_access_token
+  attr_accessor :draft_access_token, :ab_test_show_contents_list
 
   def page_title
     if parts.any?
@@ -42,7 +42,7 @@ class GuidePresenter < ContentItemPresenter
   end
 
   def show_guide_navigation?
-    multi_page_guide? && !hide_chapter_navigation?
+    ab_test_show_contents_list || (multi_page_guide? && !hide_chapter_navigation?)
   end
 
   def content_title

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,6 +56,7 @@
   <%= stylesheet_link_tag "application", :media => "all", integrity: false %>
   <%= javascript_include_tag "application", integrity: false, type: "module" %>
   <%= csrf_meta_tags %>
+  <%= contents_list_variant.analytics_meta_tag.html_safe if step_by_step_page_under_test? %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item.content_item %>
 
   <% if @content_item.description.present? %>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -368,6 +368,48 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_equal "true", @response.headers[Slimmer::Headers::REMOVE_SEARCH_HEADER]
   end
 
+  test "Contents List AB test variant A" do
+    content_item = content_store_has_schema_example("guide", "guide-with-step-navs")
+    content_item["base_path"] = "/help-with-childcare-costs/support-while-you-study"
+    content_item["details"]["hide_chapter_navigation"] = true
+
+    stub_content_store_has_item(content_item["base_path"], content_item)
+
+    with_variant ContentsList: "A" do
+      get :show, params: { path: "help-with-childcare-costs/support-while-you-study" }
+      assert_response :success
+      assert_not response.body.include?("contents-list")
+    end
+  end
+
+  test "Contents List AB test variant B" do
+    content_item = content_store_has_schema_example("guide", "guide-with-step-navs")
+    content_item["base_path"] = "/help-with-childcare-costs/support-while-you-study"
+    content_item["details"]["hide_chapter_navigation"] = true
+
+    stub_content_store_has_item(content_item["base_path"], content_item)
+
+    with_variant ContentsList: "B" do
+      get :show, params: { path: "help-with-childcare-costs/support-while-you-study" }
+      assert_response :success
+      assert response.body.include?("contents-list")
+    end
+  end
+
+  test "Contents List AB test variant Z" do
+    content_item = content_store_has_schema_example("guide", "guide-with-step-navs")
+    content_item["base_path"] = "/help-with-childcare-costs/support-while-you-study"
+    content_item["details"]["hide_chapter_navigation"] = true
+
+    stub_content_store_has_item(content_item["base_path"], content_item)
+
+    with_variant ContentsList: "Z" do
+      get :show, params: { path: "help-with-childcare-costs/support-while-you-study" }
+      assert_response :success
+      assert_not response.body.include?("contents-list")
+    end
+  end
+
   def path_for(content_item, locale = nil)
     base_path = content_item["base_path"].sub(/^\//, "")
     base_path.gsub!(/\.#{locale}$/, "") if locale


### PR DESCRIPTION
## What
For users allocated a variant B cookie, it shows a Contents list on some Step-by-Step guides.

|Variant A or Z | Variant B|
|--|--|
|<img width="994" alt="Screenshot 2025-02-06 at 09 34 02" src="https://github.com/user-attachments/assets/8d392d1b-d75b-4b22-a8ec-c5f51849a36d" />|<img width="1016" alt="Screenshot 2025-02-06 at 09 38 27" src="https://github.com/user-attachments/assets/f4d204ff-c630-4c54-b7c3-ac162c7431b5" />|

https://government-frontend-pr-3546.herokuapp.com/help-with-childcare-costs/universal-credit
https://government-frontend-pr-3546.herokuapp.com/help-with-childcare-costs/free-childcare-and-education-for-3-to-4-year-olds
https://government-frontend-pr-3546.herokuapp.com/help-with-childcare-costs/childcare-vouchers
https://government-frontend-pr-3546.herokuapp.com/help-with-childcare-costs/support-while-you-study
https://government-frontend-pr-3546.herokuapp.com/help-with-childcare-costs/free-childcare-2-year-olds-claim-benefits

Trello card: https://trello.com/c/nHQvtBM3/3244-go-live-with-contents-list-ab-test-100-z

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
