### PR TITLE
 Use new-style csv preview links for attachments

### DIFF
--- a/app/presenters/content_item/attachments.rb
+++ b/app/presenters/content_item/attachments.rb
@@ -1,19 +1,32 @@
 module ContentItem
   module Attachments
     def attachments
-      return [] unless content_item["details"]["attachments"]
+      content_item_attachments = content_item.dig("details", "attachments") || []
 
-      docs = content_item["details"]["attachments"].select { |a| !a.key?("locale") || a["locale"] == locale }
+      docs = content_item_attachments.select { |a| !a.key?("locale") || a["locale"] == locale }
       docs.each do |doc|
         doc["type"] = "html" unless doc["content_type"]
         doc["type"] = "external" if doc["attachment_type"] == "external"
-        doc["preview_url"] = "#{doc['url']}/preview" if doc["preview_url"]
+        doc["preview_url"] = csv_preview_url(doc) if doc["content_type"] == "text/csv"
         doc["alternative_format_contact_email"] = nil if doc["accessible"] == true
       end
     end
 
     def attachments_from(attachment_id_list)
       attachments.select { |doc| (attachment_id_list || []).include? doc["id"] }
+    end
+
+  private
+
+    def csv_preview_url(doc)
+      asset = doc["assets"]&.first
+      if asset.nil?
+        # This is a temporary edge case whilst assets are a new field on all csv attachments.
+        Rails.logger.warn("Assets key is missing from attachment at #{doc['url']}")
+        "#{doc['url']}/preview"
+      elsif asset["filename"] == doc["filename"]
+        "/csv-preview/#{asset['asset_manager_id']}/#{asset['filename']}"
+      end
     end
   end
 end

--- a/app/presenters/content_item/attachments.rb
+++ b/app/presenters/content_item/attachments.rb
@@ -7,7 +7,7 @@ module ContentItem
       docs.each do |doc|
         doc["type"] = "html" unless doc["content_type"]
         doc["type"] = "external" if doc["attachment_type"] == "external"
-        doc["preview_url"] = csv_preview_url(doc) if doc["content_type"] == "text/csv"
+        doc["preview_url"] = csv_preview_url(doc) if csv_content_type.include?(doc["content_type"])
         doc["alternative_format_contact_email"] = nil if doc["accessible"] == true
       end
     end
@@ -17,6 +17,10 @@ module ContentItem
     end
 
   private
+
+    def csv_content_type
+      ["text/csv", "application/csv"]
+    end
 
     def csv_preview_url(doc)
       asset = doc["assets"]&.first

--- a/test/presenters/content_item/attachments_test.rb
+++ b/test/presenters/content_item/attachments_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class AttachmentsTest < ActiveSupport::TestCase
+  setup do
+    @subject = (Class.new do
+      attr_accessor :content_item
+
+      include ContentItem::Attachments
+    end).new
+  end
+
+  test "#attachments returns an empty array when there are no attachments" do
+    attachments = []
+    @subject.content_item = { "details" => { "attachments" => attachments } }
+    assert_equal [], @subject.attachments
+  end
+
+  test "#attachments returns attachments with type html by default" do
+    attachments = [
+      { "any-key" => "any-value" },
+    ]
+    @subject.content_item = { "details" => { "attachments" => attachments } }
+    assert_equal [{ "any-key" => "any-value", "type" => "html" }], @subject.attachments
+  end
+
+  test "#attachments returns attachments with preview_urls based on url" do
+    attachments = [
+      { "preview_url" => "some-preview-url", "url" => "some-url", "content_type" => "text/csv" },
+    ]
+    @subject.content_item = { "details" => { "attachments" => attachments } }
+    assert_equal [{ "preview_url" => "some-url/preview", "url" => "some-url", "content_type" => "text/csv" }], @subject.attachments
+  end
+
+  test "#attachments returns attachments with preview_urls based on asset_manager_id and filename" do
+    attachments = [{
+      "preview_url" => "some-preview-url",
+      "url" => "some-url",
+      "assets" => [{ "asset_manager_id" => "some-attachment-data-id", "filename" => "some-filename" }],
+      "filename" => "some-filename",
+      "content_type" => "text/csv",
+    }]
+    @subject.content_item = { "details" => { "attachments" => attachments } }
+    assert_equal [{
+      "preview_url" => "/csv-preview/some-attachment-data-id/some-filename",
+      "url" => "some-url",
+      "assets" => [{ "asset_manager_id" => "some-attachment-data-id", "filename" => "some-filename" }],
+      "filename" => "some-filename",
+      "content_type" => "text/csv",
+    }], @subject.attachments
+  end
+end

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -50,6 +50,27 @@ class PublicationPresenterTest < PresenterTestCase
     assert presented_item("statistics_publication").national_statistics?
   end
 
+  test "#attachments_for_components presents featured attachments" do
+    content_item = schema_item
+    content_item["details"]["featured_attachments"] = %w[some-id]
+    content_item["details"]["attachments"] = [{
+      "id" => "some-id",
+      "content_type" => "text/csv",
+      "preview_url" => "some-preview-url",
+      "url" => "some-url",
+    }]
+    presented = present_example(content_item)
+    expected = [{
+      "id" => "some-id",
+      "content_type" => "text/csv",
+      # NOTE: preview_url is the url with /preview appended, not the preview_url from above,
+      #       because we're working around a bug with preview_url
+      "preview_url" => "some-url/preview",
+      "url" => "some-url",
+    }]
+    assert_equal expected, presented.attachments_for_components
+  end
+
   test "presents withdrawn notices" do
     example = schema_item("withdrawn_publication")
     presented = presented_item("withdrawn_publication")


### PR DESCRIPTION
After the new /csv-preview url is available, we need to update government-frontend to use this new link on the document page.
 
Trello card: https://trello.com/c/6w8WHMeX/3482-update-government-frontend-to-use-the-new-csv-preview-url

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


This is a recreation of [the PR originally created by @richardTowers](https://github.com/alphagov/government-frontend/pull/3434), as there were some issues with actionlint in the previous PR.