### PR TITLE
Extract display date and time methods to a helper

### DIFF
--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -1,0 +1,19 @@
+module DateTimeHelper
+  def self.display_date(timestamp, locale: I18n.locale, format: "%-d %B %Y")
+    I18n.l(Time.zone.parse(timestamp), format:, locale:) if timestamp
+  end
+
+  def self.display_date_and_time(date, rollback_midnight: false)
+    time = Time.zone.parse(date)
+    date_format = "%-e %B %Y"
+    time_format = "%l:%M%P"
+
+    if rollback_midnight && (time.strftime(time_format) == "12:00am")
+      # 12am, 12:00am and "midnight on" can all be misinterpreted
+      # Use 11:59pm on the day before to remove ambiguity
+      # 12am on 10 January becomes 11:59pm on 9 January
+      time -= 1.second
+    end
+    I18n.l(time, format: "#{time_format} on #{date_format}").gsub(":00", "").gsub("12pm", "midday").gsub("12am on ", "").strip
+  end
+end

--- a/app/presenters/call_for_evidence_presenter.rb
+++ b/app/presenters/call_for_evidence_presenter.rb
@@ -17,7 +17,7 @@ class CallForEvidencePresenter < ContentItemPresenter
   end
 
   def opening_date
-    display_date_and_time(opening_date_time)
+    DateTimeHelper.display_date_and_time(opening_date_time)
   end
 
   def opening_date_midnight?
@@ -25,7 +25,7 @@ class CallForEvidencePresenter < ContentItemPresenter
   end
 
   def closing_date
-    display_date_and_time(closing_date_time, rollback_midnight: true)
+    DateTimeHelper.display_date_and_time(closing_date_time, rollback_midnight: true)
   end
 
   def open?
@@ -101,20 +101,6 @@ class CallForEvidencePresenter < ContentItemPresenter
   end
 
 private
-
-  def display_date_and_time(date, rollback_midnight: false)
-    time = Time.zone.parse(date)
-    date_format = "%-e %B %Y"
-    time_format = "%l:%M%P"
-
-    if rollback_midnight && (time.strftime(time_format) == "12:00am")
-      # 12am, 12:00am and "midnight on" can all be misinterpreted
-      # Use 11:59pm on the day before to remove ambiguity
-      # 12am on 10 January becomes 11:59pm on 9 January
-      time -= 1.second
-    end
-    I18n.l(time, format: "#{time_format} on #{date_format}").gsub(":00", "").gsub("12pm", "midday").gsub("12am on ", "").strip
-  end
 
   def ways_to_respond
     content_item["details"]["ways_to_respond"]

--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -17,7 +17,7 @@ class ConsultationPresenter < ContentItemPresenter
   end
 
   def opening_date
-    display_date_and_time(opening_date_time)
+    DateTimeHelper.display_date_and_time(opening_date_time)
   end
 
   def opening_date_midnight?
@@ -25,7 +25,7 @@ class ConsultationPresenter < ContentItemPresenter
   end
 
   def closing_date
-    display_date_and_time(closing_date_time, rollback_midnight: true)
+    DateTimeHelper.display_date_and_time(closing_date_time, rollback_midnight: true)
   end
 
   def open?
@@ -115,20 +115,6 @@ class ConsultationPresenter < ContentItemPresenter
   end
 
 private
-
-  def display_date_and_time(date, rollback_midnight: false)
-    time = Time.zone.parse(date)
-    date_format = "%-e %B %Y"
-    time_format = "%l:%M%P"
-
-    if rollback_midnight && (time.strftime(time_format) == "12:00am")
-      # 12am, 12:00am and "midnight on" can all be misinterpreted
-      # Use 11:59pm on the day before to remove ambiguity
-      # 12am on 10 January becomes 11:59pm on 9 January
-      time -= 1.second
-    end
-    I18n.l(time, format: "#{time_format} on #{date_format}").gsub(":00", "").gsub("12pm", "midday").gsub("12am on ", "").strip
-  end
 
   def ways_to_respond
     content_item["details"]["ways_to_respond"]

--- a/app/presenters/content_item/last_updated.rb
+++ b/app/presenters/content_item/last_updated.rb
@@ -1,7 +1,7 @@
 module ContentItem
   module LastUpdated
     def last_updated
-      display_date(content_item["public_updated_at"]) if content_item["public_updated_at"]
+      DateTimeHelper.display_date(content_item["public_updated_at"]) if content_item["public_updated_at"]
     end
   end
 end

