### PR TITLE
Add ability to render sub facets as metadata

### DIFF
--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -329,5 +329,32 @@ class SpecialistDocumentPresenterTest
       presented = present_example(example)
       assert Time.zone.parse(presented.published) == Time.zone.parse("2010-01-01")
     end
+
+    test "includes nested facets as text in metadata" do
+      values = { "facet-key" => "main-facet-1-value", "sub-facet-key" => "sub-facet-1-value" }
+      facet = example_facet({
+        "sub_facet_name" => "Sub Facet name",
+        "sub_facet_key" => "sub-facet-key",
+        "nested_facet" => true,
+        "allowed_values" => [
+          {
+            "label" => "Main Facet Value",
+            "value" => "main-facet-1-value",
+            "sub_facets" => [
+              {
+                "label" => "Sub Facet Value",
+                "value" => "sub-facet-1-value",
+              },
+            ],
+          },
+        ],
+      })
+      example = example_with_finder_facets([facet], values)
+
+      presented = present_example(example)
+
+      assert_equal "Main Facet Value", presented.important_metadata["Facet name"]
+      assert_equal "Main Facet Value - Sub Facet Value", presented.important_metadata["Sub Facet name"]
+    end
   end
 end


### PR DESCRIPTION
Sub-facets are introduced as part of Nested Facet work on Specialist Publisher. The new structure introduced allows users to define one level of nesting for facet values. These also need to be surfaced as part of metadata.

https://trello.com/c/4RJusHld/3374-nested-facets-add-new-document
https://trello.com/c/OA4zE8m0/3430-ipo-finder-request

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Routes in this application are being migrated to another application, please check with #govuk-patterns-and-pages when making changes.