### PR TITLE
Revert removal of Call for evidence locales

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -88,6 +88,13 @@ ar:
         other: مخططات دعم تمويل الأعمال
         two:
         zero:
+      call_for_evidence:
+        few:
+        many:
+        one:
+        other:
+        two:
+        zero:
       call_for_evidence_outcome:
         few:
         many:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -68,6 +68,9 @@ az:
       business_finance_support_scheme:
         one: Biznesin maliyələşdirilməsinə dəstək sxemi
         other: Biznesin maliyələşdirilməsinə dəstək sxemləri
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -78,6 +78,11 @@ be:
         many:
         one: Схема падтрымкі фінансавання бізнесу
         other: Схемы падтрымкі фінансавання бізнесу
+      call_for_evidence:
+        few:
+        many:
+        one:
+        other:
       call_for_evidence_outcome:
         few:
         many:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -68,6 +68,9 @@ bg:
       business_finance_support_scheme:
         one: Схема за подпомагане на бизнес финансирането
         other: Схеми за подпомагане на бизнес финансирането
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -68,6 +68,9 @@ bn:
       business_finance_support_scheme:
         one: ব্যবসায়িক অর্থায়ন সহায়তা স্কিম
         other: ব্যবসায়িক অর্থায়ন সহায়তা স্কিমসমূহ
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -73,6 +73,10 @@ cs:
         few:
         one: Režim podpory financování podniků
         other: Režimy podpory financování podniků
+      call_for_evidence:
+        few:
+        one:
+        other:
       call_for_evidence_outcome:
         few:
         one:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -88,6 +88,13 @@ cy:
         other: Cynlluniau cymorth cyllid busnes
         two:
         zero:
+      call_for_evidence:
+        few:
+        many:
+        one: Galwad am dystiolaeth
+        other: Galwadau am dystiolaeth
+        two:
+        zero:
       call_for_evidence_outcome:
         few:
         many:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -68,6 +68,9 @@ da:
       business_finance_support_scheme:
         one: Forretningsfinansieringsstøtteordning
         other: Forretningsfinansieringsstøtteordninger
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -68,6 +68,9 @@ de:
       business_finance_support_scheme:
         one: Förderprogramm zur Unternehmensfinanzierung
         other: Förderprogramme zur Unternehmensfinanzierung
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -68,6 +68,9 @@ dr:
       business_finance_support_scheme:
         one: طرح حمایت مالی از کسب و کار
         other: طرح هایی حمایت مالی از کسب و کار
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -68,6 +68,9 @@ el:
       business_finance_support_scheme:
         one: Πρόγραμμα στήριξης χρηματοδότησης επιχειρήσεων
         other: Προγράμματα στήριξης χρηματοδότησης επιχειρήσεων
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,6 +68,9 @@ en:
       business_finance_support_scheme:
         one: Business finance support scheme
         other: Business finance support schemes
+      call_for_evidence:
+        one: Call for evidence
+        other: Calls for evidence
       call_for_evidence_outcome:
         one: Call for evidence outcome
         other: Call for evidence outcomes

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -68,6 +68,9 @@ es-419:
       business_finance_support_scheme:
         one: Programa de apoyo financiero a empresas
         other: Programas de apoyo financiero a empresas
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -68,6 +68,9 @@ es:
       business_finance_support_scheme:
         one: Plan de apoyo a la financiación de empresas
         other: Planes de apoyo a la financiación de empresas
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -68,6 +68,9 @@ et:
       business_finance_support_scheme:
         one: Ettevõtte rahastamise toetusskeem
         other: Ettevõtte rahastamise toetusskeemid
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -68,6 +68,9 @@ fa:
       business_finance_support_scheme:
         one: طرح حمایت مالی از کسب‌و‌کار
         other: طرح‌های حمایت مالی از کسب‌و‌کار
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -68,6 +68,9 @@ fi:
       business_finance_support_scheme:
         one: Yritysrahoituksen tukijärjestelmä
         other: Yritysrahoituksen tukijärjestelmät
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -68,6 +68,9 @@ fr:
       business_finance_support_scheme:
         one: Programme d'aide au financement des entreprises
         other: Programmes d'aide au financement des entreprises
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -78,6 +78,11 @@ gd:
         one: Scéim tacaíochta maoinithe gnó
         other: Meicníochtaí tacaíochta do mhaoiniú gnó
         two:
