### PR TITLE
Correct GOV.UK app noindex url

### DIFF
--- a/app/presenters/publication_presenter.rb
+++ b/app/presenters/publication_presenter.rb
@@ -33,7 +33,7 @@ class PublicationPresenter < ContentItemPresenter
     mobile_paths = %w[
       /government/publications/govuk-app-terms-and-conditions
       /government/publications/govuk-app-privacy-notice-how-we-use-your-data
-      /government/publications/govuk-app-test-privacy-notice-how-we-use-your-data
+      /government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data
       /government/publications/accessibility-statement-for-the-govuk-app
     ]
     mobile_paths.include?(content_item["base_path"])

--- a/test/integration/publication_test.rb
+++ b/test/integration/publication_test.rb
@@ -304,7 +304,7 @@ class PublicationTest < ActionDispatch::IntegrationTest
     mobile_paths = %w[
       /government/publications/govuk-app-terms-and-conditions
       /government/publications/govuk-app-privacy-notice-how-we-use-your-data
-      /government/publications/govuk-app-test-privacy-notice-how-we-use-your-data
+      /government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data
       /government/publications/accessibility-statement-for-the-govuk-app
     ]
     mobile_paths.each do |path|

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -107,7 +107,7 @@ class PublicationPresenterTest < PresenterTestCase
     mobile_paths = %w[
       /government/publications/govuk-app-terms-and-conditions
       /government/publications/govuk-app-privacy-notice-how-we-use-your-data
-      /government/publications/govuk-app-test-privacy-notice-how-we-use-your-data
+      /government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data
       /government/publications/accessibility-statement-for-the-govuk-app
     ]
     mobile_paths.each do |path|


### PR DESCRIPTION
# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [ ] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