--- a/app/presenters/content_item/manual.rb
+++ b/app/presenters/content_item/manual.rb
@@ -47,10 +47,10 @@ module ContentItem
       current_path = view_context.request.path
 
       if (hmrc? || manual?) && current_path == "#{base_path}/updates"
-        update_at_text = display_date(updated_at).to_s
+        update_at_text = DateTimeHelper.display_date(updated_at).to_s
       else
         updates_link = view_context.link_to(I18n.t("manuals.see_all_updates"), "#{base_path}/updates")
-        update_at_text = "#{display_date(updated_at)} - #{updates_link}"
+        update_at_text = "#{DateTimeHelper.display_date(updated_at)} - #{updates_link}"
       end
 
       { I18n.t("manuals.updated") => update_at_text }

--- a/app/presenters/content_item/manual_section.rb
+++ b/app/presenters/content_item/manual_section.rb
@@ -46,7 +46,7 @@ module ContentItem
     end
 
     def published
-      display_date(manual_content_item["first_published_at"])
+      DateTimeHelper.display_date(manual_content_item["first_published_at"])
     end
 
     def other_metadata

--- a/app/presenters/content_item/updatable.rb
+++ b/app/presenters/content_item/updatable.rb
@@ -1,11 +1,11 @@
 module ContentItem
   module Updatable
     def published
-      display_date(first_public_at)
+      DateTimeHelper.display_date(first_public_at)
     end
 
     def updated
-      display_date(public_updated_at) if any_updates?
+      DateTimeHelper.display_date(public_updated_at) if any_updates?
     end
 
     def history
@@ -28,7 +28,7 @@ module ContentItem
       changes = content_item["details"]["change_history"] || []
       changes.map do |item|
         {
-          display_time: display_date(item["public_timestamp"]),
+          display_time: DateTimeHelper.display_date(item["public_timestamp"]),
           note: item["note"],
           timestamp: item["public_timestamp"],
         }

--- a/app/presenters/content_item/withdrawable.rb
+++ b/app/presenters/content_item/withdrawable.rb
@@ -35,13 +35,9 @@ module ContentItem
 
     def withdrawal_notice_time
       view_context.tag.time(
-        english_display_date(withdrawal_notice["withdrawn_at"]),
+        DateTimeHelper.display_date(withdrawal_notice["withdrawn_at"], locale: :en),
         datetime: withdrawal_notice["withdrawn_at"],
       )
-    end
-
-    def english_display_date(timestamp, format = "%-d %B %Y")
-      I18n.l(Time.zone.parse(timestamp), format:, locale: :en) if timestamp
     end
   end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -129,10 +129,6 @@ private
     Time.zone.now < polls_closing_time
   end
 
-  def display_date(timestamp, format = "%-d %B %Y")
-    I18n.l(Time.zone.parse(timestamp), format:, locale:) if timestamp
-  end
-
   def sorted_locales(translations)
     translations.sort_by { |t| t["locale"] == I18n.default_locale.to_s ? "" : t["locale"] }
   end

--- a/app/presenters/html_publication_presenter.rb
+++ b/app/presenters/html_publication_presenter.rb
@@ -22,7 +22,7 @@ class HtmlPublicationPresenter < ContentItemPresenter
   end
 
   def last_changed
-    timestamp = display_date(public_timestamp)
+    timestamp = DateTimeHelper.display_date(public_timestamp)
 
     # This assumes that a translation doesn't need the date to come beforehand.
     if content_item["details"]["first_published_version"]

--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -147,7 +147,7 @@ private
   end
 
   def friendly_facet_date(dates)
-    dates.map { |date| display_date(date) }
+    dates.map { |date| DateTimeHelper.display_date(date) }
   end
 
   def friendly_facet_text(facet, values)

--- a/app/presenters/speech_presenter.rb
+++ b/app/presenters/speech_presenter.rb
@@ -39,7 +39,7 @@ private
 
   def delivered_on
     delivered_on_date = content_item["details"]["delivered_on"]
-    view_context.tag.time(display_date(delivered_on_date), datetime: delivered_on_date)
+    view_context.tag.time(DateTimeHelper.display_date(delivered_on_date), datetime: delivered_on_date)
   end
 
   def speech_type_explanation

--- a/test/presenters/content_item/manual_test.rb
+++ b/test/presenters/content_item/manual_test.rb
@@ -11,6 +11,7 @@ class ContentItemManualTest < ActiveSupport::TestCase
         "title" => "Super title",
         "base_path" => "/a/base/path",
         "public_updated_at" => "2022-03-23T08:30:20.000+00:00",
