### PR TITLE
Add rendering for Sub Facet value and sub facet link

### DIFF
--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -330,5 +330,45 @@ class SpecialistDocumentPresenterTest
       presented = present_example(example)
       assert Time.zone.parse(presented.published) == Time.zone.parse("2010-01-01")
     end
+
+    test "Generate correct label and link for a sub facet" do
+      values = { "facet-key" => "main-facet-1-value", "sub-facet-key" => "sub-facet-1-value" }
+      facet = example_facet({
+        "name" => "Facet name",
+        "key" => "facet-key",
+        "sub_facet_name" => "Sub Facet name",
+        "sub_facet_key" => "sub-facet-key",
+        "nested_facet" => true,
+        "filterable" => true,
+        "allowed_values" => [
+          {
+            "label" => "Main Facet Value",
+            "value" => "main-facet-1-value",
+          },
+        ],
+      })
+      sub_facet = example_facet({
+        "name" => "Sub Facet name",
+        "key" => "sub-facet-key",
+        "nested_facet" => true,
+        "filterable" => true,
+        "allowed_values" => [
+          {
+            "label" => "Sub Facet Value",
+            "value" => "sub-facet-1-value",
+            "main_facet_label" => "Main Facet Value",
+            "main_facet_value" => "main-facet-1-value",
+          },
+        ],
+      })
+      example = example_with_finder_facets([facet, sub_facet], values)
+
+      presented = present_example(example)
+
+      expected_main_facet_link = "<a class=\"govuk-link govuk-link--inverse\" href=\"/finder-base-path?facet-key%5B%5D=main-facet-1-value\">Main Facet Value</a>"
+      expected_sub_facet_link = "<a class=\"govuk-link govuk-link--inverse\" href=\"/finder-base-path?facet-key%5B%5D=main-facet-1-value&amp;sub-facet-key%5B%5D=sub-facet-1-value\">Main Facet Value - Sub Facet Value</a>"
+      assert_equal expected_main_facet_link, presented.important_metadata["Facet name"]
+      assert_equal expected_sub_facet_link, presented.important_metadata["Sub Facet name"]
+    end
   end
 end


### PR DESCRIPTION
Any facet that is a sub facet needs to be rendered with a label in the format "[main facet] - [sub facet]". The link also needs to include the main facet as part of query params in addition to the sub facet. The linked main facet label and value is passed through in the finder schema via allowed values as illustrated in the test.

https://trello.com/c/4RJusHld/3374-nested-facets-add-new-document

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Routes in this application are being migrated to another application, please check with #govuk-patterns-and-pages when making changes.