### PR TITLE
Replace title components with heading components

### DIFF
--- a/app/presenters/call_for_evidence_presenter.rb
+++ b/app/presenters/call_for_evidence_presenter.rb
@@ -6,7 +6,7 @@ class CallForEvidencePresenter < ContentItemPresenter
   include ContentItem::Political
   include ContentItem::Shareable
   include ContentItem::SinglePageNotificationButton
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
 
   def opening_date_time
     content_item["details"]["opening_date"]

--- a/app/presenters/case_study_presenter.rb
+++ b/app/presenters/case_study_presenter.rb
@@ -1,7 +1,7 @@
 class CaseStudyPresenter < ContentItemPresenter
   include ContentItem::Body
   include ContentItem::Metadata
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
 
   def image
     content_item["details"]["image"]

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -6,7 +6,7 @@ class ConsultationPresenter < ContentItemPresenter
   include ContentItem::Political
   include ContentItem::Shareable
   include ContentItem::SinglePageNotificationButton
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
 
   def opening_date_time
     content_item["details"]["opening_date"]

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -1,10 +1,10 @@
 class ContactPresenter < ContentItemPresenter
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
   include ContentItem::ContactDetails
 
-  def title_and_context
+  def heading_and_context
     super.tap do |t|
-      t.delete(:average_title_length)
+      t[:font_size] = "xl"
       t.delete(:context)
     end
   end

--- a/app/presenters/content_item/heading_and_context.rb
+++ b/app/presenters/content_item/heading_and_context.rb
@@ -1,11 +1,13 @@
 module ContentItem
-  module TitleAndContext
-    def title_and_context
+  module HeadingAndContext
+    def heading_and_context
       {
-        title:,
+        text: title,
         context: I18n.t("content_item.schema_name.#{document_type}", count: 1),
         context_locale: view_context.t_locale_fallback("content_item.schema_name.#{document_type}", count: 1),
-        average_title_length: "long",
+        heading_level: 1,
+        margin_bottom: 8,
+        font_size: "l",
       }
     end
   end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -118,6 +118,10 @@ class ContentItemPresenter
     true
   end
 
+  def exclude_main_wrapper_class?
+    false
+  end
+
 private
 
   def voting_is_open?

--- a/app/presenters/corporate_information_page_presenter.rb
+++ b/app/presenters/corporate_information_page_presenter.rb
@@ -1,7 +1,7 @@
 class CorporateInformationPagePresenter < ContentItemPresenter
   include ContentItem::Body
   include ContentItem::ContentsList
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
   include ContentItem::OrganisationBranding
   include ContentItem::CorporateInformationGroups
 
@@ -11,9 +11,9 @@ class CorporateInformationPagePresenter < ContentItemPresenter
     page_title
   end
 
-  def title_and_context
+  def heading_and_context
     super.tap do |t|
-      t.delete(:average_title_length)
+      t[:font_size] = "xl"
       t.delete(:context)
     end
   end

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -4,10 +4,10 @@ class DetailedGuidePresenter < ContentItemPresenter
   include ContentItem::Metadata
   include ContentItem::NationalApplicability
   include ContentItem::Political
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
   include ContentItem::SinglePageNotificationButton
 
-  def title_and_context
+  def heading_and_context
     super.tap do |t|
       t[:context] = I18n.t("content_item.schema_name.guidance", count: 1)
     end

--- a/app/presenters/document_collection_presenter.rb
+++ b/app/presenters/document_collection_presenter.rb
@@ -2,7 +2,7 @@ class DocumentCollectionPresenter < ContentItemPresenter
   include ContentItem::Body
   include ContentItem::Metadata
   include ContentItem::Political
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
   include ContentItem::ContentsList
   include ContentItem::SinglePageNotificationButton
   include DocumentCollection::SignupLink

--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -1,6 +1,6 @@
 class FatalityNoticePresenter < ContentItemPresenter
   include ContentItem::Body
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
   include ContentItem::Metadata
 
   def field_of_operation
@@ -23,7 +23,7 @@ class FatalityNoticePresenter < ContentItemPresenter
     end
   end
 
-  def title_and_context
+  def heading_and_context
     super.tap do |t|
       if field_of_operation
         t[:context] = I18n.t("fatality_notice.operations_in", location: field_of_operation.try(:title))

