### PR TITLE
Remove take part link, simplify text

### DIFF
--- a/app/views/content_items/how_government_works.html.erb
+++ b/app/views/content_items/how_government_works.html.erb
@@ -331,25 +331,7 @@
           margin_bottom: 4,
         } %>
 
-        <p class="govuk-body">Read about ways to <%= link_to "get involved", "/government/get-involved/", class: "govuk-link" %>.</p>
-
-        <%= render "govuk_publishing_components/components/heading", {
-          text: "Engage with government",
-          font_size: "m",
-          heading_level: 3,
-          margin_bottom: 4,
-        } %>
-
-        <p class="govuk-body">Interact with government through <%= link_to "consultations and petitions", "/government/get-involved#engage-with-government", class: "govuk-link" %> to inform and influence the decisions it makes.</p>
-
-        <%= render "govuk_publishing_components/components/heading", {
-          text: "Take part",
-          font_size: "m",
-          heading_level: 3,
-          margin_bottom: 4,
-        } %>
-
-        <p class="govuk-body"><%= link_to "Offer your skills and energy", "/government/get-involved#take-part", class: "govuk-link" %> to a project in your neighbourhood, around the UK or overseas.</p>
+        <p class="govuk-body">Find out how to <%= link_to "get involved", "/government/get-involved/", class: "govuk-link" %> with the work of the government, such as through consultations and petitions.</p>
       </section>
 
       <section class="govuk-!-margin-bottom-9">


### PR DESCRIPTION
https://trello.com/c/DMRyJwgG#comment-67cace753f69679d5da11d77

https://trello.com/c/DMRyJwgG/521-remove-links-to-take-part-pages-from-get-involved-page

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [x] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

