### PR TITLE
Use default spacing between notice and banner components on consultations

### DIFF
--- a/app/presenters/consultation_presenter.rb
+++ b/app/presenters/consultation_presenter.rb
@@ -110,10 +110,6 @@ class ConsultationPresenter < ContentItemPresenter
     ways_to_respond["attachment_url"]
   end
 
-  def add_margin?
-    final_outcome? || public_feedback_detail || public_feedback_attachments_for_components.any?
-  end
-
 private
 
   def ways_to_respond

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -47,8 +47,7 @@
       <% end %>
       <%= render 'govuk_publishing_components/components/notice',
         title: t("consultation.analysing_feedback"),
-        description_text: content_item_final_outcome,
-        margin_bottom:(0 unless @content_item.add_margin?)
+        description_text: content_item_final_outcome
       %>
 
     <% elsif @content_item.final_outcome? %>


### PR DESCRIPTION
## What
Restore the spacing between the summary banner and notice components on consultation pages as discussed with a designer.

## Why
To align with design feedback and to visually separate the components.

## Before
<img width="643" alt="Screenshot 2025-04-08 at 15 26 26" src="https://github.com/user-attachments/assets/9820175d-e981-4c92-84be-015757b3b9a4" />

## After

<img width="604" alt="Screenshot 2025-04-08 at 15 30 03" src="https://github.com/user-attachments/assets/c6d35251-7bfd-47b4-b11f-87e6bc8786ea" />


## Background
We've got some cards in our backlog to review the layout of these pages as it's possible that some of the components used (notice/summary banner/metada) should be consolidated to improve the information hierarchy on consultations. 

[Trello](https://trello.com/c/piJlXt43/3356-fix-issue-on-consultations-and-statistics-announcements-where-notice-and-metadata-components-dont-have-spacing-between-them-m)

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

