### PR TITLE
Change nested facet lookup logic

### DIFF
--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -54,17 +54,17 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item("countryside-stewardship-grants")
 
     assert_has_important_metadata(
-      "Grant type": { "Option": "/countryside-stewardship-grants?grant_type%5B%5D=option" },
+      "Grant type": { "Option": "/countryside-stewardship-grants?grant_type=option" },
       "Land use": {
-        "Arable land": "/countryside-stewardship-grants?land_use%5B%5D=arable-land",
-        "Water quality": "/countryside-stewardship-grants?land_use%5B%5D=water-quality",
+        "Arable land": "/countryside-stewardship-grants?land_use=arable-land",
+        "Water quality": "/countryside-stewardship-grants?land_use=water-quality",
       },
       "Tiers or standalone items": {
-        "Higher Tier": "/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=higher-tier",
-        "Mid Tier": "/countryside-stewardship-grants?tiers_or_standalone_items%5B%5D=mid-tier",
+        "Higher Tier": "/countryside-stewardship-grants?tiers_or_standalone_items=higher-tier",
+        "Mid Tier": "/countryside-stewardship-grants?tiers_or_standalone_items=mid-tier",
       },
       "Funding (per unit per year)": {
-        "More than £500": "/countryside-stewardship-grants?funding_amount%5B%5D=more-than-500",
+        "More than £500": "/countryside-stewardship-grants?funding_amount=more-than-500",
       },
     )
   end

--- a/test/presenters/specialist_document_presenter_test.rb
+++ b/test/presenters/specialist_document_presenter_test.rb
@@ -283,7 +283,7 @@ class SpecialistDocumentPresenterTest
       example = example_with_finder_facets([example_facet(overrides)], values)
 
       presented = present_example(example)
-      expected_link = "<a class=\"govuk-link govuk-link--inverse\" href=\"/finder-base-path?facet-key%5B%5D=something\">Something</a>"
+      expected_link = "<a class=\"govuk-link govuk-link--inverse\" href=\"/finder-base-path?facet-key=something\">Something</a>"
       assert_equal expected_link, presented.important_metadata["Facet name"]
     end
 
@@ -335,38 +335,32 @@ class SpecialistDocumentPresenterTest
       values = { "facet-key" => "main-facet-1-value", "sub-facet-key" => "sub-facet-1-value" }
       facet = example_facet({
         "name" => "Facet name",
+        "type" => "nested",
         "key" => "facet-key",
         "sub_facet_name" => "Sub Facet name",
         "sub_facet_key" => "sub-facet-key",
-        "nested_facet" => true,
         "filterable" => true,
         "allowed_values" => [
           {
             "label" => "Main Facet Value",
             "value" => "main-facet-1-value",
+            "sub_facets" => [
+              {
+                "label" => "Sub Facet Value",
+                "value" => "sub-facet-1-value",
+                "main_facet_label" => "Main Facet Value",
+                "main_facet_value" => "main-facet-1-value",
+              },
+            ],
           },
         ],
       })
-      sub_facet = example_facet({
-        "name" => "Sub Facet name",
-        "key" => "sub-facet-key",
-        "nested_facet" => true,
-        "filterable" => true,
-        "allowed_values" => [
-          {
-            "label" => "Sub Facet Value",
-            "value" => "sub-facet-1-value",
-            "main_facet_label" => "Main Facet Value",
-            "main_facet_value" => "main-facet-1-value",
-          },
-        ],
-      })
-      example = example_with_finder_facets([facet, sub_facet], values)
+      example = example_with_finder_facets([facet], values)
 
       presented = present_example(example)
 
-      expected_main_facet_link = "<a class=\"govuk-link govuk-link--inverse\" href=\"/finder-base-path?facet-key%5B%5D=main-facet-1-value\">Main Facet Value</a>"
-      expected_sub_facet_link = "<a class=\"govuk-link govuk-link--inverse\" href=\"/finder-base-path?facet-key%5B%5D=main-facet-1-value&amp;sub-facet-key%5B%5D=sub-facet-1-value\">Main Facet Value - Sub Facet Value</a>"
+      expected_main_facet_link = "<a class=\"govuk-link govuk-link--inverse\" href=\"/finder-base-path?facet-key=main-facet-1-value\">Main Facet Value</a>"
+      expected_sub_facet_link = "<a class=\"govuk-link govuk-link--inverse\" href=\"/finder-base-path?facet-key=main-facet-1-value&amp;sub-facet-key=sub-facet-1-value\">Main Facet Value - Sub Facet Value</a>"
       assert_equal expected_main_facet_link, presented.important_metadata["Facet name"]
       assert_equal expected_sub_facet_link, presented.important_metadata["Sub Facet name"]
     end


### PR DESCRIPTION
The backend has been remodelled so that it sends a single facet with a nested structure through (and of type "nested"), as opposed to two distinct type "text" facets marked as "nested". That nested facet logic was originally introduced in commit 3e9785c3 / PR https://github.com/alphagov/government-frontend/pull/3574.

These changes adjust the extraction logic, but preserve the behaviour:
- the labels read "Main Facet - Sub Facet"
- the sub-facet links include the Main Facet value.

The `sub_facet_key` and `sub_facet_name` are still sent along, as well as the `main_facet_label` and `main_facet_label` references in the sub-facet, so the only required change is to duplicate the call to the `friendly_facet_value` for the sub-facet key.

[Trello](https://trello.com/c/EeZOA3iW/3534-spike-replicating-taxons-approach-for-nested-facets)

