### PR TITLE
Fix welsh translations consultation pages

### DIFF
--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -14,6 +14,6 @@ module DateTimeHelper
       # 12am on 10 January becomes 11:59pm on 9 January
       time -= 1.second
     end
-    I18n.l(time, format: "#{time_format} on #{date_format}").gsub(":00", "").gsub("12pm", "midday").gsub("12am on ", "").strip
+    I18n.l(time, format: "#{time_format} #{I18n.t('consultation.on')} #{date_format}").gsub(":00", "").gsub("12pm", "midday").gsub("12am #{I18n.t('consultation.on')} ", "").strip
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -57,7 +57,7 @@ cy:
     feedback_received: Adborth wedi dod i law
     is_being: yn cael ei
     not_open_yet: Nid yw'r ymgynghoriad hwn wedi agor eto
-    'on':
+    'on': ar
     opens: Mae'r ymgynghoriad hwn yn agor
     or:
     original_consultation: Ymgynghoriad gwreiddiol


### PR DESCRIPTION

##  What
Fix Welsh translations where "on" and "at" are used in the blue callout box.

Example page:

https://www.gov.uk/government/consultations/cerbydau-awtomataidd-diogelu-termau-marchnata.cy

## Why
Reported in [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/6141048)

[Trello card](https://trello.com/c/3GJmOFHl/723-consultation-page-welsh-translation-issue)

## Screenshots?

Before:
https://www.gov.uk/government/consultations/cerbydau-awtomataidd-diogelu-termau-marchnata.cy

<img width="628" height="287" alt="Screenshot 2025-07-15 at 12 30 26" src="https://github.com/user-attachments/assets/8d8b1653-5af5-45bf-b710-b75226d147fe" />

After:

<img width="629" height="287" alt="Screenshot 2025-07-15 at 12 30 36" src="https://github.com/user-attachments/assets/bbb1daae-bbab-4fa2-8ff8-36aedf19417e" />


# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [ ] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

