### PR TITLE
Restore HTML publication H1s

### DIFF
--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -34,6 +34,7 @@
     inverse: true,
     margin_bottom: 0,
     font_size: "xl",
+    heading_level: 1,
   } %>
 <% end %>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- we recently swapped out the title component (which displays a H1) with the heading component (which defaults to a H2)
- but forgot to explicitly tell the heading component to render a H1
- this fixes that, restoring the title of HTML publications to a H1

Example HTML publication: https://www.gov.uk/government/publications/govuk-proposition/govuk-proposition

## Visual changes
None.
