### PR TITLE
Option 1 - Align the h1 font size on guide pages

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -45,7 +45,12 @@
   <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6" id="guide-contents">
     <% if @content_item.has_parts? %>
       <% if @content_item.show_guide_navigation? %>
-        <%= render 'govuk_publishing_components/components/heading', heading_level: 1, font_size: 'l', margin_bottom: 6, text: @content_item.current_part_title %>
+        <%= render 'govuk_publishing_components/components/heading', {
+          text: @content_item.current_part_title,
+          heading_level: 1,
+          font_size: 'xl',
+          margin_bottom: 6
+        } %>
       <% end %>
       <%
         disable_youtube_expansions = true


### PR DESCRIPTION
## What
Align the h1 font size on guide pages

## Why
https://trello.com/c/LwvdwRiX

## Visual changes

- https://government-frontend-pr-3780.herokuapp.com/evisa/view-evisa-get-share-code-prove-immigration-status
- https://government-frontend-pr-3780.herokuapp.com/log-in-register-hmrc-online-services/problems-signing-in
- https://government-frontend-pr-3780.herokuapp.com/carers-allowance