### PR TITLE
Revert spacing changes to service manual homepage

### DIFF
--- a/app/presenters/service_manual_presenter.rb
+++ b/app/presenters/service_manual_presenter.rb
@@ -7,6 +7,10 @@ class ServiceManualPresenter < ContentItemPresenter
     @details ||= content_item["details"] || {}
   end
 
+  def exclude_main_wrapper_class?
+    service_manual_homepage?
+  end
+
   def include_search_in_header?
     true
   end

--- a/app/presenters/service_manual_service_toolkit_presenter.rb
+++ b/app/presenters/service_manual_service_toolkit_presenter.rb
@@ -7,6 +7,10 @@ class ServiceManualServiceToolkitPresenter < ServiceManualPresenter
     details.fetch("collections", [])
   end
 
+  def exclude_main_wrapper_class?
+    true
+  end
+
   def show_default_breadcrumbs?
     false
   end


### PR DESCRIPTION
## What

Revert spacing changes to service manual homepage

## Why

The `govuk-main-wrapper` class adds the correct spacing to the view templates and follows the design system guidance.

When used on the service-manual and service-toolkit homepage, it adds extra unwanted spacing at the top of the blue banner. To fix this, the new `exclude_main_wrapper_class` method has been used to remove the `govuk-main-wrapper` class from these pages.

## Visual Changes

### Before



### After