### PR TITLE
NAV-2624 Hide suggested related links

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -146,9 +146,7 @@ private
   def ordered_related_items(links)
     return [] if links["ordered_related_items_overrides"].present?
 
-    links["ordered_related_items"].presence || links.fetch(
-      "suggested_ordered_related_items", []
-    )
+    links["ordered_related_items"].presence || []
   end
 
   def format_banner_links(links)

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -147,7 +147,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     assert_response :success
     assert_empty content_item["links"]["ordered_related_items"], "Content item should not have existing related links"
     assert_not_empty content_item["links"]["suggested_ordered_related_items"], "Content item should have existing suggested related links"
-    assert_equal assigns[:content_item].content_item["links"]["ordered_related_items"], content_item["links"]["suggested_ordered_related_items"]
+    assert_empty assigns[:content_item].content_item["links"]["ordered_related_items"]
   end
 
   test "sets the expiry as sent by content-store" do


### PR DESCRIPTION
Suggested related links have be falling more and more out of date since
2022. We are planning to remove them to make sure we don't show confusing or outdated links.

This work hides the links on government-frontend. The links may still exist in the content item until we complete tidy up work, but will not be shown to the user.

## Screenshots

