### PR TITLE
Remove unneeded exclude class condition from worldwide office pages

### DIFF
--- a/app/presenters/worldwide_office_presenter.rb
+++ b/app/presenters/worldwide_office_presenter.rb
@@ -30,10 +30,6 @@ class WorldwideOfficePresenter < ContentItemPresenter
     worldwide_organisation&.sponsoring_organisations
   end
 
-  def exclude_main_wrapper_class?
-    true
-  end
-
 private
 
   def show_contents_list?


### PR DESCRIPTION
## What

Remove unneeded exclude class condition from worldwide office pages.

https://gds.slack.com/archives/C052X8S2P8A/p1757583565888609

**Review URL**: https://government-frontend-pr-3827.herokuapp.com/world/organisations/british-consulate-general-chicago/office/british-consulate-general-chicago

## Why

To resolve a spacing issue.

## Visual changes

### Before

<img width="2732" height="2047" alt="www gov uk_world_organisations_british-consulate-general-chicago_office_british-consulate-general-chicago(iPad Pro)" src="https://github.com/user-attachments/assets/965cd212-9963-4ab3-acf4-322ed2797983" />

### After

<img width="2732" height="2047" alt="127 0 0 1_3090_world_organisations_british-consulate-general-chicago(iPad Pro)" src="https://github.com/user-attachments/assets/73c9f681-ba1f-401c-861e-e38eccdaae41" />