+        "first_published_at" => "2022-03-23T08:30:20.000+00:00",
         "schema_name" => schema_name,
         "details" => {
           "body" => "body",
@@ -61,7 +62,6 @@ class ContentItemManualTest < ActiveSupport::TestCase
 
   test "returns extra publisher metadata" do
     item = DummyContentItem.new
-    item.stubs(:display_date).returns("23 March 2022")
 
     view_context = mock
     view_context.stubs(:request).returns(ActionDispatch::TestRequest.create)

--- a/test/presenters/content_item/metadata_test.rb
+++ b/test/presenters/content_item/metadata_test.rb
@@ -11,6 +11,7 @@ class ContentItemMetadataTest < ActiveSupport::TestCase
         "title" => "Super title",
         "base_path" => "/a/base/path",
         "public_updated_at" => "2022-03-23T08:30:20.000+00:00",
+        "first_published_at" => "2000-03-23T08:30:20.000+00:00",
         "schema_name" => schema_name,
         "details" => {
           "body" => "body",
@@ -32,12 +33,11 @@ class ContentItemMetadataTest < ActiveSupport::TestCase
 
   test "returns see_updates_link true if published" do
     item = DummyContentItem.new
-    item.stubs(:display_date).returns("23 March 2000")
 
     expected_publisher_metadata = {
       from: ["<a class=\"govuk-link\" href=\"/blah\">blah</a>"],
       first_published: "23 March 2000",
-      last_updated: nil,
+      last_updated: "23 March 2022",
       see_updates_link: true,
     }
 
@@ -46,14 +46,12 @@ class ContentItemMetadataTest < ActiveSupport::TestCase
 
   test "does not return see_updates_link if pending" do
     item = DummyContentItem.new
-    item.stubs(:display_date).returns("23 March 3000")
-
     item.content_item["details"]["display_date"] = "23 March 3000"
 
     expected_publisher_metadata = {
       from: ["<a class=\"govuk-link\" href=\"/blah\">blah</a>"],
-      first_published: "23 March 3000",
-      last_updated: nil,
+      first_published: "23 March 2000",
+      last_updated: "23 March 2022",
     }
 
     assert_equal expected_publisher_metadata, item.publisher_metadata

--- a/test/presenters/content_item/updatable_test.rb
+++ b/test/presenters/content_item/updatable_test.rb
@@ -1,11 +1,5 @@
 require "test_helper"
 
-module ContentItemUpdatableStubs
-  def display_date(date)
-    date
-  end
-end
-
 module ContentItemUpdatableWithUpdates
   def any_updates?
     true
@@ -16,7 +10,6 @@ class ContentItemUpdatableTest < ActiveSupport::TestCase
   def setup
     @updatable = Object.new
     @updatable.extend(ContentItem::Updatable)
-    @updatable.extend(ContentItemUpdatableStubs)
   end
 
   test "#history returns an empty array when there is no change history" do
@@ -49,7 +42,7 @@ class ContentItemUpdatableTest < ActiveSupport::TestCase
     end
 
     assert @updatable.history.any?
-    assert_equal @updatable.updated, "2002-02-02"
+    assert_equal "2 February 2002", @updatable.updated
   end
 
   test "#history returns no updates when first_public_at matches public_updated_at" do
@@ -133,14 +126,14 @@ class ContentItemUpdatableTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal @updatable.history,
-                 [
-                   {
-                     display_time: "2016-02-29T09:24:10.000+00:00",
-                     note: "notes",
-                     timestamp: "2016-02-29T09:24:10.000+00:00",
-                   },
-                 ]
+    expected_history = [
+      {
+        display_time: "29 February 2016",
+        note: "notes",
+        timestamp: "2016-02-29T09:24:10.000+00:00",
+      },
+    ]
+    assert_equal expected_history, @updatable.history
   end
 
   test "#history returns a reverse chronologically sorted array of hashes when there is change history" do

--- a/test/presenters/content_item/withdrawable_test.rb
+++ b/test/presenters/content_item/withdrawable_test.rb
@@ -52,10 +52,6 @@ class ContentItemWithdrawableTest < ActiveSupport::TestCase
         "news_article"
       end
 
-      def display_date(date)
-        date
-      end
-
       def content_item
         {
           "title" => "Proportion of residents who do any walking or cycling (at local authority level) (CW010)",


### PR DESCRIPTION
There are duplicate code where display date is used (e.g. consultation and call for evidence). We also currently have a hard set reliance on the content item presenter to use date displays. Extracting this to a helper module will allow us to remove that coupling. 

Additionally, there are stubs of the method all over tests which means tests are not testing actual values. Have removed some of this stubbing. 


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Routes in this application are being migrated to another application, please check with #govuk-patterns-and-pages when making changes.