+      call_for_evidence:
+        few:
+        one:
+        other:
+        two:
       call_for_evidence_outcome:
         few:
         one:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -68,6 +68,9 @@ gu:
       business_finance_support_scheme:
         one: વ્યાપાર નાણાંકીય સહાય યોજના
         other: વ્યાપાર નાણાંકીય સહાય યોજનાઓ
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -68,6 +68,9 @@ he:
       business_finance_support_scheme:
         one: תכנית תמיכה במימון עסקים
         other: תוכניות תמיכה במימון עסקים
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -68,6 +68,9 @@ hi:
       business_finance_support_scheme:
         one: व्यावसायिक वित्त सहायता योजना
         other: व्यावसायिक वित्त सहायता योजनाएं
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -73,6 +73,10 @@ hr:
         few:
         one: Shema potpore poslovnom financiranju
         other: Sheme potpore poslovnom financiranju
+      call_for_evidence:
+        few:
+        one:
+        other:
       call_for_evidence_outcome:
         few:
         one:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -68,6 +68,9 @@ hu:
       business_finance_support_scheme:
         one: Vállalkozás pénzügyi támogatására szolgáló terv
         other: Vállalkozás pénzügyi támogatására szolgáló tervek
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -68,6 +68,9 @@ hy:
       business_finance_support_scheme:
         one: Բիզնեսի ֆինանսավորման աջակցության պլան
         other: Բիզնեսի ֆինանսավորման աջակցության պլաններ
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -63,6 +63,8 @@ id:
         other: Artikel bersumber
       business_finance_support_scheme:
         other: Skema dukungan keuangan bisnis
+      call_for_evidence:
+        other:
       call_for_evidence_outcome:
         other:
       case_study:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -68,6 +68,9 @@ is:
       business_finance_support_scheme:
         one: Ráðagerð um fjárhagslegan stuðning við fyrirtæki
         other: Ráðagerðir um fjárhagslegan stuðning við fyrirtæki
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -68,6 +68,9 @@ it:
       business_finance_support_scheme:
         one: Schema di sostegno alla finanza aziendale
         other: Schemi di sostegno alla finanza aziendale
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -63,6 +63,8 @@ ja:
         other: 執筆記事
       business_finance_support_scheme:
         other: 企業金融支援制度
+      call_for_evidence:
+        other:
       call_for_evidence_outcome:
         other:
       case_study:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -68,6 +68,9 @@ ka:
       business_finance_support_scheme:
         one: ბიზნესის დაფინანსების მხარდაჭერის სქემა
         other: ბიზნესის დაფინანსების მხარდაჭერის სქემები
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -68,6 +68,9 @@ kk:
       business_finance_support_scheme:
         one: Кәсіпкерлікті қаржыландыру схемасы
         other: Кәсіпкерлікті қаржыландыру схемалары
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -63,6 +63,8 @@ ko:
         other: 저작물
       business_finance_support_scheme:
         other: 비즈니스 재무 지원 계획
+      call_for_evidence:
+        other:
       call_for_evidence_outcome:
         other:
       case_study:

--- a/config/locales/ky.yml
+++ b/config/locales/ky.yml
@@ -77,6 +77,9 @@ ky:
       business_finance_support_scheme:
         one: Бизнести каржылоону колдоочу схема
         other: Бизнести каржылоону колдоочу схемалар
+      call_for_evidence:
+        one: Далилдерди талап кылуу
+        other: Далилдерди талап кылуулар
       call_for_evidence_outcome:
         one: Натыйжанын далилдөөсүн талап кылуу
         other: Натыйжанын далилдөөлөрүн талап кылуу

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -73,6 +73,10 @@ lt:
         few:
         one: Verslo finansų paramos planas
         other: Verslo finansų paramos planas
+      call_for_evidence:
+        few:
+        one:
+        other:
       call_for_evidence_outcome:
         few:
         one:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -68,6 +68,9 @@ lv:
       business_finance_support_scheme:
         one: Biznesa finanšu atbalsta shēma
         other: Biznesa finanšu atbalsta shēmas
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -63,6 +63,8 @@ ms:
         other: Artikel ditulis penulis
       business_finance_support_scheme:
         other: Skim sokongan kewangan perniagaan
