### PR TITLE
Update success_alert component spacing

### DIFF
--- a/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
+++ b/app/views/shared/_email_subscribe_unsubscribe_flash.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% if show_email_subscription_success_banner?(@account_flash) %>
-  <div class="govuk-grid-row govuk-!-margin-top-3">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%
         ga4_data = {
@@ -23,7 +23,6 @@
         <%= render "govuk_publishing_components/components/success_alert", {
           message: email_subscription_success_banner_heading(@account_flash),
           description: banner_description,
-          margin_bottom: 0,
         } %>
       <% end %>
     </div>


### PR DESCRIPTION
## What

Update success_alert component spacing

## Why

- `margin_bottom: 0` was causing the component to sit in top of the heading component without any white space to between them, by removing this we can rely on the default margin-bottom set by the design system
- `govuk-!-margin-top-3` was adding extra space between the component and breadcrumbs component

Previous PR showing expected spacing: https://github.com/alphagov/government-frontend/pull/2306

## Visual Changes

### Mobile

| Before | After |
| --- | --- |
| <img width="370" alt="Screenshot 2025-04-11 at 11 23 28" src="https://github.com/user-attachments/assets/afd5807b-b805-41a7-ab86-cb74b8fb3091" /> | <img width="368" alt="Screenshot 2025-04-11 at 11 24 48" src="https://github.com/user-attachments/assets/eb2047c1-3d02-4e18-b5f2-eb0313334070" /> |

### Desktop

| Before | After |
| --- | --- |
| <img width="979" alt="Screenshot 2025-04-11 at 11 23 15" src="https://github.com/user-attachments/assets/b620ee6d-11af-4a6a-aa46-c3581044f6d9" /> | <img width="977" alt="Screenshot 2025-04-11 at 11 25 06" src="https://github.com/user-attachments/assets/19ed2177-3c26-4327-8e85-2efe41aef3f6" /> |


# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [x] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

