### PR TITLE
Improve the code on setting csv attachments preview url

### DIFF
--- a/app/presenters/content_item/attachments.rb
+++ b/app/presenters/content_item/attachments.rb
@@ -27,7 +27,11 @@ module ContentItem
       if asset.nil?
         # This is a temporary edge case whilst assets are a new field on all csv attachments.
         Rails.logger.warn("Assets key is missing from attachment at #{doc['url']}")
-        "#{doc['url']}/preview"
+
+        url = doc["url"].match(/.*\/media\/(?<asset_manager_id>\w+)\/(?<filename>.*\.csv)/)
+        if url && (url["filename"] == doc["filename"])
+          "/csv-preview/#{url['asset_manager_id']}/#{url['filename']}"
+        end
       elsif asset["filename"] == doc["filename"]
         "/csv-preview/#{asset['asset_manager_id']}/#{asset['filename']}"
       end

--- a/test/presenters/content_item/attachments_test.rb
+++ b/test/presenters/content_item/attachments_test.rb
@@ -24,11 +24,14 @@ class AttachmentsTest < ActiveSupport::TestCase
   end
 
   test "#attachments returns attachments with preview_urls based on url" do
-    attachments = [
-      { "preview_url" => "some-preview-url", "url" => "some-url", "content_type" => "text/csv" },
-    ]
+    attachments = [{
+      "preview_url" => "some-preview-url",
+      "url" => "assets.test.gov.uk/media/123/some-filename.csv",
+      "content_type" => "text/csv",
+      "filename" => "some-filename.csv",
+    }]
     @subject.content_item = { "details" => { "attachments" => attachments } }
-    assert_equal [{ "preview_url" => "some-url/preview", "url" => "some-url", "content_type" => "text/csv" }], @subject.attachments
+    assert_equal [{ "preview_url" => "/csv-preview/123/some-filename.csv", "url" => "assets.test.gov.uk/media/123/some-filename.csv", "content_type" => "text/csv", "filename" => "some-filename.csv" }], @subject.attachments
   end
 
   test "#attachments returns attachments with preview_urls based on asset_manager_id and filename" do

--- a/test/presenters/publication_presenter_test.rb
+++ b/test/presenters/publication_presenter_test.rb
@@ -56,17 +56,18 @@ class PublicationPresenterTest < PresenterTestCase
     content_item["details"]["attachments"] = [{
       "id" => "some-id",
       "content_type" => "text/csv",
-      "preview_url" => "some-preview-url",
       "url" => "some-url",
+      "filename" => "some-filename.csv",
+      "assets" => [{ "asset_manager_id" => 123, "filename" => "some-filename.csv" }],
     }]
     presented = present_example(content_item)
     expected = [{
       "id" => "some-id",
       "content_type" => "text/csv",
-      # NOTE: preview_url is the url with /preview appended, not the preview_url from above,
-      #       because we're working around a bug with preview_url
-      "preview_url" => "some-url/preview",
+      "preview_url" => "/csv-preview/123/some-filename.csv",
       "url" => "some-url",
+      "filename" => "some-filename.csv",
+      "assets" => [{ "asset_manager_id" => 123, "filename" => "some-filename.csv" }],
     }]
     assert_equal expected, presented.attachments_for_components
   end


### PR DESCRIPTION
We want to make the code that sets the preview url for csv attachments consistent with the routes that render that preview. https://github.com/alphagov/frontend/blob/main/config/routes.rb#L81 This is for improving readability of the code and making this logic easier to understand.

Trello card: https://trello.com/c/ldz6xMOx/2042-refactor-government-fronted-logic-https-githubcom-alphagov-government-frontend-pull-3702

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [ ] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

