### PR TITLE
fix: improve language names for chinese languages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -385,9 +385,9 @@ en:
     uz: Uzbeki
     vi: Vietnamese
     yi: Yiddish
-    zh: Chinese
-    zh-hk: Cantonese
-    zh-tw: Traditional Chinese
+    zh: Simplified Chinese
+    zh-hk: Traditional Chinese (Hong Kong)
+    zh-tw: Traditional Chinese (Taiwan)
   manuals:
     breadcrumb_contents: Back to contents
     contents_list_breadcrumb_contents: Manual homepage

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -316,7 +316,7 @@ zh-hk:
     vi:
     yi:
     zh:
-    zh-hk: 中文
+    zh-hk: 繁體中文（香港）
     zh-tw:
   manuals:
     breadcrumb_contents:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -317,7 +317,7 @@ zh-tw:
     yi:
     zh:
     zh-hk:
-    zh-tw: 繁體中文
+    zh-tw: 繁體中文（臺灣)
   manuals:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -315,7 +315,7 @@ zh:
     uz:
     vi:
     yi:
-    zh: 中文
+    zh: 简体中文
     zh-hk:
     zh-tw:
   manuals:


### PR DESCRIPTION
- the previous translations for these values were confused, and didn't really reflect a useful differentiation. Cantonese is really the spoken language, and the written version of it is Traditional Chinese, but it differs slightly from the written form used in Taiwan. The mapping we want is:

  -  zh = 简体中文
  - zh-hk = 繁體中文（香港）
  - zh-tw = 繁體中文（臺灣,

  which is equivalent to:

  - Simplified Chinese
  - Traditional Chinese (Hong Kong)
  - Traditional Chinese (Taiwan)

See also: https://github.com/alphagov/frontend/pull/4926

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [ ] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

