### PR TITLE
Specialist document presenter refactor

### DIFF
--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -113,7 +113,7 @@ private
     finder.dig("details", "facets")
   end
 
-  def facet_values
+  def content_item_metadata
     # Metadata is a required field
     content_item["details"]["metadata"]
   end
@@ -122,7 +122,7 @@ private
     facets_with_values.map do |facet|
       facet_key = facet["key"]
       # Cast all values into an array
-      values = [facet_values[facet_key]].flatten
+      values = [content_item_metadata[facet_key]].flatten
 
       facet["values"] = case facet["type"]
                         when "date"
@@ -138,10 +138,10 @@ private
   end
 
   def facets_with_values
-    return [] unless facets && facet_values.any?
+    return [] unless facets && content_item_metadata.any?
 
     facets
-      .select { |f| facet_values[f["key"]] && facet_values[f["key"]].present? }
+      .select { |f| content_item_metadata[f["key"]] && content_item_metadata[f["key"]].present? }
       .reject { |f| f["key"] == first_published_at_facet_key }
       .reject { |f| f["key"] == internal_notes_facet_key }
   end
@@ -208,8 +208,8 @@ private
   #
   # Instead use first date in change history
   def first_public_at
-    @first_public_at ||= if facet_values[first_published_at_facet_key]
-                           facet_values[first_published_at_facet_key]
+    @first_public_at ||= if content_item_metadata[first_published_at_facet_key]
+                           content_item_metadata[first_published_at_facet_key]
                          else
                            changes = reverse_chronological_change_history
                            changes.any? ? changes.last[:timestamp] : nil
@@ -236,7 +236,7 @@ private
   # Example:
   # https://www.gov.uk/aaib-reports/lockheed-l1011-385-1-15-g-bhbr-19-december-1989
   def bulk_published?
-    facet_values["bulk_published"].present?
+    content_item_metadata["bulk_published"].present?
   end
 
   def statutory_instrument?


### PR DESCRIPTION
As follow on discussion on PR: https://github.com/alphagov/government-frontend/pull/3565
Refactored the specialist document presenter. 

Closed the previous PR as we may no longer need to manipulate the finder schema to fetch sub-facets anymore. Refactorings are stand alone.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Routes in this application are being migrated to another application, please check with #govuk-patterns-and-pages when making changes.