### PR TITLE
fix: chinese closing bracket rather than latin at the end of the zh-tw language name

### DIFF
--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -317,7 +317,7 @@ zh-tw:
     yi:
     zh:
     zh-hk:
-    zh-tw: 繁體中文（臺灣)
+    zh-tw: 繁體中文（臺灣）
   manuals:
     breadcrumb_contents:
     contents_list_breadcrumb_contents:


### PR DESCRIPTION

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [x] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