--- a/app/presenters/field_of_operation_presenter.rb
+++ b/app/presenters/field_of_operation_presenter.rb
@@ -1,13 +1,13 @@
 class FieldOfOperationPresenter < ContentItemPresenter
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
 
   FatalityNotice = Struct.new(:roll_call_introduction, :casualties, :title, :base_path)
 
-  def title_and_context
+  def heading_and_context
     super.tap do |t|
       t[:context] = I18n.t("field_of_operation.context")
-      t[:title] = "#{I18n.t('field_of_operation.title')} #{@content_item['title']}"
-      t.delete(:average_title_length)
+      t[:text] = "#{I18n.t('field_of_operation.title')} #{@content_item['title']}"
+      t[:font_size] = "xl"
     end
   end
 

--- a/app/presenters/fields_of_operation_presenter.rb
+++ b/app/presenters/fields_of_operation_presenter.rb
@@ -1,14 +1,14 @@
 class FieldsOfOperationPresenter < ContentItemPresenter
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
 
   def fields_of_operation
     content_item.dig("links", "fields_of_operation").map { |field| [field["title"], field["base_path"]] }
   end
 
-  def title_and_context
+  def heading_and_context
     super.tap do |t|
       t[:context] = I18n.t("fields_of_operation.context")
-      t.delete(:average_title_length)
+      t[:font_size] = "xl"
     end
   end
 end

--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -48,6 +48,10 @@ class HtmlPublicationPresenter < ContentItemPresenter
     request.base_url + request.path
   end
 
+  def exclude_main_wrapper_class?
+    true
+  end
+
 private
 
   def public_timestamp

--- a/app/presenters/news_article_presenter.rb
+++ b/app/presenters/news_article_presenter.rb
@@ -4,7 +4,7 @@ class NewsArticlePresenter < ContentItemPresenter
   include ContentItem::Linkable
   include ContentItem::Updatable
   include ContentItem::Shareable
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
   include ContentItem::Metadata
   include ContentItem::NewsImage
 end

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -2,12 +2,12 @@ class SpecialistDocumentPresenter < ContentItemPresenter
   include ContentItem::Body
   include ContentItem::Updatable
   include ContentItem::Linkable
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
   include ContentItem::Metadata
   include TypographyHelper
   include ContentItem::ContentsList
 
-  def title_and_context
+  def heading_and_context
     super.tap do |t|
       t.delete(:context)
     end

--- a/app/presenters/speech_presenter.rb
+++ b/app/presenters/speech_presenter.rb
@@ -3,7 +3,7 @@ class SpeechPresenter < ContentItemPresenter
   include ContentItem::Linkable
   include ContentItem::Political
   include ContentItem::Updatable
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
   include ContentItem::Metadata
   include ContentItem::NewsImage
 

--- a/app/presenters/statistical_data_set_presenter.rb
+++ b/app/presenters/statistical_data_set_presenter.rb
@@ -1,7 +1,7 @@
 class StatisticalDataSetPresenter < ContentItemPresenter
   include ContentItem::Body
   include ContentItem::ContentsList
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
   include ContentItem::Political
   include ContentItem::Metadata
 end

--- a/app/presenters/statistics_announcement_presenter.rb
+++ b/app/presenters/statistics_announcement_presenter.rb
@@ -1,7 +1,7 @@
 class StatisticsAnnouncementPresenter < ContentItemPresenter
   include ContentItem::Metadata
   include ContentItem::NationalStatisticsLogo
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
   include StatisticsAnnouncementHelper
 
   FORTHCOMING_NOTICE = I18n.t("statistics_announcement.forthcoming").freeze

--- a/app/presenters/topical_event_about_page_presenter.rb
+++ b/app/presenters/topical_event_about_page_presenter.rb
@@ -1,11 +1,11 @@
 class TopicalEventAboutPagePresenter < ContentItemPresenter
   include ContentItem::Body
   include ContentItem::ContentsList
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
 
-  def title_and_context
+  def heading_and_context
     super.tap do |t|
-      t.delete(:average_title_length)
+      t[:font_size] = "xl"
       t.delete(:context)
     end
   end

