### PR TITLE
Fix `undefined method [] for nil (ActionView::Template::Error)`

### DIFF
--- a/app/presenters/worldwide_organisation_presenter.rb
+++ b/app/presenters/worldwide_organisation_presenter.rb
@@ -55,8 +55,8 @@ class WorldwideOrganisationPresenter < ContentItemPresenter
     {
       name: person["title"],
       href: person["base_path"],
-      image_url: person["details"]["image"]["url"],
-      image_alt: person["details"]["image"]["alt_text"],
+      image_url: person.dig("details", "image", "url"),
+      image_alt: person.dig("details", "image", "alt_text"),
       description: presented_title_for_roles(current_roles),
     }
   end


### PR DESCRIPTION
## What

Use the [dig method](https://apidock.com/ruby/Hash/dig) in the `WorldwideOrganisationPresenter` to return `nil` if any intermediate step is `nil`.

## Why

To fix `undefined method [] for nil (ActionView::Template::Error)`, this happens because we are trying to access `url` and `alt_text` from a nil value (`image`)

Example page: https://www.gov.uk/world/organisations/british-high-commission-barbados

## Visual changes with fix

| Before | After |
| --- | --- |
| <img width="1081" height="1264" alt="desktop-before" src="https://github.com/user-attachments/assets/f9a770ea-c18d-4ea9-9b55-884d5d5a1fd1" /> | <img width="1034" height="1034" alt="desktop-after" src="https://github.com/user-attachments/assets/7e6f1320-9460-48cc-9bd4-2499da62460b" /> |