### PR TITLE
Add failure summary to test reporter

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ require "minitest/reporters"
 
 Dir[Rails.root.join("test/support/*.rb")].sort.each { |f| require f }
 
-Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new(print_failure_summary: true)
 
 GovukTest.configure
 


### PR DESCRIPTION
- the verbose output of the test suite makes it very hard to find small numbers of failures. Adding this config option shows the failures again at the end, a la RSpec

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [x] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

