### PR TITLE
Adjust position of translation nav header

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -2,15 +2,7 @@
 
 .translation-nav-header {
   @include govuk-media-query($from: tablet) {
-    display: flex;
-    align-items: end;
     margin-bottom: govuk-spacing(8);
-  }
-}
-
-.direction-rtl {
-  .translation-nav-header {
-    flex-direction: row-reverse;
   }
 }
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
- slight adjustment to the work done in https://github.com/alphagov/government-frontend/pull/3811
- allow the translation nav to sit at the top, rather than the bottom
- some examples where the number of translations is high, previously resulting in the page title being pushed down
- removing flexbox entirely as not needed now

Making consistent with frontend: https://github.com/alphagov/frontend/pull/5011

## Visual changes
Header and translation nav now start at the top of the screen. No change on mobile.

Before | After
------ | ------
<img width="1074" height="458" alt="Screenshot 2025-09-18 at 14 19 57" src="https://github.com/user-attachments/assets/85933d35-28a3-4dac-a99f-4c55af19d764" /> | <img width="1080" height="463" alt="Screenshot 2025-09-18 at 14 20 06" src="https://github.com/user-attachments/assets/ced6d949-e641-4a1f-b656-3d2bbd39166b" />