+      call_for_evidence:
+        other:
       call_for_evidence_outcome:
         other:
       case_study:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -78,6 +78,11 @@ mt:
         many:
         one: Skema ta' għajnuna għall-finanzjament tan-negozju
         other: Skemi ta' għajnuna għall-finanzjament tan-negozju
+      call_for_evidence:
+        few:
+        many:
+        one:
+        other:
       call_for_evidence_outcome:
         few:
         many:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -68,6 +68,9 @@ ne:
       business_finance_support_scheme:
         one: व्यापार वित्त समर्थन योजना
         other: व्यापार वित्त समर्थन योजनाहरु
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -68,6 +68,9 @@ nl:
       business_finance_support_scheme:
         one: Zakelijke financiering steunregeling
         other: Ondersteuningsregelingen voor bedrijfsfinanciering
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -68,6 +68,9 @@
       business_finance_support_scheme:
         one: Forretningsfinansieringsstøtteordning
         other: Forretningsfinansieringsstøtteordninger
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -68,6 +68,9 @@ pa-pk:
       business_finance_support_scheme:
         one: کاروبار دی مالی مدد دا منصوبہ
         other: کاروبار دی مالی مدد دے منصوبے
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -68,6 +68,9 @@ pa:
       business_finance_support_scheme:
         one: ਵਪਾਰ ਵਿੱਤ ਸਹਾਇਤਾ ਯੋਜਨਾ
         other: ਵਪਾਰ ਵਿੱਤ ਸਹਾਇਤਾ ਯੋਜਨਾਵਾਂ
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -78,6 +78,11 @@ pl:
         many:
         one: Program wsparcia finansowego przedsiębiorstw
         other: Programy wsparcia finansowego przedsiębiorstw
+      call_for_evidence:
+        few:
+        many:
+        one:
+        other:
       call_for_evidence_outcome:
         few:
         many:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -68,6 +68,9 @@ ps:
       business_finance_support_scheme:
         one: د سوداګرۍ د مالي ملاتړ طرحه
         other: د سوداګرۍ د مالي ملاتړ طرحې
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -68,6 +68,9 @@ pt:
       business_finance_support_scheme:
         one: Regime de apoio financeiro a empresas
         other: Regimes de apoio financeiro a empresas
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -73,6 +73,10 @@ ro:
         few:
         one: Schema de sprijin pentru finanțarea întreprinderilor
         other: Scheme de sprijin pentru finanțarea întreprinderilor
+      call_for_evidence:
+        few:
+        one:
+        other:
       call_for_evidence_outcome:
         few:
         one:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -78,6 +78,11 @@ ru:
         many:
         one: План поддержки финансирования бизнеса
         other: Планы поддержки финансирования бизнеса
+      call_for_evidence:
+        few:
+        many:
+        one:
+        other:
       call_for_evidence_outcome:
         few:
         many:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -68,6 +68,9 @@ si:
       business_finance_support_scheme:
         one: ව්යාපාර මූල්ය සහාය යෝජනා ක්රමය
         other: ව්යාපාර මූල්ය සහාය යෝජනා ක්රම
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -73,6 +73,10 @@ sk:
         few:
         one: Schéma podpory financovania podnikov
         other: Systémy podpory financovania podnikov
+      call_for_evidence:
+        few:
+        one:
+        other:
       call_for_evidence_outcome:
         few:
         one:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -78,6 +78,11 @@ sl:
         one: Program podpore za poslovne finance
         other: Programi podpore za poslovne finance
         two:
+      call_for_evidence:
+        few:
+        one:
+        other:
+        two:
       call_for_evidence_outcome:
         few:
         one:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -68,6 +68,9 @@ so:
       business_finance_support_scheme:
         one: Qorshaha caawimada maaliyada ganacsi
         other: Qorshayaasha caawimada maaliyada ganacsi
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -68,6 +68,9 @@ sq:
       business_finance_support_scheme:
         one: Skema e mbështetjes së financimit të biznesit
         other: Skemat e mbështetjes së financimit të biznesit
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -73,6 +73,10 @@ sr:
         few:
         one: Šema podrške za poslovno finansiranje
         other: Šeme podrške za poslovno finansiranje