--- a/app/presenters/working_group_presenter.rb
+++ b/app/presenters/working_group_presenter.rb
@@ -1,7 +1,7 @@
 class WorkingGroupPresenter < ContentItemPresenter
   include ContentItem::Body
   include ContentItem::ContentsList
-  include ContentItem::TitleAndContext
+  include ContentItem::HeadingAndContext
 
   def email
     content_item["details"]["email"]
@@ -19,9 +19,9 @@ class WorkingGroupPresenter < ContentItemPresenter
     content_item["links"]["policies"]
   end
 
-  def title_and_context
+  def heading_and_context
     super.tap do |t|
-      t.delete(:average_title_length)
+      t[:font_size] = "xl"
       t.delete(:context)
     end
   end

--- a/app/presenters/worldwide_corporate_information_page_presenter.rb
+++ b/app/presenters/worldwide_corporate_information_page_presenter.rb
@@ -21,6 +21,10 @@ class WorldwideCorporateInformationPagePresenter < ContentItemPresenter
     worldwide_organisation&.sponsoring_organisations
   end
 
+  def exclude_main_wrapper_class?
+    true
+  end
+
 private
 
   def show_contents_list?

--- a/app/presenters/worldwide_office_presenter.rb
+++ b/app/presenters/worldwide_office_presenter.rb
@@ -30,6 +30,10 @@ class WorldwideOfficePresenter < ContentItemPresenter
     worldwide_organisation&.sponsoring_organisations
   end
 
+  def exclude_main_wrapper_class?
+    true
+  end
+
 private
 
   def show_contents_list?

--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -123,6 +123,10 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
     content_item.dig("links", "sponsoring_organisations") || []
   end
 
+  def exclude_main_wrapper_class?
+    true
+  end
+
 private
 
   def office(office, contact)

--- a/app/views/content_items/_body_with_related_links.html.erb
+++ b/app/views/content_items/_body_with_related_links.html.erb
@@ -2,8 +2,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title',
-      title: @content_item.title %>
+    <%= render 'govuk_publishing_components/components/heading',
+      text: @content_item.title,
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8
+    %>
   </div>
 </div>
 <div class="govuk-grid-row">

--- a/app/views/content_items/call_for_evidence.html.erb
+++ b/app/views/content_items/call_for_evidence.html.erb
@@ -4,11 +4,11 @@
   ) %>
 <% end %>
 
-<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title_and_context[:title] } %>
+<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.heading_and_context[:text] } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
   <%= render 'shared/translations' %>
 </div>

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds responsive-top-margin">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
   <%= render 'shared/translations' %>

--- a/app/views/content_items/case_study.html.erb
+++ b/app/views/content_items/case_study.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds responsive-top-margin">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
   <%= render 'shared/translations' %>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -4,11 +4,12 @@
   ) %>
 <% end %>
 
-<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title_and_context[:title] } %>
+<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.heading_and_context[:text] } %>
+
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
   <%= render 'shared/translations' %>
 </div>

--- a/app/views/content_items/contact.html.erb
+++ b/app/views/content_items/contact.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
 </div>
 

--- a/app/views/content_items/corporate_information_page.html.erb
+++ b/app/views/content_items/corporate_information_page.html.erb
@@ -29,7 +29,12 @@
 <div class="<%= @content_item.organisation_brand_class %>">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render 'govuk_publishing_components/components/title', title: @content_item.title %>
+      <%= render 'govuk_publishing_components/components/heading', 
+        text: @content_item.title,
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8
+      %>
     </div>
     <%= render 'shared/translations' %>
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/detailed_guide.html.erb
+++ b/app/views/content_items/detailed_guide.html.erb
@@ -4,11 +4,11 @@
   ) %>
 <% end %>
 
-<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title_and_context[:title] } %>
+<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.heading_and_context[:text] } %>
 
 <div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
   <%= render 'shared/translations' %>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/document_collection.html.erb
+++ b/app/views/content_items/document_collection.html.erb
@@ -4,14 +4,17 @@
   ) %>
 <% end %>
 
-<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.title_and_context[:title] } %>
+<%= render 'shared/email_subscribe_unsubscribe_flash', { title: @content_item.heading_and_context[:text] } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title',
+    <%= render 'govuk_publishing_components/components/heading',
        context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
