### PR TITLE
Hide updates link

### DIFF
--- a/app/presenters/content_item/metadata.rb
+++ b/app/presenters/content_item/metadata.rb
@@ -4,15 +4,19 @@ module ContentItem
     include Updatable
 
     def metadata
-      {
-        from:,
-        first_published: published,
-        last_updated: updated,
-        see_updates_link: true,
-        part_of:,
-        direction: text_direction,
-        other: {},
-      }
+      metadata =
+        {
+          from:,
+          first_published: published,
+          last_updated: updated,
+          part_of:,
+          direction: text_direction,
+          other: {},
+        }
+      if has_change_history?
+        metadata[:see_updates_link] = true
+      end
+      metadata
     end
 
     def important_metadata
@@ -20,13 +24,14 @@ module ContentItem
     end
 
     def publisher_metadata
-      metadata = {
-        from:,
-        first_published: published,
-        last_updated: updated,
-      }
+      metadata =
+        {
+          from:,
+          first_published: published,
+          last_updated: updated,
+        }
 
-      unless pending_stats_announcement?
+      if has_change_history?
         metadata[:see_updates_link] = true
       end
 
@@ -39,6 +44,10 @@ module ContentItem
 
     def details_display_date
       content_item["details"]["display_date"]
+    end
+
+    def has_change_history?
+      change_history.present?
     end
   end
 end

--- a/app/presenters/content_item/metadata.rb
+++ b/app/presenters/content_item/metadata.rb
@@ -4,19 +4,11 @@ module ContentItem
     include Updatable
 
     def metadata
-      metadata =
-        {
-          from:,
-          first_published: published,
-          last_updated: updated,
-          part_of:,
-          direction: text_direction,
-          other: {},
-        }
-      if has_change_history?
-        metadata[:see_updates_link] = true
-      end
-      metadata
+      publisher_metadata.merge(
+        part_of:,
+        direction: text_direction,
+        other: {},
+      )
     end
 
     def important_metadata
@@ -24,26 +16,15 @@ module ContentItem
     end
 
     def publisher_metadata
-      metadata =
-        {
-          from:,
-          first_published: published,
-          last_updated: updated,
-        }
+      metadata = {
+        from:,
+        first_published: published,
+        last_updated: updated,
+      }
 
-      if has_change_history?
-        metadata[:see_updates_link] = true
-      end
+      metadata[:see_updates_link] = true if has_change_history?
 
       metadata
-    end
-
-    def pending_stats_announcement?
-      details_display_date.present? && Time.zone.parse(details_display_date).future?
-    end
-
-    def details_display_date
-      content_item["details"]["display_date"]
     end
 
     def has_change_history?

--- a/app/presenters/content_item/updatable.rb
+++ b/app/presenters/content_item/updatable.rb
@@ -22,8 +22,6 @@ module ContentItem
       content_item["public_updated_at"]
     end
 
-  private
-
     def change_history
       changes = content_item["details"]["change_history"] || []
       changes.map do |item|
@@ -34,6 +32,8 @@ module ContentItem
         }
       end
     end
+
+  private
 
     # The direction of change history isn't guaranteed
     # https://github.com/alphagov/govuk-content-schemas/issues/545


### PR DESCRIPTION
# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [x] #govuk-patterns-and-pages have been notified of this change

____

This removes the see all updates link in two scenarios:
1. On stats announcement pages where the announcement has been cancelled
2. On standard content items where there are no previous updates.

We are removing the links since it is strange to have the link if there is no section the page can link to. It could be confusing for the user that the link does nothing and seem like a bug.

[Trello card](https://trello.com/c/2RemO0mt/3403-hide-see-all-updates-unless-there-is-a-change-history)

