### PR TITLE
Remove any reference of preview_url from attachments

### DIFF
--- a/test/presenters/content_item/attachments_test.rb
+++ b/test/presenters/content_item/attachments_test.rb
@@ -25,7 +25,6 @@ class AttachmentsTest < ActiveSupport::TestCase
 
   test "#attachments returns attachments with preview_urls based on url" do
     attachments = [{
-      "preview_url" => "some-preview-url",
       "url" => "assets.test.gov.uk/media/123/some-filename.csv",
       "content_type" => "text/csv",
       "filename" => "some-filename.csv",
@@ -36,7 +35,6 @@ class AttachmentsTest < ActiveSupport::TestCase
 
   test "#attachments returns attachments with preview_urls based on asset_manager_id and filename" do
     attachments = [{
-      "preview_url" => "some-preview-url",
       "url" => "some-url",
       "assets" => [{ "asset_manager_id" => "some-attachment-data-id", "filename" => "some-filename" }],
       "filename" => "some-filename",


### PR DESCRIPTION
Jira card: https://gov-uk.atlassian.net/browse/NAV-18198

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [ ] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