-       title: @content_item.title,
-       average_title_length: "long" %>
+       text: @content_item.title,
+       heading_level: 1,
+       font_size: "l",
+       margin_bottom: 8
+      %>
   </div>
   <%= render 'shared/translations', content_item: @content_item %>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/fatality_notice.html.erb
+++ b/app/views/content_items/fatality_notice.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
   <%= render 'shared/translations' %>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/field_of_operation.html.erb
+++ b/app/views/content_items/field_of_operation.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/title", @content_item.title_and_context %>
+      <%= render "govuk_publishing_components/components/heading", @content_item.heading_and_context %>
     </div>
     <div class="govuk-grid-column-one-third govuk-!-margin-top-8 govuk-!-margin-bottom-8">
       <%= render "govuk_publishing_components/components/organisation_logo", {

--- a/app/views/content_items/field_of_operation.html.erb
+++ b/app/views/content_items/field_of_operation.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", @content_item.heading_and_context %>
     </div>
-    <div class="govuk-grid-column-one-third govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+    <div class="govuk-grid-column-one-third govuk-!-margin-bottom-8">
       <%= render "govuk_publishing_components/components/organisation_logo", {
         organisation: @content_item.organisation
       } %>

--- a/app/views/content_items/fields_of_operation.html.erb
+++ b/app/views/content_items/fields_of_operation.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/gone.html.erb
+++ b/app/views/content_items/gone.html.erb
@@ -1,7 +1,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/title", {
-      title: t("gone.title"),
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("gone.title"),
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8
     } %>
 
     <p class="summary govuk-!-font-size-19 govuk-!-margin-bottom-3">

--- a/app/views/content_items/guide.html+print.erb
+++ b/app/views/content_items/guide.html+print.erb
@@ -8,9 +8,11 @@
 
 <div class="govuk-grid-row gem-print-columns-none" id="guide-print">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', {
-      margin_bottom: 6,
-      title: @content_item.title,
+    <%= render 'govuk_publishing_components/components/heading', {
+      text: @content_item.title,
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 6
     } %>
 
     <div class="govuk-!-display-none-print">

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -20,9 +20,19 @@
 <div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
     <% if show_contents_list_ab_test? %>
-      <%= render 'govuk_publishing_components/components/title', { title: @content_item.title } %>
+      <%= render 'govuk_publishing_components/components/heading', { 
+        text: @content_item.title,
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8
+      } %>
     <% else %>
