### PR TITLE
NAV-18497 Ensure h1 elements have the same font-size on guide pages

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -45,7 +45,12 @@
   <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6" id="guide-contents">
     <% if @content_item.has_parts? %>
       <% if @content_item.show_guide_navigation? %>
-        <%= render 'govuk_publishing_components/components/heading', heading_level: 1, font_size: 'l', margin_bottom: 6, text: @content_item.current_part_title %>
+        <%= render 'govuk_publishing_components/components/heading', {
+          text: @content_item.current_part_title,
+          heading_level: 1,
+          font_size: 'xl',
+          margin_bottom: 6
+        } %>
       <% end %>
       <%
         disable_youtube_expansions = true


### PR DESCRIPTION
## What

Ensure h1 elements have the same font-size on guide pages

## Why

There are two h1 elements on the page, one includes the `content_title` and the other includes the `content_part_title`.

When different font sizes are used for each h1 element, it implies a structure and relationship that may not be reliably perceived by some users of assistive technology.

This change ensures that both h1 elements use the same font-size to fix the accessibility issue, Level A failure of WCAG 2.2 Success Criteria 1.3.1 Info and Relationships.

Jira: https://gov-uk.atlassian.net/browse/NAV-18497

## Visual Changes

| Before | After |
| --- | --- |
| | |

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [ ] #govuk-patterns-and-pages have been notified of this change
