### PR TITLE
Option 2 - Change second h1 to h2

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -45,7 +45,12 @@
   <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6" id="guide-contents">
     <% if @content_item.has_parts? %>
       <% if @content_item.show_guide_navigation? %>
-        <%= render 'govuk_publishing_components/components/heading', heading_level: 1, font_size: 'l', margin_bottom: 6, text: @content_item.current_part_title %>
+        <%= render 'govuk_publishing_components/components/heading', {
+          text: @content_item.current_part_title,
+          heading_level: 2,
+          font_size: 'l',
+          margin_bottom: 6
+        } %>
       <% end %>
       <%
         disable_youtube_expansions = true

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -167,7 +167,7 @@ class GuideTest < ActionDispatch::IntegrationTest
       content_item = setup_and_visit_voting_guide
 
       first_part = content_item["details"]["parts"].first
-      assert_nothing_raised { assert_selector "h1", text: first_part["title"] }
+      assert_nothing_raised { assert_selector "h2", text: first_part["title"] }
 
       part_titles = content_item["details"]["parts"].drop(1).map { |part| part["title"] }
       part_titles.each do |part_title|


### PR DESCRIPTION
## What
Change second h1 to h2 on guide pages

## Why
https://trello.com/c/LwvdwRiX

## Visual changes

- https://government-frontend-pr-3782.herokuapp.com/evisa/view-evisa-get-share-code-prove-immigration-status
- https://government-frontend-pr-3782.herokuapp.com/log-in-register-hmrc-online-services/problems-signing-in
- https://government-frontend-pr-3782.herokuapp.com/carers-allowance