### PR TITLE
Add scroll tracking to Evisa guide pages

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -17,9 +17,15 @@
 
 <% content_for :simple_header, true %>
 
+<% content_for :extra_head_content do %>
+  <% if ["/evisa", "/evisa/set-up-ukvi-account", "/evisa/view-evisa-get-share-code-prove-immigration-status", "/evisa/travel-with-evisa", "/evisa/update-ukvi-account", "/evisa/report-error-evisa"].include?(@content_item.base_path) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker" data-ga4-track-type="headings">
+  <% end %>
+<% end %>
+
 <div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/heading', { 
+    <%= render 'govuk_publishing_components/components/heading', {
       text: @content_item.content_title,
       heading_level: 1,
       font_size: "xl",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds scroll tracking (for headings) to Evisa guide pages.

https://www.gov.uk/evisa
https://www.gov.uk/evisa/set-up-ukvi-account
https://www.gov.uk/evisa/view-evisa-get-share-code-prove-immigration-status
https://www.gov.uk/evisa/travel-with-evisa
https://www.gov.uk/evisa/update-ukvi-account
https://www.gov.uk/evisa/report-error-evisa

## Why
Requested by analysts, for three months.

## Visual changes
None.

Trello card: https://trello.com/c/swBWdJdu/457-addition-of-header-based-scroll-tracking-on-6-pages
