### PR TITLE
Add conditional check for contents list component

### DIFF
--- a/app/presenters/specialist_document_presenter.rb
+++ b/app/presenters/specialist_document_presenter.rb
@@ -89,6 +89,10 @@ class SpecialistDocumentPresenter < ContentItemPresenter
     content_item.dig("links", "finder", 0, "details", "show_metadata_block")
   end
 
+  def show_table_of_contents_list?
+    content_item.dig("links", "finder", 0, "details", "show_table_of_contents_list")
+  end
+
 private
 
   def nested_headers

--- a/app/views/content_items/specialist_document.html.erb
+++ b/app/views/content_items/specialist_document.html.erb
@@ -31,7 +31,9 @@
       <% end %>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @content_item.contents do %>
+    <% if @content_item.show_table_of_contents_list? %>
+      <%= render "govuk_publishing_components/components/contents_list_with_body", contents: @content_item.contents do %>
+    <% end %>
 
       <% if @content_item.protected_food_drink_name? %>
         <img

--- a/test/integration/specialist_document_test.rb
+++ b/test/integration/specialist_document_test.rb
@@ -168,4 +168,16 @@ class SpecialistDocumentTest < ActionDispatch::IntegrationTest
 
     assert_not page.has_css?(".important-metadata"), "Expected metadata block not to be rendered"
   end
+
+  test "renders table of contents when show_table_of_contents_list is true" do
+    setup_and_visit_content_item("countryside-stewardship-grants")
+
+    assert page.has_css?(".gem-c-contents-list"), "Expected table of contents to be rendered"
+  end
+
+  test "does not render table of contents when show_table_of_contents_list is false" do
+    setup_and_visit_content_item("cma-cases")
+
+    assert_not page.has_css?(".gem-c-contents-list"), "Expected table of contents not to be rendered"
+  end
 end


### PR DESCRIPTION
This change will make rendering the table of contents component in specialist documents dependent on a value defined in the schema of each finder. 

Specialist publisher frontend rendering may be eventually moved to alphagov/frontend, at the moment that only applies to [license specialist documents](https://www.gov.uk/find-licences/licence-to-abstract-and-or-impound-water-northern-ireland). I have raised a PR for frontend replicating the behaviour of this PR, in anticipation of this migration. 

Tests in this PR depend on example schemas from the Publishing API repository, which may cause CI failures until the related changes are merged.

**Associated PRs**

[Publishing API](https://github.com/alphagov/publishing-api/pull/3265)
[Frontend](https://github.com/alphagov/frontend/pull/4740)
[Specialist Publisher](https://github.com/alphagov/specialist-publisher/pull/3083)

[Trello](https://trello.com/c/2eakEGOo/3570-make-it-possible-to-hide-the-table-of-contents-on-specialist-documents)

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [ ] #govuk-patterns-and-pages have been notified of this change