+      call_for_evidence:
+        few:
+        one:
+        other:
       call_for_evidence_outcome:
         few:
         one:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -68,6 +68,9 @@ sv:
       business_finance_support_scheme:
         one: Stödsystem för företagsfinansiering
         other: Stödsystem för företagsfinansiering
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -68,6 +68,9 @@ sw:
       business_finance_support_scheme:
         one: Mpango wa msaada wa fedha za biashara
         other: Mipango ya msaada wa fedha za biashara
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -68,6 +68,9 @@ ta:
       business_finance_support_scheme:
         one: தொழில் நிதி உதவித் திட்டம்
         other: தொழில் நிதி உதவித் திட்டங்கள்
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -63,6 +63,8 @@ th:
         other: บทความที่มีผู้เขียน
       business_finance_support_scheme:
         other: โครงการสนับสนุนการเงินแก่ธุรกิจ
+      call_for_evidence:
+        other:
       call_for_evidence_outcome:
         other:
       case_study:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -68,6 +68,9 @@ tk:
       business_finance_support_scheme:
         one: Telekeçiligi maliýeleşdirmegiň shemasy
         other: Telekeçiligi maliýeleşdirmegi goldamak shemalary
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -68,6 +68,9 @@ tr:
       business_finance_support_scheme:
         one: İşletme finans desteği planı
         other: İşletme finans desteği planları
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -78,6 +78,11 @@ uk:
         many:
         one: Схема підтримки фінансування бізнесу
         other: Схеми підтримки фінансування бізнесу
+      call_for_evidence:
+        few:
+        many:
+        one:
+        other:
       call_for_evidence_outcome:
         few:
         many:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -68,6 +68,9 @@ ur:
       business_finance_support_scheme:
         one: بزنس فائنانس معاونتی اسکیم
         other: بزنس فائنانس معاونتی اسکیمز
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -68,6 +68,9 @@ uz:
       business_finance_support_scheme:
         one: Бизнесни молиялаштиришни қўллаб-қувватлаш режаси
         other: Бизнесни молиялаштиришни қўллаб-қувватлаш режалари
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -63,6 +63,8 @@ vi:
         other: Bài viết có tác giả
       business_finance_support_scheme:
         other: Kế hoạch hỗ trợ tài chính doanh nghiệp
+      call_for_evidence:
+        other:
       call_for_evidence_outcome:
         other:
       case_study:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -68,6 +68,9 @@ yi:
       business_finance_support_scheme:
         one:
         other:
+      call_for_evidence:
+        one:
+        other:
       call_for_evidence_outcome:
         one:
         other:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -63,6 +63,8 @@ zh-hk:
         other: 撰寫文章
       business_finance_support_scheme:
         other: 商業融資支援計劃
+      call_for_evidence:
+        other:
       call_for_evidence_outcome:
         other:
       case_study:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -63,6 +63,8 @@ zh-tw:
         other: 授權文章
       business_finance_support_scheme:
         other: 企業融資支援計劃
+      call_for_evidence:
+        other:
       call_for_evidence_outcome:
         other:
       case_study:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -63,6 +63,8 @@ zh:
         other: 撰写文章
       business_finance_support_scheme:
         other: 商业财务支持计划
+      call_for_evidence:
+        other:
       call_for_evidence_outcome:
         other:
       case_study:


### PR DESCRIPTION
We recently migrated call of evidence pages to be rendered by Frontend and removed the code from Government Frontend (see https://github.com/alphagov/government-frontend/pull/3725)

HTML publications still relies on the content item schema name, so we shouldn't have removed these locales.

| Before | After |
|-------|--------|
| <img width="971" height="269" alt="Screenshot 2025-08-28 at 13 41 34" src="https://github.com/user-attachments/assets/aaf81441-d4cc-4f72-82fe-a9f8b730d765" />|<img width="976" height="234" alt="Screenshot 2025-08-28 at 13 45 20" src="https://github.com/user-attachments/assets/1679f57e-10e0-43ff-84cb-edb012944160" />|
|<img width="969" height="232" alt="Screenshot 2025-08-28 at 13 45 52" src="https://github.com/user-attachments/assets/ba880282-1b3c-4cfe-b745-f6e0a1b1ea18" />|<img width="972" height="233" alt="Screenshot 2025-08-28 at 13 46 26" src="https://github.com/user-attachments/assets/e90abd34-1e43-40ee-9eca-def005394a52" />|

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [x] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

