### PR TITLE
Remove unnecessary classes

### DIFF
--- a/app/views/content_items/call_for_evidence.html.erb
+++ b/app/views/content_items/call_for_evidence.html.erb
@@ -88,7 +88,7 @@
     <% call_for_evidence_desc = capture do %>
       <%= @content_item.description %>
       <% if @content_item.held_on_another_website? %>
-        <p class="gem-c-summary-banner__text">
+        <p>
           <strong>
             <% if @content_item.closed? %>
               <%= t("call_for_evidence.closed_another_website_html", url: @content_item.held_on_another_website_url) %>.

--- a/app/views/content_items/consultation.html.erb
+++ b/app/views/content_items/consultation.html.erb
@@ -119,7 +119,7 @@
     <% consultation_desc = capture do %>
       <%= @content_item.description %>
       <% if @content_item.held_on_another_website? %>
-        <p class="gem-c-summary-banner__text">
+        <p>
           <strong>
             <%= t("consultation.another_website_html", closed: @content_item.closed? ? t("consultation.was") : t("consultation.is_being"), url: @content_item.held_on_another_website_url) %>.
           </strong>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- gem classes were being applied to p tags and then inserted into the summary banner component
- arguably okay, but it triggered a warning in the component auditing
- turns out that not applying these classes makes no visual difference, so removing them
- can be seen on pages like https://www.gov.uk/government/calls-for-evidence/the-tax-treatment-of-carried-interest-call-for-evidence (except not on that one, it only shows up where the `held_on_another_website` logic is triggered to include the extra paragraph, can't find a wild example of that but easy enough to fake locally)

## Visual changes
None. Well, almost none. If you toggle the class in your browser inspector it there's a 1px difference in spacing, but it's so small as to not be noticeable. This is the element in question, showing the 'another website' text.

![Screenshot 2025-06-18 at 09 18 18](https://github.com/user-attachments/assets/99e4cbbc-aad2-4932-b40b-842adea65642)
