### PR TITLE
Add GitHub Actions to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
## What

Add GitHub Actions to dependabot configuration, this approach is consistent with [frontend](https://github.com/alphagov/frontend/blob/main/.github/dependabot.yml#L20-L23) and [collections](https://github.com/alphagov/collections/blob/main/.github/dependabot.yml#L25-L28)

## Why

To ensure that GitHub actions are kept up-to-date

[Trello card](https://trello.com/c/tnUxY7k6/3366-add-github-actions-to-dependabot-checks-to-static-and-government-frontend)

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [x] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

