### PR TITLE
Use HTML publication header variant of inverse header

### DIFF
--- a/app/views/content_items/html_publication.html.erb
+++ b/app/views/content_items/html_publication.html.erb
@@ -28,6 +28,7 @@
 <% end %>
 
 <%= render 'govuk_publishing_components/components/inverse_header', {
+  html_publication_header: true,
   padding_top: 6,
   padding_bottom: 6,
   subtext: @content_item.last_changed


### PR DESCRIPTION
The html publication header variant was previously documented in the gem docs but wasn't actually programatically being set anywhere. We now need to set it since it now differs from the default by having the deeper blue background colour instead of the default light blue.

# 📣 On-going work to be aware of

**Routes in this application are being migrated to another application, please check with [#govuk-patterns-and-pages](https://gds.slack.com/archives/C06T3EFUUQ6) when making changes.**

- [ ] #govuk-patterns-and-pages have been notified of this change

____

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

