### PR TITLE
Retire /media path

### DIFF
--- a/app/controllers/asset_manager_redirect_controller.rb
+++ b/app/controllers/asset_manager_redirect_controller.rb
@@ -3,10 +3,6 @@ class AssetManagerRedirectController < ApplicationController
     redirect
   end
 
-  def redirect_media_path
-    redirect
-  end
-
 private
 
   def redirect

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,6 @@ Rails.application.routes.draw do
   )
 
   get "/government/uploads/*path" => "asset_manager_redirect#redirect_government_uploads_path", format: false
-  get "/media/*path" => "asset_manager_redirect#redirect_media_path", format: false
 
   get "/government/organisations/hm-passport-office/contact/hm-passport-office-webchat", to: "webchat#webchat"
 

--- a/test/controllers/asset_manager_redirect_controller_test.rb
+++ b/test/controllers/asset_manager_redirect_controller_test.rb
@@ -14,25 +14,11 @@ class AssetManagerRedirectControllerTest < ActionController::TestCase
     assert_redirected_to "http://assets.test.gov.uk/government/uploads/asset.txt"
   end
 
-  test "redirects asset requests from '/media' path to the assets hostname" do
-    get :redirect_media_path, params: { path: "filename/asset.txt" }
-
-    assert_redirected_to "http://assets.test.gov.uk/media/filename/asset.txt"
-  end
-
   test "redirects to assets hostname respect the draft stack for legacy path" do
     ClimateControl.modify PLEK_HOSTNAME_PREFIX: "draft-" do
       get :redirect_government_uploads_path, params: { path: "asset.txt" }
 
       assert_redirected_to "http://draft-assets.test.gov.uk/government/uploads/asset.txt"
-    end
-  end
-
-  test "redirects to assets hostname respect the draft stack for modern path" do
-    ClimateControl.modify PLEK_HOSTNAME_PREFIX: "draft-" do
-      get :redirect_media_path, params: { path: "filename/asset.txt" }
-
-      assert_redirected_to "http://draft-assets.test.gov.uk/media/filename/asset.txt"
     end
   end
 end

--- a/test/integration/asset_manager_redirect_test.rb
+++ b/test/integration/asset_manager_redirect_test.rb
@@ -5,9 +5,4 @@ class AssetManagerRedirectTest < ActionDispatch::IntegrationTest
     get "/government/uploads/system/uploads/attachment_data/file/1234567/example.pdf"
     assert_redirected_to "http://assets.test.gov.uk/government/uploads/system/uploads/attachment_data/file/1234567/example.pdf"
   end
-
-  test "should redirect to asset path for '/media/*path'" do
-    get "/media/1234567/example.pdf"
-    assert_redirected_to "http://assets.test.gov.uk/media/1234567/example.pdf"
-  end
 end


### PR DESCRIPTION
This route was added when assets were moved from Whitehall to Asset Manager, and the urls for downloading and previewing attachments changed format from `/government/upload` to `/media/`.
Its purpose is to redirect `www.gov.uk/media/<asset_id>/<filename>` to `https://assets.publishing.service.gov.uk/media/<asset_id>/<filename>`.

We don't have any gov.uk/media links on our pages. And the traffic that this route has is mostly from web crawlers.
There are a few other requests made, probably from bookmarked pages and some external websites, but the numbers are not that high.

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [ ] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

