### PR TITLE
Make contacting patterns and pages team bold

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,12 @@
+# 📣 On-going work to be aware of
+
+**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**
+
+- [ ] #govuk-patterns-and-pages have been notified of this change
+
+____
+
 ⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
 
 Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
 
-Routes in this application are being migrated to another application, please check with #govuk-patterns-and-pages when making changes.


### PR DESCRIPTION
It's easy to miss this line, and we want avoid clashes with teams making changes in government-frontend and routes being migrated to frontend.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Routes in this application are being migrated to another application, please check with #govuk-patterns-and-pages when making changes.