### PR TITLE
Bump actions/checkout and github-script

### DIFF
--- a/.github/workflows/copy-pr-template-to-dependabot-prs.yml
+++ b/.github/workflows/copy-pr-template-to-dependabot-prs.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Post PR template as a comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs')

--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: alphagov/government-frontend
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Checkout Publishing API (for Content Schemas)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: alphagov/publishing-api
           ref: ${{ inputs.publishingApiRef }}


### PR DESCRIPTION
## What
- Bump actions/checkout from 3 to 4
- Bump actions/github-script from 6 to 7

## Why
This resolves the CI errors below:

> the runner of "actions/checkout@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]

> the runner of "actions/github-script@v6" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]

consistent with versions used in other applications, for example actions/checkout@v4 and actions/github-script@v7 are already in used in frontend - 
  https://github.com/alphagov/frontend/blob/main/.github/workflows/ci.yml#L54
  https://github.com/alphagov/frontend/blob/main/.github/workflows/copy-pr-template-to-dependabot-prs.yml#L20

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [x] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.