-      <%= render 'govuk_publishing_components/components/title', { title: @content_item.content_title } %>
+      <%= render 'govuk_publishing_components/components/heading', { 
+        text: @content_item.content_title,
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8
+      } %>
     <% end %>
     <% if show_contents_list_ab_test? || @content_item.show_guide_navigation? %>
       <%= render "govuk_publishing_components/components/skip_link", {

--- a/app/views/content_items/guide_single.html.erb
+++ b/app/views/content_items/guide_single.html.erb
@@ -17,7 +17,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', { title: @content_item.content_title } %>
+    <%= render 'govuk_publishing_components/components/heading', { 
+      text: @content_item.content_title,
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8
+    } %>
 
     <% if @content_item.show_guide_navigation? %>
       <aside class="part-navigation-container" role="complementary">

--- a/app/views/content_items/how_government_works.html.erb
+++ b/app/views/content_items/how_government_works.html.erb
@@ -1,8 +1,11 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/title", {
-        title: "How government works",
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "How government works",
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8
       } %>
 
       <%= render "govuk_publishing_components/components/lead_paragraph", {

--- a/app/views/content_items/news_article.html.erb
+++ b/app/views/content_items/news_article.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
   <%= render 'shared/translations' %>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/publication.html.erb
+++ b/app/views/content_items/publication.html.erb
@@ -12,11 +12,14 @@
 
 <div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title',
+    <%= render 'govuk_publishing_components/components/heading',
       context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
       context_locale: t_locale_fallback("content_item.schema_name.#{@content_item.document_type}", count: 1),
-      title: @content_item.title,
-      average_title_length: "long" %>
+      text: @content_item.title,
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 8
+    %>
   </div>
   <%= render 'shared/translations' %>
 

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -22,9 +22,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="app-page-header">
-        <%= render "govuk_publishing_components/components/title", {
+        <%= render "govuk_publishing_components/components/heading", {
           context: @content_item.category_title,
-          title: @content_item.title,
+          text: @content_item.title,
+          heading_level: 1,
+          font_size: "xl",
           margin_bottom: 8
         } %>
         <% if @content_item.show_description? %>

--- a/app/views/content_items/service_manual_service_standard.html.erb
+++ b/app/views/content_items/service_manual_service_standard.html.erb
@@ -16,8 +16,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="app-page-header govuk-!-margin-top-3 govuk-!-margin-bottom-3">
-        <%= render "govuk_publishing_components/components/title", {
-          title: @content_item.title,
+        <%= render "govuk_publishing_components/components/heading", {
+          text: @content_item.title,
+          heading_level: 1,
+          font_size: "xl",
+          margin_bottom: 8
         } %>
         <p class="govuk-body-l govuk-!-margin-bottom-7 app-page-header__summary">
           <%= @content_item.content_item["description"] %>

--- a/app/views/content_items/service_manual_topic.html.erb
+++ b/app/views/content_items/service_manual_topic.html.erb
@@ -11,8 +11,10 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/title", {
-        title: @content_item.title,
+      <%= render "govuk_publishing_components/components/heading", {
+        text: @content_item.title,
+        heading_level: 1,
+        font_size: "xl",
         margin_bottom: 7
       } %>
       <p class="govuk-body-l">

--- a/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
+++ b/app/views/content_items/service_sign_in/_choose_sign_in.html.erb
@@ -15,7 +15,12 @@
 <% end %>
 <%= form_tag({controller: 'content_items', action: 'service_sign_in_options'},
              method: "post") do %>
-  <% legend_text = render 'govuk_publishing_components/components/title', title: @content_item.title %>
+  <% legend_text = render 'govuk_publishing_components/components/heading', 
+    text: @content_item.title,
+    heading_level: 1,
+    font_size: "xl",
+    margin_bottom: 8
+  %>
   <% description_text = render 'govuk_publishing_components/components/govspeak' do %>
     <% raw(@content_item.description) %>
   <% end %>

--- a/app/views/content_items/service_sign_in/_create_new_account.html.erb
+++ b/app/views/content_items/service_sign_in/_create_new_account.html.erb
@@ -1,6 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', title: @content_item.title %>
+    <%= render 'govuk_publishing_components/components/heading', 
+      text: @content_item.title,
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8
+    %>
     <%= render 'govuk_publishing_components/components/govspeak', {} do %>
       <% raw(@content_item.body) %>
     <% end %>

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds responsive-top-margin">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
   <%= render 'shared/translations' %>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -8,7 +8,7 @@
 <% content_for :simple_header, true %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds responsive-top-margin">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
   <%= render 'shared/translations' %>

--- a/app/views/content_items/speech.html.erb
+++ b/app/views/content_items/speech.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
   <%= render 'shared/translations' %>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/statistical_data_set.html.erb
+++ b/app/views/content_items/statistical_data_set.html.erb
@@ -6,10 +6,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title',
-               context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
-               title: @content_item.title,
-               average_title_length: "long" %>
+    <%= render 'govuk_publishing_components/components/heading',
+      context: t("content_item.schema_name.#{@content_item.document_type}", count: 1),
+      text: @content_item.title,
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 8
+    %>
   </div>
   <%= render 'shared/translations', content_item: @content_item %>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/statistics_announcement.html.erb
+++ b/app/views/content_items/statistics_announcement.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
     <%= render 'govuk_publishing_components/components/lead_paragraph', text: @content_item.description %>
   </div>
 </div>

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -22,7 +22,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds responsive-top-margin">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
   <%= render 'shared/translations' %>
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/content_items/working_group.html.erb
+++ b/app/views/content_items/working_group.html.erb
@@ -21,7 +21,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds responsive-top-margin">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
   <%= render 'shared/translations' %>

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -9,7 +9,7 @@
 </head>
 <body>
   <div id="wrapper">
-    <main class="govspeak" id="content">
+    <main class="govspeak govuk-main-wrapper" id="content">
       <%= render 'govuk_publishing_components/components/heading', 
         text: 'government-frontend',
         heading_level: 1,

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -10,7 +10,12 @@
 <body>
   <div id="wrapper">
     <main class="govspeak" id="content">
-      <%= render 'govuk_publishing_components/components/title', title: 'government-frontend' %>
+      <%= render 'govuk_publishing_components/components/heading', 
+        text: 'government-frontend',
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8
+      %>
 
       <% html = capture do %>
         <p>

--- a/app/views/histories/history.html.erb
+++ b/app/views/histories/history.html.erb
@@ -1,8 +1,11 @@
 <header class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <%= render "govuk_publishing_components/components/title", {
-        title: "History of the UK&nbsp;government".html_safe
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "History of the UK&nbsp;government".html_safe,
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8
       } %>
     </div>
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
 
     <%= yield :header %>
 
-    <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %>" lang="<%= I18n.locale %>">
+    <main role="main" id="content" class="<%= @content_item.schema_name.dasherize %> <%= 'govuk-main-wrapper' unless @content_item.exclude_main_wrapper_class? %>" lang="<%= I18n.locale %>">
       <span id="Top"></span>
       <%= yield :main %>
     </main>

--- a/app/views/shared/_title_and_translations.html.erb
+++ b/app/views/shared/_title_and_translations.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/title', @content_item.title_and_context %>
+    <%= render 'govuk_publishing_components/components/heading', @content_item.heading_and_context %>
   </div>
   <%= render 'shared/translations' %>
 </div>

--- a/test/integration/service_manual_service_standard_test.rb
+++ b/test/integration/service_manual_service_standard_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class ServiceManualServiceStandardTest < ActionDispatch::IntegrationTest
-  test "service standard page has a title, summary and intro" do
+  test "service standard page has a heading, summary and intro" do
     setup_and_visit_content_item("service_manual_service_standard",
                                  "title" => "Service Standard",
                                  "description" => "The Service Standard is a set of 14 criteria.",
@@ -9,7 +9,7 @@ class ServiceManualServiceStandardTest < ActionDispatch::IntegrationTest
                                    "body" => "All public facing transactional services must meet the standard.",
                                  })
 
-    assert page.has_css?(".gem-c-title__text", text: "Service Standard"), "No title found"
+    assert page.has_css?(".gem-c-heading__text", text: "Service Standard"), "No title found"
     assert page.has_css?(".app-page-header__summary", text: "The Service Standard is a set of 14 criteria"), "No description found"
     assert page.has_css?(".app-page-header__intro", text: "All public facing transactional services must meet the standard."), "No body found"
   end

--- a/test/presenters/corporate_information_page_presenter_test.rb
+++ b/test/presenters/corporate_information_page_presenter_test.rb
@@ -28,11 +28,11 @@ class CorporateInformationPagePresenterTest
       assert presented_item.is_a?(ContentItem::ContentsList)
     end
 
-    test "has title without context" do
-      assert presented_item.is_a?(ContentItem::TitleAndContext)
-      title_component_params = { title: "About us", context_locale: :en }
+    test "has heading without context" do
+      assert presented_item.is_a?(ContentItem::HeadingAndContext)
+      heading_component_params = { text: "About us", context_locale: :en, heading_level: 1, margin_bottom: 8, font_size: "xl" }
 
-      assert_equal title_component_params, presented_item.title_and_context
+      assert_equal heading_component_params, presented_item.heading_and_context
     end
 
     test "has organisation branding" do

--- a/test/presenters/detailed_guide_presenter_test.rb
+++ b/test/presenters/detailed_guide_presenter_test.rb
@@ -70,7 +70,7 @@ class DetailedGuidePresenterTest < PresenterTestCase
 
   test "context in title is overridden to display as guidance" do
     I18n.with_locale("fr") do
-      assert_equal I18n.t("content_item.schema_name.guidance", count: 1), presented_item.title_and_context[:context]
+      assert_equal I18n.t("content_item.schema_name.guidance", count: 1), presented_item.heading_and_context[:context]
     end
   end
 

--- a/test/presenters/field_of_operation_presenter_test.rb
+++ b/test/presenters/field_of_operation_presenter_test.rb
@@ -5,13 +5,16 @@ class FieldOfOperationPresenterTest < PresenterTestCase
     "field_of_operation"
   end
 
-  test "#title_and_context" do
-    expected_title_and_context = {
-      title: "Operations in Iraq",
+  test "#heading_and_context" do
+    expected_heading_and_context = {
+      text: "Operations in Iraq",
       context: "British fatalities",
       context_locale: :en,
+      heading_level: 1,
+      margin_bottom: 8,
+      font_size: "xl",
     }
-    assert_equal expected_title_and_context, presented_item.title_and_context
+    assert_equal expected_heading_and_context, presented_item.heading_and_context
   end
 
   test "it presents a description" do
@@ -29,7 +32,7 @@ class FieldOfOperationPresenterTest < PresenterTestCase
     assert_equal expected, presented_item.organisation
   end
 
-  test "it presents fatlity notices when they are present" do
+  test "it presents fatality notices when they are present" do
     expected_notices = [
       FieldOfOperationPresenter::FatalityNotice.new("A fatality sadly occurred on 1 December", nil, "A fatality notice", "/government/fatalities/fatality-notice-one"),
       FieldOfOperationPresenter::FatalityNotice.new("A fatality sadly occurred on 2 December", nil, "A second fatality notice", "/government/fatalities/fatality-notice-two"),
@@ -38,7 +41,7 @@ class FieldOfOperationPresenterTest < PresenterTestCase
     assert_equal expected_notices, presented_item.fatality_notices
   end
 
-  test "it presents an ampty array when no fatlity notices are present" do
+  test "it presents an empty array when no fatality notices are present" do
     without_fatalities = schema_item
     without_fatalities["links"].delete("fatality_notices")
 

--- a/test/presenters/fields_of_operation_presenter_test.rb
+++ b/test/presenters/fields_of_operation_presenter_test.rb
@@ -5,14 +5,17 @@ class FieldsOfOperationPresenterTest < PresenterTestCase
     "fields_of_operation"
   end
 
-  test "presents the title and context" do
-    title_component_params = {
-      title: "Fields of operation",
+  test "presents the heading and context" do
+    heading_component_params = {
+      text: "Fields of operation",
       context: "British fatalities",
       context_locale: :en,
+      heading_level: 1,
+      margin_bottom: 8,
+      font_size: "xl",
     }
 
-    assert_equal title_component_params, presented_item.title_and_context
+    assert_equal heading_component_params, presented_item.heading_and_context
   end
 
   test "presents the fields of operation" do

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -91,16 +91,17 @@ class SpecialistDocumentPresenterTest
       assert Time.zone.parse(presented.published) == Time.zone.parse("2002-02-02")
     end
 
-    test "has title without context" do
-      assert presented_item("aaib-reports").is_a?(ContentItem::TitleAndContext)
-      title_component_params = {
-        title: schema_item("aaib-reports")["title"],
+    test "has heading without context" do
+      assert presented_item("aaib-reports").is_a?(ContentItem::HeadingAndContext)
+      heading_component_params = {
+        text: schema_item("aaib-reports")["title"],
         context_locale: nil,
-        average_title_length: "long",
-
+        heading_level: 1,
+        margin_bottom: 8,
+        font_size: "l",
       }
 
-      assert_equal title_component_params, presented_item("aaib-reports").title_and_context
+      assert_equal heading_component_params, presented_item("aaib-reports").heading_and_context
     end
 
     test "should not present continuation_link" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
This PR replaces instances of the title component with the heading component.

## Why
[Trello card](https://trello.com/c/ELvrt0ra/467-replace-title-with-heading-in-government-frontend)

## Visual changes
There is a very small decrease in spacing above the heading on larger screen sizes due to introducing the `govuk-main-wrapper` class on the `main` element to handle spacing. On smaller screen sizes, spacing has been introduced above the heading where it didn't exist before (screenshots below).

Due to the very small difference on larger screens and the benefit of additional spacing on smaller screens, I'd argue these changes aren't a blocker. Happy to discuss though.

| Before (desktop) | After (desktop) |
|------------------|----------------|
| ![image](https://github.com/user-attachments/assets/74b2a1d8-14fe-4380-9321-0cdf90f0ffd6) | ![image](https://github.com/user-attachments/assets/bdad1745-ef48-4bc4-b598-cb8cce995fad) |

| Before (mobile) | After (mobile) |
|------------------|----------------|
| ![image](https://github.com/user-attachments/assets/241a324b-10b7-431a-9965-38295e810c43) | ![image](https://github.com/user-attachments/assets/34bc4365-28c4-4f9d-bc4b-69e5a6b291a8) |