### PR TITLE
Fix base paths in call for evidence tests

### DIFF
--- a/test/presenters/call_for_evidence_presenter_test.rb
+++ b/test/presenters/call_for_evidence_presenter_test.rb
@@ -148,8 +148,8 @@ class CallForEvidencePresenterTest
     end
 
     test "presents share urls with encoded url and title" do
-      assert_equal "https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.test.gov.uk%2Fgovernment%2Fcall_for_evidence%2Fyouth-vaping-call-for-evidence", presented_item("open_call_for_evidence").share_links[0][:href]
-      assert_equal "https://twitter.com/share?url=https%3A%2F%2Fwww.test.gov.uk%2Fgovernment%2Fcall_for_evidence%2Fyouth-vaping-call-for-evidence&text=Youth%20Vaping", presented_item("open_call_for_evidence").share_links[1][:href]
+      assert_equal "https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.test.gov.uk%2Fgovernment%2Fcalls-for-evidence%2Fyouth-vaping-call-for-evidence", presented_item("open_call_for_evidence").share_links[0][:href]
+      assert_equal "https://twitter.com/share?url=https%3A%2F%2Fwww.test.gov.uk%2Fgovernment%2Fcalls-for-evidence%2Fyouth-vaping-call-for-evidence&text=Youth%20Vaping", presented_item("open_call_for_evidence").share_links[1][:href]
     end
 
     test "displays the single page notification button on English pages" do


### PR DESCRIPTION
Related PR - https://github.com/alphagov/publishing-api/pull/3405

Trello card: https://trello.com/c/GzNmv0Ag/647-move-callforevidence-from-government-frontend-to-frontend

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [ ] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

