### PR TITLE
Option 3 - Merge two h1 elements and use caption

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,3 +57,9 @@ $govuk-include-default-font-face: false;
   background: $govuk-brand-colour;
   color: govuk-colour("white");
 }
+
+.guide {
+  .gem-c-contents-list__title {
+    @include govuk-font($size: 24, $weight: bold);
+  }
+}

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -25,12 +25,6 @@
 
 <div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'govuk_publishing_components/components/heading', {
-      text: @content_item.content_title,
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 8
-    } %>
     <% if @content_item.show_guide_navigation? %>
       <%= render "govuk_publishing_components/components/skip_link", {
         text: t("guide.skip_contents"),
@@ -43,10 +37,24 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6" id="guide-contents">
+    <% if @content_item.has_parts? && @content_item.show_guide_navigation? %>
+      <%= render 'govuk_publishing_components/components/heading', {
+        context: @content_item.content_title,
+        text: @content_item.current_part_title,
+        heading_level: 1,
+        font_size: "xl",
+        context_inside: true,
+        margin_bottom: 8
+      } %>
+    <% else %>
+      <%= render 'govuk_publishing_components/components/heading', {
+        text: @content_item.content_title,
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 8
+      } %>
+    <% end %>
     <% if @content_item.has_parts? %>
-      <% if @content_item.show_guide_navigation? %>
-        <%= render 'govuk_publishing_components/components/heading', heading_level: 1, font_size: 'l', margin_bottom: 6, text: @content_item.current_part_title %>
-      <% end %>
       <%
         disable_youtube_expansions = true
         # This is for the /child-benefit/how-to-claim page


### PR DESCRIPTION
## What
- Merge two h1 elements and use caption feature from the design system
- Move the contents list above the h1 element
- Override the h2 "contents" font-size to be 24px, the same as all of the other h2 elements on the page

## Why
https://trello.com/c/LwvdwRiX

## Visual changes

- https://government-frontend-pr-3783.herokuapp.com/evisa/view-evisa-get-share-code-prove-immigration-status
- https://government-frontend-pr-3783.herokuapp.com/log-in-register-hmrc-online-services/problems-signing-in
- https://government-frontend-pr-3783.herokuapp.com/carers-allowance