### PR TITLE
[GOVUKAPP-1300] Add noindex metatag to mobile specific pages

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -26,8 +26,16 @@ class PublicationPresenter < ContentItemPresenter
     %(national_statistics official_statistics transparency).include? document_type
   end
 
-  # this is a temporary hack and should be removed in approx 3 months
   def hide_from_search_engines?
-    content_item["base_path"] == "/government/publications/pension-credit-claim-form--2"
+    # this is a temporary hack and should be removed in approx 3 months
+    return true if content_item["base_path"] == "/government/publications/pension-credit-claim-form--2"
+
+    mobile_paths = %w[
+      /government/publications/govuk-app-terms-and-conditions
+      /government/publications/govuk-app-privacy-notice-how-we-use-your-data
+      /government/publications/govuk-app-test-privacy-notice-how-we-use-your-data
+      /government/publications/accessibility-statement-for-the-govuk-app
+    ]
+    mobile_paths.include?(content_item["base_path"])
   end
 end

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -300,6 +300,20 @@ class PublicationTest < ActionDispatch::IntegrationTest
     assert page.has_css?('meta[name="robots"][content="noindex"]', visible: false)
   end
 
+  test "adds the noindex meta tag to mobile paths" do
+    mobile_paths = %w[
+      /government/publications/govuk-app-terms-and-conditions
+      /government/publications/govuk-app-privacy-notice-how-we-use-your-data
+      /government/publications/govuk-app-test-privacy-notice-how-we-use-your-data
+      /government/publications/accessibility-statement-for-the-govuk-app
+    ]
+    mobile_paths.each do |path|
+      overrides = { "base_path" => path }
+      setup_and_visit_content_item("publication-with-featured-attachments", overrides)
+      assert page.has_css?('meta[name="robots"][content="noindex"]', visible: false)
+    end
+  end
+
   test "translates Welsh published date correctly" do
     setup_and_visit_content_item("publication", { "locale" => "cy" })
 

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -101,4 +101,19 @@ class PublicationPresenterTest < PresenterTestCase
 
     assert presented.hide_from_search_engines?
   end
+
+  test "hide_from_search_engines? returns true if the page is related to mobile" do
+    schema_example = schema_item("publication-with-featured-attachments")
+    mobile_paths = %w[
+      /government/publications/govuk-app-terms-and-conditions
+      /government/publications/govuk-app-privacy-notice-how-we-use-your-data
+      /government/publications/govuk-app-test-privacy-notice-how-we-use-your-data
+      /government/publications/accessibility-statement-for-the-govuk-app
+    ]
+    mobile_paths.each do |path|
+      schema_example["base_path"] = path
+      presented = presented_item("publication", schema_example)
+      assert presented.hide_from_search_engines?
+    end
+  end
 end


### PR DESCRIPTION
The publications will be linked to from mobile. We don't want them being indexed by search engines as they should be solely consumed by users of the GOV.UK mobile app.

https://govukverify.atlassian.net/jira/software/c/projects/GOVUKAPP/boards/616?selectedIssue=GOVUKAPP-1300

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [ ] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

