### PR TITLE
Make blue metadata box optional

### DIFF
--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -85,6 +85,10 @@ class SpecialistDocumentPresenter < ContentItemPresenter
     }
   end
 
+  def show_metadata_block?
+    content_item.dig("links", "finder", 0, "details", "show_metadata_block")
+  end
+
 private
 
   def nested_headers

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -21,7 +21,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @content_item.important_metadata.any? %>
+    <% if @content_item.important_metadata.any? && @content_item.show_metadata_block? %>
       <%= content_tag :div, class: "important-metadata inverse-background responsive-bottom-margin" do %>
         <%= render "govuk_publishing_components/components/metadata", {
           inverse: true, 

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -156,4 +156,16 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
     setup_and_visit_content_item("aaib-reports")
     assert_not page.has_css?(".gem-c-single-page-notification-button")
   end
+
+  test "renders metadata block when show_metadata_block is true and important_metadata is present" do
+    setup_and_visit_content_item("countryside-stewardship-grants")
+
+    assert page.has_css?(".important-metadata"), "Expected metadata block to be rendered"
+  end
+
+  test "does not render metadata block when show_metadata_block is false" do
+    setup_and_visit_content_item("cma-cases")
+
+    assert_not page.has_css?(".important-metadata"), "Expected metadata block not to be rendered"
+  end
 end


### PR DESCRIPTION
This change will make rendering the blue metadata box at the top of specialist documents dependent on a value defined in the schema of each finder. 

Specialist publisher frontend rendering may be eventually moved to alphagov/frontend, at the moment that only applies to [license specialist documents](https://www.gov.uk/find-licences/licence-to-abstract-and-or-impound-water-northern-ireland). The approach to this feature should be broadly the same, so eventually migrating over there shouldn't be too arduous. 

The tests in this PR are dependent on example schemas in the publishing API repo and so may brake CI until that is merged. 

**Associated PRs**

1.[ Publishing-API](https://github.com/alphagov/publishing-api/pull/3241)
2. [Specialist-Publisher
](https://github.com/alphagov/specialist-publisher/pull/3076)
[Trello](https://trello.com/c/spUCgJtQ/3539-make-it-possible-to-hide-the-blue-box-on-specialist-documents)