### PR TITLE
Revert "Bump to latest govuk_publishing_components"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (54.0.0)
+    govuk_publishing_components (53.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown


### PR DESCRIPTION
## What

Reverts alphagov/government-frontend#3582

## Why

https://trello.com/c/Eh88hfrm/80-list-numbers-appearing-in-legislative-lists

Preview link to example page: https://government-frontend-pr-3587.herokuapp.com/guidance/immigration-rules/immigration-rules-introduction

Reverting the change gets the required govspeak styles back: https://github.com/alphagov/govuk_publishing_components/pull/4623/files#diff-0350534e53a36a1c1df873d5e970890c05adc557c38c023285f608dcc6a34792L22-L25