### PR TITLE
(CM-294) Add styling for content blocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "~> 3.3.6"
 gem "rails", "8.0.2"
 
 gem "bootsnap", require: false
+gem "content_block_tools"
 gem "dalli"
 gem "dartsass-rails"
 gem "gds-api-adapters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
+    content_block_tools (1.0.3)
+      actionview (>= 6)
+      govspeak (= 10.6.1)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -701,6 +704,7 @@ DEPENDENCIES
   bootsnap
   capybara
   climate_control
+  content_block_tools
   dalli
   dartsass-rails
   faker

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,9 @@ $govuk-include-default-font-face: false;
 // Components from govuk_publishing_components gem
 @import "govuk_publishing_components/govuk_frontend_support";
 
+// Components from content_block_tools gem
+@import "content_block_tools";
+
 // government-frontend mixins
 @import "mixins/margins";
 


### PR DESCRIPTION
This adds the `content_block_tools` gem as a dependency and loads in the `content_block_tools` styles. See https://github.com/alphagov/frontend/pull/4943 for more context.